### PR TITLE
Worker processing comm

### DIFF
--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -1,7 +1,10 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import gc
-from mooncake.engine import TransferEngine
+try:
+    from mooncake.engine import TransferEngine
+except ImportError:
+    TransferEngine = None
 import torch
 
 
@@ -34,14 +37,16 @@ class TensorCommunicationManager(ABC):
         pass
 
     @abstractmethod
-    def start_read_tensors(self, graph_pointers: list[GraphPointer]):
+    def start_read_tensors(
+        self, request_id: str, graph_pointers: list[GraphPointer]
+    ):
         """
-        Initializes empty buffer, initializes a read. May return immediately. 
+        Initializes empty buffer, initializes a read. May return immediately.
         """
         pass
 
     @abstractmethod
-    def get_ready_tensors(self) -> dict[str, GraphPointer]:
+    def get_ready_tensors(self) -> dict[str, list[GraphPointer]]:
         """
         Returns request_id: list of the GraphPointers that are currently
         ready for that request
@@ -49,7 +54,7 @@ class TensorCommunicationManager(ABC):
         pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class NameAndRequestId:
     tensor_name: str
     request_id: str
@@ -59,6 +64,7 @@ class NameAndRequestId:
 class EventAndPointers:
     event: torch.cuda.Event
     pointers: list[GraphPointer]
+    request_id: str = ""
 
 
 class MooncakeCommunicationManager(TensorCommunicationManager):
@@ -72,20 +78,23 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
         
     ):
         self.my_entity_id = my_entity_id
-        self.tensors: dict[NameAndRequestId, torch.Tensor]
+        self.tensors: dict[NameAndRequestId, torch.Tensor] = {}
         self.communicator = communicator
         self.protocol = protocol
         self.my_session_id = communicator.get_session_id()
 
-        self.engine = TransferEngine()
-        self.engine.initialize(
-            hostname,
-            metadata_server,
-            protocol,
-            ""
-        )        
-        # request_id: EventAndPointers
-        self.pending: dict[str, EventAndPointers] = {}
+        if TransferEngine is not None:
+            self.engine = TransferEngine()
+            self.engine.initialize(
+                hostname,
+                metadata_server,
+                protocol,
+                ""
+            )
+        else:
+            self.engine = None
+        # Per-transfer pending list (allows partial tensor readiness)
+        self.pending: list[EventAndPointers] = []
 
     def register_and_prepare_to_send(
         self, request_id: str, tensors: dict[str, torch.Tensor],
@@ -144,21 +153,54 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
             tensor_name, request_id
         )]
 
-    def get_ready_tensors(self) -> dict[str, GraphPointer]:
+    def get_ready_tensors(self) -> dict[str, list[GraphPointer]]:
         """
-        Returns request_id: list of the GraphPointers that are currently
-        ready for that request (by querying the events in self.pending)
+        Poll CUDA events. Return {request_id: [ready GraphPointers]}.
+        Remove completed entries from self.pending.
         """
-        pass # TODO Atindra
+        ready: dict[str, list[GraphPointer]] = {}
+        still_pending = []
+        for ep in self.pending:
+            if ep.event.query():
+                for ptr in ep.pointers:
+                    ready.setdefault(ep.request_id, []).append(ptr)
+            else:
+                still_pending.append(ep)
+        self.pending = still_pending
+        return ready
 
-    def start_read_tensors(self, graph_pointers: list[GraphPointer]):
+    def start_read_tensors(
+        self, request_id: str, graph_pointers: list[GraphPointer]
+    ):
         """
-        Initializes empty buffer, initializes a read. May return immediately. 
+        For each pointer with tensor_info (RDMA source): allocate dst tensor,
+        register memory, call engine.transfer_read_on_cuda(), record CUDA event.
+        For each pointer WITHOUT tensor_info (signal-only): no data to transfer.
+        """
+        stream = torch.cuda.Stream()
+        for ptr in graph_pointers:
+            if ptr.tensor_info is None:
+                continue  # signal-only pointer, no data to transfer
 
-        Kicks of the engine transfer read on cuda. Updates self.pending.
-        """
-        # This also probably needs to handle None pointer.tensor_info, in which
-        # case the tensor becomes ready immediately and is available in
-        # self.tensors. Maybe this function should also read the corresponding
-        # tensor names
-        pass # TODO Atindra
+            info = ptr.tensor_info
+            dst = torch.empty(info.dims, dtype=info.dtype, device="cuda")
+            self.tensors[NameAndRequestId(ptr.name, request_id)] = dst
+
+            if self.protocol == CommProtocol.RDMA:
+                self.engine.register_memory(dst.data_ptr(), info.nbytes)
+
+                with torch.cuda.stream(stream):
+                    self.engine.transfer_read_on_cuda(
+                        info.source_session_id,
+                        dst.data_ptr(),
+                        info.address,
+                        info.nbytes,
+                        stream.cuda_stream,
+                    )
+                event = torch.cuda.Event()
+                event.record(stream)
+                self.pending.append(
+                    EventAndPointers(
+                        event=event, pointers=[ptr], request_id=request_id
+                    )
+                )

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -1,0 +1,289 @@
+import queue
+from dataclasses import dataclass, field
+
+import torch
+
+from mminf.engine.base import BaseEngine, EngineType, StageBatch, StageOutput
+
+
+@dataclass
+class KVRequestState:
+    """Per-request KV cache state for the AR engine."""
+    page_indices: list[int] = field(default_factory=list)
+    seq_len: int = 0
+    is_paused: bool = False
+
+
+class PageAllocator:
+    """Simple page allocator using a FIFO queue of free page indices."""
+
+    def __init__(self, max_num_pages: int):
+        self.max_num_pages = max_num_pages
+        self.free_pages: queue.Queue[int] = queue.Queue()
+        for i in range(max_num_pages):
+            self.free_pages.put(i)
+
+    def allocate(self, n: int) -> list[int]:
+        if self.free_pages.qsize() < n:
+            raise RuntimeError(
+                f"Not enough free pages: requested {n}, "
+                f"available {self.free_pages.qsize()}"
+            )
+        return [self.free_pages.get() for _ in range(n)]
+
+    def free(self, pages: list[int]) -> None:
+        for page in pages:
+            self.free_pages.put(page)
+
+    @property
+    def num_free(self) -> int:
+        return self.free_pages.qsize()
+
+
+class AREngine(BaseEngine):
+    """
+    Autoregressive engine with paged KV cache.
+    Uses FlashInfer for prefill/decode when available.
+    Supports pause/resume for interleaved loops (LLM <-> flow).
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module | None = None,
+        kv_cache_config: dict | None = None,
+    ):
+        self.model = model
+        self.kv_cache_config = kv_cache_config or {}
+        self.device = None
+        self.kv_cache = None  # [num_layers, max_pages, 2, page_size, num_kv_heads, head_dim]
+        self.page_allocator: PageAllocator | None = None
+        self.request_states: dict[str, KVRequestState] = {}
+
+        # FlashInfer wrappers (initialized in load_model if available)
+        self.prefill_wrapper = None
+        self.decode_wrapper = None
+        self.workspace_buffer = None
+
+    def engine_type(self) -> EngineType:
+        return EngineType.AR
+
+    def load_model(self, model_config: dict, device: torch.device) -> None:
+        self.device = device
+        cfg = model_config.get("kv_cache", self.kv_cache_config)
+        if not cfg:
+            return  # dummy mode without config
+
+        num_layers = cfg["num_layers"]
+        max_num_pages = cfg["max_num_pages"]
+        page_size = cfg["page_size"]
+        num_kv_heads = cfg["num_kv_heads"]
+        head_dim = cfg["head_dim"]
+
+        self.kv_cache = torch.zeros(
+            num_layers, max_num_pages, 2,
+            page_size, num_kv_heads, head_dim,
+            dtype=torch.bfloat16, device=device,
+        )
+        self.page_allocator = PageAllocator(max_num_pages)
+
+        # 256MB workspace for FlashInfer
+        self.workspace_buffer = torch.empty(
+            256 * 1024 * 1024, dtype=torch.uint8, device=device
+        )
+
+        try:
+            import flashinfer
+            self.prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+                self.workspace_buffer, "NHD"
+            )
+            self.decode_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+                self.workspace_buffer, "NHD"
+            )
+        except ImportError:
+            pass  # Dummy mode — no FlashInfer
+
+    def execute_batch(self, batch: StageBatch) -> StageOutput:
+        if self.model is None:
+            # Dummy mode: return empty output per request
+            return StageOutput(
+                per_request_output_tensors={
+                    rid: {} for rid in batch.request_ids
+                }
+            )
+
+        is_prefill = batch.metadata.get("is_prefill", False)
+
+        if is_prefill:
+            return self._execute_prefill(batch)
+        else:
+            return self._execute_decode(batch)
+
+    def _execute_prefill(self, batch: StageBatch) -> StageOutput:
+        """Run prefill (prompt processing) for a batch of requests."""
+        if self.prefill_wrapper is None or self.kv_cache is None:
+            return StageOutput(
+                per_request_output_tensors={
+                    rid: {} for rid in batch.request_ids
+                }
+            )
+
+        cfg = self.kv_cache_config
+        page_size = cfg["page_size"]
+        num_kv_heads = cfg["num_kv_heads"]
+        head_dim = cfg["head_dim"]
+        num_qo_heads = cfg.get("num_qo_heads", num_kv_heads)
+
+        # Build FlashInfer arguments from request states
+        qo_indptr = [0]
+        paged_kv_indptr = [0]
+        paged_kv_indices = []
+        paged_kv_last_page_len = []
+        all_q = []
+
+        for rid in batch.request_ids:
+            state = self.request_states[rid]
+            inputs = batch.per_request_input_tensors.get(rid, {})
+            q = inputs.get("hidden_states", inputs.get("text_emb"))
+            if q is None:
+                continue
+            seq_len = q.shape[0]
+
+            # Allocate pages for this sequence
+            num_pages_needed = (state.seq_len + seq_len + page_size - 1) // page_size
+            num_new_pages = num_pages_needed - len(state.page_indices)
+            if num_new_pages > 0:
+                new_pages = self.page_allocator.allocate(num_new_pages)
+                state.page_indices.extend(new_pages)
+
+            state.seq_len += seq_len
+            last_page_len = state.seq_len % page_size or page_size
+
+            qo_indptr.append(qo_indptr[-1] + seq_len)
+            paged_kv_indptr.append(paged_kv_indptr[-1] + len(state.page_indices))
+            paged_kv_indices.extend(state.page_indices)
+            paged_kv_last_page_len.append(last_page_len)
+            all_q.append(q)
+
+        if not all_q:
+            return StageOutput(
+                per_request_output_tensors={
+                    rid: {} for rid in batch.request_ids
+                }
+            )
+
+        q_tensor = torch.cat(all_q, dim=0)
+        qo_indptr_t = torch.tensor(qo_indptr, dtype=torch.int32, device=self.device)
+        kv_indptr_t = torch.tensor(paged_kv_indptr, dtype=torch.int32, device=self.device)
+        kv_indices_t = torch.tensor(paged_kv_indices, dtype=torch.int32, device=self.device)
+        kv_last_page_t = torch.tensor(paged_kv_last_page_len, dtype=torch.int32, device=self.device)
+
+        self.prefill_wrapper.plan(
+            qo_indptr_t, kv_indptr_t, kv_indices_t, kv_last_page_t,
+            num_qo_heads, num_kv_heads, head_dim, page_size, causal=True,
+        )
+
+        # Run model forward (attention handled by FlashInfer wrapper)
+        with torch.no_grad():
+            output = self.model(q_tensor, self.kv_cache, self.prefill_wrapper)
+
+        # Split outputs back per request
+        per_request_outputs = {}
+        offset = 0
+        for rid in batch.request_ids:
+            seq_len = qo_indptr[batch.request_ids.index(rid) + 1] - qo_indptr[batch.request_ids.index(rid)]
+            per_request_outputs[rid] = {"hidden_states": output[offset:offset + seq_len]}
+            offset += seq_len
+
+        return StageOutput(per_request_output_tensors=per_request_outputs)
+
+    def _execute_decode(self, batch: StageBatch) -> StageOutput:
+        """Run decode (single token generation) for a batch of requests."""
+        if self.decode_wrapper is None or self.kv_cache is None:
+            return StageOutput(
+                per_request_output_tensors={
+                    rid: {} for rid in batch.request_ids
+                }
+            )
+
+        cfg = self.kv_cache_config
+        page_size = cfg["page_size"]
+        num_kv_heads = cfg["num_kv_heads"]
+        head_dim = cfg["head_dim"]
+        num_qo_heads = cfg.get("num_qo_heads", num_kv_heads)
+
+        indptr = [0]
+        indices = []
+        last_page_len = []
+        all_q = []
+
+        for rid in batch.request_ids:
+            state = self.request_states[rid]
+            inputs = batch.per_request_input_tensors.get(rid, {})
+            q = inputs.get("hidden_states", inputs.get("text_emb"))
+            if q is None:
+                continue
+
+            # Allocate one more page if needed
+            state.seq_len += 1
+            num_pages_needed = (state.seq_len + page_size - 1) // page_size
+            num_new_pages = num_pages_needed - len(state.page_indices)
+            if num_new_pages > 0:
+                new_pages = self.page_allocator.allocate(num_new_pages)
+                state.page_indices.extend(new_pages)
+
+            lpl = state.seq_len % page_size or page_size
+
+            indptr.append(indptr[-1] + len(state.page_indices))
+            indices.extend(state.page_indices)
+            last_page_len.append(lpl)
+            all_q.append(q)
+
+        if not all_q:
+            return StageOutput(
+                per_request_output_tensors={
+                    rid: {} for rid in batch.request_ids
+                }
+            )
+
+        q_tensor = torch.cat(all_q, dim=0)
+        indptr_t = torch.tensor(indptr, dtype=torch.int32, device=self.device)
+        indices_t = torch.tensor(indices, dtype=torch.int32, device=self.device)
+        last_page_t = torch.tensor(last_page_len, dtype=torch.int32, device=self.device)
+
+        self.decode_wrapper.plan(
+            indptr_t, indices_t, last_page_t,
+            num_qo_heads, num_kv_heads, head_dim, page_size,
+        )
+
+        with torch.no_grad():
+            output = self.model(q_tensor, self.kv_cache, self.decode_wrapper)
+
+        per_request_outputs = {}
+        for i, rid in enumerate(batch.request_ids):
+            per_request_outputs[rid] = {"hidden_states": output[i:i + 1]}
+
+        return StageOutput(per_request_output_tensors=per_request_outputs)
+
+    def add_request(self, request_id: str) -> None:
+        self.request_states[request_id] = KVRequestState()
+
+    def remove_request(self, request_id: str) -> None:
+        if request_id in self.request_states:
+            if self.page_allocator is not None:
+                self.page_allocator.free(self.request_states[request_id].page_indices)
+            del self.request_states[request_id]
+
+    def pause_request(self, request_id: str) -> None:
+        """For interleaved loop: mark as paused, keep KV pages allocated."""
+        if request_id in self.request_states:
+            self.request_states[request_id].is_paused = True
+
+    def resume_request(self, request_id: str) -> None:
+        """Resume from paused state for next LLM step in loop."""
+        if request_id in self.request_states:
+            self.request_states[request_id].is_paused = False
+
+    def shutdown(self) -> None:
+        self.kv_cache = None
+        self.workspace_buffer = None
+        self.request_states.clear()

--- a/mminf/engine/base.py
+++ b/mminf/engine/base.py
@@ -1,0 +1,60 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+
+import torch
+
+
+class EngineType(Enum):
+    AR = "ar"
+    FLOW = "flow"
+    ENC_DEC = "enc_dec"
+
+
+@dataclass
+class StageBatch:
+    """Input to an engine's execute_batch()."""
+    stage_name: str
+    phase: str
+    request_ids: list[str]
+    # {request_id: {input_name: tensor}}
+    per_request_input_tensors: dict[str, dict[str, torch.Tensor]]
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class StageOutput:
+    """Output from an engine's execute_batch()."""
+    # {request_id: {output_name: tensor}}
+    per_request_output_tensors: dict[str, dict[str, torch.Tensor]]
+    # {request_id: engine-specific metadata (e.g., generated token id)}
+    per_request_metadata: dict[str, dict] = field(default_factory=dict)
+
+
+class BaseEngine(ABC):
+    @abstractmethod
+    def engine_type(self) -> EngineType:
+        ...
+
+    @abstractmethod
+    def load_model(self, model_config: dict, device: torch.device) -> None:
+        ...
+
+    @abstractmethod
+    def execute_batch(self, batch: StageBatch) -> StageOutput:
+        ...
+
+    @abstractmethod
+    def add_request(self, request_id: str) -> None:
+        ...
+
+    @abstractmethod
+    def remove_request(self, request_id: str) -> None:
+        ...
+
+    def warmup(self) -> None:
+        """Optional CUDA graph capture. Override in subclasses."""
+        pass
+
+    def shutdown(self) -> None:
+        pass

--- a/mminf/engine/enc_dec_engine.py
+++ b/mminf/engine/enc_dec_engine.py
@@ -1,0 +1,51 @@
+import torch
+
+from mminf.engine.base import BaseEngine, EngineType, StageBatch, StageOutput
+
+
+class EncoderDecoderEngine(BaseEngine):
+    """
+    Wraps an nn.Module for stateless forward passes
+    (ViT encoder, text embedding, VAE decoder).
+    """
+
+    def __init__(self, model: torch.nn.Module | None = None):
+        self.model = model
+        self.device = None
+
+    def engine_type(self) -> EngineType:
+        return EngineType.ENC_DEC
+
+    def load_model(self, model_config: dict, device: torch.device) -> None:
+        self.device = device
+        # Load model from config if self.model is None
+        # For now, model must be passed in constructor or remains None (dummy mode)
+
+    def execute_batch(self, batch: StageBatch) -> StageOutput:
+        if self.model is None:
+            # Dummy mode: return empty tensors matching expected output names
+            return StageOutput(
+                per_request_output_tensors={
+                    rid: {} for rid in batch.request_ids
+                }
+            )
+
+        with torch.no_grad():
+            # Batch inputs, run model, split outputs per request
+            outputs = {}
+            for rid in batch.request_ids:
+                inputs = batch.per_request_input_tensors.get(rid, {})
+                result = self.model(**{k: v.unsqueeze(0) for k, v in inputs.items()})
+                if isinstance(result, torch.Tensor):
+                    outputs[rid] = {"output": result.squeeze(0)}
+                elif isinstance(result, dict):
+                    outputs[rid] = {k: v.squeeze(0) for k, v in result.items()}
+                else:
+                    outputs[rid] = {}
+            return StageOutput(per_request_output_tensors=outputs)
+
+    def add_request(self, request_id: str) -> None:
+        pass  # stateless
+
+    def remove_request(self, request_id: str) -> None:
+        pass  # stateless

--- a/mminf/engine/flow_engine.py
+++ b/mminf/engine/flow_engine.py
@@ -1,0 +1,48 @@
+import torch
+
+from mminf.engine.base import BaseEngine, EngineType, StageBatch, StageOutput
+
+
+class FlowEngine(BaseEngine):
+    """
+    Flow/diffusion engine. Executes a single denoising step per call.
+    Loop iteration is handled by the graph system.
+    """
+
+    def __init__(self, model: torch.nn.Module | None = None):
+        self.model = model
+        self.device = None
+
+    def engine_type(self) -> EngineType:
+        return EngineType.FLOW
+
+    def load_model(self, model_config: dict, device: torch.device) -> None:
+        self.device = device
+
+    def execute_batch(self, batch: StageBatch) -> StageOutput:
+        if self.model is None:
+            # Dummy mode
+            return StageOutput(
+                per_request_output_tensors={
+                    rid: {} for rid in batch.request_ids
+                }
+            )
+
+        with torch.no_grad():
+            outputs = {}
+            for rid in batch.request_ids:
+                inputs = batch.per_request_input_tensors.get(rid, {})
+                result = self.model(**{k: v.unsqueeze(0) for k, v in inputs.items()})
+                if isinstance(result, torch.Tensor):
+                    outputs[rid] = {"output": result.squeeze(0)}
+                elif isinstance(result, dict):
+                    outputs[rid] = {k: v.squeeze(0) for k, v in result.items()}
+                else:
+                    outputs[rid] = {}
+            return StageOutput(per_request_output_tensors=outputs)
+
+    def add_request(self, request_id: str) -> None:
+        pass
+
+    def remove_request(self, request_id: str) -> None:
+        pass

--- a/mminf/graph/request_queues.py
+++ b/mminf/graph/request_queues.py
@@ -45,7 +45,10 @@ class PerRequestStageQueues:
         to different subgraphs)
         """
         if self.waiting is None:
-            return new_inputs
+            return ProcessedInputs(
+                routed_to_this_subgraph=set(),
+                for_other_subgraphs=new_inputs,
+            )
 
         new_inputs: DestToGraphPointers = get_stage_to_inputs_mapping(new_inputs)
         ingested = self.waiting.ingest_inputs(new_inputs)

--- a/mminf/worker/dummy_worker.py
+++ b/mminf/worker/dummy_worker.py
@@ -213,7 +213,10 @@ class SubgraphsManager:
                 stage=ptr.next_stage, phase=self.get_phase(request_id)
             )
             if stage_phase not in self.per_request_info[request_id].stage_to_worker:
-                continue
+                raise ValueError(
+                    f"Output pointer targets unknown stage/phase: {stage_phase}. "
+                    f"Check graph construction."
+                )
             worker_id = self.per_request_info[request_id].stage_to_worker[stage_phase]
             if worker_id not in to_workers:
                 to_workers[worker_id] = []

--- a/mminf/worker/dummy_worker.py
+++ b/mminf/worker/dummy_worker.py
@@ -50,14 +50,15 @@ class SubgraphQueues:
         return self.per_request_queues[request_id].process_new_inputs(inputs)
     
     def is_done(self, request_id) -> bool:
-        return self.per_request_queues[request_id].waiting is None
+        q = self.per_request_queues[request_id]
+        return q.waiting is None and len(q.ready) == 0
     
     def add_request(self, request_id: str):
         """
         Initialize queues for a new request
         """
         self.per_request_queues[request_id] = PerRequestStageQueues(
-            waiting=deepcopy(self.subgraph),
+            waiting=deepcopy(self.subgraph.section),
             subgraph_id=self.subgraph_id
         )
 
@@ -99,7 +100,7 @@ class SubgraphQueues:
         At the end of a subgraph, reset the queues for that request so that it
         can be used for the next full model forward pass
         """
-        self.per_request_queues[request_id].waiting = deepcopy(self.subgraph)
+        self.per_request_queues[request_id].waiting = deepcopy(self.subgraph.section)
         self.per_request_queues[request_id].ready = []
 
 
@@ -202,11 +203,18 @@ class SubgraphsManager:
         # in different workers)
 
         # (3) get mapping of worker to external outputs
+        # Filter out back_to_conductor pointers (e.g., stream_out) — they
+        # don't route to any worker
         to_workers: dict[str, list[GraphPointer]] = {}
         for ptr in outputs:
-            worker_id = self.per_request_info[request_id].stage_to_worker[StageAndPhase(
+            if ptr.back_to_conductor:
+                continue
+            stage_phase = StageAndPhase(
                 stage=ptr.next_stage, phase=self.get_phase(request_id)
-            )]
+            )
+            if stage_phase not in self.per_request_info[request_id].stage_to_worker:
+                continue
+            worker_id = self.per_request_info[request_id].stage_to_worker[stage_phase]
             if worker_id not in to_workers:
                 to_workers[worker_id] = []
             to_workers[worker_id].append(ptr)

--- a/mminf/worker/engine_manager.py
+++ b/mminf/worker/engine_manager.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass, field
+
+import torch
+
+from mminf.engine.base import BaseEngine, EngineType
+from mminf.engine.ar_engine import AREngine
+from mminf.engine.flow_engine import FlowEngine
+from mminf.engine.enc_dec_engine import EncoderDecoderEngine
+
+
+ENGINE_TYPE_TO_CLASS: dict[str, type[BaseEngine]] = {
+    "ar": AREngine,
+    "flow": FlowEngine,
+    "enc_dec": EncoderDecoderEngine,
+}
+
+
+@dataclass
+class EngineManager:
+    """Maps stage names to engine instances."""
+    stage_to_engine: dict[str, BaseEngine] = field(default_factory=dict)
+
+    @classmethod
+    def from_config(
+        cls, engine_configs: list[dict], device: torch.device
+    ) -> "EngineManager":
+        """
+        Build an EngineManager from a list of engine configs.
+
+        engine_configs example:
+        [
+            {"engine_type": "ar", "stage_names": ["LLM"], "model_config": {...}},
+            {"engine_type": "flow", "stage_names": ["flow"], "model_config": {...}},
+            {"engine_type": "enc_dec", "stage_names": ["text_emb", "image_emb", "VAE_dec"], ...}
+        ]
+        """
+        stage_to_engine: dict[str, BaseEngine] = {}
+
+        for cfg in engine_configs:
+            engine_type_str = cfg["engine_type"]
+            stage_names = cfg["stage_names"]
+            model_config = cfg.get("model_config", {})
+            model = cfg.get("model", None)
+
+            engine_cls = ENGINE_TYPE_TO_CLASS[engine_type_str]
+
+            if engine_type_str == "ar":
+                engine = engine_cls(
+                    model=model,
+                    kv_cache_config=model_config.get("kv_cache", {}),
+                )
+            else:
+                engine = engine_cls(model=model)
+
+            engine.load_model(model_config, device)
+
+            for name in stage_names:
+                stage_to_engine[name] = engine
+
+        return cls(stage_to_engine=stage_to_engine)
+
+    def get_engine(self, stage_name: str) -> BaseEngine:
+        return self.stage_to_engine[stage_name]
+
+    def add_request(self, request_id: str) -> None:
+        """Propagate add_request to all unique engines."""
+        seen = set()
+        for engine in self.stage_to_engine.values():
+            eid = id(engine)
+            if eid not in seen:
+                seen.add(eid)
+                engine.add_request(request_id)
+
+    def remove_request(self, request_id: str) -> None:
+        """Propagate remove_request to all unique engines."""
+        seen = set()
+        for engine in self.stage_to_engine.values():
+            eid = id(engine)
+            if eid not in seen:
+                seen.add(eid)
+                engine.remove_request(request_id)
+
+    def shutdown(self) -> None:
+        seen = set()
+        for engine in self.stage_to_engine.values():
+            eid = id(engine)
+            if eid not in seen:
+                seen.add(eid)
+                engine.shutdown()

--- a/mminf/worker/micro_scheduler.py
+++ b/mminf/worker/micro_scheduler.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass
+
+from mminf.engine.base import EngineType
+from mminf.graph.base import GraphStage
+from mminf.worker.engine_manager import EngineManager
+from mminf.worker.dummy_worker import SubgraphsManager
+
+
+@dataclass
+class ScheduledBatch:
+    """A batch of stages ready to be executed."""
+    stage_name: str
+    phase: str
+    request_ids: list[str]
+    stages: list[GraphStage]  # the popped GraphStage objects
+
+
+# Priority: lower value = higher priority
+# AR decode is most latency-sensitive
+PRIORITY = {
+    EngineType.AR: 0,
+    EngineType.FLOW: 1,
+    EngineType.ENC_DEC: 2,
+}
+
+
+class MicroScheduler:
+    """
+    Simple MVP scheduler: scans all subgraph queues for ready stages,
+    groups by stage name, returns the highest-priority group.
+    """
+
+    def __init__(self, engine_manager: EngineManager):
+        self.engine_manager = engine_manager
+
+    def get_next_batch(
+        self, subgraphs_manager: SubgraphsManager
+    ) -> ScheduledBatch | None:
+        """
+        Scans all subgraph queues for ready stages.
+        Groups by stage name. Returns highest-priority group.
+        """
+        # Collect all ready (stage_name, request_id, phase) tuples
+        # grouped by stage name
+        stage_name_to_requests: dict[str, list[tuple[str, str, str]]] = {}
+
+        for subgraph_id, queue in subgraphs_manager.queues.items():
+            ready_map = queue.get_ready_stage_names()
+            for request_id, stage_names in ready_map.items():
+                phase = subgraphs_manager.get_phase(request_id)
+                for sname in stage_names:
+                    stage_name_to_requests.setdefault(sname, []).append(
+                        (request_id, subgraph_id, phase)
+                    )
+
+        if not stage_name_to_requests:
+            return None
+
+        # Pick the stage name with highest priority (lowest PRIORITY value)
+        best_stage_name = None
+        best_priority = float("inf")
+
+        for sname in stage_name_to_requests:
+            if sname not in self.engine_manager.stage_to_engine:
+                continue
+            engine = self.engine_manager.get_engine(sname)
+            prio = PRIORITY.get(engine.engine_type(), 99)
+            if prio < best_priority:
+                best_priority = prio
+                best_stage_name = sname
+
+        if best_stage_name is None:
+            return None
+
+        # Pop ready stages for all requests of this stage name
+        entries = stage_name_to_requests[best_stage_name]
+        request_ids = []
+        all_stages = []
+        phase = entries[0][2]  # all entries for same stage share the phase
+
+        for request_id, subgraph_id, req_phase in entries:
+            queue = subgraphs_manager.queues[subgraph_id]
+            popped = queue.pop_ready_stages(request_id, [best_stage_name])
+            if popped:
+                request_ids.append(request_id)
+                all_stages.extend(popped)
+                phase = req_phase
+
+        if not request_ids:
+            return None
+
+        return ScheduledBatch(
+            stage_name=best_stage_name,
+            phase=phase,
+            request_ids=request_ids,
+            stages=all_stages,
+        )

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -1,0 +1,291 @@
+import torch
+
+from mminf.communication.communicator import CommProtocol, ZMQCommunicator
+from mminf.communication.tensors import MooncakeCommunicationManager, NameAndRequestId
+from mminf.engine.base import StageBatch
+from mminf.graph.base import GraphPointer, TensorPointerInfo
+from mminf.ipc_formats import (
+    ConductorMessage, ConductorMessageType, InputSignals,
+    NewRequest, RemoveRequest, SubgraphsDone, WorkerMessage, WorkerMessageType,
+)
+from mminf.model.base import Subgraph
+from mminf.worker.dummy_worker import (
+    StageOutputRouting, SubgraphQueues, SubgraphsManager,
+)
+from mminf.worker.engine_manager import EngineManager
+from mminf.worker.micro_scheduler import MicroScheduler, ScheduledBatch
+
+
+class Worker:
+    """
+    Real worker that integrates SubgraphsManager, EngineManager,
+    MicroScheduler, and MooncakeCommunicationManager to execute
+    computation via engines.
+    """
+
+    def __init__(
+        self,
+        worker_id: str,
+        worker_ids: list[str],
+        my_subgraphs: list[Subgraph],
+        engine_configs: list[dict],
+        all_subgraph_ids_to_phases: dict[str, set[str]],
+        all_subgraph_ids_to_stages: dict[str, list[str]],
+        hostname: str = "localhost",
+        socket_path_prefix: str = "/tmp/mminf",
+        tensor_comm_protocol: CommProtocol = CommProtocol.RDMA,
+        device: torch.device = torch.device("cuda"),
+    ):
+        self.worker_id = worker_id
+        self.device = device
+
+        self.subgraphs_manager = SubgraphsManager(
+            queues={
+                subgraph.subgraph_id: SubgraphQueues(
+                    subgraph_id=subgraph.subgraph_id,
+                    phases=subgraph.phases,
+                    subgraph=subgraph,
+                    per_request_queues={},
+                )
+                for subgraph in my_subgraphs
+            },
+            per_request_info={},
+            all_subgraph_ids_to_phases=all_subgraph_ids_to_phases,
+            all_subgraph_ids_to_stages=all_subgraph_ids_to_stages,
+        )
+
+        self.engine_manager = EngineManager.from_config(engine_configs, device)
+        self.scheduler = MicroScheduler(self.engine_manager)
+
+        self.communicator = ZMQCommunicator(
+            my_id=worker_id,
+            push_ids=worker_ids + ["conductor", "api_server"],
+            ipc_socket_path_prefix=socket_path_prefix,
+        )
+        self.tensor_manager = MooncakeCommunicationManager(
+            my_entity_id=worker_id,
+            hostname=hostname,
+            communicator=self.communicator,
+            protocol=tensor_comm_protocol,
+        )
+
+    # ------------------------------------------------------------------
+    # Message handling
+    # ------------------------------------------------------------------
+
+    def _add_new_request(self, body: NewRequest) -> None:
+        self.subgraphs_manager.add_request(
+            request_id=body.request_id,
+            subgraph_ids=body.subgraph_ids,
+            subgraph_to_worker=body.subgraph_to_worker,
+        )
+        self.engine_manager.add_request(body.request_id)
+
+        self.subgraphs_manager.update_phase(
+            body.request_id, body.initial_phase
+        )
+
+        # Start RDMA reads for tensors that have tensor_info
+        self.tensor_manager.start_read_tensors(
+            body.request_id, body.initial_inputs
+        )
+
+        # Signal-only pointers (tensor_info is None) can be processed immediately
+        signal_only = [
+            ptr for ptr in body.initial_inputs if ptr.tensor_info is None
+        ]
+        if signal_only:
+            self.subgraphs_manager.process_new_inputs(
+                request_id=body.request_id, inputs=signal_only
+            )
+
+    def _remove_request(self, body: RemoveRequest) -> None:
+        self.engine_manager.remove_request(body.request_id)
+        self.subgraphs_manager.remove_request(body.request_id)
+
+    def _process_new_inputs(self, body: InputSignals) -> None:
+        self.subgraphs_manager.update_phase(body.request_id, body.phase)
+
+        # Start RDMA reads for tensors with tensor_info
+        self.tensor_manager.start_read_tensors(body.request_id, body.inputs)
+
+        # Signal-only pointers can be processed immediately
+        signal_only = [ptr for ptr in body.inputs if ptr.tensor_info is None]
+        if signal_only:
+            self.subgraphs_manager.process_new_inputs(
+                request_id=body.request_id, inputs=signal_only
+            )
+
+    def _process_messages(self) -> None:
+        for message in self.communicator.get_all_new_messages():
+            if message.message_type == WorkerMessageType.NEW_REQUEST:
+                self._add_new_request(message.body)
+            elif message.message_type == WorkerMessageType.REMOVE_REQUEST:
+                self._remove_request(message.body)
+            elif message.message_type == WorkerMessageType.INPUT_SIGNALS:
+                self._process_new_inputs(message.body)
+
+    # ------------------------------------------------------------------
+    # Tensor readiness
+    # ------------------------------------------------------------------
+
+    def _check_ready_tensors(self) -> None:
+        """Poll for completed RDMA transfers, feed ready pointers to subgraph queues."""
+        ready = self.tensor_manager.get_ready_tensors()
+        for request_id, pointers in ready.items():
+            self.subgraphs_manager.process_new_inputs(
+                request_id=request_id, inputs=pointers
+            )
+
+    # ------------------------------------------------------------------
+    # Batch building
+    # ------------------------------------------------------------------
+
+    def _build_stage_batch(self, batch: ScheduledBatch) -> StageBatch:
+        """Gather input tensors from tensor_manager for all requests in the batch."""
+        per_request_inputs: dict[str, dict[str, torch.Tensor]] = {}
+
+        for i, request_id in enumerate(batch.request_ids):
+            stage = batch.stages[i] if i < len(batch.stages) else batch.stages[0]
+            tensors = {}
+            for input_name in stage.input_ids:
+                key = NameAndRequestId(input_name, request_id)
+                if key in self.tensor_manager.tensors:
+                    tensors[input_name] = self.tensor_manager.tensors[key]
+            per_request_inputs[request_id] = tensors
+
+        return StageBatch(
+            stage_name=batch.stage_name,
+            phase=batch.phase,
+            request_ids=batch.request_ids,
+            per_request_input_tensors=per_request_inputs,
+        )
+
+    # ------------------------------------------------------------------
+    # Output handling
+    # ------------------------------------------------------------------
+
+    def _store_outputs(
+        self,
+        batch: ScheduledBatch,
+        output: "StageOutput",
+        routing_per_request: dict[str, StageOutputRouting],
+    ) -> dict[str, list[GraphPointer]]:
+        """
+        For outputs going to other workers: register tensors for RDMA send
+        and populate tensor_info on the GraphPointers.
+        For outputs staying local: store tensors in tensor_manager.
+        Returns the output pointers per request (with tensor_info filled in).
+        """
+        output_pointers: dict[str, list[GraphPointer]] = {}
+
+        for i, request_id in enumerate(batch.request_ids):
+            stage = batch.stages[i] if i < len(batch.stages) else batch.stages[0]
+            request_output_tensors = output.per_request_output_tensors.get(
+                request_id, {}
+            )
+
+            # Store all output tensors locally
+            for tensor_name, tensor in request_output_tensors.items():
+                self.tensor_manager.tensors[
+                    NameAndRequestId(tensor_name, request_id)
+                ] = tensor
+
+            routing = routing_per_request[request_id]
+
+            # For tensors going to other workers, register for RDMA send
+            external_pointers = []
+            for worker_id, pointers in routing.to_workers.items():
+                external_pointers.extend(pointers)
+
+            if external_pointers and request_output_tensors:
+                # Filter to only tensors that actually go external
+                external_names = {ptr.name for ptr in external_pointers}
+                external_tensors = {
+                    name: t for name, t in request_output_tensors.items()
+                    if name in external_names
+                }
+                if external_tensors:
+                    self.tensor_manager.register_and_prepare_to_send(
+                        request_id, external_tensors, external_pointers
+                    )
+
+            output_pointers[request_id] = stage.outputs
+
+        return output_pointers
+
+    def _send_outputs(
+        self, request_id: str, outputs: StageOutputRouting
+    ) -> None:
+        """Send outputs to other workers and to the conductor."""
+        for worker_id, pointers in outputs.to_workers.items():
+            message = WorkerMessage(
+                message_type=WorkerMessageType.INPUT_SIGNALS,
+                body=InputSignals(
+                    request_id=request_id,
+                    phase=self.subgraphs_manager.get_phase(request_id),
+                    inputs=pointers,
+                ),
+            )
+            self.communicator.send(worker_id, message)
+
+        if outputs.to_conductor:
+            message = ConductorMessage(
+                message_type=ConductorMessageType.PERSIST_SIGNALS,
+                body=InputSignals(
+                    request_id=request_id,
+                    inputs=outputs.to_conductor,
+                    phase=self.subgraphs_manager.get_phase(request_id),
+                ),
+            )
+            self.communicator.send("conductor", message)
+
+        if outputs.completed_subgraphs:
+            message = ConductorMessage(
+                message_type=ConductorMessageType.SUBGRAPHS_DONE,
+                body=SubgraphsDone(
+                    request_id=request_id,
+                    subgraph_ids=outputs.completed_subgraphs,
+                ),
+            )
+            self.communicator.send("conductor", message)
+
+    # ------------------------------------------------------------------
+    # Main loop
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        while True:
+            # 1. Process ZMQ messages (new requests, input signals, removals)
+            self._process_messages()
+
+            # 2. Check for ready RDMA tensors, feed to subgraph queues
+            self._check_ready_tensors()
+
+            # 3. Pick next batch via MicroScheduler
+            batch = self.scheduler.get_next_batch(self.subgraphs_manager)
+            if batch is None:
+                continue
+
+            # 4. Gather input tensors for the batch
+            stage_batch = self._build_stage_batch(batch)
+
+            # 5. Execute via engine
+            engine = self.engine_manager.get_engine(batch.stage_name)
+            output = engine.execute_batch(stage_batch)
+
+            # 6. Route outputs through SubgraphsManager first to determine routing
+            routing_per_request: dict[str, StageOutputRouting] = {}
+            for i, request_id in enumerate(batch.request_ids):
+                stage = batch.stages[i] if i < len(batch.stages) else batch.stages[0]
+                routing = self.subgraphs_manager.process_stage_outputs(
+                    request_id, stage.outputs
+                )
+                routing_per_request[request_id] = routing
+
+            # 7. Store output tensors, register RDMA if needed
+            self._store_outputs(batch, output, routing_per_request)
+
+            # 8. Send outputs to other workers / conductor
+            for request_id in batch.request_ids:
+                self._send_outputs(request_id, routing_per_request[request_id])

--- a/test/test_phase1.py
+++ b/test/test_phase1.py
@@ -1,0 +1,456 @@
+"""
+Phase 1 tests: Engine execution + Mooncake integration.
+Tests engines in dummy mode (model=None, no GPU required) and verifies
+the interleaved LLM<->flow loop fires stages in the correct order.
+"""
+import sys
+sys.path.insert(0, ".")
+
+import pytest
+from copy import deepcopy
+
+from mminf.engine.base import EngineType, StageBatch, StageOutput
+from mminf.engine.ar_engine import AREngine, PageAllocator, KVRequestState
+from mminf.engine.flow_engine import FlowEngine
+from mminf.engine.enc_dec_engine import EncoderDecoderEngine
+from mminf.engine.base import BaseEngine
+
+from mminf.graph.base import GraphPointer, GraphStage, Loop, Parallel, Sequential
+from mminf.graph.request_queues import PerRequestStageQueues
+from mminf.model.dummy_model import DummyModel
+from mminf.model.base import Subgraph
+from mminf.worker.dummy_worker import (
+    SubgraphQueues, SubgraphsManager, StageOutputRouting,
+)
+from mminf.worker.engine_manager import EngineManager
+from mminf.worker.micro_scheduler import MicroScheduler, ScheduledBatch
+
+
+# ======================================================================
+# PageAllocator tests
+# ======================================================================
+
+
+class TestPageAllocator:
+    def test_allocate_and_free(self):
+        alloc = PageAllocator(max_num_pages=10)
+        assert alloc.num_free == 10
+
+        pages = alloc.allocate(3)
+        assert len(pages) == 3
+        assert alloc.num_free == 7
+        # Pages should be unique
+        assert len(set(pages)) == 3
+
+        alloc.free(pages)
+        assert alloc.num_free == 10
+
+    def test_allocate_all_pages(self):
+        alloc = PageAllocator(max_num_pages=5)
+        pages = alloc.allocate(5)
+        assert len(pages) == 5
+        assert alloc.num_free == 0
+
+    def test_exhaustion_raises(self):
+        alloc = PageAllocator(max_num_pages=3)
+        alloc.allocate(3)
+        with pytest.raises(RuntimeError, match="Not enough free pages"):
+            alloc.allocate(1)
+
+    def test_free_then_reallocate(self):
+        alloc = PageAllocator(max_num_pages=4)
+        p1 = alloc.allocate(4)
+        alloc.free(p1[:2])
+        assert alloc.num_free == 2
+        p2 = alloc.allocate(2)
+        assert len(p2) == 2
+        assert alloc.num_free == 0
+
+    def test_allocate_zero(self):
+        alloc = PageAllocator(max_num_pages=5)
+        pages = alloc.allocate(0)
+        assert pages == []
+        assert alloc.num_free == 5
+
+
+# ======================================================================
+# Engine tests (dummy mode — model=None)
+# ======================================================================
+
+
+class TestEngines:
+    def _make_batch(self, stage_name: str, request_ids: list[str]) -> StageBatch:
+        return StageBatch(
+            stage_name=stage_name,
+            phase="test",
+            request_ids=request_ids,
+            per_request_input_tensors={rid: {} for rid in request_ids},
+        )
+
+    def test_ar_engine_type(self):
+        engine = AREngine()
+        assert engine.engine_type() == EngineType.AR
+
+    def test_ar_engine_dummy_execute(self):
+        engine = AREngine()
+        batch = self._make_batch("LLM", ["req1", "req2"])
+        output = engine.execute_batch(batch)
+        assert isinstance(output, StageOutput)
+        assert "req1" in output.per_request_output_tensors
+        assert "req2" in output.per_request_output_tensors
+
+    def test_ar_engine_add_remove_request(self):
+        engine = AREngine()
+        engine.add_request("req1")
+        assert "req1" in engine.request_states
+        assert engine.request_states["req1"].seq_len == 0
+        assert engine.request_states["req1"].page_indices == []
+
+        engine.remove_request("req1")
+        assert "req1" not in engine.request_states
+
+    def test_ar_engine_pause_resume(self):
+        engine = AREngine()
+        engine.add_request("req1")
+        assert not engine.request_states["req1"].is_paused
+
+        engine.pause_request("req1")
+        assert engine.request_states["req1"].is_paused
+
+        engine.resume_request("req1")
+        assert not engine.request_states["req1"].is_paused
+
+    def test_ar_engine_remove_nonexistent(self):
+        engine = AREngine()
+        # Should not raise
+        engine.remove_request("nonexistent")
+
+    def test_flow_engine_type(self):
+        engine = FlowEngine()
+        assert engine.engine_type() == EngineType.FLOW
+
+    def test_flow_engine_dummy_execute(self):
+        engine = FlowEngine()
+        batch = self._make_batch("flow", ["req1"])
+        output = engine.execute_batch(batch)
+        assert isinstance(output, StageOutput)
+        assert "req1" in output.per_request_output_tensors
+
+    def test_enc_dec_engine_type(self):
+        engine = EncoderDecoderEngine()
+        assert engine.engine_type() == EngineType.ENC_DEC
+
+    def test_enc_dec_engine_dummy_execute(self):
+        engine = EncoderDecoderEngine()
+        batch = self._make_batch("text_emb", ["req1", "req2", "req3"])
+        output = engine.execute_batch(batch)
+        assert isinstance(output, StageOutput)
+        assert len(output.per_request_output_tensors) == 3
+
+
+# ======================================================================
+# EngineManager tests
+# ======================================================================
+
+
+class TestEngineManager:
+    def test_from_config_dummy(self):
+        configs = [
+            {"engine_type": "ar", "stage_names": ["LLM"], "model_config": {}},
+            {"engine_type": "flow", "stage_names": ["flow"], "model_config": {}},
+            {
+                "engine_type": "enc_dec",
+                "stage_names": ["text_emb", "image_emb", "VAE_dec"],
+                "model_config": {},
+            },
+        ]
+        mgr = EngineManager.from_config(configs, device="cpu")
+        assert mgr.get_engine("LLM").engine_type() == EngineType.AR
+        assert mgr.get_engine("flow").engine_type() == EngineType.FLOW
+        assert mgr.get_engine("text_emb").engine_type() == EngineType.ENC_DEC
+        assert mgr.get_engine("VAE_dec").engine_type() == EngineType.ENC_DEC
+        # text_emb and image_emb share the same engine instance
+        assert mgr.get_engine("text_emb") is mgr.get_engine("image_emb")
+
+    def test_add_remove_request_propagation(self):
+        configs = [
+            {"engine_type": "ar", "stage_names": ["LLM"], "model_config": {}},
+            {"engine_type": "flow", "stage_names": ["flow"], "model_config": {}},
+        ]
+        mgr = EngineManager.from_config(configs, device="cpu")
+        mgr.add_request("req1")
+        ar_engine = mgr.get_engine("LLM")
+        assert isinstance(ar_engine, AREngine)
+        assert "req1" in ar_engine.request_states
+
+        mgr.remove_request("req1")
+        assert "req1" not in ar_engine.request_states
+
+
+# ======================================================================
+# Image generation loop integration test
+# ======================================================================
+
+
+class TestImageGenLoop:
+    """
+    Uses DummyModel's image_gen phase graph to verify the interleaved
+    LLM<->flow loop fires stages in the correct order.
+
+    The image_gen graph structure:
+    Sequential([
+        Parallel([text_emb_section, img_emb_section]),
+        Loop(
+            Sequential([LLM, flow]),
+            n_iters=10,
+            outputs=[latents -> VAE_dec]
+        ),
+        VAE_dec
+    ])
+    """
+
+    def _build_image_gen_graph(self):
+        model = DummyModel()
+        graphs = model.get_phase_graphs()
+        return graphs["image_gen"]
+
+    def test_loop_stage_order(self):
+        """Verify stages fire in the correct order through the loop."""
+        graph = self._build_image_gen_graph()
+        queues = PerRequestStageQueues(waiting=graph)
+
+        # Provide all initial external inputs
+        initial_inputs = [
+            GraphPointer(name="text", next_stage="text_emb"),
+            GraphPointer(name="images", next_stage="image_emb"),
+            GraphPointer(name="existing_text_emb", next_stage="concat_text"),
+            GraphPointer(name="existing_image_emb", next_stage="concat_img"),
+            GraphPointer(name="latents", next_stage="LLM"),
+        ]
+        queues.process_new_inputs(initial_inputs)
+
+        fired_stages = []
+        max_iterations = 100  # safety bound
+
+        for _ in range(max_iterations):
+            if not queues.ready and queues.waiting is None:
+                break
+            assert queues.ready, "Deadlock: no ready stages but waiting stages remain"
+
+            # Pop and process one stage at a time
+            stage = queues.ready.pop(0)
+            fired_stages.append(stage.name)
+            queues.process_new_inputs(stage.outputs)
+
+        # Expected order:
+        # 1. text_emb and image_emb fire (parallel, order may vary)
+        # 2. concat_text and concat_img fire (parallel, order may vary)
+        # 3. 10 iterations of LLM then flow
+        # 4. VAE_dec fires last
+        assert fired_stages[-1] == "VAE_dec"
+
+        # Count LLM and flow occurrences — should be 10 each
+        llm_count = fired_stages.count("LLM")
+        flow_count = fired_stages.count("flow")
+        assert llm_count == 10, f"Expected 10 LLM stages, got {llm_count}"
+        assert flow_count == 10, f"Expected 10 flow stages, got {flow_count}"
+
+        # Verify LLM always fires before flow within each iteration
+        llm_indices = [i for i, s in enumerate(fired_stages) if s == "LLM"]
+        flow_indices = [i for i, s in enumerate(fired_stages) if s == "flow"]
+        for llm_idx, flow_idx in zip(llm_indices, flow_indices):
+            assert llm_idx < flow_idx, (
+                f"LLM (index {llm_idx}) should fire before flow (index {flow_idx})"
+            )
+
+        # Verify VAE_dec fires only once
+        assert fired_stages.count("VAE_dec") == 1
+
+    def test_loop_with_subgraph_manager(self):
+        """
+        Test the full loop using SubgraphsManager (single-worker scenario).
+        All stages on one worker, verifying queue management works end-to-end.
+        """
+        graph = self._build_image_gen_graph()
+
+        subgraph_id = "sg_image_gen"
+        subgraph = Subgraph(
+            section=graph,
+            phases={"image_gen"},
+            subgraph_id=subgraph_id,
+        )
+
+        manager = SubgraphsManager(
+            queues={
+                subgraph_id: SubgraphQueues(
+                    subgraph_id=subgraph_id,
+                    phases={"image_gen"},
+                    subgraph=subgraph,
+                    per_request_queues={},
+                )
+            },
+            per_request_info={},
+            all_subgraph_ids_to_phases={subgraph_id: {"image_gen"}},
+            all_subgraph_ids_to_stages={
+                subgraph_id: graph.get_stage_names()
+            },
+        )
+
+        # Add a request
+        request_id = "test_req_1"
+        manager.add_request(
+            request_id=request_id,
+            subgraph_ids=[subgraph_id],
+            subgraph_to_worker={subgraph_id: "worker_0"},
+        )
+        manager.update_phase(request_id, "image_gen")
+
+        # Provide initial inputs
+        initial_inputs = [
+            GraphPointer(name="text", next_stage="text_emb"),
+            GraphPointer(name="images", next_stage="image_emb"),
+            GraphPointer(name="existing_text_emb", next_stage="concat_text"),
+            GraphPointer(name="existing_image_emb", next_stage="concat_img"),
+            GraphPointer(name="latents", next_stage="LLM"),
+        ]
+        manager.process_new_inputs(request_id, initial_inputs)
+
+        fired_stages = []
+        max_iterations = 100
+
+        for _ in range(max_iterations):
+            queue = manager.queues[subgraph_id]
+            ready_map = queue.get_ready_stage_names()
+
+            if request_id not in ready_map or not ready_map[request_id]:
+                # Check if done
+                if queue.is_done(request_id):
+                    break
+                break  # no more ready stages
+
+            # Pop one stage at a time
+            stage_name = ready_map[request_id][0]
+            stages = queue.pop_ready_stages(request_id, [stage_name])
+            assert stages, f"Expected to pop stage {stage_name}"
+
+            stage = stages[0]
+            fired_stages.append(stage.name)
+
+            # Process outputs through the manager
+            routing = manager.process_stage_outputs(request_id, stage.outputs)
+
+            # In single-worker scenario, all routing should be internal
+            # (to_workers should be empty since all stages are on this worker)
+
+        assert "VAE_dec" in fired_stages
+        assert fired_stages.count("LLM") == 10
+        assert fired_stages.count("flow") == 10
+
+    def test_micro_scheduler_picks_stages(self):
+        """Test that MicroScheduler correctly selects and batches ready stages."""
+        graph = self._build_image_gen_graph()
+        subgraph_id = "sg_test"
+        subgraph = Subgraph(
+            section=graph,
+            phases={"image_gen"},
+            subgraph_id=subgraph_id,
+        )
+
+        engine_configs = [
+            {"engine_type": "ar", "stage_names": ["LLM"], "model_config": {}},
+            {"engine_type": "flow", "stage_names": ["flow"], "model_config": {}},
+            {
+                "engine_type": "enc_dec",
+                "stage_names": [
+                    "text_emb", "image_emb", "concat_text", "concat_img", "VAE_dec"
+                ],
+                "model_config": {},
+            },
+        ]
+        engine_mgr = EngineManager.from_config(engine_configs, device="cpu")
+        scheduler = MicroScheduler(engine_mgr)
+
+        manager = SubgraphsManager(
+            queues={
+                subgraph_id: SubgraphQueues(
+                    subgraph_id=subgraph_id,
+                    phases={"image_gen"},
+                    subgraph=subgraph,
+                    per_request_queues={},
+                )
+            },
+            per_request_info={},
+            all_subgraph_ids_to_phases={subgraph_id: {"image_gen"}},
+            all_subgraph_ids_to_stages={
+                subgraph_id: graph.get_stage_names()
+            },
+        )
+
+        request_id = "req_sched"
+        manager.add_request(
+            request_id=request_id,
+            subgraph_ids=[subgraph_id],
+            subgraph_to_worker={subgraph_id: "w0"},
+        )
+        manager.update_phase(request_id, "image_gen")
+
+        # Initially no stages ready
+        batch = scheduler.get_next_batch(manager)
+        assert batch is None
+
+        # Feed inputs
+        initial_inputs = [
+            GraphPointer(name="text", next_stage="text_emb"),
+            GraphPointer(name="images", next_stage="image_emb"),
+            GraphPointer(name="existing_text_emb", next_stage="concat_text"),
+            GraphPointer(name="existing_image_emb", next_stage="concat_img"),
+            GraphPointer(name="latents", next_stage="LLM"),
+        ]
+        manager.process_new_inputs(request_id, initial_inputs)
+
+        # Now scheduler should find ready stages (text_emb and image_emb)
+        batch = scheduler.get_next_batch(manager)
+        assert batch is not None
+        # enc_dec has lowest priority, but these are the only ready stages
+        assert batch.stage_name in ("text_emb", "image_emb")
+
+
+# ======================================================================
+# Prefill/decode graph test
+# ======================================================================
+
+
+class TestPrefillDecodeGraph:
+    def test_prefill_graph(self):
+        """Verify prefill graph fires text_emb + image_emb -> concat -> LLM."""
+        model = DummyModel()
+        graphs = model.get_phase_graphs()
+        prefill = graphs["prefill"]
+
+        queues = PerRequestStageQueues(waiting=prefill)
+        inputs = [
+            GraphPointer(name="text", next_stage="text_emb"),
+            GraphPointer(name="images", next_stage="image_emb"),
+            GraphPointer(name="existing_text_emb", next_stage="concat_text"),
+            GraphPointer(name="existing_image_emb", next_stage="concat_img"),
+        ]
+        queues.process_new_inputs(inputs)
+
+        fired = []
+        for _ in range(20):
+            if not queues.ready and queues.waiting is None:
+                break
+            assert queues.ready
+            stage = queues.ready.pop(0)
+            fired.append(stage.name)
+            queues.process_new_inputs(stage.outputs)
+
+        assert fired[-1] == "LLM"
+        assert "text_emb" in fired
+        assert "image_emb" in fired
+        assert "concat_text" in fired
+        assert "concat_img" in fired
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Here's a summary of everything implemented:                                                                                                                                                                                                       
                                                                                                                                                                                                                                                    
  Files Created                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                    
  1. mminf/engine/__init__.py — Empty package init                                                                                                                                                                                                  
  2. mminf/engine/base.py — BaseEngine ABC, EngineType enum, StageBatch and StageOutput data classes                                                                                                                                                
  3. mminf/engine/enc_dec_engine.py — EncoderDecoderEngine for stateless forward passes (ViT, text emb, VAE)                                                                                                                                        
  4. mminf/engine/flow_engine.py — FlowEngine for single denoising step execution                                                                                                                                                                   
  5. mminf/engine/ar_engine.py — AREngine with PageAllocator, KVRequestState, FlashInfer-guarded prefill/decode, pause/resume                                                                                                                       
  6. mminf/worker/engine_manager.py — EngineManager mapping stage names to engine instances                                                                                                                                                         
  7. mminf/worker/micro_scheduler.py — MicroScheduler with priority-based stage selection (AR > Flow > EncDec)                                                                                                                                      
  8. mminf/worker/worker.py — Real Worker integrating SubgraphsManager, EngineManager, MicroScheduler, and MooncakeCommunicationManager                                                                                                             
  9. test/test_phase1.py — 20 tests covering PageAllocator, all engines, EngineManager, image_gen loop, SubgraphsManager integration, MicroScheduler, and prefill graph                                                                             
                                                                                                                                                                                                                                                    
  Files Modified

  1. mminf/communication/tensors.py — Completed start_read_tensors() and get_ready_tensors(), changed self.pending from dict to list[EventAndPointers], added request_id to EventAndPointers, made NameAndRequestId frozen/hashable, guarded
  mooncake import
  2. mminf/worker/dummy_worker.py — Fixed 3 bugs:
    - SubgraphQueues.add_request/reset: used deepcopy(self.subgraph.section) instead of deepcopy(self.subgraph) (Subgraph vs GraphSection)
    - SubgraphQueues.is_done: now checks waiting is None AND ready is empty (was prematurely marking subgraphs complete)
    - SubgraphsManager.process_stage_outputs: skip back_to_conductor pointers and unknown stages when routing to workers
  3. mminf/graph/request_queues.py — Fixed process_new_inputs to return ProcessedInputs instead of raw list when waiting is None