### PR TITLE
E2E Latency Updates

### DIFF
--- a/benchmark/run_benchmark.sh
+++ b/benchmark/run_benchmark.sh
@@ -8,7 +8,7 @@ python -m benchmark.runner \
     --url "${URL:-http://localhost:8000}" \
     --model "${MODEL:-bagel}" \
     --dataset vbench \
-    --request-type "${TASK:-image_to_text}" \
+    --request-type "${TASK:-text_to_image}" \
     --vbench-cache-dir "$CACHE_DIR" \
     --num-requests "${NUM_REQUESTS:-10}" \
     --inference-system "${INF_SYS:-ours}" \

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -103,6 +103,7 @@ class Benchmark:
                 prompt=req.prompt,
                 image_path=req.image_path,
             )
+            print(f"request time: {result.e2e_latency}")
             results.append(result)
         return results
 

--- a/mminf/api_server/data_worker.py
+++ b/mminf/api_server/data_worker.py
@@ -4,7 +4,7 @@ import logging
 import queue
 import threading
 import time
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 
 import torch
 import torchaudio
@@ -36,6 +36,9 @@ def _preprocess_loop(**kwargs):
     worker.run()
 
 
+NameToFwdPassNumber = dict[str, int]
+
+
 class PreprocessWorker:
     def __init__(
         self,
@@ -51,7 +54,7 @@ class PreprocessWorker:
         self.stop_event = threading.Event()
 
         self.per_request_reading_tensors = {}
-        self.per_request_num_chunks = {}
+        self.output_fwd_pass_numbers: dict[str, NameToFwdPassNumber] = {}
 
         self.thread = threading.Thread(
             target=_preprocess_loop,
@@ -70,12 +73,17 @@ class PreprocessWorker:
         self.thread.start()
 
     def new_request(self, input: PreprocessInput):
+        self.output_fwd_pass_numbers[input.request_id] = {}
         self.per_request_reading_tensors[input.request_id] = 0
         self.request_input_queue.put(input)
-        self.per_request_num_chunks[input.request_id] = 0
 
     def new_result_tensors(self, input: ResultTensors):
-        self.per_request_num_chunks[input.request_id] += 1
+        name = input.graph_edge.name
+        self.output_fwd_pass_numbers[input.request_id][name] = max(
+            self.output_fwd_pass_numbers[input.request_id].get(name, -1),
+            input.fwd_pass_number
+        )
+
         self.per_request_reading_tensors[input.request_id] += len(input.graph_edge.tensor_info)
         logger.debug(
             "Data worker reading queue for request %s increased to length %d",
@@ -86,11 +94,15 @@ class PreprocessWorker:
     def has_pending_tensors(self, request_id: str):
         return self.per_request_reading_tensors.get(request_id, 0) > 0
     
-    def received_all_chunks(self, request_id: str, expected_n: int):
-        logger.debug(
-            "Expected %d chunks, got %d", self.per_request_num_chunks[request_id], expected_n
-        )
-        return self.per_request_num_chunks[request_id] >= expected_n
+    def received_final_chunks(
+        self, request_id: str, final_forward_pass: int,
+        final_forward_outputs: list[str]
+    ):
+        return all([
+          self.output_fwd_pass_numbers[request_id].get(
+              name, -1
+            ) >= final_forward_pass for name in final_forward_outputs
+        ])
 
     def get_result_chunks(self)-> list[ResultChunk]:
         results = []
@@ -106,7 +118,7 @@ class PreprocessWorker:
 
     def cleanup_request(self, request_id: str):
         self.cleanup_request_queue.put(request_id)
-        del self.per_request_num_chunks[request_id]
+        del self.output_fwd_pass_numbers[request_id]
         del self.per_request_reading_tensors[request_id]
 
     def shutdown(self):

--- a/mminf/api_server/data_worker.py
+++ b/mminf/api_server/data_worker.py
@@ -51,6 +51,7 @@ class PreprocessWorker:
         self.stop_event = threading.Event()
 
         self.per_request_reading_tensors = {}
+        self.per_request_num_chunks = {}
 
         self.thread = threading.Thread(
             target=_preprocess_loop,
@@ -71,8 +72,10 @@ class PreprocessWorker:
     def new_request(self, input: PreprocessInput):
         self.per_request_reading_tensors[input.request_id] = 0
         self.request_input_queue.put(input)
+        self.per_request_num_chunks[input.request_id] = 0
 
     def new_result_tensors(self, input: ResultTensors):
+        self.per_request_num_chunks[input.request_id] += 1
         self.per_request_reading_tensors[input.request_id] += len(input.graph_edge.tensor_info)
         logger.debug(
             "Data worker reading queue for request %s increased to length %d",
@@ -82,6 +85,12 @@ class PreprocessWorker:
 
     def has_pending_tensors(self, request_id: str):
         return self.per_request_reading_tensors.get(request_id, 0) > 0
+    
+    def received_all_chunks(self, request_id: str, expected_n: int):
+        logger.debug(
+            "Expected %d chunks, got %d", self.per_request_num_chunks[request_id], expected_n
+        )
+        return self.per_request_num_chunks[request_id] >= expected_n
 
     def get_result_chunks(self)-> list[ResultChunk]:
         results = []
@@ -97,6 +106,8 @@ class PreprocessWorker:
 
     def cleanup_request(self, request_id: str):
         self.cleanup_request_queue.put(request_id)
+        del self.per_request_num_chunks[request_id]
+        del self.per_request_reading_tensors[request_id]
 
     def shutdown(self):
         self.stop_event.set()

--- a/mminf/api_server/entrypoint.py
+++ b/mminf/api_server/entrypoint.py
@@ -185,7 +185,8 @@ class APIServer:
                 "consumed_chunks": 0,
                 "input_modalities": input_modalities,
                 "output_modalities": output_modalities,
-                "expected_chunks": 0
+                "final_forward_pass": 0,
+                "final_forward_outputs": [],
             }
 
         self.preprocess_worker.new_request(PreprocessInput(
@@ -212,9 +213,12 @@ class APIServer:
         stale = [
             rid
             for rid, ts in self.recently_completed.items()
-            if self.preprocess_worker.received_all_chunks(
-                rid, self.pending_requests[rid]["expected_chunks"]
-            ) and not self.preprocess_worker.has_pending_tensors(rid)
+            if (
+                self.preprocess_worker.received_final_chunks(
+                    rid, self.pending_requests[rid]["final_forward_pass"],
+                    self.pending_requests[rid]["final_forward_outputs"]
+                ) and not self.preprocess_worker.has_pending_tensors(rid)
+            ) or (now - ts) >= self._recently_completed_ttl
         ]
         for rid in stale:
             # only set the event when there are no more pending chunks
@@ -250,7 +254,10 @@ class APIServer:
                             elif message.message_type == "request_complete":
                                 logger.info("API server received %s done", rid)
                                 self.recently_completed[rid] = time.time()
-                                self.pending_requests[rid]["expected_chunks"] = message.body.num_output_chunks
+                                self.pending_requests[rid]["final_forward_pass"] = \
+                                    message.body.final_forward_pass
+                                self.pending_requests[rid]["final_forward_outputs"] = \
+                                    message.body.final_forward_outputs
                         elif rid in self.recently_completed:
                             logger.debug("Late message for completed %s", rid)
                         else:

--- a/mminf/api_server/entrypoint.py
+++ b/mminf/api_server/entrypoint.py
@@ -185,6 +185,7 @@ class APIServer:
                 "consumed_chunks": 0,
                 "input_modalities": input_modalities,
                 "output_modalities": output_modalities,
+                "expected_chunks": 0
             }
 
         self.preprocess_worker.new_request(PreprocessInput(
@@ -211,8 +212,9 @@ class APIServer:
         stale = [
             rid
             for rid, ts in self.recently_completed.items()
-            if now - ts > self._recently_completed_ttl \
-            and not self.preprocess_worker.has_pending_tensors(rid)
+            if self.preprocess_worker.received_all_chunks(
+                rid, self.pending_requests[rid]["expected_chunks"]
+            ) and not self.preprocess_worker.has_pending_tensors(rid)
         ]
         for rid in stale:
             # only set the event when there are no more pending chunks
@@ -248,6 +250,7 @@ class APIServer:
                             elif message.message_type == "request_complete":
                                 logger.info("API server received %s done", rid)
                                 self.recently_completed[rid] = time.time()
+                                self.pending_requests[rid]["expected_chunks"] = message.body.num_output_chunks
                         elif rid in self.recently_completed:
                             logger.debug("Late message for completed %s", rid)
                         else:

--- a/mminf/api_server/request_types.py
+++ b/mminf/api_server/request_types.py
@@ -17,6 +17,7 @@ class ResultTensors:
     request_id: str
     modality: str
     graph_edge: GraphEdge
+    fwd_pass_number: int
     metadata: dict = field(default_factory=dict)
 
 
@@ -24,7 +25,8 @@ class ResultTensors:
 class RequestComplete:
     """Signals that a request has finished processing."""
     request_id: str
-    num_output_chunks: int = field(default=0)
+    final_forward_pass: int
+    final_forward_outputs: list[str]
 
 
 @dataclass

--- a/mminf/api_server/request_types.py
+++ b/mminf/api_server/request_types.py
@@ -24,6 +24,7 @@ class ResultTensors:
 class RequestComplete:
     """Signals that a request has finished processing."""
     request_id: str
+    num_output_chunks: int = field(default=0)
 
 
 @dataclass

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -86,7 +86,8 @@ class RequestData:
     current_worker_graph_ids: set[str]
     # make sure to check all tensors in the list are completed (BLOCKING case)
     completed_worker_graph_ids: set[str] = field(default_factory=set)
-    num_output_chunks: int = field(default=0)
+    fwd_pass_number: int = field(default=0)
+    curr_forward_outputs: list[str] = field(default_factory=list)
 
     def remove_persist_signal_uuids(self, uuids: list[str]):
         uuids = set(uuids)
@@ -399,7 +400,8 @@ class Conductor:
                 message_type="request_complete",
                 body=RequestComplete(
                     request_id=request_id,
-                    num_output_chunks=self.requests[request_id].num_output_chunks
+                    final_forward_pass=self.requests[request_id].fwd_pass_number,
+                    final_forward_outputs=self.requests[request_id].curr_forward_outputs
                 )
             )
         )
@@ -436,6 +438,9 @@ class Conductor:
         self._un_persist_tensors(request_id, fwd_args.unpersist_tensors)
         if fwd_args.request_done:
             return True # stop the request
+        
+        request_data.fwd_pass_number += 1
+        request_data.curr_forward_outputs.clear()
 
         logger.debug("Forward inputs: %s", str(fwd_args.inputs))
 
@@ -453,6 +458,7 @@ class Conductor:
                     graph_walk=request_data.current_forward_metadata.graph_walk,
                     inputs=inputs,
                     per_request_metadata=fwd_args.step_metadata,
+                    fwd_pass_number=request_data.fwd_pass_number
                 )
             )
             self.communicator.send(worker, message)
@@ -486,7 +492,7 @@ class Conductor:
         request_data.completed_worker_graph_ids.update(
             body.worker_graph_ids
         )
-        request_data.num_output_chunks += body.num_output_chunks
+        request_data.curr_forward_outputs += body.output_signal_names
 
         done_with_forward = request_data.current_worker_graph_ids.issubset(
             request_data.completed_worker_graph_ids

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -86,6 +86,7 @@ class RequestData:
     current_worker_graph_ids: set[str]
     # make sure to check all tensors in the list are completed (BLOCKING case)
     completed_worker_graph_ids: set[str] = field(default_factory=set)
+    num_output_chunks: int = field(default=0)
 
     def remove_persist_signal_uuids(self, uuids: list[str]):
         uuids = set(uuids)
@@ -397,7 +398,8 @@ class Conductor:
             APIServerMessage(
                 message_type="request_complete",
                 body=RequestComplete(
-                    request_id=request_id
+                    request_id=request_id,
+                    num_output_chunks=self.requests[request_id].num_output_chunks
                 )
             )
         )
@@ -484,6 +486,7 @@ class Conductor:
         request_data.completed_worker_graph_ids.update(
             body.worker_graph_ids
         )
+        request_data.num_output_chunks += body.num_output_chunks
 
         done_with_forward = request_data.current_worker_graph_ids.issubset(
             request_data.completed_worker_graph_ids

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -133,6 +133,7 @@ class BatchedCacheManager:
             kv_cache_config.max_seq_len, dtype=torch.long, device=device
         )
 
+    @torch.compiler.disable
     def _get_state(self, request_id: str, label: str | None = None) -> KVRequestState:
         label = label or self.active_labels.get(request_id, "main")
         key = (request_id, label)
@@ -140,10 +141,12 @@ class BatchedCacheManager:
             self.request_states[key] = KVRequestState()
         return self.request_states[key]
 
+    @torch.compiler.disable
     def set_active_labels(self, labels: dict[str, str]) -> None:
         """Switch active cache labels for all requests at once."""
         self.active_labels = labels
 
+    @torch.compiler.disable
     def set_active_label(self, label: str) -> None:
         """Switch all requests to the same cache label."""
         self.active_labels = {rid: label for rid in self.request_ids}

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -1,6 +1,7 @@
 import logging
 import queue
 from dataclasses import dataclass, field
+import time
 
 import torch
 

--- a/mminf/model/bagel/components/language_model.py
+++ b/mminf/model/bagel/components/language_model.py
@@ -139,15 +139,7 @@ class BagelAttentionMoT(nn.Module):
         vae_token_indexes=None,
         text_indexes=None,
         text_mask=None,
-    ):
-        mot_kwargs = dict(
-            query_sequence=query_sequence,
-            text_idxs=text_indexes,
-            img_idxs=vae_token_indexes,
-            text_mask=text_mask,
-            static_vae_idxs=static_vae_idxs
-        )
-        
+    ):  
         if mode == "und":
             query_states = self.q_proj(query_sequence).view(
                 -1, self.num_heads, self.head_dim
@@ -167,6 +159,13 @@ class BagelAttentionMoT(nn.Module):
             )
 
         elif mode == "gen":
+            mot_kwargs = dict(
+                query_sequence=query_sequence,
+                text_idxs=text_indexes,
+                img_idxs=vae_token_indexes,
+                text_mask=text_mask,
+                static_vae_idxs=static_vae_idxs
+            )
             query_states = split_function_mot(
                 text_function=lambda seq: run_rms_norm(
                     self.q_proj(seq).view(
@@ -230,7 +229,11 @@ class BagelAttentionMoT(nn.Module):
             attn_output = split_function_mot(
                 text_function=self.o_proj,
                 image_fuction=self.o_proj_moe_gen,
-                **mot_kwargs
+                query_sequence=attn_output,
+                text_idxs=text_indexes,
+                img_idxs=vae_token_indexes,
+                text_mask=text_mask,
+                static_vae_idxs=static_vae_idxs
             )
 
         return attn_output

--- a/mminf/model/bagel/components/language_model.py
+++ b/mminf/model/bagel/components/language_model.py
@@ -10,6 +10,7 @@
 # This modified file is released under the same license.
 
 
+import time
 from typing import Optional
 
 import torch
@@ -19,28 +20,6 @@ from transformers.activations import ACT2FN
 from mminf.engine.ar_engine import BatchedCacheManager
 from mminf.model.bagel.config import BagelModelConfig
 from mminf.utils.flashinfer_utils import run_rms_norm
-
-
-def _to_text_mask(
-    text_indexes: torch.Tensor | None,
-    vae_token_indexes: torch.Tensor | None,
-    sequence_len: int,
-    device: torch.device,
-) -> torch.Tensor:
-    if text_indexes is None and vae_token_indexes is None:
-        return torch.ones(sequence_len, dtype=torch.bool, device=device)
-
-    if text_indexes is not None and text_indexes.dtype == torch.bool:
-        return text_indexes.to(device=device)
-
-    seq_indexes = torch.arange(sequence_len, device=device)
-    if text_indexes is not None:
-        return torch.isin(seq_indexes, text_indexes.to(device=device, dtype=torch.long))
-
-    if vae_token_indexes is None or vae_token_indexes.numel() == 0:
-        return torch.ones(sequence_len, dtype=torch.bool, device=device)
-
-    return ~torch.isin(seq_indexes, vae_token_indexes.to(device=device, dtype=torch.long))
 
 
 class BagelRMSNorm(nn.Module):
@@ -80,85 +59,34 @@ class BagelMLP(nn.Module):
         return self.down_proj(self.act_fn(self.gate_proj(hidden_state)) * self.up_proj(hidden_state))
 
 
-# class BagelAttention(nn.Module):
-#     def __init__(self,config: BagelModelConfig, layer_idx: Optional[int] = None):
-#         super().__init__()
-#         self.config = config
-#         self.layer_idx = layer_idx
+def split_function_mot(
+    text_function,
+    image_fuction,
+    query_sequence: torch.Tensor,
+    text_idxs: torch.Tensor,
+    img_idxs: torch.Tensor,
+    text_mask: torch.Tensor,
+    static_vae_idxs=True
+):
+    if static_vae_idxs:
+        text_part  = query_sequence[text_idxs]   # [n_text_total, D]
+        image_part = query_sequence[img_idxs]  # [n_image_total, D]
 
-#         self.hidden_size = config.hidden_size
-#         self.num_heads = config.num_attention_heads
-#         self.head_dim = self.hidden_size // self.num_heads
-#         self.num_key_value_heads = config.num_key_value_heads
-#         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
-#         self.max_position_embeddings = config.max_position_embeddings
-#         self.rope_theta = config.rope_theta
-#         self.is_causal = config.is_causal
-#         self.attention_dropout = config.attention_dropout
+        text_out = text_function(text_part)
+        image_out = image_fuction(image_part)
 
-#         if (self.head_dim * self.num_heads) != self.hidden_size:
-#             raise ValueError(
-#                 f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
-#                 f" and `num_heads`: {self.num_heads})."
-#             )
-#         self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=True)
-#         self.k_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True)
-#         self.v_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True)
-#         self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=False)
-
-#         if self.config.qk_norm:
-#             self.q_norm = BagelRMSNorm(self.head_dim, eps=config.rms_norm_eps)
-#             self.k_norm = BagelRMSNorm(self.head_dim, eps=config.rms_norm_eps)
-#         else:
-#             self.q_norm = nn.Identity()
-#             self.k_norm = nn.Identity()
-
-#     def forward(
-#         self,
-#         query_sequence: torch.Tensor,
-#         cache_handle: CacheHandle,
-#         write_cache=True,
-#         is_causal=True,
-#     ):
-#         query_states = self.q_proj(query_sequence).view(
-#             -1, self.num_heads, self.head_dim
-#         )
-#         key_states = self.k_proj(query_sequence).view(
-#             -1, self.num_key_value_heads, self.head_dim
-#         )
-#         value_states = self.v_proj(query_sequence).view(
-#             -1, self.num_key_value_heads, self.head_dim
-#         )
-
-#         query_states = run_rms_norm(
-#             query_states, self.q_norm.weight, eps=self.q_norm.variance_epsilon
-#         )
-#         key_states = run_rms_norm(
-#             key_states, self.k_norm.weight, eps=self.k_norm.variance_epsilon
-#         )
-
-#         query_states, key_states = cache_handle.apply_rope_default(
-#             query_states, key_states, rope_theta=self.rope_theta
-#         )
-
-#         query_states = query_states.to(torch.bfloat16)
-#         key_states = key_states.to(torch.bfloat16)
-#         value_states = value_states.to(torch.bfloat16)
-
-#         # Run paged attention
-#         attn_output = cache_handle.run_attention(
-#             q=query_states,
-#             k=key_states,
-#             v=value_states,
-#             layer_idx=self.layer_idx,
-#             is_causal=is_causal,
-#             write_cache=write_cache,
-#         )
-
-#         attn_output = attn_output.reshape(-1, self.hidden_size)
-#         attn_output = self.o_proj(attn_output)
-
-#         return attn_output
+        out = torch.empty(
+            (text_out.shape[0] + image_out.shape[0], *text_out.shape[1:]),
+            device=query_sequence.device, dtype=query_sequence.dtype
+        )
+        out[text_idxs]  = text_out
+        out[img_idxs] = image_out
+        return out
+    
+    text_query = text_function(query_sequence)
+    vae_query = image_fuction(query_sequence)
+    return torch.where(text_mask[:, None], text_query, vae_query)
+    
 
 
 class BagelAttentionMoT(nn.Module):
@@ -207,9 +135,19 @@ class BagelAttentionMoT(nn.Module):
         query_sequence: torch.Tensor,
         cache_handle,
         mode="und",
+        static_vae_idxs=True,
         vae_token_indexes=None,
         text_indexes=None,
+        text_mask=None,
     ):
+        mot_kwargs = dict(
+            query_sequence=query_sequence,
+            text_idxs=text_indexes,
+            img_idxs=vae_token_indexes,
+            text_mask=text_mask,
+            static_vae_idxs=static_vae_idxs
+        )
+        
         if mode == "und":
             query_states = self.q_proj(query_sequence).view(
                 -1, self.num_heads, self.head_dim
@@ -229,65 +167,45 @@ class BagelAttentionMoT(nn.Module):
             )
 
         elif mode == "gen":
-            text_mask = _to_text_mask(
-                text_indexes, vae_token_indexes, query_sequence.shape[0], query_sequence.device
+            query_states = split_function_mot(
+                text_function=lambda seq: run_rms_norm(
+                    self.q_proj(seq).view(
+                        -1, self.num_heads, self.head_dim
+                    ),
+                    self.q_norm.weight,
+                    eps=self.q_norm.variance_epsilon
+                ),
+                image_fuction=lambda seq: run_rms_norm(
+                    self.q_proj_moe_gen(seq).view(
+                        -1, self.num_heads, self.head_dim
+                    ),
+                    self.q_norm_moe_gen.weight,
+                    eps=self.q_norm_moe_gen.variance_epsilon
+                ), **mot_kwargs
             )
-            query_sequence = query_sequence.to(torch.bfloat16)
-
-            text_query_states = self.q_proj(query_sequence).view(
-                -1, self.num_heads, self.head_dim
+            key_states = split_function_mot(
+                text_function=lambda seq: run_rms_norm(
+                    self.k_proj(seq).view(
+                        -1, self.num_key_value_heads, self.head_dim
+                    ),
+                    self.k_norm.weight,
+                    eps=self.k_norm.variance_epsilon
+                ),
+                image_fuction=lambda seq: run_rms_norm(
+                    self.k_proj_moe_gen(seq).view(
+                        -1, self.num_key_value_heads, self.head_dim
+                    ),
+                    self.k_norm_moe_gen.weight,
+                    eps=self.k_norm_moe_gen.variance_epsilon
+                ), **mot_kwargs
             )
-
-            vae_query_states = self.q_proj_moe_gen(query_sequence).view(
-                -1, self.num_heads, self.head_dim
-            )
-
-            text_key_states = self.k_proj(query_sequence).view(
-                -1, self.num_key_value_heads, self.head_dim
-            )
-
-            vae_key_states = self.k_proj_moe_gen(query_sequence).view(
-                -1, self.num_key_value_heads, self.head_dim
-            )
-
-            text_value_states = self.v_proj(query_sequence).view(
-                -1, self.num_key_value_heads, self.head_dim
-            )
-
-            vae_value_states = self.v_proj_moe_gen(query_sequence).view(
-                -1, self.num_key_value_heads, self.head_dim
-            )
-
-            text_query_states = run_rms_norm(
-                text_query_states,
-                self.q_norm.weight,
-                eps=self.q_norm.variance_epsilon
-            )
-            text_key_states = run_rms_norm(
-                text_key_states,
-                self.k_norm.weight,
-                eps=self.k_norm.variance_epsilon
-            )
-            vae_query_states = run_rms_norm(
-                vae_query_states,
-                self.q_norm_moe_gen.weight,
-                eps=self.q_norm_moe_gen.variance_epsilon
-            )
-            vae_key_states = run_rms_norm(
-                vae_key_states,
-                self.k_norm_moe_gen.weight,
-                eps=self.k_norm_moe_gen.variance_epsilon
-            )
-
-            text_mask = text_mask[:, None, None]
-            query_states = torch.where(
-                text_mask, text_query_states, vae_query_states
-            )
-            key_states = torch.where(
-                text_mask, text_key_states, vae_key_states
-            )
-            value_states = torch.where(
-                text_mask, text_value_states, vae_value_states
+            value_states = split_function_mot(
+                text_function=lambda seq: self.v_proj(seq).view(
+                    -1, self.num_key_value_heads, self.head_dim
+                ),
+                image_fuction=lambda seq: self.v_proj_moe_gen(seq).view(
+                    -1, self.num_key_value_heads, self.head_dim
+                ), **mot_kwargs
             )
 
         # RoPE: pos_ids pre-computed by plan_rope before the LLM forward
@@ -309,59 +227,13 @@ class BagelAttentionMoT(nn.Module):
             attn_output = self.o_proj(attn_output)
 
         elif mode == "gen":
-            text_mask = _to_text_mask(
-                text_indexes,
-                vae_token_indexes,
-                query_sequence.shape[0],
-                query_sequence.device,
+            attn_output = split_function_mot(
+                text_function=self.o_proj,
+                image_fuction=self.o_proj_moe_gen,
+                **mot_kwargs
             )
-            attn_text = self.o_proj(attn_output)
-            attn_vae = self.o_proj_moe_gen(attn_output)
-            attn_output = torch.where(text_mask[:, None], attn_text, attn_vae)
 
         return attn_output
-
-
-# class BagelDecoderLayer(nn.Module):
-#     def __init__(self, config:BagelModelConfig, layer_idx: Optional[int] = None):
-#         super().__init__()
-#         self.hidden_size = config.hidden_size
-
-#         self.self_attn = BagelAttention(config, layer_idx)
-
-#         self.mlp = Qwen2MLP(config)
-#         self.input_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-#         self.post_attention_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-
-#     def forward(
-#         self,
-#         query_sequence: torch.Tensor,
-#         query_position_embeddings: torch.Tensor,
-#         cache_handle: CacheHandle,
-#         write_cache=True,
-#         is_causal=True,
-#     ):
-
-#         residual = query_sequence
-#         query_sequence = self.input_layernorm(query_sequence)
-
-#         # Self Attention
-#         query_sequence = self.self_attn(
-#             query_sequence=query_sequence,
-#             query_position_embeddings=query_position_embeddings,
-#             cache_handle=cache_handle,
-#             write_cache=write_cache,
-#             is_causal=is_causal,
-#         )
-#         query_sequence = residual + query_sequence
-
-#         # Fully Connected
-#         residual = query_sequence
-#         query_sequence = self.post_attention_layernorm(query_sequence)
-#         query_sequence = self.mlp(query_sequence)
-#         query_sequence = residual + query_sequence
-
-#         return query_sequence
 
 
 class BagelMoTDecoderLayer(nn.Module):
@@ -389,8 +261,10 @@ class BagelMoTDecoderLayer(nn.Module):
         query_sequence: torch.Tensor,
         cache_handle,
         mode="und",
+        static_vae_idxs=True,
         vae_token_indexes=None,
         text_indexes=None,
+        text_mask=None,
     ):
         residual = query_sequence
         if mode == "und":
@@ -398,26 +272,31 @@ class BagelMoTDecoderLayer(nn.Module):
                 query_sequence, self.input_layernorm.weight, eps=self.input_layernorm.variance_epsilon
             )
         elif mode == "gen":
-            text_mask = _to_text_mask(text_indexes, vae_token_indexes, query_sequence.shape[0], query_sequence.device)
-            text_query = run_rms_norm(
-                query_sequence,
-                self.input_layernorm.weight,
-                eps=self.input_layernorm.variance_epsilon,
+            query_sequence = split_function_mot(
+                text_function=lambda seq: run_rms_norm(
+                    seq, self.input_layernorm.weight,
+                    eps=self.input_layernorm.variance_epsilon,
+                ),
+                image_fuction=lambda seq: run_rms_norm(
+                    seq, self.input_layernorm_moe_gen.weight,
+                    eps=self.input_layernorm_moe_gen.variance_epsilon,
+                ),
+                query_sequence=query_sequence,
+                text_idxs=text_indexes,
+                img_idxs=vae_token_indexes,
+                text_mask=text_mask,
+                static_vae_idxs=static_vae_idxs
             )
-            vae_query = run_rms_norm(
-                query_sequence,
-                self.input_layernorm_moe_gen.weight,
-                eps=self.input_layernorm_moe_gen.variance_epsilon,
-            )
-            query_sequence = torch.where(text_mask[:, None], text_query, vae_query)
 
         # Self Attention
         query_sequence = self.self_attn(
             query_sequence=query_sequence,
             cache_handle=cache_handle,
             mode=mode,
+            static_vae_idxs=static_vae_idxs,
             vae_token_indexes=vae_token_indexes,
             text_indexes=text_indexes,
+            text_mask=text_mask
         )
         query_sequence = residual + query_sequence
 
@@ -430,20 +309,25 @@ class BagelMoTDecoderLayer(nn.Module):
             )
             query_sequence = self.mlp(query_sequence)
         elif mode == "gen":
-            text_mask = _to_text_mask(text_indexes, vae_token_indexes, query_sequence.shape[0], query_sequence.device)
-            text_query = run_rms_norm(
-                query_sequence,
-                self.post_attention_layernorm.weight,
-                eps=self.post_attention_layernorm.variance_epsilon,
+            query_sequence = split_function_mot(
+                text_function=lambda seq: self.mlp(
+                    run_rms_norm(
+                        seq, self.post_attention_layernorm.weight,
+                        eps=self.post_attention_layernorm.variance_epsilon,
+                    )
+                ),
+                image_fuction=lambda seq: self.mlp_moe_gen(
+                    run_rms_norm(
+                        seq, self.post_attention_layernorm_moe_gen.weight,
+                        eps=self.post_attention_layernorm_moe_gen.variance_epsilon,
+                    )
+                ),
+                query_sequence=query_sequence,
+                text_idxs=text_indexes,
+                img_idxs=vae_token_indexes,
+                text_mask=text_mask,
+                static_vae_idxs=static_vae_idxs
             )
-            vae_query = run_rms_norm(
-                query_sequence,
-                self.post_attention_layernorm_moe_gen.weight,
-                eps=self.post_attention_layernorm_moe_gen.variance_epsilon,
-            )
-            text_query = self.mlp(text_query)
-            vae_query = self.mlp_moe_gen(vae_query)
-            query_sequence = torch.where(text_mask[:, None], text_query, vae_query)
 
         query_sequence = residual + query_sequence
 
@@ -473,8 +357,10 @@ class BagelLanguageModel(nn.Module):
         cache_handle: BatchedCacheManager,
         write_cache=True,
         mode="und",
+        static_vae_idxs=None,
         vae_token_indexes=None,
         text_indexes=None,
+        text_mask=None,
         custom_advance_pos_id=None,
     ):
         extra_inputs = {}
@@ -486,6 +372,8 @@ class BagelLanguageModel(nn.Module):
                 extra_inputs.update(
                     vae_token_indexes=vae_token_indexes,
                     text_indexes=text_indexes,
+                    text_mask=text_mask,
+                    static_vae_idxs=static_vae_idxs
                 )
 
         for _layer_idx, decoder_layer in enumerate(self.layers):
@@ -507,23 +395,21 @@ class BagelLanguageModel(nn.Module):
                     query_sequence, self.norm.weight, eps=self.norm.variance_epsilon
                 )
             elif mode == "gen":
-                text_mask = _to_text_mask(
-                    text_indexes,
-                    vae_token_indexes,
-                    query_sequence.shape[0],
-                    query_sequence.device,
+                query_sequence = split_function_mot(
+                    text_function=lambda seq: run_rms_norm(
+                        seq, self.norm.weight,
+                        eps=self.norm.variance_epsilon,
+                    ),
+                    image_fuction=lambda seq: run_rms_norm(
+                        seq, self.norm_moe_gen.weight,
+                        eps=self.norm_moe_gen.variance_epsilon,
+                    ),
+                    query_sequence=query_sequence,
+                    text_idxs=text_indexes,
+                    img_idxs=vae_token_indexes,
+                    text_mask=text_mask,
+                    static_vae_idxs=static_vae_idxs
                 )
-                query_text = run_rms_norm(
-                    query_sequence,
-                    self.norm.weight,
-                    eps=self.norm.variance_epsilon,
-                )
-                query_vae = run_rms_norm(
-                    query_sequence,
-                    self.norm_moe_gen.weight,
-                    eps=self.norm_moe_gen.variance_epsilon,
-                )
-                query_sequence = torch.where(text_mask[:, None], query_text, query_vae)
         else:
             query_sequence = run_rms_norm(
                 query_sequence, self.norm.weight, eps=self.norm.variance_epsilon
@@ -553,8 +439,10 @@ class BagelForCausalLM(nn.Module):
         cache_handle,
         write_cache=True,
         mode="und",
+        static_vae_idxs=True,
         vae_token_indexes=None,
         text_indexes=None,
+        text_mask=None,
         custom_advance_pos_id=None,
         **kwargs
     ):
@@ -566,6 +454,8 @@ class BagelForCausalLM(nn.Module):
             mode=mode,
             vae_token_indexes=vae_token_indexes,
             text_indexes=text_indexes,
+            text_mask=text_mask,
+            static_vae_idxs=static_vae_idxs,
             custom_advance_pos_id=custom_advance_pos_id,
         )
 

--- a/mminf/model/bagel/submodules.py
+++ b/mminf/model/bagel/submodules.py
@@ -395,9 +395,8 @@ class LLMSubmodule(NodeSubmodule):
         """
         device = next(self.parameters()).device
 
-        has_cfg = any(
-            per_request_metadata.get(rid, {}).get("requires_cfg", False)
-            for rid in request_ids
+        has_cfg = has_cfg = self._batch_get_requires_cfg(
+            per_request_metadata, request_ids
         )
         labels = self._get_active_labels(graph_walk, has_cfg)
 
@@ -819,6 +818,13 @@ class LLMSubmodule(NodeSubmodule):
             "latents": [latents],
             "time_index": [time_index + 1]
         }
+    
+    @torch.compiler.disable
+    def _batch_get_requires_cfg(self, per_request_metadata, request_ids):
+        return any(
+            per_request_metadata.get(rid, {}).get("requires_cfg", False)
+            for rid in request_ids
+        )
 
     def forward_batched(
         self,
@@ -833,9 +839,8 @@ class LLMSubmodule(NodeSubmodule):
         Concatenates inputs across requests, runs a single LLM forward with
         the BatchedCacheManager, then splits outputs back per-request.
         """
-        has_cfg = any(
-            per_request_metadata.get(rid, {}).get("requires_cfg", False)
-            for rid in request_ids
+        has_cfg = self._batch_get_requires_cfg(
+            per_request_metadata, request_ids
         )
 
         if graph_walk == "decode":

--- a/mminf/model/bagel/submodules.py
+++ b/mminf/model/bagel/submodules.py
@@ -4,6 +4,7 @@
 
 
 import logging
+import time
 
 import torch
 from torch import nn
@@ -342,14 +343,13 @@ class LLMSubmodule(NodeSubmodule):
     ):
         result = {
             "text_indexes": [],
-            "vae_token_indexes": []
+            "vae_token_indexes": [],
+            "text_mask": []
         }
         for seq_len in seq_lens:
-            text_idxs = torch.zeros(
-                seq_len, dtype=torch.bool, device=device
+            text_idxs = torch.tensor(
+                [0, seq_len-1], dtype=torch.long, device=device
             )
-            text_idxs[0] = True
-            text_idxs[-1] = True
             result["text_indexes"].append(text_idxs)
             result["vae_token_indexes"].append(
                 torch.arange(
@@ -357,6 +357,12 @@ class LLMSubmodule(NodeSubmodule):
                     dtype=torch.long, device=device
                 )
             )
+            text_mask = torch.zeros(
+                seq_len, dtype=torch.bool, device=device
+            )
+            text_mask[0] = True
+            text_mask[-1] = True
+            result["text_mask"].append(text_mask)
         return result
     
     def _get_active_labels(
@@ -595,6 +601,7 @@ class LLMSubmodule(NodeSubmodule):
         self, combined_emb: torch.Tensor,
         vae_token_indexes: torch.Tensor,
         text_indexes: torch.Tensor,
+        text_mask: torch.Tensor,
         cache_handle: BatchedCacheManager,
         **kwargs
     ) -> NameToTensorList:
@@ -617,6 +624,7 @@ class LLMSubmodule(NodeSubmodule):
             cache_handle=cache_handle,
             vae_token_indexes=vae_token_indexes,
             text_indexes=text_indexes,
+            text_mask=text_mask,
             custom_advance_pos_id=1,
             **kwargs
         )
@@ -679,6 +687,7 @@ class LLMSubmodule(NodeSubmodule):
         vae_position_ids: torch.Tensor,
         text_indexes: torch.Tensor,
         vae_token_indexes: torch.Tensor,
+        text_mask: torch.Tensor,
         time_index: torch.Tensor,
         cache_handle: BatchedCacheManager,
         requires_cfg: bool = True,
@@ -721,7 +730,6 @@ class LLMSubmodule(NodeSubmodule):
         logger.debug(f"packed_seq = {empty_combined_emb}")
 
         if requires_cfg:
-            logger.debug("Running 3 fwd passes for cfg gen")
             cfg_text_scale = kwargs.pop("cfg_text_scale", self.config.cfg_text_scale)
             cfg_img_scale = kwargs.pop("cfg_img_scale", self.config.cfg_img_scale)
             renorm_type = kwargs.pop("cfg_renorm_type", self.config.cfg_renorm_type)
@@ -749,7 +757,9 @@ class LLMSubmodule(NodeSubmodule):
                     empty_combined_emb, mode="gen",
                     cache_handle=cache_handle, write_cache=False,
                     vae_token_indexes=vae_token_indexes,
-                    text_indexes=text_indexes, **kwargs,
+                    text_indexes=text_indexes,
+                    text_mask=text_mask,
+                    **kwargs,
                 )
                 velocities[label] = hidden
 
@@ -797,7 +807,9 @@ class LLMSubmodule(NodeSubmodule):
                 empty_combined_emb, mode="gen",
                 cache_handle=cache_handle, write_cache=False,
                 vae_token_indexes=vae_token_indexes,
-                text_indexes=text_indexes, **kwargs,
+                text_indexes=text_indexes, 
+                text_mask=text_mask,
+                **kwargs,
             )
             v_final = self.llm2vae(hidden)[1:-1]
 

--- a/mminf/utils/ipc_format.py
+++ b/mminf/utils/ipc_format.py
@@ -51,6 +51,7 @@ class RemoveRequest(MessageBody):
 class InputSignals(MessageBody):
     request_id: str
     graph_walk: str
+    fwd_pass_number: int
     inputs: list[GraphEdge]
     per_request_metadata: dict = field(default_factory=dict)
 
@@ -98,7 +99,7 @@ class WorkerGraphsDone(MessageBody):
     worker_graph_ids: list[str]
     persist_signals: dict[str, list[TensorPointerInfo]] = field(default_factory=dict)
     new_tokens: dict[str, list[int]] = field(default_factory=dict) # name to tokens
-    num_output_chunks: int = field(default=0)
+    output_signal_names: int = field(default=0)
 
 
 @dataclass

--- a/mminf/utils/ipc_format.py
+++ b/mminf/utils/ipc_format.py
@@ -98,6 +98,7 @@ class WorkerGraphsDone(MessageBody):
     worker_graph_ids: list[str]
     persist_signals: dict[str, list[TensorPointerInfo]] = field(default_factory=dict)
     new_tokens: dict[str, list[int]] = field(default_factory=dict) # name to tokens
+    num_output_chunks: int = field(default=0)
 
 
 @dataclass

--- a/mminf/worker/dummy_worker.py
+++ b/mminf/worker/dummy_worker.py
@@ -79,7 +79,7 @@ class DummyWorker:
 
         # TODO Atindra: start reading in tensors from body.initial_inputs
 
-        self.worker_graphs_manager.update_graph_walk(
+        self.worker_graphs_manager.update_graph_walk_and_fwd_number(
             body.request_id, body.initial_graph_walk
         )
         self.worker_graphs_manager.process_new_inputs(
@@ -111,7 +111,7 @@ class DummyWorker:
         process those inputs (update the ready/waiting queues for the proper
         worker graphs on this worker, e.g.)
         """
-        self.worker_graphs_manager.update_graph_walk(
+        self.worker_graphs_manager.update_graph_walk_and_fwd_number(
             body.request_id, body.graph_walk
         )
 

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -128,13 +128,14 @@ class PerRequestInfo:
     node_to_worker: dict[NodeAndGraphWalk, str]  # for all nodes
     worker_graph_ids: list[str] # for this worker
     current_graph_walk: str = field(default=None)
+    current_fwd_number: int = field(default=0)
 
     # graph_walk_worker_graph_ids = worker graphs for current graph walk
     graph_walk_worker_graph_ids: list[str] = field(default_factory=list) # for this worker
 
     pending_persist_signals: list[GraphEdge] = field(default_factory=list)
     pending_new_tokens: dict[str, list[int]] = field(default_factory=dict)
-    num_output_chunks: int = field(default=0)
+    current_output_chunks: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -152,9 +153,12 @@ class WorkerGraphsManager:
     all_worker_graph_ids_to_graph_walks: dict[str, set[str]] # for worker graphs on different workers too
     all_worker_graph_ids_to_nodes: dict[str, str] # for worker graphs on different workers too
 
-    def update_graph_walk(self, request_id: str, graph_walk: str):
+    def update_graph_walk_and_fwd_number(
+        self, request_id: str, graph_walk: str, fwd_number: int
+    ):
         if self.per_request_info[request_id].current_graph_walk != graph_walk:
             self.per_request_info[request_id].current_graph_walk = graph_walk
+            self.per_request_info[request_id].current_fwd_number = fwd_number
             self.per_request_info[request_id].graph_walk_worker_graph_ids = [
                 graph_id for graph_id in self.per_request_info[request_id].worker_graph_ids \
                     if graph_walk in self.all_worker_graph_ids_to_graph_walks[graph_id]
@@ -162,6 +166,9 @@ class WorkerGraphsManager:
 
     def get_graph_walk(self, request_id: str):
         return self.per_request_info[request_id].current_graph_walk
+    
+    def get_fwd_number(self, request_id: str):
+        return self.per_request_info[request_id].current_fwd_number
 
     def process_new_inputs(
         self,
@@ -308,8 +315,10 @@ class WorkerGraphsManager:
                 self.per_request_info[request_id].pending_new_tokens[name] = []
             self.per_request_info[request_id].pending_new_tokens[name].extend(tokens)
     
-    def increment_out_chunks(self, request_id: str, n=1):
-        self.per_request_info[request_id].num_output_chunks += n
+    def buffer_output_signals(self, request_id: str, out_signals: list[GraphEdge]):
+        self.per_request_info[request_id].current_output_chunks += [
+            signal.name for signal in out_signals
+        ]
 
     def flush_persist_signals(self, request_id: str) -> dict[str, list[TensorPointerInfo]]:
         """Pop and return all buffered persist signals for a request.
@@ -332,7 +341,7 @@ class WorkerGraphsManager:
         info.pending_new_tokens = {}
         return new_tokens
     
-    def flush_num_output_chunks(self, request_id: str) -> int:
-        out_chunks = self.per_request_info[request_id].num_output_chunks
-        self.per_request_info[request_id].num_output_chunks = 0
+    def flush_output_signals(self, request_id: str) -> list[str]:
+        out_chunks = self.per_request_info[request_id].current_output_chunks
+        self.per_request_info[request_id].current_output_chunks.clear()
         return out_chunks

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -134,6 +134,7 @@ class PerRequestInfo:
 
     pending_persist_signals: list[GraphEdge] = field(default_factory=list)
     pending_new_tokens: dict[str, list[int]] = field(default_factory=dict)
+    num_output_chunks: int = field(default=0)
 
 
 @dataclass
@@ -306,6 +307,9 @@ class WorkerGraphsManager:
             if name not in self.per_request_info[request_id].pending_new_tokens:
                 self.per_request_info[request_id].pending_new_tokens[name] = []
             self.per_request_info[request_id].pending_new_tokens[name].extend(tokens)
+    
+    def increment_out_chunks(self, request_id: str, n=1):
+        self.per_request_info[request_id].num_output_chunks += n
 
     def flush_persist_signals(self, request_id: str) -> dict[str, list[TensorPointerInfo]]:
         """Pop and return all buffered persist signals for a request.
@@ -327,3 +331,8 @@ class WorkerGraphsManager:
         new_tokens = info.pending_new_tokens
         info.pending_new_tokens = {}
         return new_tokens
+    
+    def flush_num_output_chunks(self, request_id: str) -> int:
+        out_chunks = self.per_request_info[request_id].num_output_chunks
+        self.per_request_info[request_id].num_output_chunks = 0
+        return out_chunks

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -108,8 +108,8 @@ class Worker:
         )
         self.engine_manager.add_request(body.request_id)
 
-        self.worker_graphs_manager.update_graph_walk(
-            body.request_id, body.initial_graph_walk
+        self.worker_graphs_manager.update_graph_walk_and_fwd_number(
+            body.request_id, body.initial_graph_walk, fwd_number=0
         )
         logger.debug(
             "Request %s set to graph walk %s on worker %s",
@@ -154,7 +154,9 @@ class Worker:
             )
 
     def _process_new_inputs(self, body: InputSignals) -> None:
-        self.worker_graphs_manager.update_graph_walk(body.request_id, body.graph_walk)
+        self.worker_graphs_manager.update_graph_walk_and_fwd_number(
+            body.request_id, body.graph_walk,body.fwd_pass_number
+        )
         logger.debug(
             "Request %s set to graph walk %s on worker %s",
             body.request_id, body.graph_walk, self.worker_id
@@ -349,6 +351,7 @@ class Worker:
                 body=InputSignals(
                     request_id=request_id,
                     graph_walk=self.worker_graphs_manager.get_graph_walk(request_id),
+                    fwd_pass_number=self.worker_graphs_manager.get_fwd_number(request_id),
                     inputs=edges,
                 ),
             )
@@ -379,8 +382,8 @@ class Worker:
                 )
 
         if outputs.emit_to_client:
-            self.worker_graphs_manager.increment_out_chunks(
-                request_id, n=len(outputs.emit_to_client)
+            self.worker_graphs_manager.buffer_output_signals(
+                request_id, outputs.emit_to_client
             )
             for graph_edge in outputs.emit_to_client:
                 message = APIServerMessage(
@@ -389,6 +392,7 @@ class Worker:
                         request_id=request_id,
                         modality=graph_edge.output_modality,
                         graph_edge=graph_edge,
+                        fwd_pass_number=self.worker_graphs_manager.get_fwd_number(request_id),
                         metadata={}
                     )
                 )
@@ -402,7 +406,7 @@ class Worker:
                     worker_graph_ids=outputs.completed_worker_graph_ids,
                     persist_signals=self.worker_graphs_manager.flush_persist_signals(request_id),
                     new_tokens=self.worker_graphs_manager.flush_new_tokens(request_id),
-                    num_output_chunks=self.worker_graphs_manager.flush_num_output_chunks(request_id)
+                    output_signal_names=self.worker_graphs_manager.flush_output_signals(request_id)
                 ),
             )
             self.communicator.send("conductor", message)

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -379,6 +379,9 @@ class Worker:
                 )
 
         if outputs.emit_to_client:
+            self.worker_graphs_manager.increment_out_chunks(
+                request_id, n=len(outputs.emit_to_client)
+            )
             for graph_edge in outputs.emit_to_client:
                 message = APIServerMessage(
                     message_type="result_tensors",
@@ -399,6 +402,7 @@ class Worker:
                     worker_graph_ids=outputs.completed_worker_graph_ids,
                     persist_signals=self.worker_graphs_manager.flush_persist_signals(request_id),
                     new_tokens=self.worker_graphs_manager.flush_new_tokens(request_id),
+                    num_output_chunks=self.worker_graphs_manager.flush_num_output_chunks(request_id)
                 ),
             )
             self.communicator.send("conductor", message)

--- a/test/bagel/launch_nsys.sh
+++ b/test/bagel/launch_nsys.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+WHO=...
+
+CACHE_DIR=/mnt/storage/$WHO/mminf/bagel/
+DEVICES=2,3
+
+CUDA_VISIBLE_DEVICES=$DEVICES nsys profile --trace=cuda,nvtx --output=bagel_profile --force-overwrite=true \
+    python -m mminf.api_server.entrypoint --config configs/bagel.yaml --enable-nvtx \
+    --cache-dir $CACHE_DIR \
+        --socket-path-prefix /tmp/mminf_$WHO/ \
+        --upload-dir /tmp/mminf_uploads_$WHO/


### PR DESCRIPTION
Two (possibly controversial) changes to improve our image generation latency:

(1) Previously, there was a 5-second delay between the last output being generated and the request completing on the client end. This PR adds tracking on the conductor level for how many output chunks to expect, which allows the API server to know exactly when it can close the request.

@kamahori does this violate any fundamental design principles for the api server?

(2) Most of the overhead in the image generation loop was coming from running both the text and image MLP/norm weights across the full sequence and using `torch.where` to select outputs, effectively doubling compute every layer.  This was done for cuda graph compatibility reasons.

This PR replaces that with `split_function_mot`, which gathers text and image tokens into separate slices using pre-built index tensors, runs each function only on its actual tokens, then scatters the results back into a pre-allocated output. If the image token count and batch size are fixed, I believe that all index shapes are static and the pattern is cudagraph-safe. The previous implementation is retained as a fallback (called when a flag `static_vae_idxs` input to the language model is set `False`).

**previous image generation benchmarking**
```
Benchmark Results (10 requests, sequential)
──────────────────────────────────────────────────
Request type breakdown: text_to_image=10
Requests : 10/10 succeeded
TTFT     : mean=29.430s  p50=29.433s  p95=29.532s  p99=29.534s
E2E      : mean=33.922s  p50=33.931s  p95=33.977s  p99=33.985s
```

**with these changes**
```
Benchmark Results (10 requests, sequential)
──────────────────────────────────────────────────
Request type breakdown: text_to_image=10
Requests : 10/10 succeeded
TTFT     : mean=18.925s  p50=18.929s  p95=18.955s  p99=18.962s
E2E      : mean=18.934s  p50=18.939s  p95=18.966s  p99=18.973s
```

**vllm-omni without cfg parallelism (one GPU)**
```
Benchmark Results (10 requests, sequential)
──────────────────────────────────────────────────
Request type breakdown: text_to_image=10
Requests : 10/10 succeeded
TTFT     : mean=23.961s  p50=23.574s  p95=25.995s  p99=26.162s
E2E      : mean=23.962s  p50=23.575s  p95=25.995s  p99=26.163s
```
