### PR TITLE
Implement option a (per slack group message)

### DIFF
--- a/mminf/conductor/dummy_conductor.py
+++ b/mminf/conductor/dummy_conductor.py
@@ -32,6 +32,7 @@ def _worker_process_target(
     all_subgraph_ids_to_stages: dict[str, list[str]],
     hostname: str,
     socket_path_prefix: str,
+    model: Model | None = None,
     device: str = "cuda",
 ):
     """Top-level target for spawned worker processes. Must be module-level for picklability."""
@@ -48,6 +49,7 @@ def _worker_process_target(
         hostname=hostname,
         socket_path_prefix=socket_path_prefix,
         device=torch.device(device),
+        model=model,
     )
     worker.run()
 
@@ -164,6 +166,7 @@ class DummyConductor:
                     "all_subgraph_ids_to_stages": self._all_subgraph_ids_to_stages,
                     "hostname": self.hostname,
                     "socket_path_prefix": self.socket_path_prefix,
+                    "model": self.model,
                     "device": f"cuda:{rank}",
                 },
                 daemon=True,

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -49,10 +49,9 @@ class AREngine(BaseEngine):
 
     def __init__(
         self,
-        model: torch.nn.Module | None = None,
         kv_cache_config: dict | None = None,
     ):
-        self.model = model
+        self.submodules: dict[str, torch.nn.Module] = {}
         self.kv_cache_config = kv_cache_config or {}
         self.device = None
         self.kv_cache = None  # [num_layers, max_pages, 2, page_size, num_kv_heads, head_dim]
@@ -67,7 +66,13 @@ class AREngine(BaseEngine):
     def engine_type(self) -> EngineType:
         return EngineType.AR
 
-    def load_model(self, model_config: dict, device: torch.device) -> None:
+    def load_model(
+        self,
+        submodules: dict[str, torch.nn.Module],
+        model_config: dict,
+        device: torch.device,
+    ) -> None:
+        self.submodules = submodules
         self.device = device
         cfg = model_config.get("kv_cache", self.kv_cache_config)
         if not cfg:
@@ -103,7 +108,8 @@ class AREngine(BaseEngine):
             pass  # Dummy mode — no FlashInfer
 
     def execute_batch(self, batch: StageBatch) -> StageOutput:
-        if self.model is None:
+        submodule = self.submodules.get(batch.stage_name)
+        if submodule is None:
             # Dummy mode: return empty output per request
             return StageOutput(
                 per_request_output_tensors={
@@ -114,11 +120,11 @@ class AREngine(BaseEngine):
         is_prefill = batch.metadata.get("is_prefill", False)
 
         if is_prefill:
-            return self._execute_prefill(batch)
+            return self._execute_prefill(batch, submodule)
         else:
-            return self._execute_decode(batch)
+            return self._execute_decode(batch, submodule)
 
-    def _execute_prefill(self, batch: StageBatch) -> StageOutput:
+    def _execute_prefill(self, batch: StageBatch, submodule: torch.nn.Module) -> StageOutput:
         """Run prefill (prompt processing) for a batch of requests."""
         if self.prefill_wrapper is None or self.kv_cache is None:
             return StageOutput(
@@ -182,9 +188,9 @@ class AREngine(BaseEngine):
             num_qo_heads, num_kv_heads, head_dim, page_size, causal=True,
         )
 
-        # Run model forward (attention handled by FlashInfer wrapper)
+        # Run submodule forward (attention handled by FlashInfer wrapper)
         with torch.no_grad():
-            output = self.model(q_tensor, self.kv_cache, self.prefill_wrapper)
+            output = submodule(q_tensor, self.kv_cache, self.prefill_wrapper)
 
         # Split outputs back per request
         per_request_outputs = {}
@@ -196,7 +202,7 @@ class AREngine(BaseEngine):
 
         return StageOutput(per_request_output_tensors=per_request_outputs)
 
-    def _execute_decode(self, batch: StageBatch) -> StageOutput:
+    def _execute_decode(self, batch: StageBatch, submodule: torch.nn.Module) -> StageOutput:
         """Run decode (single token generation) for a batch of requests."""
         if self.decode_wrapper is None or self.kv_cache is None:
             return StageOutput(
@@ -256,7 +262,7 @@ class AREngine(BaseEngine):
         )
 
         with torch.no_grad():
-            output = self.model(q_tensor, self.kv_cache, self.decode_wrapper)
+            output = submodule(q_tensor, self.kv_cache, self.decode_wrapper)
 
         per_request_outputs = {}
         for i, rid in enumerate(batch.request_ids):

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -149,9 +149,10 @@ class AREngine(BaseEngine):
         for rid in batch.request_ids:
             state = self.request_states[rid]
             inputs = batch.per_request_input_tensors.get(rid, {})
-            q = inputs.get("hidden_states", inputs.get("text_emb"))
-            if q is None:
+            q_list = inputs.get("hidden_states", inputs.get("text_emb"))
+            if q_list is None:
                 continue
+            q = q_list[0]  # AR engine expects single tensor per input
             seq_len = q.shape[0]
 
             # Allocate pages for this sequence
@@ -197,7 +198,7 @@ class AREngine(BaseEngine):
         offset = 0
         for rid in batch.request_ids:
             seq_len = qo_indptr[batch.request_ids.index(rid) + 1] - qo_indptr[batch.request_ids.index(rid)]
-            per_request_outputs[rid] = {"hidden_states": output[offset:offset + seq_len]}
+            per_request_outputs[rid] = {"hidden_states": [output[offset:offset + seq_len]]}
             offset += seq_len
 
         return StageOutput(per_request_output_tensors=per_request_outputs)
@@ -225,9 +226,10 @@ class AREngine(BaseEngine):
         for rid in batch.request_ids:
             state = self.request_states[rid]
             inputs = batch.per_request_input_tensors.get(rid, {})
-            q = inputs.get("hidden_states", inputs.get("text_emb"))
-            if q is None:
+            q_list = inputs.get("hidden_states", inputs.get("text_emb"))
+            if q_list is None:
                 continue
+            q = q_list[0]  # AR engine expects single tensor per input
 
             # Allocate one more page if needed
             state.seq_len += 1
@@ -266,7 +268,7 @@ class AREngine(BaseEngine):
 
         per_request_outputs = {}
         for i, rid in enumerate(batch.request_ids):
-            per_request_outputs[rid] = {"hidden_states": output[i:i + 1]}
+            per_request_outputs[rid] = {"hidden_states": [output[i:i + 1]]}
 
         return StageOutput(per_request_output_tensors=per_request_outputs)
 

--- a/mminf/engine/audio_codec_engine.py
+++ b/mminf/engine/audio_codec_engine.py
@@ -38,13 +38,17 @@ class AudioCodecEngine(BaseEngine):
             outputs = {}
             for rid in batch.request_ids:
                 inputs = batch.per_request_input_tensors.get(rid, {})
-                result = submodule(**{k: v[0].unsqueeze(0) for k, v in inputs.items()})
-                if isinstance(result, torch.Tensor):
-                    outputs[rid] = {"output": [result.squeeze(0)]}
-                elif isinstance(result, dict):
-                    outputs[rid] = {k: [v.squeeze(0)] for k, v in result.items()}
+                if hasattr(submodule, 'preprocess'):
+                    preprocessed = submodule.preprocess(**inputs)
+                    outputs[rid] = submodule(**preprocessed)
                 else:
-                    outputs[rid] = {}
+                    result = submodule(**{k: v[0] for k, v in inputs.items()})
+                    if isinstance(result, dict):
+                        outputs[rid] = result
+                    elif isinstance(result, torch.Tensor):
+                        outputs[rid] = {"output": [result]}
+                    else:
+                        outputs[rid] = {}
             return StageOutput(per_request_output_tensors=outputs)
 
     def add_request(self, request_id: str) -> None:

--- a/mminf/engine/audio_codec_engine.py
+++ b/mminf/engine/audio_codec_engine.py
@@ -5,22 +5,29 @@ from mminf.engine.base import BaseEngine, EngineType, StageBatch, StageOutput
 
 class AudioCodecEngine(BaseEngine):
     """
-    Wraps an nn.Module for audio codec forward passes.
+    Wraps nn.Module submodules for audio codec forward passes.
     Stateless — identical lifecycle to EncoderDecoderEngine.
     """
 
-    def __init__(self, model: torch.nn.Module | None = None):
-        self.model = model
+    def __init__(self):
+        self.submodules: dict[str, torch.nn.Module] = {}
         self.device = None
 
     def engine_type(self) -> EngineType:
         return EngineType.AUDIO_CODEC
 
-    def load_model(self, model_config: dict, device: torch.device) -> None:
+    def load_model(
+        self,
+        submodules: dict[str, torch.nn.Module],
+        model_config: dict,
+        device: torch.device,
+    ) -> None:
+        self.submodules = submodules
         self.device = device
 
     def execute_batch(self, batch: StageBatch) -> StageOutput:
-        if self.model is None:
+        submodule = self.submodules.get(batch.stage_name)
+        if submodule is None:
             return StageOutput(
                 per_request_output_tensors={
                     rid: {} for rid in batch.request_ids
@@ -31,11 +38,11 @@ class AudioCodecEngine(BaseEngine):
             outputs = {}
             for rid in batch.request_ids:
                 inputs = batch.per_request_input_tensors.get(rid, {})
-                result = self.model(**{k: v.unsqueeze(0) for k, v in inputs.items()})
+                result = submodule(**{k: v[0].unsqueeze(0) for k, v in inputs.items()})
                 if isinstance(result, torch.Tensor):
-                    outputs[rid] = {"output": result.squeeze(0)}
+                    outputs[rid] = {"output": [result.squeeze(0)]}
                 elif isinstance(result, dict):
-                    outputs[rid] = {k: v.squeeze(0) for k, v in result.items()}
+                    outputs[rid] = {k: [v.squeeze(0)] for k, v in result.items()}
                 else:
                     outputs[rid] = {}
             return StageOutput(per_request_output_tensors=outputs)

--- a/mminf/engine/base.py
+++ b/mminf/engine/base.py
@@ -42,12 +42,38 @@ class BaseEngine(ABC):
         ...
 
     @abstractmethod
-    def load_model(self, model_config: dict, device: torch.device) -> None:
+    def load_model(
+        self,
+        submodules: dict[str, torch.nn.Module],
+        model_config: dict,
+        device: torch.device,
+    ) -> None:
+        """
+        Receive the nn.Module submodules this engine is responsible for
+        (keyed by stage name) and perform engine-specific initialization
+        (KV cache allocation, FlashInfer workspace, etc.).
+        """
         ...
 
     @abstractmethod
     def execute_batch(self, batch: StageBatch) -> StageOutput:
         ...
+
+    def execute_single_request(
+        self,
+        submodule: torch.nn.Module | None,
+        input_tensors: NameToTensorList,
+        **kwargs,
+    ) -> NameToTensorList:
+        """
+        Execute a single request through a submodule. Called by Model.step().
+        Default: simple forward pass. Override for engine-specific behavior
+        (e.g., KV cache management for AR engines).
+        """
+        if submodule is None:
+            return {}
+        with torch.no_grad():
+            return submodule(input_tensors, **kwargs)
 
     @abstractmethod
     def add_request(self, request_id: str) -> None:

--- a/mminf/engine/base.py
+++ b/mminf/engine/base.py
@@ -22,7 +22,6 @@ class StageBatch:
     request_ids: list[str]
 
     # {request_id: {input_name: list[tensor]}}
-    # TODO: refactor how the engine handles per_request_input_tensors now that it's a list
     per_request_input_tensors: dict[str, NameToTensorList]
     metadata: dict = field(default_factory=dict)
 
@@ -67,12 +66,16 @@ class BaseEngine(ABC):
     ) -> NameToTensorList:
         """
         Execute a single request through a submodule. Called by Model.step().
-        Default: simple forward pass. Override for engine-specific behavior
-        (e.g., KV cache management for AR engines).
+        Default: uses preprocess/forward pattern if submodule has preprocess(),
+        otherwise falls back to direct call.
+        Override for engine-specific behavior (e.g., KV cache management).
         """
         if submodule is None:
             return {}
         with torch.no_grad():
+            if hasattr(submodule, 'preprocess'):
+                preprocessed = submodule.preprocess(**input_tensors)
+                return submodule(**preprocessed, **kwargs)
             return submodule(input_tensors, **kwargs)
 
     @abstractmethod

--- a/mminf/engine/enc_dec_engine.py
+++ b/mminf/engine/enc_dec_engine.py
@@ -39,13 +39,19 @@ class EncoderDecoderEngine(BaseEngine):
             outputs = {}
             for rid in batch.request_ids:
                 inputs = batch.per_request_input_tensors.get(rid, {})
-                result = submodule(**{k: v[0].unsqueeze(0) for k, v in inputs.items()})
-                if isinstance(result, torch.Tensor):
-                    outputs[rid] = {"output": [result.squeeze(0)]}
-                elif isinstance(result, dict):
-                    outputs[rid] = {k: [v.squeeze(0)] for k, v in result.items()}
+                if hasattr(submodule, 'preprocess'):
+                    # StageSubmodule: preprocess (list → tensor) then forward
+                    preprocessed = submodule.preprocess(**inputs)
+                    outputs[rid] = submodule(**preprocessed)
                 else:
-                    outputs[rid] = {}
+                    # Raw nn.Module: unwrap single tensors, run, re-wrap
+                    result = submodule(**{k: v[0] for k, v in inputs.items()})
+                    if isinstance(result, dict):
+                        outputs[rid] = result
+                    elif isinstance(result, torch.Tensor):
+                        outputs[rid] = {"output": [result]}
+                    else:
+                        outputs[rid] = {}
             return StageOutput(per_request_output_tensors=outputs)
 
     def add_request(self, request_id: str) -> None:

--- a/mminf/engine/enc_dec_engine.py
+++ b/mminf/engine/enc_dec_engine.py
@@ -5,24 +5,29 @@ from mminf.engine.base import BaseEngine, EngineType, StageBatch, StageOutput
 
 class EncoderDecoderEngine(BaseEngine):
     """
-    Wraps an nn.Module for stateless forward passes
+    Wraps nn.Module submodules for stateless forward passes
     (ViT encoder, text embedding, VAE decoder).
     """
 
-    def __init__(self, model: torch.nn.Module | None = None):
-        self.model = model
+    def __init__(self):
+        self.submodules: dict[str, torch.nn.Module] = {}
         self.device = None
 
     def engine_type(self) -> EngineType:
         return EngineType.ENC_DEC
 
-    def load_model(self, model_config: dict, device: torch.device) -> None:
+    def load_model(
+        self,
+        submodules: dict[str, torch.nn.Module],
+        model_config: dict,
+        device: torch.device,
+    ) -> None:
+        self.submodules = submodules
         self.device = device
-        # Load model from config if self.model is None
-        # For now, model must be passed in constructor or remains None (dummy mode)
 
     def execute_batch(self, batch: StageBatch) -> StageOutput:
-        if self.model is None:
+        submodule = self.submodules.get(batch.stage_name)
+        if submodule is None:
             # Dummy mode: return empty tensors matching expected output names
             return StageOutput(
                 per_request_output_tensors={
@@ -31,15 +36,14 @@ class EncoderDecoderEngine(BaseEngine):
             )
 
         with torch.no_grad():
-            # Batch inputs, run model, split outputs per request
             outputs = {}
             for rid in batch.request_ids:
                 inputs = batch.per_request_input_tensors.get(rid, {})
-                result = self.model(**{k: v.unsqueeze(0) for k, v in inputs.items()})
+                result = submodule(**{k: v[0].unsqueeze(0) for k, v in inputs.items()})
                 if isinstance(result, torch.Tensor):
-                    outputs[rid] = {"output": result.squeeze(0)}
+                    outputs[rid] = {"output": [result.squeeze(0)]}
                 elif isinstance(result, dict):
-                    outputs[rid] = {k: v.squeeze(0) for k, v in result.items()}
+                    outputs[rid] = {k: [v.squeeze(0)] for k, v in result.items()}
                 else:
                     outputs[rid] = {}
             return StageOutput(per_request_output_tensors=outputs)

--- a/mminf/engine/flow_engine.py
+++ b/mminf/engine/flow_engine.py
@@ -9,18 +9,25 @@ class FlowEngine(BaseEngine):
     Loop iteration is handled by the graph system.
     """
 
-    def __init__(self, model: torch.nn.Module | None = None):
-        self.model = model
+    def __init__(self):
+        self.submodules: dict[str, torch.nn.Module] = {}
         self.device = None
 
     def engine_type(self) -> EngineType:
         return EngineType.FLOW
 
-    def load_model(self, model_config: dict, device: torch.device) -> None:
+    def load_model(
+        self,
+        submodules: dict[str, torch.nn.Module],
+        model_config: dict,
+        device: torch.device,
+    ) -> None:
+        self.submodules = submodules
         self.device = device
 
     def execute_batch(self, batch: StageBatch) -> StageOutput:
-        if self.model is None:
+        submodule = self.submodules.get(batch.stage_name)
+        if submodule is None:
             # Dummy mode
             return StageOutput(
                 per_request_output_tensors={
@@ -32,11 +39,11 @@ class FlowEngine(BaseEngine):
             outputs = {}
             for rid in batch.request_ids:
                 inputs = batch.per_request_input_tensors.get(rid, {})
-                result = self.model(**{k: v.unsqueeze(0) for k, v in inputs.items()})
+                result = submodule(**{k: v[0].unsqueeze(0) for k, v in inputs.items()})
                 if isinstance(result, torch.Tensor):
-                    outputs[rid] = {"output": result.squeeze(0)}
+                    outputs[rid] = {"output": [result.squeeze(0)]}
                 elif isinstance(result, dict):
-                    outputs[rid] = {k: v.squeeze(0) for k, v in result.items()}
+                    outputs[rid] = {k: [v.squeeze(0)] for k, v in result.items()}
                 else:
                     outputs[rid] = {}
             return StageOutput(per_request_output_tensors=outputs)

--- a/mminf/engine/flow_engine.py
+++ b/mminf/engine/flow_engine.py
@@ -39,13 +39,17 @@ class FlowEngine(BaseEngine):
             outputs = {}
             for rid in batch.request_ids:
                 inputs = batch.per_request_input_tensors.get(rid, {})
-                result = submodule(**{k: v[0].unsqueeze(0) for k, v in inputs.items()})
-                if isinstance(result, torch.Tensor):
-                    outputs[rid] = {"output": [result.squeeze(0)]}
-                elif isinstance(result, dict):
-                    outputs[rid] = {k: [v.squeeze(0)] for k, v in result.items()}
+                if hasattr(submodule, 'preprocess'):
+                    preprocessed = submodule.preprocess(**inputs)
+                    outputs[rid] = submodule(**preprocessed)
                 else:
-                    outputs[rid] = {}
+                    result = submodule(**{k: v[0] for k, v in inputs.items()})
+                    if isinstance(result, dict):
+                        outputs[rid] = result
+                    elif isinstance(result, torch.Tensor):
+                        outputs[rid] = {"output": [result]}
+                    else:
+                        outputs[rid] = {}
             return StageOutput(per_request_output_tensors=outputs)
 
     def add_request(self, request_id: str) -> None:

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -230,14 +230,27 @@ class Model(ABC):
         pass
 
     @abstractmethod
+    def get_submodule(self, stage_name: str) -> torch.nn.Module | None:
+        """
+        Return the nn.Module for this stage, or None for dummy mode.
+        The engine calls this (via EngineManager) to get the submodule it
+        will execute directly with engine-specific wrapping (KV cache,
+        FlashInfer, etc.).
+        """
+        pass
+
     def step(
         self, stage_name: str,
         phase: str,
         input_tensors: NameToTensorList,
-        state, # TODO: figure out state
+        engine,  # BaseEngine — untyped to avoid circular import
         **kwargs
     ) -> NameToTensorList:
         """
-        Called by the worker to execute a stage
+        Thin wrapper that dispatches to the engine. The engine handles all
+        engine-specific logic (KV cache, FlashInfer, etc.).
+        Models can override this for model-specific dispatch logic.
         """
-        pass
+        return engine.execute_single_request(
+            self.get_submodule(stage_name), input_tensors, **kwargs
+        )

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -15,6 +15,38 @@ STREAM_OUT = "stream_out"
 SPECIAL_DESTINATIONS = {STREAM_OUT}  # add RELAY etc. later
 
 
+class StageSubmodule(torch.nn.Module):
+    """
+    Base class for stage wrapper submodules.
+
+    Separates preprocessing (variable-length list[Tensor] → fixed Tensor)
+    from computation (Tensor → NameToTensorList), enabling torch.compile
+    and CUDA graphs on the forward() path.
+
+    Engine call pattern:
+        preprocessed = submodule.preprocess(**inputs)   # list → tensors
+        result = submodule(**preprocessed)              # tensor → tensor (compilable)
+    """
+
+    def preprocess(self, **inputs: list[torch.Tensor]) -> dict[str, torch.Tensor]:
+        """
+        Convert variable-length list[Tensor] inputs to fixed tensors.
+        NOT compiled — handles Python-level variability.
+
+        Default: assert each input has exactly 1 tensor and unwrap it.
+        Override for stages that handle multiple tensors (e.g., stacking images).
+        """
+        return {k: v[0] for k, v in inputs.items()}
+
+    @abstractmethod
+    def forward(self, **kwargs) -> NameToTensorList:
+        """
+        Pure tensor → NameToTensorList computation.
+        Compilable + CUDA-graphable.
+        """
+        ...
+
+
 @dataclass
 class Subgraph:
     section: GraphSection

--- a/mminf/model/dummy_model.py
+++ b/mminf/model/dummy_model.py
@@ -187,11 +187,5 @@ class DummyModel(Model):
             metadata.output_modalities = ["image"]
         return metadata
 
-    def step(
-        self, stage_name: str,
-        phase: str,
-        input_tensors: NameToTensorList,
-        state, # TODO: figure out state
-        **kwargs
-    ):
-        return # do nothing
+    def get_submodule(self, stage_name: str) -> torch.nn.Module | None:
+        return None  # dummy mode — no real computation

--- a/mminf/worker/engine_manager.py
+++ b/mminf/worker/engine_manager.py
@@ -7,6 +7,7 @@ from mminf.engine.audio_codec_engine import AudioCodecEngine
 from mminf.engine.base import BaseEngine
 from mminf.engine.enc_dec_engine import EncoderDecoderEngine
 from mminf.engine.flow_engine import FlowEngine
+from mminf.model.base import Model
 
 ENGINE_TYPE_TO_CLASS: dict[str, type[BaseEngine]] = {
     "ar": AREngine,
@@ -23,10 +24,18 @@ class EngineManager:
 
     @classmethod
     def from_config(
-        cls, engine_configs: list[dict], device: torch.device
+        cls,
+        engine_configs: list[dict],
+        device: torch.device,
+        model: Model | None = None,
     ) -> "EngineManager":
         """
         Build an EngineManager from a list of engine configs.
+
+        The Model object (if provided) supplies nn.Module submodules for
+        each stage via model.get_submodule(stage_name). In dummy mode
+        (model=None or get_submodule returns None), engines run without
+        real computation.
 
         engine_configs example:
         [
@@ -41,19 +50,25 @@ class EngineManager:
             engine_type_str = cfg["engine_type"]
             stage_names = cfg["stage_names"]
             model_config = cfg.get("model_config", {})
-            model = cfg.get("model", None)
 
             engine_cls = ENGINE_TYPE_TO_CLASS[engine_type_str]
 
             if engine_type_str == "ar":
                 engine = engine_cls(
-                    model=model,
                     kv_cache_config=model_config.get("kv_cache", {}),
                 )
             else:
-                engine = engine_cls(model=model)
+                engine = engine_cls()
 
-            engine.load_model(model_config, device)
+            # Extract submodules from the Model for this engine's stages
+            submodules: dict[str, torch.nn.Module] = {}
+            if model is not None:
+                for name in stage_names:
+                    submodule = model.get_submodule(name)
+                    if submodule is not None:
+                        submodules[name] = submodule
+
+            engine.load_model(submodules, model_config, device)
 
             for name in stage_names:
                 stage_to_engine[name] = engine

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -15,7 +15,7 @@ from mminf.ipc_formats import (
     WorkerMessage,
     WorkerMessageType,
 )
-from mminf.model.base import Subgraph
+from mminf.model.base import Model, Subgraph
 from mminf.worker.engine_manager import EngineManager
 from mminf.worker.micro_scheduler import MicroScheduler, ScheduledBatch
 from mminf.worker.stage_manager_utils import (
@@ -44,6 +44,7 @@ class Worker:
         socket_path_prefix: str = "/tmp/mminf",
         tensor_comm_protocol: CommProtocol = CommProtocol.RDMA,
         device: torch.device = torch.device("cuda"),
+        model: Model | None = None,
     ):
         self.worker_id = worker_id
         self.device = device
@@ -63,7 +64,9 @@ class Worker:
             all_subgraph_ids_to_stages=all_subgraph_ids_to_stages,
         )
 
-        self.engine_manager = EngineManager.from_config(engine_configs, device)
+        self.engine_manager = EngineManager.from_config(
+            engine_configs, device, model=model
+        )
         self.scheduler = MicroScheduler(self.engine_manager)
 
         self.communicator = ZMQCommunicator(


### PR DESCRIPTION
The engine now gets its nn.Module submodules from the Model class (via get_submodule()), rather than receiving a raw nn.Module in its constructor. Model.step() is a concrete thin wrapper that delegates to engine.execute_single_request().