### PR TITLE
Precision + Workspace Buffer Changes

### DIFF
--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -164,7 +164,8 @@ class Conductor:
         self._per_worker_engine_configs: dict[str, list[dict]] = {}
 
         engine_model_cfg = {
-            "kv_cache": self.model.get_kv_cache_config()
+            "kv_cache": self.model.get_kv_cache_config(),
+            "autocast_dtype": self.model.get_autocast_dtype()
         }
         for rank in self._sorted_ranks:
             worker_id = f"worker_{rank}"

--- a/mminf/engine/__init__.py
+++ b/mminf/engine/__init__.py
@@ -1,3 +1,4 @@
 import torch
 torch._dynamo.config.recompile_limit = 32
 torch._dynamo.config.allow_unspec_int_on_nn_module = True
+torch.set_float32_matmul_precision('high')

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -404,6 +404,7 @@ class BatchedCacheManager:
         interleave: bool = False,
         rope_scale: float = 1,
         rope_theta: float = 10000.0,
+        rope_dtype=None
     ):
         """Apply RoPE using the active label's pre-computed position IDs."""
         # Assert all active labels are the same
@@ -415,9 +416,12 @@ class BatchedCacheManager:
         assert ps.pos_ids is not None
 
         orig_dtype = q.dtype
-        if q.dtype == torch.float32:
-            q = q.to(torch.bfloat16)
-            k = k.to(torch.bfloat16)
+
+        if rope_dtype is not None:
+            q, k = q.to(rope_dtype), k.to(rope_dtype)
+        elif torch.is_autocast_enabled():
+            dtype = torch.get_autocast_gpu_dtype()
+            q, k = q.to(dtype), k.to(dtype)
 
         import flashinfer
         flashinfer.rope.apply_rope_pos_ids_inplace(
@@ -438,6 +442,7 @@ class BatchedCacheManager:
         interleave: bool = False,
         rope_scale: float = 1,
         rope_theta: float = 10000.0,
+        rope_dtype=None
     ):
         """Apply RoPE using the active label's pre-computed position IDs."""
         labels = list(self.active_labels.values())
@@ -448,9 +453,11 @@ class BatchedCacheManager:
         assert ps.pos_ids is not None
 
         orig_dtype = q.dtype
-        if q.dtype == torch.float32:
-            q = q.to(torch.bfloat16)
-            k = k.to(torch.bfloat16)
+        if rope_dtype is not None:
+            q, k = q.to(rope_dtype), k.to(rope_dtype)
+        elif torch.is_autocast_enabled():
+            dtype = torch.get_autocast_gpu_dtype()
+            q, k = q.to(dtype), k.to(dtype)
 
         import flashinfer
         flashinfer.rope.apply_llama31_rope_pos_ids_inplace(

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -62,6 +62,22 @@ class PageAllocator:
         return self.free_pages.qsize()
 
 
+class WorkspaceBufferManager:
+    def __init__(
+        self, size, device
+    ):
+        self.size = size
+        self.device = device
+        self.buffers = {}
+    
+    def get(self, label: str="main"):
+        if label not in self.buffers:
+            self.buffers[label] = torch.empty(
+                self.size, dtype=torch.uint8, device=self.device
+            )
+        return self.buffers[label]
+            
+
 @dataclass
 class _PlanState:
     """Pre-computed state from plan_attention/plan_rope for a single cache label.
@@ -102,7 +118,7 @@ class BatchedCacheManager:
         kv_cache: torch.Tensor,
         page_allocator: PageAllocator,
         request_states: dict[tuple[str, str], KVRequestState],
-        workspace_buffer: torch.Tensor,
+        buffer_manager: WorkspaceBufferManager,
         kv_cache_config: KVCacheConfig,
         device,
         cuda_graph_plan_states: dict[str, _PlanState] | None = None,
@@ -112,7 +128,7 @@ class BatchedCacheManager:
         self.kv_cache = kv_cache
         self.page_allocator = page_allocator
         self.request_states = request_states
-        self.workspace_buffer = workspace_buffer
+        self.buffer_manager = buffer_manager
         self.kv_cache_config = kv_cache_config
         self.device = device
         self.layer_idx = 0
@@ -183,6 +199,8 @@ class BatchedCacheManager:
 
         effective_label = label
         if effective_label is None:
+            labels = list(self.active_labels.values())
+            assert len(set(labels)) == 1, f"All active labels must be the same, got {labels}"
             effective_label = next(iter(self.active_labels.values()))
 
         cfg = self.kv_cache_config
@@ -238,69 +256,57 @@ class BatchedCacheManager:
         paged_kv_indices = torch.tensor(all_page_indices, dtype=torch.int32, device=device)
         paged_kv_last_page_len = torch.tensor(kv_last_page_lens, dtype=torch.int32, device=device)
 
-        if self._cuda_graph_mode:
-            # CUDA graph mode: use persistent wrapper, call its plan() method.
-            # The wrapper was created by CudaGraphRunner and stored in _plan_states.
-            ps = self._plan_states[effective_label]
+
+        is_decode = all([sl == 1 for sl in seq_lens])
+        ps = self._plan_states.get(effective_label)
+        if ps is not None and ps.wrapper is not None:
             wrapper = ps.wrapper
-
-            if isinstance(wrapper, FlashInferDecodeWrapper):
-                wrapper.plan(
-                    paged_kv_indptr=paged_kv_indptr,
-                    paged_kv_indices=paged_kv_indices,
-                    paged_kv_last_page_len=paged_kv_last_page_len,
-                    dtype=dtype,
-                )
-            else:
-                wrapper.plan(
-                    qo_indptr=qo_indptr,
-                    paged_kv_indptr=paged_kv_indptr,
-                    paged_kv_indices=paged_kv_indices,
-                    paged_kv_last_page_len=paged_kv_last_page_len,
-                    causal=is_causal,
-                    dtype=dtype,
-                )
-
-            # Note: plain assignment (not .copy_()) is intentional here.
-            # These fields are NOT read inside the CUDA graph — run_attention()
-            # uses wrapper.set_kv_cache()/run() which rely on the wrapper's own
-            # internal static tensors (updated via .copy_() inside wrapper.plan()).
-            # These are stored on _PlanState only for bookkeeping/debugging.
-            ps.page_indices = page_indices
-            ps.page_offsets = page_offsets
-            ps.token_offsets = token_offsets
-            ps.seq_lens = seq_lens
+        elif is_decode:
+            wrapper = FlashInferDecodeWrapper(
+                workspace_buffer=self.buffer_manager.get(effective_label),
+                num_qo_heads=num_qo_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                page_size=page_size,
+            )
+            ps = _PlanState(wrapper=wrapper)
+            self._plan_states[effective_label] = ps
         else:
-            # Eager mode: reuse wrapper if one already exists for this label.
-            # Avoids recreating FlashInfer wrapper objects on every call.
-            ps = self._plan_states.get(effective_label)
-            if ps is not None and ps.wrapper is not None:
-                wrapper = ps.wrapper
-            else:
-                import flashinfer
-                wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-                    self.workspace_buffer, "NHD"
-                )
-                ps = _PlanState(wrapper=wrapper)
-                self._plan_states[effective_label] = ps
+            wrapper = FlashInferPrefillWrapper(
+                workspace_buffer=self.buffer_manager.get(effective_label),
+                num_qo_heads=num_qo_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                page_size=page_size,
+            )
+            ps = _PlanState(wrapper=wrapper)
+            self._plan_states[effective_label] = ps
 
+        if isinstance(wrapper, FlashInferDecodeWrapper):
+            wrapper.plan(
+                paged_kv_indptr=paged_kv_indptr,
+                paged_kv_indices=paged_kv_indices,
+                paged_kv_last_page_len=paged_kv_last_page_len,
+                dtype=dtype,
+            )
+        else:
             wrapper.plan(
                 qo_indptr=qo_indptr,
                 paged_kv_indptr=paged_kv_indptr,
                 paged_kv_indices=paged_kv_indices,
                 paged_kv_last_page_len=paged_kv_last_page_len,
-                num_qo_heads=num_qo_heads,
-                num_kv_heads=num_kv_heads,
-                head_dim_qk=head_dim,
-                page_size=page_size,
                 causal=is_causal,
-                q_data_type=dtype,
+                dtype=dtype,
             )
-
-            ps.page_indices = page_indices
-            ps.page_offsets = page_offsets
-            ps.token_offsets = token_offsets
-            ps.seq_lens = seq_lens
+        # Note: plain assignment (not .copy_()) is intentional here.
+        # These fields are NOT read inside the CUDA graph — run_attention()
+        # uses wrapper.set_kv_cache()/run() which rely on the wrapper's own
+        # internal static tensors (updated via .copy_() inside wrapper.plan()).
+        # These are stored on _PlanState only for bookkeeping/debugging.
+        ps.page_indices = page_indices
+        ps.page_offsets = page_offsets
+        ps.token_offsets = token_offsets
+        ps.seq_lens = seq_lens
     
     def plan_rope(
         self,
@@ -321,6 +327,8 @@ class BatchedCacheManager:
         """
         effective_label = label
         if effective_label is None:
+            labels = list(self.active_labels.values())
+            assert len(set(labels)) == 1, f"All active labels must be the same, got {labels}"
             effective_label = next(iter(self.active_labels.values()))
 
         if effective_label not in self._plan_states:
@@ -376,19 +384,16 @@ class BatchedCacheManager:
         """
         if layer_idx is None:
             layer_idx = self.layer_idx
+
+        labels = list(self.active_labels.values())
+        assert len(set(labels)) == 1, f"All active labels must be the same, got {labels}"
         label = next(iter(self.active_labels.values()))
+
         ps = self._plan_states[label]
         assert self.kv_cache is not None and ps.wrapper is not None
 
-        if self._cuda_graph_mode:
-            # CUDA graph mode: use wrapper's set_kv_cache + run
-            ps.wrapper.set_kv_cache(self.kv_cache[layer_idx], k, v)
-            return ps.wrapper.run(q, self.kv_cache[layer_idx])
-        else:
-            # Eager mode: direct fancy indexing for KV writes
-            self.kv_cache[layer_idx, ps.page_indices, 0, ps.page_offsets] = k[ps.token_offsets]
-            self.kv_cache[layer_idx, ps.page_indices, 1, ps.page_offsets] = v[ps.token_offsets]
-            return ps.wrapper.run(q, self.kv_cache[layer_idx])
+        ps.wrapper.set_kv_cache(self.kv_cache[layer_idx], k, v)
+        return ps.wrapper.run(q, self.kv_cache[layer_idx])
 
     @torch.compiler.disable
     def apply_rope(
@@ -401,10 +406,18 @@ class BatchedCacheManager:
         rope_theta: float = 10000.0,
     ):
         """Apply RoPE using the active label's pre-computed position IDs."""
+        # Assert all active labels are the same
+        labels = list(self.active_labels.values())
+        assert len(set(labels)) == 1, f"All active labels must be the same, got {labels}"
         label = next(iter(self.active_labels.values()))
     
         ps = self._plan_states[label]
         assert ps.pos_ids is not None
+
+        orig_dtype = q.dtype
+        if q.dtype == torch.float32:
+            q = q.to(torch.bfloat16)
+            k = k.to(torch.bfloat16)
 
         import flashinfer
         flashinfer.rope.apply_rope_pos_ids_inplace(
@@ -414,8 +427,42 @@ class BatchedCacheManager:
             rope_scale=rope_scale,
             rope_theta=rope_theta,
         )
-        return q, k
+        return q.to(orig_dtype), k.to(orig_dtype)
+    
+    @torch.compiler.disable
+    def apply_rope_llama(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        rotary_dim: int | None = None,
+        interleave: bool = False,
+        rope_scale: float = 1,
+        rope_theta: float = 10000.0,
+    ):
+        """Apply RoPE using the active label's pre-computed position IDs."""
+        labels = list(self.active_labels.values())
+        assert len(set(labels)) == 1, f"All active labels must be the same, got {labels}"
+        label = next(iter(self.active_labels.values()))
+    
+        ps = self._plan_states[label]
+        assert ps.pos_ids is not None
 
+        orig_dtype = q.dtype
+        if q.dtype == torch.float32:
+            q = q.to(torch.bfloat16)
+            k = k.to(torch.bfloat16)
+
+        import flashinfer
+        flashinfer.rope.apply_llama31_rope_pos_ids_inplace(
+            q, k, ps.pos_ids,
+            rotary_dim=rotary_dim,
+            interleave=interleave,
+            rope_scale=rope_scale,
+            rope_theta=rope_theta,
+        )
+        return q.to(orig_dtype), k.to(orig_dtype)
+
+    @torch.compiler.disable
     def advance_seq_len(self, n: int | None = None, pos_id_n: int | None = None) -> None:
         """Advance seq_len for all requests.
 
@@ -423,27 +470,14 @@ class BatchedCacheManager:
         per-request seq_lens from the last plan_attention call. Errors if
         both n and planned seq_lens are None.
         """
-        if n is not None:
-            for rid in self.request_ids:
-                state = self._get_state(rid)
-                state.seq_len += n
-                state.position_id_start += (pos_id_n if pos_id_n is not None else n)
-        else:
-            # Fall back to planned seq_lens from active label's plan state
-            label = next(iter(self.active_labels.values()))
-            ps = self._plan_states.get(label)
-            planned = ps.seq_lens if ps is not None else None
-            if planned is None:
-                raise ValueError(
-                    "advance_seq_len: both n and planned seq_lens are None"
-                )
-            for i, rid in enumerate(self.request_ids):
-                state = self._get_state(rid)
-                state.seq_len += planned[i]
-                state.position_id_start += (
-                    pos_id_n if pos_id_n is not None else planned[i]
-                )
-
+        if n is None:
+            return self.advance_seq_lens(pos_id_n)
+        for rid in self.request_ids:
+            state = self._get_state(rid)
+            state.seq_len += n
+            state.position_id_start += (pos_id_n if pos_id_n is not None else n)
+    
+    @torch.compiler.disable
     def advance_seq_lens(self, pos_id_ns: list[int] | int | None = None) -> None:
         """Advance seq_len for each request by different amounts."""
         for i, rid in enumerate(self.request_ids):
@@ -496,6 +530,7 @@ class AREngine(BaseEngine):
     def __init__(
         self,
         kv_cache_config: KVCacheConfig | dict,
+        autocast_dtype=torch.bfloat16,
         enable_nvtx: bool = False,
     ):
         super().__init__(enable_nvtx=enable_nvtx)
@@ -504,17 +539,14 @@ class AREngine(BaseEngine):
         self.submodules: dict[str, torch.nn.Module] = {}
         self.kv_cache_config = kv_cache_config
         self.device = None
+        self.autocast_dtype = autocast_dtype
         self.kv_cache = None  # [num_layers, max_pages, 2, page_size, num_kv_heads, head_dim]
         self.page_allocator: PageAllocator | None = None
         # Keyed by (request_id, cache_label) to support multiple KV caches
         # per request (needed for BAGEL's classifier-free guidance which
         # maintains "main", "cfg_text", and "cfg_img" caches).
         self.request_states: dict[tuple[str, str], KVRequestState] = {}
-
-        # FlashInfer wrappers (initialized in load_model if available)
-        self.prefill_wrapper = None
-        self.decode_wrapper = None
-        self.workspace_buffer = None
+        self.buffer_manager = None
 
         # CUDA graph runners (initialized in warmup())
         self.cuda_graph_runners: dict[str, "CudaGraphRunner"] = {}
@@ -527,6 +559,7 @@ class AREngine(BaseEngine):
         submodules: dict[str, torch.nn.Module],
         model_config: dict,
         device: torch.device,
+        kv_cache_type=torch.bfloat16,
     ) -> None:
         self.submodules = submodules
         self.device = device
@@ -547,25 +580,14 @@ class AREngine(BaseEngine):
         self.kv_cache = torch.zeros(
             num_layers, max_num_pages, 2,
             page_size, num_kv_heads, head_dim,
-            dtype=torch.bfloat16, device=device,
+            dtype=kv_cache_type, device=device,
         )
         self.page_allocator = PageAllocator(max_num_pages)
 
         # 256MB workspace for FlashInfer
-        self.workspace_buffer = torch.empty(
-            256 * 1024 * 1024, dtype=torch.uint8, device=device
+        self.buffer_manager = WorkspaceBufferManager(
+            256 * 1024 * 1024, device=device
         )
-
-        try:
-            import flashinfer
-            self.prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-                self.workspace_buffer, "NHD"
-            )
-            self.decode_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
-                self.workspace_buffer, "NHD"
-            )
-        except ImportError:
-            pass  # Dummy mode — no FlashInfer
 
     def _create_cache_manager(self, request_id: str) -> BatchedCacheManager:
         """Create a CacheHandle for a single request."""
@@ -575,7 +597,7 @@ class AREngine(BaseEngine):
             kv_cache=self.kv_cache,
             page_allocator=self.page_allocator,
             request_states=self.request_states,
-            workspace_buffer=self.workspace_buffer,
+            buffer_manager=self.buffer_manager,
             kv_cache_config=self.kv_cache_config,
             device=self.device
         )
@@ -653,7 +675,7 @@ class AREngine(BaseEngine):
             kv_cache=self.kv_cache,
             page_allocator=self.page_allocator,
             request_states=self.request_states,
-            workspace_buffer=self.workspace_buffer,
+            buffer_manager=self.buffer_manager,
             kv_cache_config=self.kv_cache_config,
             device=self.device,
         )
@@ -675,14 +697,13 @@ class AREngine(BaseEngine):
             per_request_metadata=batch.per_request_metadata,
         )
 
-        with torch.no_grad():
-            batched_output = submodule.forward_batched(
-                graph_walk=batch.graph_walk,
-                cache_manager=cache_manager,
-                packed_inputs=preprocessed,
-                request_ids=rids,
-                per_request_metadata=batch.per_request_metadata,
-            )
+        batched_output = submodule.forward_batched(
+            graph_walk=batch.graph_walk,
+            cache_manager=cache_manager,
+            packed_inputs=preprocessed,
+            request_ids=rids,
+            per_request_metadata=batch.per_request_metadata,
+        )
 
         return NodeOutput(per_request_output_tensors=batched_output)
 
@@ -707,13 +728,12 @@ class AREngine(BaseEngine):
                 request_ids=[rid],
                 per_request_metadata=metadata,
             )
-            with torch.no_grad():
-                output = submodule(
-                    graph_walk=batch.graph_walk,
-                    cache_handle=cache_handle,
-                    **preprocessed,
-                    **metadata[rid],
-                )
+            output = submodule(
+                graph_walk=batch.graph_walk,
+                cache_handle=cache_handle,
+                **preprocessed,
+                **metadata[rid],
+            )
             per_request_outputs[rid] = output
 
         return NodeOutput(per_request_output_tensors=per_request_outputs)
@@ -758,15 +778,14 @@ class AREngine(BaseEngine):
             batch.per_request_input_tensors[rid] for rid in rids
         ]
 
-        with torch.no_grad():
-            batched_output = runner.run(
-                graph_walk=batch.graph_walk,
-                requires_cfg=has_cfg,
-                request_ids=rids,
-                per_request_inputs=input_tensors,
-                per_request_metadata=batch.per_request_metadata,
-                submodule=submodule,
-            )
+        batched_output = runner.run(
+            graph_walk=batch.graph_walk,
+            requires_cfg=has_cfg,
+            request_ids=rids,
+            per_request_inputs=input_tensors,
+            per_request_metadata=batch.per_request_metadata,
+            submodule=submodule,
+        )
 
         return NodeOutput(per_request_output_tensors=batched_output)
 
@@ -784,13 +803,15 @@ class AREngine(BaseEngine):
             return output
 
         try:
-            # Priority: CUDA graph > batched > sequential
-            if self._can_use_cuda_graph(batch):
-                return self._execute_with_cuda_graph(batch, submodule)
-            elif self._can_batch(batch):
-                return self._execute_batched(batch, submodule)
-            else:
-                return self._execute_sequential(batch, submodule)
+            with torch.no_grad():
+                with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
+                    # Priority: CUDA graph > batched > sequential
+                    if self._can_use_cuda_graph(batch):
+                        return self._execute_with_cuda_graph(batch, submodule)
+                    elif self._can_batch(batch):
+                        return self._execute_batched(batch, submodule)
+                    else:
+                        return self._execute_sequential(batch, submodule)
         finally:
             if self.enable_nvtx:
                 range_pop()
@@ -829,5 +850,5 @@ class AREngine(BaseEngine):
 
     def shutdown(self) -> None:
         self.kv_cache = None
-        self.workspace_buffer = None
+        self.buffer_manager = None
         self.request_states.clear()

--- a/mminf/engine/audio_codec_engine.py
+++ b/mminf/engine/audio_codec_engine.py
@@ -10,7 +10,7 @@ class AudioCodecEngine(BaseEngine):
     Stateless — identical lifecycle to EncoderDecoderEngine.
     """
 
-    def __init__(self, enable_nvtx: bool = False):
+    def __init__(self, enable_nvtx: bool = False, **kwargs):
         super().__init__(enable_nvtx=enable_nvtx)
         self.submodules: dict[str, torch.nn.Module] = {}
         self.device = None

--- a/mminf/engine/audio_codec_engine.py
+++ b/mminf/engine/audio_codec_engine.py
@@ -10,10 +10,15 @@ class AudioCodecEngine(BaseEngine):
     Stateless — identical lifecycle to EncoderDecoderEngine.
     """
 
-    def __init__(self, enable_nvtx: bool = False, **kwargs):
+    def __init__(
+        self, enable_nvtx: bool = False,
+        autocast_dtype=torch.bfloat16,
+        **kwargs
+    ):
         super().__init__(enable_nvtx=enable_nvtx)
         self.submodules: dict[str, torch.nn.Module] = {}
         self.device = None
+        self.autocast_dtype = autocast_dtype
 
     def engine_type(self) -> EngineType:
         return EngineType.AUDIO_CODEC
@@ -41,29 +46,30 @@ class AudioCodecEngine(BaseEngine):
             return output
 
         try:
-            with torch.no_grad():
-                outputs = {}
-                for rid in batch.request_ids:
-                    inputs = batch.per_request_input_tensors.get(rid, {})
-                    if hasattr(submodule, 'preprocess'):
-                        preprocessed = submodule.preprocess(
-                            batch.graph_walk,
-                            per_request_inputs=[inputs],
-                            request_ids=[rid],
-                            per_request_metadata={
-                                rid: batch.per_request_metadata.get(rid, {})
-                            },
-                        )
-                        outputs[rid] = submodule(**preprocessed)
-                    else:
-                        result = submodule(**{k: v[0] for k, v in inputs.items()})
-                        if isinstance(result, dict):
-                            outputs[rid] = result
-                        elif isinstance(result, torch.Tensor):
-                            outputs[rid] = {"output": [result]}
+            with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
+                with torch.no_grad():
+                    outputs = {}
+                    for rid in batch.request_ids:
+                        inputs = batch.per_request_input_tensors.get(rid, {})
+                        if hasattr(submodule, 'preprocess'):
+                            preprocessed = submodule.preprocess(
+                                batch.graph_walk,
+                                per_request_inputs=[inputs],
+                                request_ids=[rid],
+                                per_request_metadata={
+                                    rid: batch.per_request_metadata.get(rid, {})
+                                },
+                            )
+                            outputs[rid] = submodule(**preprocessed)
                         else:
-                            outputs[rid] = {}
-                return NodeOutput(per_request_output_tensors=outputs)
+                            result = submodule(**{k: v[0] for k, v in inputs.items()})
+                            if isinstance(result, dict):
+                                outputs[rid] = result
+                            elif isinstance(result, torch.Tensor):
+                                outputs[rid] = {"output": [result]}
+                            else:
+                                outputs[rid] = {}
+                    return NodeOutput(per_request_output_tensors=outputs)
         finally:
             if self.enable_nvtx:
                 range_pop()

--- a/mminf/engine/base.py
+++ b/mminf/engine/base.py
@@ -38,7 +38,7 @@ class NodeOutput:
 
 
 class BaseEngine(ABC):
-    def __init__(self, enable_nvtx: bool = False):
+    def __init__(self, enable_nvtx: bool = False, **kwargs):
         self.enable_nvtx = enable_nvtx
 
     @abstractmethod

--- a/mminf/engine/cuda_graph_runner.py
+++ b/mminf/engine/cuda_graph_runner.py
@@ -267,7 +267,8 @@ class CudaGraphRunner:
             # Warmup: 2 forward passes
             torch.cuda.synchronize()
             for _ in range(2):
-                output = run_forward()
+                with torch.amp.autocast("cuda", enabled=True, dtype=self.ar_engine.autocast_dtype):
+                    output = run_forward()
                 # Reset seq_lens after warmup passes so capture starts clean
                 for rid in dummy_rids:
                     for label in config.labels:
@@ -287,8 +288,9 @@ class CudaGraphRunner:
 
             # Capture
             graph = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(graph, pool=self.memory_pool):
-                output = run_forward()
+            with torch.amp.autocast("cuda", enabled=True, dtype=self.ar_engine.autocast_dtype):
+                with torch.cuda.graph(graph, pool=self.memory_pool):
+                    output = run_forward()
             torch.cuda.synchronize()
             
             self.graphs[key] = CudaGraphData(

--- a/mminf/engine/cuda_graph_runner.py
+++ b/mminf/engine/cuda_graph_runner.py
@@ -94,10 +94,6 @@ class CudaGraphRunner:
         # Keyed by (graph_walk, requires_cfg, batch_size)
         self.graphs: dict[tuple, CudaGraphData] = {}
 
-        self.workspace = torch.empty(
-            256 * 1024 * 1024, dtype=torch.uint8, device=self.device
-        )
-
         self.memory_pool = None
 
     def warmup_and_capture(self) -> None:
@@ -154,11 +150,9 @@ class CudaGraphRunner:
         # multi-pass captures (e.g., main + cfg_img in same graph).
         plan_states = {}
         for label in config.labels:
-            
-
             if config.graph_walk == "decode":
                 wrapper = FlashInferDecodeWrapper(
-                    workspace_buffer=self.workspace,
+                    workspace_buffer=self.ar_engine.buffer_manager.get(f"{label}_cugraph"),
                     num_qo_heads=cfg.num_qo_heads,
                     num_kv_heads=cfg.num_kv_heads,
                     head_dim=cfg.head_dim,
@@ -170,7 +164,7 @@ class CudaGraphRunner:
                 )
             else:
                 wrapper = FlashInferPrefillWrapper(
-                    workspace_buffer=self.workspace,
+                    workspace_buffer=self.ar_engine.buffer_manager.get(f"{label}_cugraph"),
                     num_qo_heads=cfg.num_qo_heads,
                     num_kv_heads=cfg.num_kv_heads,
                     head_dim=cfg.head_dim,
@@ -222,7 +216,7 @@ class CudaGraphRunner:
                 kv_cache=self.ar_engine.kv_cache,
                 page_allocator=self.ar_engine.page_allocator,
                 request_states=self.ar_engine.request_states,
-                workspace_buffer=self.ar_engine.workspace_buffer,
+                buffer_manager=self.ar_engine.buffer_manager,
                 kv_cache_config=cfg,
                 device=self.device,
                 cuda_graph_plan_states=plan_states,

--- a/mminf/engine/enc_dec_engine.py
+++ b/mminf/engine/enc_dec_engine.py
@@ -18,10 +18,16 @@ class EncoderDecoderEngine(BaseEngine):
     Falls back to per-request sequential execution for variable-shape inputs.
     """
 
-    def __init__(self, enable_nvtx: bool = False):
+    def __init__(
+        self,
+        enable_nvtx: bool = False,
+        autocast_dtype=torch.bfloat16,
+        **kwargs
+    ):
         super().__init__(enable_nvtx=enable_nvtx)
         self.submodules: dict[str, torch.nn.Module] = {}
         self.device = None
+        self.autocast_dtype = autocast_dtype
 
     def engine_type(self) -> EngineType:
         return EngineType.ENC_DEC
@@ -79,19 +85,6 @@ class EncoderDecoderEngine(BaseEngine):
             request_ids=batch.request_ids,
             per_request_metadata=batch.per_request_metadata,
         )
-
-        # # Stack inputs along batch dimension (dim=0)
-        # first_preprocessed = all_preprocessed[request_ids[0]]
-        # stacked_inputs = {}
-        # stackable_keys = []
-        # for key, val in first_preprocessed.items():
-        #     if isinstance(val, torch.Tensor):
-        #         tensors = [all_preprocessed[rid][key] for rid in request_ids]
-        #         stacked_inputs[key] = torch.stack(tensors, dim=0)
-        #         stackable_keys.append(key)
-        #     else:
-        #         # Non-tensor values (ints, etc.) — use first request's value
-        #         stacked_inputs[key] = val
 
         # Single forward pass
         result = submodule(**all_preprocessed)
@@ -156,11 +149,12 @@ class EncoderDecoderEngine(BaseEngine):
             return output
 
         try:
-            with torch.no_grad():
-                if self._can_batch_inputs(batch):
-                    return self._execute_batched(batch, submodule)
-                else:
-                    return self._execute_sequential(batch, submodule)
+            with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
+                with torch.no_grad():
+                    if self._can_batch_inputs(batch):
+                        return self._execute_batched(batch, submodule)
+                    else:
+                        return self._execute_sequential(batch, submodule)
         finally:
             if self.enable_nvtx:
                 range_pop()

--- a/mminf/engine/flow_engine.py
+++ b/mminf/engine/flow_engine.py
@@ -76,8 +76,9 @@ class FlowEngine(BaseEngine):
             return output
 
         try:
-            with torch.no_grad():
-                return self._execute_sequential(batch, submodule)
+            with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
+                with torch.no_grad():
+                    return self._execute_sequential(batch, submodule)
         finally:
             if self.enable_nvtx:
                 range_pop()

--- a/mminf/engine/flow_engine.py
+++ b/mminf/engine/flow_engine.py
@@ -19,7 +19,7 @@ class FlowEngine(BaseEngine):
     from Phase 1).
     """
 
-    def __init__(self, enable_nvtx: bool = False):
+    def __init__(self, enable_nvtx: bool = False, **kwargs):
         super().__init__(enable_nvtx=enable_nvtx)
         self.submodules: dict[str, torch.nn.Module] = {}
         self.device = None

--- a/mminf/model/bagel/components/language_model.py
+++ b/mminf/model/bagel/components/language_model.py
@@ -208,7 +208,7 @@ class BagelAttentionMoT(nn.Module):
             )
 
         # RoPE: pos_ids pre-computed by plan_rope before the LLM forward
-        query_states, key_states = cache_handle.apply_rope(
+        query_states, key_states = cache_handle.apply_rope_llama(
             query_states, key_states, rope_theta=self.rope_theta
         )
 

--- a/mminf/model/bagel/components/language_model.py
+++ b/mminf/model/bagel/components/language_model.py
@@ -208,7 +208,7 @@ class BagelAttentionMoT(nn.Module):
             )
 
         # RoPE: pos_ids pre-computed by plan_rope before the LLM forward
-        query_states, key_states = cache_handle.apply_rope_llama(
+        query_states, key_states = cache_handle.apply_rope(
             query_states, key_states, rope_theta=self.rope_theta
         )
 

--- a/mminf/model/bagel/components/modeling_utils.py
+++ b/mminf/model/bagel/components/modeling_utils.py
@@ -112,7 +112,7 @@ class TimestepEmbedder(nn.Module):
 
     def forward(self, t):
         t_freq = self.timestep_embedding(t, self.frequency_embedding_size)
-        t_emb = self.mlp(t_freq.to(torch.bfloat16))
+        t_emb = self.mlp(t_freq.float())
         return t_emb
 
 

--- a/mminf/model/bagel/submodules.py
+++ b/mminf/model/bagel/submodules.py
@@ -304,14 +304,18 @@ class LLMSubmodule(NodeSubmodule):
         H: int=1024,
         W: int=1024,
     ):
+        
         h, w = (H // self.config.latent_downsample,
                 W // self.config.latent_downsample)
         num_image_tokens = h * w
         # torch.random.manual_seed(42)
-        return torch.randn(
+        latents = torch.randn(
             num_image_tokens,
             self.config.vae_config.z_channels * self.config.latent_patch_size ** 2,
         ).to(device=device)
+        if torch.is_autocast_enabled():
+            latents = latents.to(torch.get_autocast_gpu_dtype())
+        return latents
     
     def _preprocess_prefill_text(
         self, text_inputs: torch.Tensor

--- a/mminf/model/bagel/submodules.py
+++ b/mminf/model/bagel/submodules.py
@@ -94,7 +94,7 @@ class ViTEncoderSubmodule(NodeSubmodule):
         max_seqlen = int(num_tokens)
 
         return {
-            "packed_pixel_values": pixel_values.to(torch.bfloat16),
+            "packed_pixel_values": pixel_values,
             "packed_position_ids": position_ids,
             "cu_seqlens": cu_seqlens,
             "max_seqlen": max_seqlen,
@@ -190,7 +190,7 @@ class VAEEncoderSubmodule(NodeSubmodule):
         )
 
         return {
-            "padded_images": image_tensor.unsqueeze(0).to(torch.bfloat16),
+            "padded_images": image_tensor.unsqueeze(0),
             "packed_vae_position_ids": packed_vae_position_ids,
             "packed_timesteps": torch.tensor([0.0], device=device),
             "h": h,
@@ -311,7 +311,7 @@ class LLMSubmodule(NodeSubmodule):
         return torch.randn(
             num_image_tokens,
             self.config.vae_config.z_channels * self.config.latent_patch_size ** 2,
-        ).to(device=device, dtype=torch.bfloat16)
+        ).to(device=device)
     
     def _preprocess_prefill_text(
         self, text_inputs: torch.Tensor
@@ -452,7 +452,7 @@ class LLMSubmodule(NodeSubmodule):
                     device=device,
                     H=H, W=W
                 )
-                result["time_index"] = torch.zeros(result["latents"].shape[0], device=device, dtype=torch.bfloat16)
+                result["time_index"] = torch.zeros(result["latents"].shape[0], device=device)
             else:
                result["latents"] = inputs["latents"][0]
                result["time_index"] = inputs["time_index"][0]
@@ -460,7 +460,7 @@ class LLMSubmodule(NodeSubmodule):
             result["empty_combined_emb"] = self._wrap_with_boi_eoi(
                 torch.empty(
                     (result["latents"].shape[0], self.config.hidden_size),
-                    dtype=torch.bfloat16,
+                    dtype=result["latents"].dtype,
                     device=device
                 )
             )

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -343,3 +343,6 @@ class Model(ABC):
 
     def get_max_output_tokens(self, **model_kwargs):
         return model_kwargs.get("max_output_tokens", MAX_OUTPUT_TOKENS)
+    
+    def get_autocast_dtype(self):
+        return torch.bfloat16

--- a/mminf/utils/flashinfer_utils.py
+++ b/mminf/utils/flashinfer_utils.py
@@ -24,13 +24,17 @@ logger = logging.getLogger(__name__)
 
 @torch.compiler.disable
 def run_rms_norm(
-        input: torch.Tensor,
-        weight: torch.Tensor,
-        eps: float = 1e-06
-    ):
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float = 1e-06,
+    rms_norm_dtype=None
+):
     orig_dtype = input.dtype
-    if input.dtype == torch.float32:
-        input = input.to(torch.bfloat16)
+    if rms_norm_dtype is not None:
+        input = input.to(rms_norm_dtype)
+    elif torch.is_autocast_enabled():
+        dtype = torch.get_autocast_gpu_dtype()
+        input = input.to(dtype)
     import flashinfer
     return flashinfer.norm.rmsnorm(
         input, weight, eps=eps

--- a/mminf/utils/flashinfer_utils.py
+++ b/mminf/utils/flashinfer_utils.py
@@ -28,10 +28,13 @@ def run_rms_norm(
         weight: torch.Tensor,
         eps: float = 1e-06
     ):
+    orig_dtype = input.dtype
+    if input.dtype == torch.float32:
+        input = input.to(torch.bfloat16)
     import flashinfer
     return flashinfer.norm.rmsnorm(
         input, weight, eps=eps
-    )
+    ).to(orig_dtype)
 
 
 def run_attention(
@@ -92,6 +95,7 @@ class FlashInferPrefillWrapper:
         self.num_kv_heads = num_kv_heads
         self.head_dim = head_dim
         self.page_size = page_size
+        self.dtype = None
 
         import flashinfer
 
@@ -154,6 +158,7 @@ class FlashInferPrefillWrapper:
         In CUDA graph mode, updates static buffers via .copy_() so that
         the same GPU addresses are used during graph replay.
         """
+        self.dtype = dtype
         self.attn_wrapper.plan(
             qo_indptr=qo_indptr,
             paged_kv_indptr=paged_kv_indptr,
@@ -225,7 +230,7 @@ class FlashInferPrefillWrapper:
         Returns:
             output: [total_tokens, num_qo_heads, head_dim]
         """
-        return self.attn_wrapper.run(q, kv_cache_layer)
+        return self.attn_wrapper.run(q.to(self.dtype), kv_cache_layer)
 
     def set_kv_cache(
         self,
@@ -243,8 +248,8 @@ class FlashInferPrefillWrapper:
         n = self._total_tokens
         page_idx = self.token_to_page[:n]
         cache_idx = self.token_to_cache[:n]
-        kv_cache_layer[page_idx, 0, cache_idx] = k[:n]
-        kv_cache_layer[page_idx, 1, cache_idx] = v[:n]
+        kv_cache_layer[page_idx, 0, cache_idx] = k[:n].to(self.dtype)
+        kv_cache_layer[page_idx, 1, cache_idx] = v[:n].to(self.dtype)
 
 
 class FlashInferDecodeWrapper:
@@ -284,6 +289,7 @@ class FlashInferDecodeWrapper:
         self.num_kv_heads = num_kv_heads
         self.head_dim = head_dim
         self.page_size = page_size
+        self.dtype = None
 
         import flashinfer
 
@@ -360,6 +366,7 @@ class FlashInferDecodeWrapper:
             self.kv_cache_locations = locations
 
         self._n_req = n_req
+        self.dtype = dtype
 
     @torch.compiler.disable
     def run(self, q: torch.Tensor, kv_cache_layer: torch.Tensor) -> torch.Tensor:
@@ -371,7 +378,7 @@ class FlashInferDecodeWrapper:
         Returns:
             output: [n_req, num_qo_heads, head_dim]
         """
-        return self.attn_wrapper.run(q, kv_cache_layer)
+        return self.attn_wrapper.run(q.to(self.dtype), kv_cache_layer)
 
     def set_kv_cache(
         self,
@@ -389,5 +396,5 @@ class FlashInferDecodeWrapper:
         n = self._n_req
         pages = self.kv_cache_locations[:n, 0]
         positions = self.kv_cache_locations[:n, 1]
-        kv_cache_layer[pages, 0, positions] = k[:n]
-        kv_cache_layer[pages, 1, positions] = v[:n]
+        kv_cache_layer[pages, 0, positions] = k[:n].to(self.dtype)
+        kv_cache_layer[pages, 1, positions] = v[:n].to(self.dtype)

--- a/mminf/worker/engine_manager.py
+++ b/mminf/worker/engine_manager.py
@@ -73,7 +73,10 @@ class EngineManager:
                 for name in node_names:
                     submodule = model.get_submodule(name, device)
                     if submodule is not None:
-                        submodules[name] = submodule.to(device=device)
+                        submodules[name] = submodule.to(
+                            device=device,
+                            dtype=model.get_autocast_dtype()
+                        )
 
             engine.load_model(submodules, model_config, device)
             logger.info("Engine %s loaded in on device %s", cfg["engine_type"], str(device))

--- a/mminf/worker/engine_manager.py
+++ b/mminf/worker/engine_manager.py
@@ -61,13 +61,11 @@ class EngineManager:
 
             engine_cls = ENGINE_TYPE_TO_CLASS[engine_type_str]
 
-            if engine_type_str == "ar":
-                engine = engine_cls(
-                    kv_cache_config=model_config.get("kv_cache", {}),
-                    enable_nvtx=enable_nvtx,
-                )
-            else:
-                engine = engine_cls(enable_nvtx=enable_nvtx)
+            engine = engine_cls(
+                kv_cache_config=model_config.get("kv_cache", {}),
+                autocast_dtype=model_config.get("autocast_dtype", torch.bfloat16),
+                enable_nvtx=enable_nvtx,
+            )
 
             # Extract submodules from the Model for this engine's nodes
             submodules: dict[str, torch.nn.Module] = {}
@@ -75,7 +73,7 @@ class EngineManager:
                 for name in node_names:
                     submodule = model.get_submodule(name, device)
                     if submodule is not None:
-                        submodules[name] = submodule.to(device=device, dtype=torch.bfloat16)
+                        submodules[name] = submodule.to(device=device)
 
             engine.load_model(submodules, model_config, device)
             logger.info("Engine %s loaded in on device %s", cfg["engine_type"], str(device))

--- a/test/bagel/launch_server_bagel.sh
+++ b/test/bagel/launch_server_bagel.sh
@@ -3,7 +3,7 @@
 WHO=naomi
 
 CACHE_DIR=/mnt/storage/$WHO/mminf/bagel/
-DEVICES=1,2
+DEVICES=0,1
 
 CUDA_VISIBLE_DEVICES=$DEVICES python mminf/api_server/entrypoint.py \
     --config configs/bagel.yaml \


### PR DESCRIPTION
- Autocast to `bfloat16` (configurable on the model level) instead of hardcoding the datatype in the engine
- Ensure there is a different workspace buffer for different KV cache labels (otherwise we will have multiple simulataneously-used flashinfer wrappers using the same buffer)
- Wherever we assume a consistent label across requests in the attention wrapper, add an assertion statement to this extent
- [chore] remove redundant code in the attention wrapper