### PR TITLE
Index spec todo

### DIFF
--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 
 import torch
 
-from mminf.engine.base import BaseEngine, EngineType, StageBatch, StageOutput
+from mminf.engine.base import BaseEngine, EngineType, ModalitySpan, StageBatch, StageOutput
 
 
 @dataclass
@@ -124,6 +124,13 @@ class AREngine(BaseEngine):
         else:
             return self._execute_decode(batch, submodule)
 
+    def _get_modality_spans(
+        self, batch: StageBatch, rid: str
+    ) -> list[ModalitySpan] | None:
+        """Extract modality spans for a request from batch metadata."""
+        req_meta = batch.per_request_metadata.get(rid, {})
+        return req_meta.get("modality_spans")
+
     def _execute_prefill(self, batch: StageBatch, submodule: torch.nn.Module) -> StageOutput:
         """Run prefill (prompt processing) for a batch of requests."""
         if self.prefill_wrapper is None or self.kv_cache is None:
@@ -145,14 +152,26 @@ class AREngine(BaseEngine):
         paged_kv_indices = []
         paged_kv_last_page_len = []
         all_q = []
+        per_request_spans: dict[str, list[ModalitySpan] | None] = {}
 
         for rid in batch.request_ids:
             state = self.request_states[rid]
             inputs = batch.per_request_input_tensors.get(rid, {})
-            q_list = inputs.get("hidden_states", inputs.get("text_emb"))
-            if q_list is None:
-                continue
-            q = q_list[0]  # AR engine expects single tensor per input
+
+            # Use preprocess/forward pattern if submodule supports it
+            if hasattr(submodule, 'preprocess'):
+                preprocessed, metadata = submodule.preprocess(**inputs)
+                per_request_spans[rid] = metadata.get("modality_spans")
+                q = preprocessed.get(
+                    "hidden_states", next(iter(preprocessed.values()))
+                )
+            else:
+                q_list = inputs.get("hidden_states", inputs.get("text_emb"))
+                if q_list is None:
+                    continue
+                q = q_list[0]
+                per_request_spans[rid] = self._get_modality_spans(batch, rid)
+
             seq_len = q.shape[0]
 
             # Allocate pages for this sequence
@@ -190,6 +209,8 @@ class AREngine(BaseEngine):
         )
 
         # Run submodule forward (attention handled by FlashInfer wrapper)
+        # TODO: pass per_request_spans to submodule when real models
+        # need modality-aware attention masks / position IDs
         with torch.no_grad():
             output = submodule(q_tensor, self.kv_cache, self.prefill_wrapper)
 
@@ -226,10 +247,18 @@ class AREngine(BaseEngine):
         for rid in batch.request_ids:
             state = self.request_states[rid]
             inputs = batch.per_request_input_tensors.get(rid, {})
-            q_list = inputs.get("hidden_states", inputs.get("text_emb"))
-            if q_list is None:
-                continue
-            q = q_list[0]  # AR engine expects single tensor per input
+
+            # Use preprocess/forward pattern if submodule supports it
+            if hasattr(submodule, 'preprocess'):
+                preprocessed, _metadata = submodule.preprocess(**inputs)
+                q = preprocessed.get(
+                    "hidden_states", next(iter(preprocessed.values()))
+                )
+            else:
+                q_list = inputs.get("hidden_states", inputs.get("text_emb"))
+                if q_list is None:
+                    continue
+                q = q_list[0]
 
             # Allocate one more page if needed
             state.seq_len += 1
@@ -263,6 +292,8 @@ class AREngine(BaseEngine):
             num_qo_heads, num_kv_heads, head_dim, page_size,
         )
 
+        # TODO: pass modality spans to submodule when real models
+        # need modality-aware attention masks / position IDs
         with torch.no_grad():
             output = submodule(q_tensor, self.kv_cache, self.decode_wrapper)
 

--- a/mminf/engine/audio_codec_engine.py
+++ b/mminf/engine/audio_codec_engine.py
@@ -36,11 +36,14 @@ class AudioCodecEngine(BaseEngine):
 
         with torch.no_grad():
             outputs = {}
+            per_request_metadata = {}
             for rid in batch.request_ids:
                 inputs = batch.per_request_input_tensors.get(rid, {})
                 if hasattr(submodule, 'preprocess'):
-                    preprocessed = submodule.preprocess(**inputs)
+                    preprocessed, metadata = submodule.preprocess(**inputs)
                     outputs[rid] = submodule(**preprocessed)
+                    if metadata:
+                        per_request_metadata[rid] = metadata
                 else:
                     result = submodule(**{k: v[0] for k, v in inputs.items()})
                     if isinstance(result, dict):
@@ -49,7 +52,10 @@ class AudioCodecEngine(BaseEngine):
                         outputs[rid] = {"output": [result]}
                     else:
                         outputs[rid] = {}
-            return StageOutput(per_request_output_tensors=outputs)
+            return StageOutput(
+                per_request_output_tensors=outputs,
+                per_request_metadata=per_request_metadata,
+            )
 
     def add_request(self, request_id: str) -> None:
         pass  # stateless

--- a/mminf/engine/base.py
+++ b/mminf/engine/base.py
@@ -15,6 +15,14 @@ class EngineType(Enum):
 
 
 @dataclass
+class ModalitySpan:
+    """A contiguous span of a single modality within a concatenated sequence."""
+    start: int      # inclusive start position
+    end: int        # exclusive end position
+    modality: str   # "text", "image", "latent", etc.
+
+
+@dataclass
 class StageBatch:
     """Input to an engine's execute_batch()."""
     stage_name: str
@@ -24,6 +32,11 @@ class StageBatch:
     # {request_id: {input_name: list[tensor]}}
     per_request_input_tensors: dict[str, NameToTensorList]
     metadata: dict = field(default_factory=dict)
+
+    # {request_id: metadata dict} — carries modality spans and other
+    # per-request metadata from upstream stages to engines.
+    # Convention: {"modality_spans": list[ModalitySpan], ...}
+    per_request_metadata: dict[str, dict] = field(default_factory=dict)
 
 
 @dataclass
@@ -74,7 +87,11 @@ class BaseEngine(ABC):
             return {}
         with torch.no_grad():
             if hasattr(submodule, 'preprocess'):
-                preprocessed = submodule.preprocess(**input_tensors)
+                preprocessed, metadata = submodule.preprocess(**input_tensors)
+                # Pass modality spans from preprocess() to forward()
+                modality_spans = metadata.get("modality_spans")
+                if modality_spans is not None:
+                    kwargs['modality_spans'] = modality_spans
                 return submodule(**preprocessed, **kwargs)
             return submodule(input_tensors, **kwargs)
 

--- a/mminf/engine/enc_dec_engine.py
+++ b/mminf/engine/enc_dec_engine.py
@@ -37,12 +37,15 @@ class EncoderDecoderEngine(BaseEngine):
 
         with torch.no_grad():
             outputs = {}
+            per_request_metadata = {}
             for rid in batch.request_ids:
                 inputs = batch.per_request_input_tensors.get(rid, {})
                 if hasattr(submodule, 'preprocess'):
                     # StageSubmodule: preprocess (list → tensor) then forward
-                    preprocessed = submodule.preprocess(**inputs)
+                    preprocessed, metadata = submodule.preprocess(**inputs)
                     outputs[rid] = submodule(**preprocessed)
+                    if metadata:
+                        per_request_metadata[rid] = metadata
                 else:
                     # Raw nn.Module: unwrap single tensors, run, re-wrap
                     result = submodule(**{k: v[0] for k, v in inputs.items()})
@@ -52,7 +55,10 @@ class EncoderDecoderEngine(BaseEngine):
                         outputs[rid] = {"output": [result]}
                     else:
                         outputs[rid] = {}
-            return StageOutput(per_request_output_tensors=outputs)
+            return StageOutput(
+                per_request_output_tensors=outputs,
+                per_request_metadata=per_request_metadata,
+            )
 
     def add_request(self, request_id: str) -> None:
         pass  # stateless

--- a/mminf/engine/flow_engine.py
+++ b/mminf/engine/flow_engine.py
@@ -37,11 +37,14 @@ class FlowEngine(BaseEngine):
 
         with torch.no_grad():
             outputs = {}
+            per_request_metadata = {}
             for rid in batch.request_ids:
                 inputs = batch.per_request_input_tensors.get(rid, {})
                 if hasattr(submodule, 'preprocess'):
-                    preprocessed = submodule.preprocess(**inputs)
+                    preprocessed, metadata = submodule.preprocess(**inputs)
                     outputs[rid] = submodule(**preprocessed)
+                    if metadata:
+                        per_request_metadata[rid] = metadata
                 else:
                     result = submodule(**{k: v[0] for k, v in inputs.items()})
                     if isinstance(result, dict):
@@ -50,7 +53,10 @@ class FlowEngine(BaseEngine):
                         outputs[rid] = {"output": [result]}
                     else:
                         outputs[rid] = {}
-            return StageOutput(per_request_output_tensors=outputs)
+            return StageOutput(
+                per_request_output_tensors=outputs,
+                per_request_metadata=per_request_metadata,
+            )
 
     def add_request(self, request_id: str) -> None:
         pass

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Type
 from uuid import uuid4
 
+import torch
 import yaml
 
 from mminf.communication.tensors import NameToTensorList
@@ -23,19 +24,33 @@ class StageSubmodule(torch.nn.Module):
     and CUDA graphs on the forward() path.
 
     Engine call pattern:
-        preprocessed = submodule.preprocess(**inputs)   # list → tensors
-        result = submodule(**preprocessed)              # tensor → tensor (compilable)
+        preprocessed, metadata = submodule.preprocess(**inputs)   # list → tensors + metadata
+        result = submodule(**preprocessed)                        # tensor → tensor (compilable)
+
+    Modality spans:
+        Subclasses that concatenate multi-modal inputs should return
+        modality span info in the metadata dict from preprocess():
+            return tensors, {"modality_spans": [ModalitySpan(0, 128, "text"), ...]}
+        The engine reads metadata and either passes spans to forward()
+        or propagates them to downstream stages via StageOutput.
+        Use engine.base.ModalitySpan(start, end, modality) objects.
     """
 
-    def preprocess(self, **inputs: list[torch.Tensor]) -> dict[str, torch.Tensor]:
+    def preprocess(
+        self, **inputs: list[torch.Tensor]
+    ) -> tuple[dict[str, torch.Tensor], dict]:
         """
         Convert variable-length list[Tensor] inputs to fixed tensors.
         NOT compiled — handles Python-level variability.
 
+        Returns:
+            (preprocessed_tensors, metadata) where metadata is a dict
+            that may contain "modality_spans" or other stage-produced info.
+
         Default: assert each input has exactly 1 tensor and unwrap it.
         Override for stages that handle multiple tensors (e.g., stacking images).
         """
-        return {k: v[0] for k, v in inputs.items()}
+        return {k: v[0] for k, v in inputs.items()}, {}
 
     @abstractmethod
     def forward(self, **kwargs) -> NameToTensorList:

--- a/mminf/model/dummy_model.py
+++ b/mminf/model/dummy_model.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 import numpy as np
+import torch
 
 from mminf.communication.tensors import NameToTensorList
 from mminf.graph.base import GraphPointer, GraphStage, Loop, Parallel, Sequential, TensorPointerInfo

--- a/mminf/worker/stage_manager_utils.py
+++ b/mminf/worker/stage_manager_utils.py
@@ -116,7 +116,9 @@ class PerRequestInfo:
         this list only includes the decode subgraph)
     - pending_persist_signals: buffered persist signals awaiting flush on
         SUBGRAPHS_DONE
-    - tensors: TBD
+    - accumulated_stage_metadata: metadata accumulated from upstream stage
+        outputs (e.g., modality spans from concat stages), forwarded to
+        downstream engines via StageBatch.per_request_metadata
     """
     stage_to_worker: dict[StageAndPhase, str]  # for all stages
     subgraph_ids: list[str] # for this worker
@@ -127,6 +129,11 @@ class PerRequestInfo:
 
     pending_persist_signals: list[GraphPointer] = field(default_factory=list)
     pending_new_tokens: dict[str, list[int]] = field(default_factory=dict)
+
+    # Metadata from upstream stages (e.g., modality_spans from concat stages).
+    # Accumulated as stages execute, forwarded to downstream engines.
+    # Convention: {"modality_spans": list[ModalitySpan], ...}
+    accumulated_stage_metadata: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -304,3 +311,22 @@ class SubgraphsManager:
         new_tokens = info.pending_new_tokens
         info.pending_new_tokens = {}
         return new_tokens
+
+    def accumulate_stage_metadata(
+        self, request_id: str, stage_metadata: dict
+    ):
+        """
+        Merge metadata from a stage output into accumulated_stage_metadata.
+        For 'modality_spans', extends the existing list.
+        For other keys, overwrites (last-writer-wins).
+        """
+        info = self.per_request_info[request_id]
+        for key, value in stage_metadata.items():
+            if key == "modality_spans" and key in info.accumulated_stage_metadata:
+                info.accumulated_stage_metadata[key].extend(value)
+            else:
+                info.accumulated_stage_metadata[key] = value
+
+    def get_stage_metadata(self, request_id: str) -> dict:
+        """Return accumulated metadata for a request."""
+        return self.per_request_info[request_id].accumulated_stage_metadata

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -172,6 +172,7 @@ class Worker:
     def _build_stage_batch(self, batch: ScheduledBatch) -> StageBatch:
         """Gather input tensors from tensor_manager for all requests in the batch."""
         per_request_inputs: dict[str, NameToTensorList] = {}
+        per_request_metadata: dict[str, dict] = {}
 
         for request_id, stage in batch.stage_objects.items():
             tensors = {}
@@ -183,12 +184,15 @@ class Worker:
                     ) for info in stage.ready_inputs[input_name].tensor_info
                 ]
             per_request_inputs[request_id] = tensors
+            per_request_metadata[request_id] = \
+                self.subgraphs_manager.get_stage_metadata(request_id)
 
         return StageBatch(
             stage_name=batch.stage_name,
             phase=batch.phase,
             request_ids=list(batch.stage_objects.keys()),
             per_request_input_tensors=per_request_inputs,
+            per_request_metadata=per_request_metadata,
         )
 
     # ------------------------------------------------------------------
@@ -352,6 +356,15 @@ class Worker:
             # 5. Execute via engine
             engine = self.engine_manager.get_engine(batch.stage_name)
             output = engine.execute_batch(stage_batch)
+
+            # 5a. Accumulate per-request metadata from stage output
+            # (e.g., modality spans produced by concat stages)
+            for request_id in batch.stage_objects:
+                stage_meta = output.per_request_metadata.get(request_id, {})
+                if stage_meta:
+                    self.subgraphs_manager.accumulate_stage_metadata(
+                        request_id, stage_meta
+                    )
 
             # 5b. Free consumed input tensors
             self._cleanup_consumed_inputs(batch)


### PR DESCRIPTION
TODO 3: Modality Index Specification (when the AR engine's LLM submodule concatenates separately-named inputs (text_emb, img_emb, latents) into a single hidden-states tensor for attention, it needs to know which positions belong to which modality).