### PR TITLE
Worker refinement

### DIFF
--- a/mminf/conductor/dummy_conductor.py
+++ b/mminf/conductor/dummy_conductor.py
@@ -9,7 +9,7 @@ from mminf.communication.communicator import ZMQCommunicator
 from mminf.graph.base import GraphPointer, TensorPointerInfo
 from mminf.ipc_formats import (
     ConductorMessageType, InputSignals,
-    NewRequest, NewRequestConductor, PersistSignals, SubgraphsDone, WorkerMessage,
+    NewRequest, NewRequestConductor, SubgraphsDone, WorkerMessage,
     WorkerMessageType
 )
 from mminf.model.base import CurrentForwardMetadata, Model
@@ -170,6 +170,13 @@ class DummyConductor:
         them to the appropriate workers)
         """
         request_data = self.requests[body.request_id]
+
+        # Absorb persist signals and new tokens sent with this message
+        if body.persist_signals:
+            request_data.persist_signals.update(body.persist_signals)
+        if body.new_tokens:
+            request_data.new_tokens.extend(body.new_tokens)
+
         request_data.completed_subgraph_ids.update(
             body.subgraph_ids
         )
@@ -218,16 +225,6 @@ class DummyConductor:
             request_data.new_tokens = []
             request_data.completed_subgraph_ids = set()
 
-    def _process_new_tensors(self, body: PersistSignals):
-        """
-        If worker has sent tensors back to the conductor, process those.
-        """
-        self.requests[body.request_id].persist_signals.update(
-            body.signals
-        )
-        self.requests[body.request_id].new_tokens.extend(body.new_tokens)
-        
-
     def run(self):
         while True:
             for message in self.communicator.get_all_new_messages():
@@ -235,8 +232,6 @@ class DummyConductor:
                     self._ingest_request(message.body)
                 elif message.message_type == ConductorMessageType.SUBGRAPHS_DONE:
                     self._process_subgraphs_done(message.body)
-                elif message.message_type == ConductorMessageType.PERSIST_SIGNALS:
-                    self._process_new_tensors(message.body)
                 else:
                     raise ValueError(f"Unknown message type: {message.message_type}")
             time.sleep(0.1) # just for dummy conductor!

--- a/mminf/ipc_formats.py
+++ b/mminf/ipc_formats.py
@@ -1,8 +1,6 @@
 from abc import ABC
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from enum import Enum
-
-from attrs import field
 
 from mminf.graph.base import GraphPointer, TensorPointerInfo
 
@@ -75,7 +73,6 @@ class WorkerMessage:
 
 class ConductorMessageType(Enum):
     NEW_REQUEST = "new_request"
-    PERSIST_SIGNALS = "persist_signal"
     SUBGRAPHS_DONE = "subgraphs_done"
 
 
@@ -91,13 +88,8 @@ class NewRequestConductor(MessageBody):
 class SubgraphsDone(MessageBody):
     request_id: str
     subgraph_ids: list[str]
-
-
-@dataclass
-class PersistSignals(MessageBody):
-    request_id: str
-    signals: dict[str, TensorPointerInfo]
-    new_tokens: list[int] = field(default=None)
+    persist_signals: dict[str, TensorPointerInfo] = field(default_factory=dict)
+    new_tokens: list[int] = field(default_factory=list)
 
 
 @dataclass

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -12,6 +12,7 @@ from mminf.graph.base import GraphPointer, GraphSection, GraphStage, Loop, Paral
 
 
 STREAM_OUT = "stream_out"
+SPECIAL_DESTINATIONS = {STREAM_OUT}  # add RELAY etc. later
 
 
 @dataclass

--- a/mminf/worker/dummy_worker.py
+++ b/mminf/worker/dummy_worker.py
@@ -203,16 +203,19 @@ class SubgraphsManager:
         # in different workers)
 
         # (3) get mapping of worker to external outputs
-        # Filter out back_to_conductor pointers (e.g., stream_out) — they
-        # don't route to any worker
+        # Skip pointers whose next_stage has no worker mapping (e.g.,
+        # stream_out is a virtual destination, not a real stage on any worker).
+        # Note: back_to_conductor pointers may ALSO route to a worker
+        # (e.g., concat_text outputs text_emb → LLM with back_to_conductor=True),
+        # so we do NOT filter on back_to_conductor here.
         to_workers: dict[str, list[GraphPointer]] = {}
         for ptr in outputs:
-            if ptr.back_to_conductor:
-                continue
             stage_phase = StageAndPhase(
                 stage=ptr.next_stage, phase=self.get_phase(request_id)
             )
             if stage_phase not in self.per_request_info[request_id].stage_to_worker:
+                if ptr.back_to_conductor:
+                    continue  # e.g., stream_out — already captured in to_conductor
                 raise ValueError(
                     f"Output pointer targets unknown stage/phase: {stage_phase}. "
                     f"Check graph construction."
@@ -306,6 +309,7 @@ class DummyWorker:
             communicator=self.communicator,
             protocol=tensor_comm_protocol,
         )
+        self.pending_persist_signals: dict[str, list[GraphPointer]] = {}
         
     def _add_new_request(
         self, body: NewRequest
@@ -372,7 +376,9 @@ class DummyWorker:
         outputs: StageOutputRouting
     ):
         """
-        Sends outputs to other workers and to the conductor
+        Sends outputs to other workers and to the conductor.
+        Persist signals are buffered and sent together with the
+        SUBGRAPHS_DONE message to avoid race conditions.
         """
         for worker in outputs.to_workers:
             message = WorkerMessage(
@@ -384,25 +390,20 @@ class DummyWorker:
                 )
             )
             self.communicator.send(worker, message)
-        
-        # to conductor
+
+        # Buffer persist signals for this request
         if outputs.to_conductor:
-            message = ConductorMessage(
-                message_type=ConductorMessageType.PERSIST_SIGNAL,
-                body=InputSignals(
-                    request_id=request_id,
-                    inputs=outputs.to_conductor,
-                    phase=self.subgraphs_manager.get_phase(request_id)
-                )
+            self.pending_persist_signals.setdefault(request_id, []).extend(
+                outputs.to_conductor
             )
-            self.communicator.send("conductor", message)
-        
+
         if outputs.completed_subgraphs:
             message = ConductorMessage(
                 message_type=ConductorMessageType.SUBGRAPHS_DONE,
                 body=SubgraphsDone(
                     request_id=request_id,
-                    subgraph_ids=outputs.completed_subgraphs
+                    subgraph_ids=outputs.completed_subgraphs,
+                    persist_signals=self.pending_persist_signals.pop(request_id, []),
                 )
             )
             self.communicator.send("conductor", message)

--- a/mminf/worker/dummy_worker.py
+++ b/mminf/worker/dummy_worker.py
@@ -1,269 +1,15 @@
-from copy import deepcopy
-from dataclasses import dataclass, field
 import time
 
 from mminf.communication.communicator import CommProtocol, ZMQCommunicator
 from mminf.communication.tensors import MooncakeCommunicationManager
 from mminf.model.base import Subgraph
-from mminf.graph.base import GraphPointer, GraphStage
-from mminf.graph.request_queues import PerRequestStageQueues, ProcessedInputs
 from mminf.ipc_formats import (
     ConductorMessage, ConductorMessageType, InputSignals,
     NewRequest, RemoveRequest, SubgraphsDone, WorkerMessage, WorkerMessageType
 )
-
-
-@dataclass(frozen=True)
-class StageAndPhase:
-    """
-    Tuple of stage name and phase, e.g., (LLM, decode) or (flow, image_gen)
-    """
-    stage: str
-    phase: str
-
-
-@dataclass
-class StageOutputRouting:
-    routed_to_this_subgraph: set[str] # set of tensor ids
-    to_conductor: list[GraphPointer] # outputs that are going back to the conductor
-    to_workers: dict[str, list[GraphPointer]] # worker id to signals
-    completed_subgraphs: list[str] = field(default_factory=[])  # list of subgraph IDs
-
-
-@dataclass
-class SubgraphQueues:
-    """
-    For a single subgraph, keeps track of which stages are waiting on which
-    inputs for each request, and which stages are ready to run per request.
-    """
-    subgraph_id: str
-    phases: set[str] # e.g., this subgraph is active during decode and image_gen
-                     # but not the prefill phase
-    subgraph: Subgraph
-    per_request_queues: dict[str, PerRequestStageQueues] # request_id -> queue
-
-    def process_new_inputs(self, request_id: str, inputs: list[GraphPointer]) -> ProcessedInputs:
-        """
-        Add new inputs for a request, and update waiting/ready stages accordingly.
-        Returns any signals that should be sent to other subgraphs.
-        """
-        return self.per_request_queues[request_id].process_new_inputs(inputs)
-    
-    def is_done(self, request_id) -> bool:
-        q = self.per_request_queues[request_id]
-        return q.waiting is None and len(q.ready) == 0
-    
-    def add_request(self, request_id: str):
-        """
-        Initialize queues for a new request
-        """
-        self.per_request_queues[request_id] = PerRequestStageQueues(
-            waiting=deepcopy(self.subgraph.section),
-            subgraph_id=self.subgraph_id
-        )
-
-    def remove_request(self, request_id: str):
-        """
-        Delete queues for a completed/removed request (saw EOS)
-        """
-        if request_id in self.per_request_queues:
-            del self.per_request_queues[request_id]
-    
-    def get_ready_stage_names(self) -> dict[str, str]:
-        """
-        Returns mapping of request id to ready stage names for that request
-        """
-        return {
-            request_id: [s.name for s in q.ready] \
-                for (request_id, q) in self.per_request_queues.items()
-        }
-
-    def pop_ready_stages(
-        self, request_id: str, stage_names: list[str]
-    ) -> list[GraphStage]:
-        """
-        Remove the given stage names from the ready queue for the request an
-        return the corresponding GraphStage objects
-        """
-        stages = []
-        if request_id in self.per_request_queues:
-            q = self.per_request_queues[request_id]
-            pop_idxs = set(
-                [i for i, stage in enumerate(q.ready) if stage.name in set(stage_names)]
-            )
-            stages = [q.ready[i] for i in pop_idxs]
-            q.ready = [stage for i, stage in enumerate(q.ready) if i not in pop_idxs]
-        return stages
-    
-    def reset(self, request_id):
-        """
-        At the end of a subgraph, reset the queues for that request so that it
-        can be used for the next full model forward pass
-        """
-        self.per_request_queues[request_id].waiting = deepcopy(self.subgraph.section)
-        self.per_request_queues[request_id].ready = []
-
-
-@dataclass
-class PerRequestInfo:
-    """
-    Information about a request that the worker needs to keep track of:
-    - stage_to_worker: for all stages. This is, e.g., how we say that if
-        an output goes to (LLM, decode phase), what worker that points to.
-    - subgraph_ids: mainly redundant information / syntactic sugar. This is
-        the list of subgraph IDs that are on this worker and used by this request
-        (across all possible phases)
-    - current_phase: which computation path we are currently on, e.g., prefill,
-        decode, image_gen, etc.
-    - phase_subgraph_ids: subgraph IDs used in the current phase (e.g., if there
-        is a prefill LLM subgraph and decode LLM subgraph and we are in decode,
-        this list only includes the decode subgraph)
-    - tensors: TBD
-    """
-    stage_to_worker: dict[StageAndPhase, str]  # for all stages
-    subgraph_ids: list[str] # for this worker
-    current_phase: str = field(default=None)
-
-    # phase_subgraph_ids = subgraphs for the current phase
-    phase_subgraph_ids: list[str] = field(default_factory=list) # for this worker
-
-
-@dataclass
-class SubgraphsManager:
-    """
-    Manages the subgraphs that this worker is responsible for, and the queues
-    for each subgraph and request. Also keeps track of which stages belong
-    to which subgraphs, and which subgraphs belong to which phases, for
-    routing external outputs to the correct worker.
-    """
-    queues: dict[str, SubgraphQueues] # subgraph_id to queues
-    per_request_info: dict[str, PerRequestInfo] # request id to info
-
-    # The following two are for routing purposes:
-    all_subgraph_ids_to_phases: dict[str, set[str]] # for subgraphs on different workers too
-    all_subgraph_ids_to_stages: dict[str, str] # for subgraphs on different workers too
-
-    def update_phase(self, request_id: str, phase: str):
-        if self.per_request_info[request_id].current_phase != phase:
-            self.per_request_info[request_id].current_phase = phase
-            self.per_request_info[request_id].phase_subgraph_ids = [
-                id for id in self.per_request_info[request_id].subgraph_ids \
-                    if phase in self.all_subgraph_ids_to_phases[id]
-            ]
-    
-    def get_phase(self, request_id: str):
-        return self.per_request_info[request_id].current_phase
-
-    def process_new_inputs(
-        self,
-        request_id: str,
-        inputs: list[GraphPointer]
-    ):
-        """
-        Updates queues with new inputs for a request
-        """
-        subgraph_ids = self.per_request_info[request_id].phase_subgraph_ids
-        for subgraph_id in subgraph_ids:
-            self.queues[subgraph_id].process_new_inputs(request_id, inputs)
-        
-
-    def process_stage_outputs(
-        self, request_id: str,
-        outputs: list[GraphPointer]
-    ) -> StageOutputRouting:
-        """
-        After a stage has finished processing, use its outputs to update
-        subgraph queues, and return any outputs that should be sent to other
-        subgraphs or the conductor.
-
-        I.e., it updates ready/waiting queues for subgraphs on this current
-        worker, and directs external outputs to subgraphs on the appropriate
-        (different) worker.
-        """
-        # (1) find back_to_conductor flags
-        to_conductor = [ptr for ptr in outputs if ptr.back_to_conductor]
-
-        # (2) process all internal-facing outputs
-        subgraph_ids = self.per_request_info[request_id].phase_subgraph_ids
-
-        completed_subgraphs = []
-        routed_to_this_subgraph = set()
-        for subgraph_id in subgraph_ids:
-            queue = self.queues[subgraph_id]
-            # process_new_inputs consumes outputs that are used as
-            # stage inputs within `queue`, and returns the graph pointers that
-            # were not consumed
-            processed_inputs = queue.process_new_inputs(request_id, outputs)
-            outputs = processed_inputs.for_other_subgraphs
-            routed_to_this_subgraph.update(processed_inputs.routed_to_this_subgraph)
-            if queue.is_done(request_id):
-                completed_subgraphs.append(subgraph_id)
-                queue.reset(request_id)
-        # all outputs left over at this point are external outputs (to stages
-        # in different workers)
-
-        # (3) get mapping of worker to external outputs
-        # Skip pointers whose next_stage has no worker mapping (e.g.,
-        # stream_out is a virtual destination, not a real stage on any worker).
-        # Note: back_to_conductor pointers may ALSO route to a worker
-        # (e.g., concat_text outputs text_emb → LLM with back_to_conductor=True),
-        # so we do NOT filter on back_to_conductor here.
-        to_workers: dict[str, list[GraphPointer]] = {}
-        for ptr in outputs:
-            stage_phase = StageAndPhase(
-                stage=ptr.next_stage, phase=self.get_phase(request_id)
-            )
-            if stage_phase not in self.per_request_info[request_id].stage_to_worker:
-                if ptr.back_to_conductor:
-                    continue  # e.g., stream_out — already captured in to_conductor
-                raise ValueError(
-                    f"Output pointer targets unknown stage/phase: {stage_phase}. "
-                    f"Check graph construction."
-                )
-            worker_id = self.per_request_info[request_id].stage_to_worker[stage_phase]
-            if worker_id not in to_workers:
-                to_workers[worker_id] = []
-            to_workers[worker_id].append(ptr)
-
-        return StageOutputRouting(
-            routed_to_this_subgraph=routed_to_this_subgraph,
-            to_conductor=to_conductor,
-            to_workers=to_workers,
-            completed_subgraphs=completed_subgraphs
-        )
-    
-    def add_request(
-        self, request_id: str,
-        subgraph_ids: list[str], # for this worker's subgraphs
-        subgraph_to_worker: dict[str, str] # for other / all subgraphs
-    ):
-        """
-        Set up queues and info for a new request. This includes adding the request
-        to the relevant subgraph queues, and updating the mapping of which worker
-        is responsible for which stages for this request (for output routing).
-        """
-        stage_to_worker = {}
-        for id in subgraph_ids:
-            self.queues[id].add_request(request_id)
-        
-        for subgraph_id, worker_id in subgraph_to_worker.items():
-            for phase in self.all_subgraph_ids_to_phases[subgraph_id]:
-                stage_to_worker.update({
-                    StageAndPhase(
-                        stage=name,
-                        phase=phase
-                    ): worker_id for name in self.all_subgraph_ids_to_stages[subgraph_id]
-                })
-        self.per_request_info[request_id] = PerRequestInfo(
-            stage_to_worker=stage_to_worker,
-            subgraph_ids=subgraph_ids
-        )
-    
-    def remove_request(self, request_id: str):
-        if request_id in self.per_request_info:
-            for queue_id in self.per_request_info[request_id].phase_subgraph_ids:
-                self.queues[queue_id].remove_request(request_id)
-            del self.per_request_info[request_id]
+from mminf.worker.stage_manager_utils import (
+    StageOutputRouting, SubgraphQueues, SubgraphsManager,
+)
 
 
 class DummyWorker:
@@ -309,8 +55,7 @@ class DummyWorker:
             communicator=self.communicator,
             protocol=tensor_comm_protocol,
         )
-        self.pending_persist_signals: dict[str, list[GraphPointer]] = {}
-        
+
     def _add_new_request(
         self, body: NewRequest
     ):
@@ -322,7 +67,7 @@ class DummyWorker:
             subgraph_ids=body.subgraph_ids,
             subgraph_to_worker_id=body.subgraph_to_worker
         )
-        
+
         # TODO Atindra: start reading in tensors from body.initial_inputs
 
         self.subgraphs_manager.update_phase(
@@ -339,7 +84,7 @@ class DummyWorker:
         just completed
         """
         self.subgraphs_manager.remove_request(body.request_id)
-    
+
     def _process_new_inputs(
         self, body: InputSignals
     ):
@@ -351,7 +96,7 @@ class DummyWorker:
         self.subgraphs_manager.update_phase(
             body.request_id, body.phase
         )
-        
+
         # TODO Atindra: start reading in tensors from body.initial_inputs
         # Also, somewhere else, we will have to call self.subgraphs_manager.process_new_inputs
         # when the tensors are actually ready
@@ -393,8 +138,8 @@ class DummyWorker:
 
         # Buffer persist signals for this request
         if outputs.to_conductor:
-            self.pending_persist_signals.setdefault(request_id, []).extend(
-                outputs.to_conductor
+            self.subgraphs_manager.buffer_persist_signals(
+                request_id, outputs.to_conductor
             )
 
         if outputs.completed_subgraphs:
@@ -403,11 +148,11 @@ class DummyWorker:
                 body=SubgraphsDone(
                     request_id=request_id,
                     subgraph_ids=outputs.completed_subgraphs,
-                    persist_signals=self.pending_persist_signals.pop(request_id, []),
+                    persist_signals=self.subgraphs_manager.flush_persist_signals(request_id),
                 )
             )
             self.communicator.send("conductor", message)
-        
+
     def run(self):
         # TODO: this is just a dummy version
         while True:
@@ -421,7 +166,7 @@ class DummyWorker:
                         outputs = self.subgraphs_manager.process_stage_outputs(
                             request_id, s.outputs
                         )
-                        # TODO: in the real worker, we have to update 
+                        # TODO: in the real worker, we have to update
                         # self.subgraphs_manager.per_request_info[request_id].tensors
                         # with the tensors from the stage output, for all tensor IDs
                         # in outputs.routed_to_this_subgraph

--- a/mminf/worker/micro_scheduler.py
+++ b/mminf/worker/micro_scheduler.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from mminf.engine.base import EngineType
 from mminf.graph.base import GraphStage
 from mminf.worker.engine_manager import EngineManager
-from mminf.worker.dummy_worker import SubgraphsManager
+from mminf.worker.stage_manager_utils import SubgraphsManager
 
 
 @dataclass

--- a/mminf/worker/stage_manager_utils.py
+++ b/mminf/worker/stage_manager_utils.py
@@ -1,0 +1,274 @@
+from copy import deepcopy
+from dataclasses import dataclass, field
+
+from mminf.graph.base import GraphPointer, GraphStage
+from mminf.graph.request_queues import PerRequestStageQueues, ProcessedInputs
+from mminf.model.base import SPECIAL_DESTINATIONS, Subgraph
+
+
+@dataclass(frozen=True)
+class StageAndPhase:
+    """
+    Tuple of stage name and phase, e.g., (LLM, decode) or (flow, image_gen)
+    """
+    stage: str
+    phase: str
+
+
+@dataclass
+class StageOutputRouting:
+    routed_to_this_subgraph: set[str] # set of tensor ids
+    to_conductor: list[GraphPointer] # outputs that are going back to the conductor
+    to_workers: dict[str, list[GraphPointer]] # worker id to signals
+    completed_subgraphs: list[str] = field(default_factory=[])  # list of subgraph IDs
+
+
+@dataclass
+class SubgraphQueues:
+    """
+    For a single subgraph, keeps track of which stages are waiting on which
+    inputs for each request, and which stages are ready to run per request.
+    """
+    subgraph_id: str
+    phases: set[str] # e.g., this subgraph is active during decode and image_gen
+                     # but not the prefill phase
+    subgraph: Subgraph
+    per_request_queues: dict[str, PerRequestStageQueues] # request_id -> queue
+
+    def process_new_inputs(self, request_id: str, inputs: list[GraphPointer]) -> ProcessedInputs:
+        """
+        Add new inputs for a request, and update waiting/ready stages accordingly.
+        Returns any signals that should be sent to other subgraphs.
+        """
+        return self.per_request_queues[request_id].process_new_inputs(inputs)
+
+    def is_done(self, request_id) -> bool:
+        q = self.per_request_queues[request_id]
+        return q.waiting is None and len(q.ready) == 0
+
+    def add_request(self, request_id: str):
+        """
+        Initialize queues for a new request
+        """
+        self.per_request_queues[request_id] = PerRequestStageQueues(
+            waiting=deepcopy(self.subgraph.section),
+            subgraph_id=self.subgraph_id
+        )
+
+    def remove_request(self, request_id: str):
+        """
+        Delete queues for a completed/removed request (saw EOS)
+        """
+        if request_id in self.per_request_queues:
+            del self.per_request_queues[request_id]
+
+    def get_ready_stage_names(self) -> dict[str, str]:
+        """
+        Returns mapping of request id to ready stage names for that request
+        """
+        return {
+            request_id: [s.name for s in q.ready] \
+                for (request_id, q) in self.per_request_queues.items()
+        }
+
+    def pop_ready_stages(
+        self, request_id: str, stage_names: list[str]
+    ) -> list[GraphStage]:
+        """
+        Remove the given stage names from the ready queue for the request an
+        return the corresponding GraphStage objects
+        """
+        stages = []
+        if request_id in self.per_request_queues:
+            q = self.per_request_queues[request_id]
+            pop_idxs = set(
+                [i for i, stage in enumerate(q.ready) if stage.name in set(stage_names)]
+            )
+            stages = [q.ready[i] for i in pop_idxs]
+            q.ready = [stage for i, stage in enumerate(q.ready) if i not in pop_idxs]
+        return stages
+
+    def reset(self, request_id):
+        """
+        At the end of a subgraph, reset the queues for that request so that it
+        can be used for the next full model forward pass
+        """
+        self.per_request_queues[request_id].waiting = deepcopy(self.subgraph.section)
+        self.per_request_queues[request_id].ready = []
+
+
+@dataclass
+class PerRequestInfo:
+    """
+    Information about a request that the worker needs to keep track of:
+    - stage_to_worker: for all stages. This is, e.g., how we say that if
+        an output goes to (LLM, decode phase), what worker that points to.
+    - subgraph_ids: mainly redundant information / syntactic sugar. This is
+        the list of subgraph IDs that are on this worker and used by this request
+        (across all possible phases)
+    - current_phase: which computation path we are currently on, e.g., prefill,
+        decode, image_gen, etc.
+    - phase_subgraph_ids: subgraph IDs used in the current phase (e.g., if there
+        is a prefill LLM subgraph and decode LLM subgraph and we are in decode,
+        this list only includes the decode subgraph)
+    - pending_persist_signals: buffered persist signals awaiting flush on
+        SUBGRAPHS_DONE
+    - tensors: TBD
+    """
+    stage_to_worker: dict[StageAndPhase, str]  # for all stages
+    subgraph_ids: list[str] # for this worker
+    current_phase: str = field(default=None)
+
+    # phase_subgraph_ids = subgraphs for the current phase
+    phase_subgraph_ids: list[str] = field(default_factory=list) # for this worker
+
+    pending_persist_signals: list[GraphPointer] = field(default_factory=list)
+
+
+@dataclass
+class SubgraphsManager:
+    """
+    Manages the subgraphs that this worker is responsible for, and the queues
+    for each subgraph and request. Also keeps track of which stages belong
+    to which subgraphs, and which subgraphs belong to which phases, for
+    routing external outputs to the correct worker.
+    """
+    queues: dict[str, SubgraphQueues] # subgraph_id to queues
+    per_request_info: dict[str, PerRequestInfo] # request id to info
+
+    # The following two are for routing purposes:
+    all_subgraph_ids_to_phases: dict[str, set[str]] # for subgraphs on different workers too
+    all_subgraph_ids_to_stages: dict[str, str] # for subgraphs on different workers too
+
+    def update_phase(self, request_id: str, phase: str):
+        if self.per_request_info[request_id].current_phase != phase:
+            self.per_request_info[request_id].current_phase = phase
+            self.per_request_info[request_id].phase_subgraph_ids = [
+                id for id in self.per_request_info[request_id].subgraph_ids \
+                    if phase in self.all_subgraph_ids_to_phases[id]
+            ]
+
+    def get_phase(self, request_id: str):
+        return self.per_request_info[request_id].current_phase
+
+    def process_new_inputs(
+        self,
+        request_id: str,
+        inputs: list[GraphPointer]
+    ):
+        """
+        Updates queues with new inputs for a request
+        """
+        subgraph_ids = self.per_request_info[request_id].phase_subgraph_ids
+        for subgraph_id in subgraph_ids:
+            self.queues[subgraph_id].process_new_inputs(request_id, inputs)
+
+
+    def process_stage_outputs(
+        self, request_id: str,
+        outputs: list[GraphPointer]
+    ) -> StageOutputRouting:
+        """
+        After a stage has finished processing, use its outputs to update
+        subgraph queues, and return any outputs that should be sent to other
+        subgraphs or the conductor.
+
+        I.e., it updates ready/waiting queues for subgraphs on this current
+        worker, and directs external outputs to subgraphs on the appropriate
+        (different) worker.
+        """
+        # (1) find back_to_conductor flags
+        to_conductor = [ptr for ptr in outputs if ptr.back_to_conductor]
+
+        # (2) process all internal-facing outputs
+        subgraph_ids = self.per_request_info[request_id].phase_subgraph_ids
+
+        completed_subgraphs = []
+        routed_to_this_subgraph = set()
+        for subgraph_id in subgraph_ids:
+            queue = self.queues[subgraph_id]
+            # process_new_inputs consumes outputs that are used as
+            # stage inputs within `queue`, and returns the graph pointers that
+            # were not consumed
+            processed_inputs = queue.process_new_inputs(request_id, outputs)
+            outputs = processed_inputs.for_other_subgraphs
+            routed_to_this_subgraph.update(processed_inputs.routed_to_this_subgraph)
+            if queue.is_done(request_id):
+                completed_subgraphs.append(subgraph_id)
+                queue.reset(request_id)
+        # all outputs left over at this point are external outputs (to stages
+        # in different workers)
+
+        # (3) get mapping of worker to external outputs
+        # Skip pointers whose next_stage is a special destination (e.g.,
+        # stream_out is a virtual destination, not a real stage on any worker).
+        # Note: back_to_conductor pointers may ALSO route to a worker
+        # (e.g., concat_text outputs text_emb -> LLM with back_to_conductor=True),
+        # so we do NOT filter on back_to_conductor here.
+        to_workers: dict[str, list[GraphPointer]] = {}
+        for ptr in outputs:
+            stage_phase = StageAndPhase(
+                stage=ptr.next_stage, phase=self.get_phase(request_id)
+            )
+            if stage_phase not in self.per_request_info[request_id].stage_to_worker:
+                if ptr.next_stage in SPECIAL_DESTINATIONS:
+                    continue  # e.g., stream_out — already captured in to_conductor
+                raise ValueError(
+                    f"Output pointer targets unknown stage/phase: {stage_phase}. "
+                    f"Check graph construction."
+                )
+            worker_id = self.per_request_info[request_id].stage_to_worker[stage_phase]
+            if worker_id not in to_workers:
+                to_workers[worker_id] = []
+            to_workers[worker_id].append(ptr)
+
+        return StageOutputRouting(
+            routed_to_this_subgraph=routed_to_this_subgraph,
+            to_conductor=to_conductor,
+            to_workers=to_workers,
+            completed_subgraphs=completed_subgraphs
+        )
+
+    def add_request(
+        self, request_id: str,
+        subgraph_ids: list[str], # for this worker's subgraphs
+        subgraph_to_worker: dict[str, str] # for other / all subgraphs
+    ):
+        """
+        Set up queues and info for a new request. This includes adding the request
+        to the relevant subgraph queues, and updating the mapping of which worker
+        is responsible for which stages for this request (for output routing).
+        """
+        stage_to_worker = {}
+        for id in subgraph_ids:
+            self.queues[id].add_request(request_id)
+
+        for subgraph_id, worker_id in subgraph_to_worker.items():
+            for phase in self.all_subgraph_ids_to_phases[subgraph_id]:
+                stage_to_worker.update({
+                    StageAndPhase(
+                        stage=name,
+                        phase=phase
+                    ): worker_id for name in self.all_subgraph_ids_to_stages[subgraph_id]
+                })
+        self.per_request_info[request_id] = PerRequestInfo(
+            stage_to_worker=stage_to_worker,
+            subgraph_ids=subgraph_ids
+        )
+
+    def remove_request(self, request_id: str):
+        if request_id in self.per_request_info:
+            for queue_id in self.per_request_info[request_id].phase_subgraph_ids:
+                self.queues[queue_id].remove_request(request_id)
+            del self.per_request_info[request_id]
+
+    def buffer_persist_signals(self, request_id: str, signals: list[GraphPointer]):
+        """Extend the pending persist signals for a request."""
+        self.per_request_info[request_id].pending_persist_signals.extend(signals)
+
+    def flush_persist_signals(self, request_id: str) -> list[GraphPointer]:
+        """Pop and return all buffered persist signals for a request."""
+        info = self.per_request_info[request_id]
+        signals = info.pending_persist_signals
+        info.pending_persist_signals = []
+        return signals

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -9,7 +9,7 @@ from mminf.ipc_formats import (
     NewRequest, RemoveRequest, SubgraphsDone, WorkerMessage, WorkerMessageType,
 )
 from mminf.model.base import Subgraph
-from mminf.worker.dummy_worker import (
+from mminf.worker.stage_manager_utils import (
     StageOutputRouting, SubgraphQueues, SubgraphsManager,
 )
 from mminf.worker.engine_manager import EngineManager
@@ -68,7 +68,6 @@ class Worker:
             communicator=self.communicator,
             protocol=tensor_comm_protocol,
         )
-        self.pending_persist_signals: dict[str, list[GraphPointer]] = {}
 
     # ------------------------------------------------------------------
     # Message handling
@@ -236,8 +235,8 @@ class Worker:
 
         # Buffer persist signals for this request
         if outputs.to_conductor:
-            self.pending_persist_signals.setdefault(request_id, []).extend(
-                outputs.to_conductor
+            self.subgraphs_manager.buffer_persist_signals(
+                request_id, outputs.to_conductor
             )
 
         if outputs.completed_subgraphs:
@@ -246,7 +245,7 @@ class Worker:
                 body=SubgraphsDone(
                     request_id=request_id,
                     subgraph_ids=outputs.completed_subgraphs,
-                    persist_signals=self.pending_persist_signals.pop(request_id, []),
+                    persist_signals=self.subgraphs_manager.flush_persist_signals(request_id),
                 ),
             )
             self.communicator.send("conductor", message)

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -68,6 +68,7 @@ class Worker:
             communicator=self.communicator,
             protocol=tensor_comm_protocol,
         )
+        self.pending_persist_signals: dict[str, list[GraphPointer]] = {}
 
     # ------------------------------------------------------------------
     # Message handling
@@ -217,7 +218,11 @@ class Worker:
     def _send_outputs(
         self, request_id: str, outputs: StageOutputRouting
     ) -> None:
-        """Send outputs to other workers and to the conductor."""
+        """
+        Send outputs to other workers and to the conductor.
+        Persist signals are buffered and sent together with the
+        SUBGRAPHS_DONE message to avoid race conditions.
+        """
         for worker_id, pointers in outputs.to_workers.items():
             message = WorkerMessage(
                 message_type=WorkerMessageType.INPUT_SIGNALS,
@@ -229,16 +234,11 @@ class Worker:
             )
             self.communicator.send(worker_id, message)
 
+        # Buffer persist signals for this request
         if outputs.to_conductor:
-            message = ConductorMessage(
-                message_type=ConductorMessageType.PERSIST_SIGNALS,
-                body=InputSignals(
-                    request_id=request_id,
-                    inputs=outputs.to_conductor,
-                    phase=self.subgraphs_manager.get_phase(request_id),
-                ),
+            self.pending_persist_signals.setdefault(request_id, []).extend(
+                outputs.to_conductor
             )
-            self.communicator.send("conductor", message)
 
         if outputs.completed_subgraphs:
             message = ConductorMessage(
@@ -246,6 +246,7 @@ class Worker:
                 body=SubgraphsDone(
                     request_id=request_id,
                     subgraph_ids=outputs.completed_subgraphs,
+                    persist_signals=self.pending_persist_signals.pop(request_id, []),
                 ),
             )
             self.communicator.send("conductor", message)

--- a/test/test_phase1.py
+++ b/test/test_phase1.py
@@ -19,7 +19,7 @@ from mminf.graph.base import GraphPointer, GraphStage, Loop, Parallel, Sequentia
 from mminf.graph.request_queues import PerRequestStageQueues
 from mminf.model.dummy_model import DummyModel
 from mminf.model.base import Subgraph
-from mminf.worker.dummy_worker import (
+from mminf.worker.stage_manager_utils import (
     SubgraphQueues, SubgraphsManager, StageOutputRouting,
 )
 from mminf.worker.engine_manager import EngineManager


### PR DESCRIPTION
Workers currently send two separate messages to the conductor when a subgraph completes:                                                                                                                                                       
1. PERSIST_SIGNALS — persist signals (embeddings, tokens) for the conductor to store                                                                                                                                                           
2. SUBGRAPHS_DONE — notification that subgraphs finished                                                                                                                                                                                       
                                                                                                                                                                                                                                                    
There's a race condition: if SUBGRAPHS_DONE arrives before the last PERSIST_SIGNALS, the conductor kicks off the next forward pass with stale data. Fix: combine them into one message.                                                        
                                                                                                                                                                                                                                                    
Also fixes a latent bug: dummy_worker.py references ConductorMessageType.PERSIST_SIGNAL (singular) but the enum is PERSIST_SIGNALS (plural). 

Summary of what changed:                                                                                                                                                                    
                                                            
  mminf/ipc_formats.py:                                                                                                                                                                                                                             
  - Removed ConductorMessageType.PERSIST_SIGNALS enum value 
  - Removed PersistSignals dataclass                                                                                                                                                                                                                
  - Added persist_signals and new_tokens fields to SubgraphsDone                                                                                                                                                                                    
  - Fixed import: field now comes from dataclasses instead of attrs (was a latent bug — attrs.field doesn't support default_factory)

  mminf/worker/dummy_worker.py:
  - Added self.pending_persist_signals buffer to DummyWorker.__init__()
  - _send_outputs(): persist signals are buffered per request and flushed with the SUBGRAPHS_DONE message (no more separate PERSIST_SIGNAL message)

  mminf/worker/worker.py:
  - Same pattern: added buffer, persist signals sent with SUBGRAPHS_DONE

  mminf/conductor/dummy_conductor.py:
  - _process_subgraphs_done() now extracts persist_signals and new_tokens from the SubgraphsDone body
  - Removed _process_new_tensors() method
  - Removed PERSIST_SIGNALS case from run() loop
  - Removed PersistSignals import
