### PR TITLE
Cfg parallelism

### DIFF
--- a/mminf/engine/cache_manager.py
+++ b/mminf/engine/cache_manager.py
@@ -302,6 +302,150 @@ class BatchedCacheManager:
             self._plan_states[effective_label].pos_ids = computed_pos_ids
 
     @torch.compiler.disable
+    def plan_attention_batched_cfg(
+        self,
+        labels: list[str],
+        seq_lens: list[int],
+        is_causal: bool = False,
+        write_store: bool = False,
+        dtype=torch.bfloat16,
+        combined_label: str = "_cfg_batched",
+    ):
+        """Plan a single FlashInfer batch across multiple cache labels.
+
+        Each (label, request_id) pair becomes one entry in the FlashInfer batch.
+        For 3-branch CFG with 1 request this creates a 3-entry batch, enabling
+        all CFG branches to execute in a single LLM forward pass.
+
+        Args:
+            labels: cache labels to batch (e.g. ["main", "cfg_text", "cfg_img"]).
+            seq_lens: number of new tokens per request (same for all labels).
+            is_causal: whether attention is causal.
+            write_store: whether to write to mooncake store (False for image_gen).
+            combined_label: key for the combined _PlanState.
+        """
+        assert self.kv_cache is not None
+
+        cfg = self.kv_cache_config
+        page_size = cfg.page_size
+        num_kv_heads = cfg.num_kv_heads
+        head_dim = cfg.head_dim
+        num_qo_heads = cfg.num_qo_heads
+        device = self.device
+
+        qo_indptr_list = [0]
+        kv_indptr_list = [0]
+        all_page_indices = []
+        kv_last_page_lens = []
+        page_indices_all = []
+        page_offsets_all = []
+        combined_seq_lens = []
+
+        for label in labels:
+            for i, rid in enumerate(self.request_ids):
+                state = self._get_state(rid, label)
+                sl = seq_lens[i]
+                total_len = state.seq_len + sl
+                state.local_cache_seq_len = total_len
+
+                self.alloc_manager.alloc(rid, label=label, seq_len=total_len)
+
+                pos = torch.arange(state.seq_len, state.seq_len + sl, device=device)
+                page_idx = torch.tensor(
+                    state.page_indices, device=device
+                )[pos // page_size]
+                page_offset = pos % page_size
+
+                page_indices_all.append(page_idx)
+                page_offsets_all.append(page_offset)
+
+                qo_indptr_list.append(qo_indptr_list[-1] + sl)
+                all_page_indices.extend(state.page_indices)
+                kv_indptr_list.append(
+                    kv_indptr_list[-1] + len(state.page_indices)
+                )
+
+                last_page_len = total_len % page_size or page_size
+                kv_last_page_lens.append(last_page_len)
+                combined_seq_lens.append(sl)
+
+        page_indices = torch.cat(page_indices_all)
+        page_offsets = torch.cat(page_offsets_all)
+        token_offsets = torch.arange(page_indices.numel(), device=device)
+
+        qo_indptr = torch.tensor(
+            qo_indptr_list, dtype=torch.int32, device=device
+        )
+        paged_kv_indptr = torch.tensor(
+            kv_indptr_list, dtype=torch.int32, device=device
+        )
+        paged_kv_indices = torch.tensor(
+            all_page_indices, dtype=torch.int32, device=device
+        )
+        paged_kv_last_page_len = torch.tensor(
+            kv_last_page_lens, dtype=torch.int32, device=device
+        )
+
+        wrapper = FlashInferPrefillWrapper(
+            workspace_buffer=self.buffer_manager.get(combined_label),
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            page_size=page_size,
+        )
+
+        wrapper.plan(
+            qo_indptr=qo_indptr,
+            paged_kv_indptr=paged_kv_indptr,
+            paged_kv_indices=paged_kv_indices,
+            paged_kv_last_page_len=paged_kv_last_page_len,
+            causal=is_causal,
+            dtype=dtype,
+        )
+
+        ps = _PlanState(
+            wrapper=wrapper,
+            page_indices=page_indices,
+            page_offsets=page_offsets,
+            token_offsets=token_offsets,
+            seq_lens=combined_seq_lens,
+            write_store=write_store,
+        )
+        self._plan_states[combined_label] = ps
+
+    @torch.compiler.disable
+    def plan_rope_batched_cfg(
+        self,
+        labels: list[str],
+        seq_lens: list[int],
+        per_label_pos_ids: dict[str, list[torch.Tensor]] | None = None,
+        combined_label: str = "_cfg_batched",
+    ):
+        """Concatenate position IDs across multiple labels for batched CFG.
+
+        Args:
+            labels: cache labels in batch order.
+            seq_lens: new tokens per request (same for all labels).
+            per_label_pos_ids: {label: [pos_ids_tensor per request]}.
+                If None or a label is missing, computed from position_id_start.
+            combined_label: key for the combined _PlanState (must already exist
+                from plan_attention_batched_cfg).
+        """
+        parts = []
+        for label in labels:
+            if per_label_pos_ids and label in per_label_pos_ids:
+                parts.append(torch.cat(per_label_pos_ids[label]))
+            else:
+                parts.append(torch.cat([
+                    torch.arange(sl, device=self.device, dtype=torch.long)
+                    + self._get_state(rid, label).position_id_start
+                    for rid, sl in zip(self.request_ids, seq_lens)
+                ]))
+
+        combined_pos_ids = torch.cat(parts)
+        self._plan_states[combined_label].pos_ids = combined_pos_ids
+
+    @torch.compiler.disable
     def run_attention(
         self,
         q: torch.Tensor,

--- a/mminf/model/bagel/submodules.py
+++ b/mminf/model/bagel/submodules.py
@@ -477,17 +477,32 @@ class LLMSubmodule(NodeSubmodule):
                 **self._get_text_vae_idxs(seq_lens, device)
             }
 
-        self._plan_for_graph_walk(
-            cache_handle=cache_manager,
-            seq_lens=seq_lens,
-            per_label_custom_pos_ids=per_label_custom_pos_ids,
-            is_causal=graph_walk in [
-                "prefill_text", "decode"
-            ],
-            labels=labels,
-            snapshots=[("main", "cfg_text")] if graph_walk == "prefill_text" and has_cfg else [],
-            write_cache=graph_walk != "image_gen"
-        )
+        if graph_walk == "image_gen" and has_cfg:
+            # Batched CFG: plan a single FlashInfer batch across all 3 labels
+            # so that image_gen can run one forward pass instead of 3.
+            cache_manager.plan_attention_batched_cfg(
+                labels=labels,
+                seq_lens=seq_lens,
+                is_causal=False,
+                write_store=False,
+            )
+            cache_manager.plan_rope_batched_cfg(
+                labels=labels,
+                seq_lens=seq_lens,
+                per_label_pos_ids=per_label_custom_pos_ids,
+            )
+        else:
+            self._plan_for_graph_walk(
+                cache_handle=cache_manager,
+                seq_lens=seq_lens,
+                per_label_custom_pos_ids=per_label_custom_pos_ids,
+                is_causal=graph_walk in [
+                    "prefill_text", "decode"
+                ],
+                labels=labels,
+                snapshots=[("main", "cfg_text")] if graph_walk == "prefill_text" and has_cfg else [],
+                write_cache=graph_walk != "image_gen"
+            )
 
         result = {
             key: torch.cat(val) if (
@@ -748,35 +763,42 @@ class LLMSubmodule(NodeSubmodule):
             # CFG interval: only apply guidance when timestep is within interval
             cfg_interval = kwargs.pop("cfg_interval", self.config.cfg_interval)
             cfg_lo, cfg_hi = cfg_interval
-            # t_val = timestep[0].item() if isinstance(timestep, torch.Tensor) else float(timestep)
-            # in_cfg_interval = (t_val > cfg_lo) and (t_val <= cfg_hi)
-            # effective_text_scale = cfg_text_scale if in_cfg_interval else 1.0
-            # effective_img_scale = cfg_img_scale if in_cfg_interval else 1.0
 
             # torch.compile compatible logic
             t_val = timestep[0]
             in_cfg_interval = ((t_val > cfg_lo) & (t_val <= cfg_hi)).float()
-            effective_text_scale = cfg_text_scale * in_cfg_interval + 1.0  * (1 - in_cfg_interval)
+            effective_text_scale = cfg_text_scale * in_cfg_interval + 1.0 * (1 - in_cfg_interval)
             effective_img_scale = cfg_img_scale * in_cfg_interval + 1.0 * (1 - in_cfg_interval)
 
-            # plan_attention/plan_rope for all 3 labels done in preprocess
-            velocities = {}
-            for label in ["main", "cfg_text", "cfg_img"]:
-                if cache_handle is not None:
-                    cache_handle.set_active_label(label)
-                hidden = self.language_model(
-                    empty_combined_emb, mode="gen",
-                    cache_handle=cache_handle, write_cache=False,
-                    vae_token_indexes=vae_token_indexes,
-                    text_indexes=text_indexes,
-                    text_mask=text_mask,
-                    **kwargs,
-                )
-                velocities[label] = hidden
+            # Batched CFG: run all 3 branches in a single LLM forward.
+            # plan_attention_batched_cfg created a single FlashInfer plan
+            # treating (main, cfg_text, cfg_img) as 3 "virtual requests".
+            S = empty_combined_emb.shape[0]
+            batched_emb = empty_combined_emb.repeat(3, 1)  # [3S, hidden]
 
-            v_main = self.llm2vae(velocities["main"])[1:-1]
-            v_cfg_text = self.llm2vae(velocities["cfg_text"])[1:-1]
-            v_cfg_img = self.llm2vae(velocities["cfg_img"])[1:-1]
+            # Expand MoT indexes with absolute offsets for each copy
+            batched_text_indexes = torch.cat([
+                text_indexes + i * S for i in range(3)
+            ])
+            batched_vae_indexes = torch.cat([
+                vae_token_indexes + i * S for i in range(3)
+            ])
+            batched_text_mask = text_mask.repeat(3)
+
+            cache_handle.set_active_label("_cfg_batched")
+            hidden = self.language_model(
+                batched_emb, mode="gen",
+                cache_handle=cache_handle, write_cache=False,
+                vae_token_indexes=batched_vae_indexes,
+                text_indexes=batched_text_indexes,
+                text_mask=batched_text_mask,
+                **kwargs,
+            )
+
+            # Split output back to 3 branches and project to VAE space
+            v_main = self.llm2vae(hidden[:S])[1:-1]
+            v_cfg_text = self.llm2vae(hidden[S:2*S])[1:-1]
+            v_cfg_img = self.llm2vae(hidden[2*S:])[1:-1]
 
             # Two-node CFG velocity combination + renormalization
             cfg_renorm_min = kwargs.pop("cfg_renorm_min", self.config.cfg_renorm_min)


### PR DESCRIPTION
See my slack message!

1. mminf/engine/cache_manager.py:                                                                                                                                                                                                  
                                                                                                                                                                                                                                                    
`plan_attention_batched_cfg()`:  Creates a single FlashInfer batch plan across multiple cache labels. Iterates over (label, request_id) pairs, collecting page tables from each label's cache state. Builds combined FlashInfer index tensors (qo_indptr, paged_kv_indptr, paged_kv_indices) treating each label as a separate "virtual request". The plan is stored under "_cfg_batched" key in _plan_states.                                                                                
                                                                                                                                                                                                                                                    
`plan_rope_batched_cfg()` : Concatenates position IDs from all labels into a single tensor for the combined plan state. Handles per-label position offsets (different prefix lengths for main/cfg_text/cfg_img).                                    
                                                                                                                                                                                                                                                    
2. mminf/model/bagel/submodules.py                                                                                                                                                                                                
                                                                                                                                                                                                                                                    
preprocess() : When `graph_walk == "image_gen"` and has_cfg, calls the new batched CFG planning methods instead of `_plan_for_graph_walk`. All other graph walks are unchanged.                                                                       
                                                                                                                                                                                                                                                    
_forward_image_gen() : Replaces the 3 sequential forward passes with a single batched forward:                                                                                                                                                    
  1. empty_combined_emb.repeat(3, 1) creates [3S, hidden] input                                                                                                                                                                                   
  2. MoT indexes (text_indexes, vae_token_indexes, text_mask) are expanded with absolute offsets for each copy                                                                                                                                      
  3. set_active_label("_cfg_batched") selects the combined plan                                                                                                                                                                                   
  4. Single self.language_model() call processes all 3 branches                                                                                                                                                                                     
  5. Output split 3 ways, projected to VAE space, CFG formula unchanged 