### PR TITLE
Performance testing v0

### DIFF
--- a/benchmark/assets/simple_text_queries.txt
+++ b/benchmark/assets/simple_text_queries.txt
@@ -1,6 +1,6 @@
-What is the capital of France?
+What is the capital of France? Talk about the city.
 Explain the difference between machine learning and deep learning.
-Write a haiku about autumn leaves.
+Write 5 haikus about autumn leaves.
 Summarize the French Revolution in three sentences.
 What are the main causes of climate change?
 Translate "Good morning, how are you?" into Spanish.

--- a/benchmark/assets/simple_text_queries.txt
+++ b/benchmark/assets/simple_text_queries.txt
@@ -1,0 +1,105 @@
+What is the capital of France?
+Explain the difference between machine learning and deep learning.
+Write a haiku about autumn leaves.
+Summarize the French Revolution in three sentences.
+What are the main causes of climate change?
+Translate "Good morning, how are you?" into Spanish.
+What is the Pythagorean theorem?
+Write a professional email declining a job offer.
+Explain how photosynthesis works.
+What is the difference between a virus and a bacterium?
+Give me a recipe for chocolate chip cookies.
+What were the main causes of World War I?
+Explain the concept of supply and demand.
+What is quantum entanglement?
+Write a short story opening about a lighthouse keeper.
+What is the time complexity of quicksort?
+How does the human immune system work?
+What is the difference between a simile and a metaphor?
+Explain the water cycle.
+What are the symptoms of dehydration?
+Write a product description for a wireless ergonomic keyboard.
+What is Occam's Razor?
+How does GPS work?
+What is the difference between affect and effect?
+Explain the concept of compound interest.
+What are the five stages of grief?
+Write a one-paragraph bio for a fictional marine biologist.
+What is the speed of light?
+How do vaccines work?
+What is the difference between a democracy and a republic?
+Explain what RAM does in a computer.
+What is the plot of Romeo and Juliet?
+How do black holes form?
+What are the benefits of meditation?
+Write a limerick about a sleepy cat.
+What is the difference between weather and climate?
+Explain recursion to a beginner programmer.
+What is the significance of the Magna Carta?
+How does the stock market work?
+What is the difference between a hypothesis and a theory?
+Describe three common logical fallacies.
+What is the mitochondria's role in the cell?
+How does bread rise when you bake it?
+Write a tagline for a fictional coffee shop called "The Daily Grind."
+What is Moore's Law?
+Explain the concept of natural selection.
+What is the difference between latitude and longitude?
+How does a combustion engine work?
+What are the primary colors of light?
+Summarize the plot of George Orwell's 1984.
+What is the difference between syntax and semantics in programming?
+How does the moon affect ocean tides?
+What is a sonnet?
+Explain what inflation is and what causes it.
+What are the branches of the U.S. federal government?
+How does Wi-Fi work?
+What is the difference between a CV and a resume?
+Explain the trolley problem.
+What is CRISPR and how does it work?
+Write a two-sentence horror story.
+What is the difference between a Roman and an Arabic numeral?
+How does a neural network learn?
+What is the Turing Test?
+Explain the concept of opportunity cost.
+What causes rainbows?
+How does the Electoral College work?
+What is the difference between renewable and nonrenewable energy?
+Explain what a REST API is.
+What is the significance of the Rosetta Stone?
+How do noise-canceling headphones work?
+What is the difference between empathy and sympathy?
+Describe the steps of the scientific method.
+What is the difference between a copyright and a trademark?
+Explain what dark matter is.
+How does a search engine index the web?
+What is the difference between TCP and UDP?
+Write a short motivational quote about perseverance.
+What is the Fermi Paradox?
+Explain how a microwave oven heats food.
+What are the key principles of object-oriented programming?
+What is the difference between a saturated and unsaturated fat?
+How does anesthesia work?
+What is the difference between monetary and fiscal policy?
+Explain what a hash function does.
+What caused the fall of the Roman Empire?
+How does carbon dating work?
+What is the difference between deductive and inductive reasoning?
+Write a one-sentence pitch for an app that helps people track their reading habits.
+What is the significance of the Heisenberg Uncertainty Principle?
+How does sleep affect memory consolidation?
+What is the difference between a mutation and a genetic disorder?
+Explain what net neutrality means.
+What is the Baader-Meinhof phenomenon?
+How does an airplane generate lift?
+What is the difference between a primary and a secondary source?
+What are the main differences between Python and JavaScript?
+Explain the concept of entropy in thermodynamics.
+What is the prisoner's dilemma?
+How does the human eye perceive color?
+What is the difference between a compiler and an interpreter?
+Explain the concept of cognitive dissonance.
+What is the Drake Equation?
+How does mRNA work in protein synthesis?
+Write a brief explanation of blockchain for a non-technical audience.
+What is the difference between weather forecasting and climate modeling?

--- a/benchmark/dataset.py
+++ b/benchmark/dataset.py
@@ -63,7 +63,7 @@ class TxtFileDataset(BaseDataset):
                     req_type=RequestType.T2T,
                     prompt=line.strip()
                 ))
-        self._resize_data(self.items)
+        self.items = self._resize_data(self.items)
     
     @property
     def num_requests(self):
@@ -102,7 +102,7 @@ class VBenchDataset(BaseDataset):
         self.task = task
         self._num_requests = num_requests
         self.items = self._load_data()
-        self._resize_data(self.items)
+        self.items = self._resize_data(self.items)
     
     @property
     def num_requests(self):

--- a/benchmark/dataset.py
+++ b/benchmark/dataset.py
@@ -22,6 +22,58 @@ class BaseDataset(ABC):
         return [
             self[i] for i in range(len(self))
         ]
+    
+    @property
+    @abstractmethod
+    def num_requests(self) -> int:
+        pass
+    
+    def _resize_data(self, data: list[RequestInput]) -> list[RequestInput]:
+        """Resize data to match num_prompts."""
+        if not self.num_requests:
+            return data
+
+        if len(data) < self.num_requests:
+            factor = (self.num_requests // len(data)) + 1
+            data = data * factor
+
+        return data[: self.num_requests]
+
+
+class TxtFileDataset(BaseDataset):
+    """
+    Dataset loader for text-to-text prompts, coming from a provided text file
+    with one line per prompt
+    """
+
+    def __init__(
+        self,
+        filename: str,
+        num_requests: int,
+        req_type=RequestType.T2T
+    ):
+        assert req_type in [
+            RequestType.T2T, RequestType.T2I
+        ]
+        self.items = []
+        self._num_requests = num_requests
+        with open(filename, "r") as f:
+            for line in f.readlines():
+                self.items.append(RequestInput(
+                    req_type=RequestType.T2T,
+                    prompt=line.strip()
+                ))
+        self._resize_data(self.items)
+    
+    @property
+    def num_requests(self):
+        return self._num_requests
+    
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __getitem__(self, idx: int) -> RequestInput:
+        return self.items[idx]
 
 
 UND_PROMPT = "Describe this image in detail."
@@ -48,9 +100,13 @@ class VBenchDataset(BaseDataset):
     ):
         self.cache_dir = cache_dir
         self.task = task
-        self.num_requests = num_requests
+        self._num_requests = num_requests
         self.items = self._load_data()
         self._resize_data(self.items)
+    
+    @property
+    def num_requests(self):
+        return self._num_requests
 
     def _load_data(self) -> list[RequestInput]:
         if self.task == RequestType.T2I:
@@ -192,17 +248,6 @@ class VBenchDataset(BaseDataset):
             )
             for f in files
         ]
-
-    def _resize_data(self, data: list[RequestInput]) -> list[RequestInput]:
-        """Resize data to match num_prompts."""
-        if not self.num_requests:
-            return data
-
-        if len(data) < self.num_requests:
-            factor = (self.num_requests // len(data)) + 1
-            data = data * factor
-
-        return data[: self.num_requests]
 
     def __len__(self) -> int:
         return len(self.items)

--- a/benchmark/request.py
+++ b/benchmark/request.py
@@ -75,13 +75,15 @@ class AggregateMetrics:
     type_counts: dict[str, int]
     total_output_tokens: int=0
     mean_output_tokens: Optional[float]=None
+    online: bool=False,
+    batch_size: int=1,
     rate: Optional[float]=None
 
     def __str__(self) -> str:
-        if self.rate is not None:
-            header = f"Benchmark Results ({self.n_requests} requests, rate={self.rate} req/s)"
+        if self.online:
+            header = f"Online Benchmark Results ({self.n_requests} requests, rate={self.rate} req/s)"
         else:
-            header = f"Benchmark Results ({self.n_requests} requests, sequential)"
+            header = f"Offline Benchmark Results ({self.n_requests} requests, batch={self.batch_size})"
         header += "\n" + ("\u2500" * 50)
 
         tpt = ""
@@ -133,6 +135,8 @@ def _latency_stats(values: list[float]) -> LatencyStats:
 def aggregate_metrics(
     requests: list[RequestMetrics],
     wall_time: float,
+    online: bool=False,
+    batch_size: int=1,
     rate: Optional[float]=None,
 ) -> AggregateMetrics:
     n_success = sum(1 for r in requests if r.status == Status.SUCCESS)
@@ -154,6 +158,8 @@ def aggregate_metrics(
         e2e_latency=_latency_stats(e2e_vals),
         itl=_latency_stats(itl_vals),
         wall_time=wall_time,
+        online=online,
+        batch_size=batch_size,
         rate=rate,
         type_counts=type_counts,
         total_output_tokens=total_tokens,

--- a/benchmark/run_benchmark.sh
+++ b/benchmark/run_benchmark.sh
@@ -8,8 +8,10 @@ python -m benchmark.runner \
     --url "${URL:-http://localhost:8000}" \
     --model "${MODEL:-bagel}" \
     --dataset vbench \
+    --profiling-type "${PROF_TYPE:-offline}" \
     --request-type "${TASK:-text_to_image}" \
     --vbench-cache-dir "$CACHE_DIR" \
     --num-requests "${NUM_REQUESTS:-10}" \
     --inference-system "${INF_SYS:-ours}" \
+    ${BATCH_SIZE:+--batch-size "$BATCH_SIZE"}
     ${RATE:+--rate "$RATE"}

--- a/benchmark/run_benchmark.sh
+++ b/benchmark/run_benchmark.sh
@@ -7,7 +7,7 @@ CACHE_DIR=/mnt/storage/$WHO/vbench
 python -m benchmark.runner \
     --url "${URL:-http://localhost:8000}" \
     --model "${MODEL:-bagel}" \
-    --dataset vbench \
+    --dataset ${DATASET:-vbench} \
     --profiling-type "${PROF_TYPE:-offline}" \
     --request-type "${TASK:-text_to_image}" \
     --vbench-cache-dir "$CACHE_DIR" \

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -29,6 +29,11 @@ class InferenceSystemType(Enum):
             return VLLMOmni()
 
 
+class ProfilingType(Enum):
+    OFFLINE = "offline"
+    ONLINE = "online"
+
+
 @dataclass
 class BenchmarkConfig:
     url: str
@@ -36,8 +41,12 @@ class BenchmarkConfig:
     dataset: DatasetType
     num_requests: int
     request_type: RequestType
+    num_warmup: int = 3
+    profiling_type: ProfilingType = ProfilingType.OFFLINE
     inference_system: InferenceSystemType = InferenceSystemType.OURS
-    rate: Optional[float] = None  # None = sequential, >0 = requests/sec
+
+    batch_size: Optional[int] = 1
+    rate: Optional[float] = 1
     output_dir: Optional[str] = None  # Save outputs here (text files / images)
     # VBench args
     vbench_cache_dir: str = "./vbench_cache"
@@ -89,7 +98,53 @@ class Benchmark:
         for request_id, error in errors:
             print(f"  [{request_id}] {error}")
 
-    async def _run_concurrent(
+    async def _run_batch(
+        self,
+        session: aiohttp.ClientSession,
+        batch: list[tuple[int, RequestInput]],
+    ) -> list[RequestMetrics]:
+        """Run a single batch of requests concurrently."""
+        tasks = [
+            asyncio.create_task(
+                self.inference_system.send_request(
+                    session=session,
+                    base_url=self.config.url,
+                    request_id=i,
+                    req_type=req.req_type,
+                    model=self.config.model,
+                    prompt=req.prompt,
+                    image_path=req.image_path,
+                )
+            )
+            for i, req in batch
+        ]
+        return list(await asyncio.gather(*tasks))
+
+
+    async def _run_concurrent_offline(
+        self,
+        session: aiohttp.ClientSession,
+        requests: list[RequestInput],
+    ) -> list[RequestMetrics]:
+        bs = self.config.batch_size
+        all_metrics: list[RequestMetrics] = []
+
+        batches = [
+            [(i, requests[i]) for i in range(start, min(start + bs, len(requests)))]
+            for start in range(0, len(requests), bs)
+        ]
+
+        for batch in batches:
+            tic = time.perf_counter()
+            metrics = await self._run_batch(session, batch)
+            toc = time.perf_counter()
+            print(toc - tic)
+            all_metrics.extend(metrics)
+            await asyncio.sleep(0.01)
+
+        return all_metrics
+    
+    async def _run_concurrent_online(
         self,
         session: aiohttp.ClientSession,
         requests: list[RequestInput],
@@ -113,28 +168,12 @@ class Benchmark:
                 await asyncio.sleep(interval)
         return list(await asyncio.gather(*tasks))
 
-    async def _run_sequential(
-        self,
-        session: aiohttp.ClientSession,
-        requests: list[RequestInput],
-    ) -> list[RequestMetrics]:
-        results = []
-        for i, req in enumerate(requests):
-            result = await self.inference_system.send_request(
-                session=session,
-                base_url=self.config.url,
-                request_id=i,
-                req_type=req.req_type,
-                model=self.config.model,
-                prompt=req.prompt,
-                image_path=req.image_path,
-            )
-            print(f"request time: {result.e2e_latency:.3f}s  tokens: {result.output_tokens}")
-            results.append(result)
-        return results
-
     async def run(self) -> tuple[list[RequestMetrics], AggregateMetrics]:
         dataset = self._get_dataset()
+        if self.config.profiling_type == ProfilingType.OFFLINE:
+            bs = self.config.batch_size
+            # make even multiple of batch size
+            self.config.num_requests = ((self.config.num_requests + bs - 1) // bs) * bs
         requests = dataset.get_requests()[: self.config.num_requests]
 
         async with aiohttp.ClientSession(
@@ -144,8 +183,8 @@ class Benchmark:
         ) as session:
             print("--- Warmup ---")
             warmup_req = requests[0]
-            for i in range(3):
-                print(f"Warmup {i} / 3")
+            for i in range(self.config.num_warmup):
+                print(f"Warmup {i+1} / {self.config.num_warmup}")
                 await self.inference_system.send_request(
                     session=session,
                     base_url=self.config.url,
@@ -159,10 +198,10 @@ class Benchmark:
 
             wall_start = time.monotonic()
 
-            if self.config.rate is None:
-                metrics = await self._run_sequential(session, requests)
+            if self.config.profiling_type == ProfilingType.OFFLINE:
+                metrics = await self._run_concurrent_offline(session, requests)
             else:
-                metrics = await self._run_concurrent(session, requests)
+                metrics = await self._run_concurrent_online(session, requests)
 
             wall_time = time.monotonic() - wall_start
 
@@ -186,16 +225,20 @@ def parse_args() -> BenchmarkConfig:
     parser.add_argument("--model", required=True, choices=[m.value for m in Model])
     parser.add_argument("--dataset", required=True, choices=[d.value for d in DatasetType])
     parser.add_argument("--inference-system", choices=[s.value for s in InferenceSystemType],
-                    default=InferenceSystemType.OURS.value)
+                        default=InferenceSystemType.OURS.value)
     parser.add_argument("--num-requests", type=int, default=10)
-    parser.add_argument("--rate", type=float, default=None,
-                        help="Requests/sec. Omit for sequential mode.")
+    parser.add_argument("--num-warmup", type=int, default=3)
+    parser.add_argument("--profiling-type", choices=[p.value for p in ProfilingType],
+                        default=ProfilingType.OFFLINE.value)
     parser.add_argument("--request-type", choices=[r.value for r in RequestType])
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--rate", type=float, default=1.0,
+                        help="Requests/sec (default: 1.0)")
     parser.add_argument("--output-dir", default=None,
                         help="Directory to save outputs (text files / images). Omit to skip.")
+
     # VBench args
     vbench = parser.add_argument_group("vbench")
-    
     vbench.add_argument("--vbench-cache-dir", default="./vbench_cache",
                         help="Directory to cache downloaded VBench data (default: ./vbench_cache)")
 
@@ -204,13 +247,16 @@ def parse_args() -> BenchmarkConfig:
     return BenchmarkConfig(
         url=args.url,
         model=Model(args.model),
-        request_type=RequestType(args.request_type),
         dataset=DatasetType(args.dataset),
         num_requests=args.num_requests,
-        rate=args.rate,
-        vbench_cache_dir=args.vbench_cache_dir,
+        request_type=RequestType(args.request_type),
+        num_warmup=args.num_warmup,
+        profiling_type=ProfilingType(args.profiling_type),
         inference_system=InferenceSystemType(args.inference_system),
+        batch_size=args.batch_size,
+        rate=args.rate,
         output_dir=args.output_dir,
+        vbench_cache_dir=args.vbench_cache_dir,
     )
 
 

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -208,7 +208,9 @@ class Benchmark:
         agg = aggregate_metrics(
             metrics,
             wall_time=wall_time,
-            rate=self.config.rate
+            online=self.config.profiling_type == ProfilingType.ONLINE,
+            batch_size=self.config.batch_size,
+            rate=self.config.rate,
         )
 
         print(f"\n--- Benchmark Results (wall time: {wall_time:.2f}s) ---")

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -10,12 +10,13 @@ from typing import Optional
 import aiohttp
 
 from benchmark.base import Model, RequestType
-from benchmark.dataset import BaseDataset, VBenchDataset
+from benchmark.dataset import BaseDataset, TxtFileDataset, VBenchDataset
 from benchmark.request import AggregateMetrics, InferenceSystem, OurSystem, RequestInput, RequestMetrics, VLLMOmni, aggregate_metrics
 
 
 class DatasetType(Enum):
     VBENCH = "vbench"
+    TEXT = "text"
 
 
 class InferenceSystemType(Enum):
@@ -51,6 +52,9 @@ class BenchmarkConfig:
     # VBench args
     vbench_cache_dir: str = "./vbench_cache"
 
+    # text dataset args
+    request_txt_file: str = "benchmark/assets/simple_text_queries.txt"
+
 
 class Benchmark:
     def __init__(self, config: BenchmarkConfig):
@@ -63,6 +67,12 @@ class Benchmark:
                 cache_dir=self.config.vbench_cache_dir,
                 task=self.config.request_type,
                 num_requests=self.config.num_requests,
+            )
+        elif self.config.dataset == DatasetType.TEXT:
+            return TxtFileDataset(
+                filename=self.config.request_txt_file,
+                num_requests=self.config.num_requests,
+                req_type=self.config.request_type 
             )
         raise ValueError(f"Unknown dataset: {self.config.dataset}")
 
@@ -243,6 +253,13 @@ def parse_args() -> BenchmarkConfig:
     vbench = parser.add_argument_group("vbench")
     vbench.add_argument("--vbench-cache-dir", default="./vbench_cache",
                         help="Directory to cache downloaded VBench data (default: ./vbench_cache)")
+    
+    # Text dataset args
+    text_dataset = parser.add_argument_group("text_dataset")
+    text_dataset.add_argument(
+        "--request-txt-file", default="benchmark/assets/simple_text_queries.txt",
+        help="Text file with one line per prompt"
+    )
 
     args = parser.parse_args()
 
@@ -259,6 +276,7 @@ def parse_args() -> BenchmarkConfig:
         rate=args.rate,
         output_dir=args.output_dir,
         vbench_cache_dir=args.vbench_cache_dir,
+        request_txt_file=args.request_txt_file
     )
 
 

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -45,6 +45,7 @@ class BenchmarkConfig:
     num_warmup: int = 3
     profiling_type: ProfilingType = ProfilingType.OFFLINE
     inference_system: InferenceSystemType = InferenceSystemType.OURS
+    verbose: bool = False
 
     batch_size: Optional[int] = 1
     rate: Optional[float] = 1
@@ -148,7 +149,8 @@ class Benchmark:
             tic = time.perf_counter()
             metrics = await self._run_batch(session, batch)
             toc = time.perf_counter()
-            print(toc - tic)
+            if self.config.verbose:
+                print(toc - tic)
             all_metrics.extend(metrics)
             await asyncio.sleep(0.01)
 
@@ -191,10 +193,12 @@ class Benchmark:
             connector=aiohttp.TCPConnector(),
             read_bufsize=5 * 2**20,  # 1MB read buffer
         ) as session:
-            print("--- Warmup ---")
+            if self.config.verbose:
+                print("--- Warmup ---")
             warmup_req = requests[0]
             for i in range(self.config.num_warmup):
-                print(f"Warmup {i+1} / {self.config.num_warmup}")
+                if self.config.verbose:
+                    print(f"Warmup {i+1} / {self.config.num_warmup}")
                 await self.inference_system.send_request(
                     session=session,
                     base_url=self.config.url,
@@ -204,7 +208,8 @@ class Benchmark:
                     prompt=warmup_req.prompt,
                     image_path=warmup_req.image_path,
                 )
-            print("Warmup complete.\n")
+            if self.config.verbose:
+                print("Warmup complete.")
 
             wall_start = time.monotonic()
 
@@ -248,6 +253,7 @@ def parse_args() -> BenchmarkConfig:
                         help="Requests/sec (default: 1.0)")
     parser.add_argument("--output-dir", default=None,
                         help="Directory to save outputs (text files / images). Omit to skip.")
+    parser.add_argument("--verbose", action="store_true")
 
     # VBench args
     vbench = parser.add_argument_group("vbench")
@@ -274,9 +280,10 @@ def parse_args() -> BenchmarkConfig:
         inference_system=InferenceSystemType(args.inference_system),
         batch_size=args.batch_size,
         rate=args.rate,
+        verbose=args.verbose,
         output_dir=args.output_dir,
         vbench_cache_dir=args.vbench_cache_dir,
-        request_txt_file=args.request_txt_file
+        request_txt_file=args.request_txt_file,
     )
 
 

--- a/configs/bagel_cfg_parallel.yaml
+++ b/configs/bagel_cfg_parallel.yaml
@@ -15,7 +15,6 @@ node_groups:
 
   # Main LLM: handles all prefill + decode + image_gen main branch + combine_cfg
   - node_names:
-      - init_latents
       - LLM
       - combine_cfg
     ranks:

--- a/configs/bagel_single_gpu.yaml
+++ b/configs/bagel_single_gpu.yaml
@@ -1,0 +1,19 @@
+model: "bagel"
+max_seq_len: 32768
+
+node_groups:
+  - node_names:
+      - vit_encoder
+    ranks:
+      - 0
+  
+  - node_names:
+      - vae_encoder
+      - vae_decoder
+    ranks:
+      - 0
+  
+  - node_names:
+      - LLM
+    ranks:
+      - 0

--- a/mminf/api_server/data_worker.py
+++ b/mminf/api_server/data_worker.py
@@ -167,6 +167,7 @@ class PreprocessWorkerThread:
             communicator=self.communicator,
             protocol=tensor_comm_protocol,
             tcp_transfer_device=tcp_transfer_device,
+            device=self.device
         )
 
     def _process_input(
@@ -263,7 +264,6 @@ class PreprocessWorkerThread:
         self.tensor_manager.start_read_tensors(
             request_id=result.request_id,
             graph_edges=[result.graph_edge],
-            device=self.device
         )
         if result.request_id not in self.tensor_uuid_to_metadata_per_request:
             self.tensor_uuid_to_metadata_per_request[result.request_id] = {}

--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Future, ThreadPoolExecutor
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -22,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class EventAndPointers:
-    event: torch.cuda.Event
+class FutureAndPointers:
+    future: Future | None
     graph_edges: list[GraphEdge]
     request_id: str = ""
 
@@ -175,11 +176,82 @@ class TensorCommunicationManager(ABC):
         pass
 
 
+@dataclass
+class TransferReadInfo:
+    source_session_id: str
+    local_ptr: int
+    remote_ptr: int
+    nbytes: int
+
+
+class AsyncMooncakeReader:
+    """Background thread for non-blocking mooncake READ operations.
+
+    Follows SGLang's pattern: caller records CUDA event on default stream,
+    submits write task to thread pool. Worker thread waits on event via
+    dedicated CUDA stream, then does blocking mooncake PUTs.
+    The default stream is never blocked by store writes.
+    """
+
+    def __init__(self, engine, device, max_workers: int = 1):
+        self._engine = engine
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._pending: list[Future] = []
+        if device != "cpu":
+            self._copy_stream = torch.cuda.Stream(device=device)
+        else:
+            self._copy_stream = torch.cuda.Stream()
+
+    def submit(self, read_info: list[TransferReadInfo]) -> Future:
+        """Non-blocking: enqueue a batch of READs.
+
+        Records a CUDA event on the current stream to ensure GPU data
+        is ready before the background thread reads it.
+        """
+        if not read_info:
+            return
+        event = torch.cuda.current_stream().record_event()
+        future = self._executor.submit(self._do_read, read_info, event)
+        self._pending.append(future)
+        # Prune completed futures to avoid unbounded growth
+        self._pending = [f for f in self._pending if not f.done()]
+        return future
+
+    def _do_read(self, read_info: list["TransferReadInfo"], event: torch.cuda.Event):
+        """Worker thread: wait for GPU data via CUDA event, then PUT."""
+        self._copy_stream.wait_event(event)
+        self._copy_stream.synchronize()
+
+        # TODO: batch sync read (must have same source session ID)
+        for info in read_info:
+            status = self._engine.transfer_sync_read(
+                info.source_session_id,
+                info.local_ptr,
+                info.remote_ptr,
+                info.nbytes,
+            )
+            if status < 0:
+                raise RuntimeError(f"Mooncake read failed. Status: {status}")
+
+    def wait_all(self):
+        """Block until all pending writes complete. Re-raises exceptions."""
+        for f in self._pending:
+            f.result()
+        self._pending.clear()
+
+    def shutdown(self):
+        """Wait for pending writes and shut down the thread pool."""
+        self.wait_all()
+        self._executor.shutdown(wait=True)
+
+
+
 class MooncakeCommunicationManager(TensorCommunicationManager):
     def __init__(
         self,
         my_entity_id: str,
         hostname: str,
+        device: str,
         communicator: BaseCommunicator,
         protocol: CommProtocol=CommProtocol.RDMA,
         metadata_server: str="P2PHANDSHAKE", # [ETCD_SERVER_URL, P2PHANDSHAKE, ...]
@@ -193,8 +265,7 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
         self.communicator = communicator
         self.protocol = protocol
         self.my_session_id = hostname
-
-        self.copy_stream = torch.cuda.Stream()
+        self.device = device
 
         if TransferEngine is not None:
             if self.protocol == CommProtocol.RDMA:
@@ -225,12 +296,16 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
                     "Install mooncake-transfer-engine or set tensor protocol to IPC."
                 )
             self.engine = None
+        self._async_reader = AsyncMooncakeReader(
+            self.engine, device=device
+        )
         # Per-transfer pending list (allows partial tensor readiness)
-        self.pending: list[EventAndPointers] = []
+        self.pending: list[FutureAndPointers] = []
 
     def store_and_return_tensor_info(
         self, request_id: str, tensors: NameToTensorList,
     ) -> dict[str, list[TensorPointerInfo]]: # name to list[tensorPointerInfo]
+        torch.cuda.default_stream().synchronize()
         tensor_info: dict[str, list[TensorPointerInfo]] = {}
         for name, tensor_list in tensors.items():
             tensor_info[name] = []
@@ -256,6 +331,7 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
         return tensor_info
 
     def register_for_send(self, request_id, uuids):
+        torch.cuda.default_stream().synchronize()
         for uuid in uuids:
             if self.protocol == CommProtocol.RDMA:
                 if self.engine is None:
@@ -269,7 +345,6 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
                     request_id=request_id, uuid=uuid
                 )
 
-                torch.cuda.default_stream().synchronize()
                 ret_value = self.engine.register_memory(
                     tensor.data_ptr(), tensor.nbytes
                 )
@@ -409,13 +484,11 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
         # request_id -> ready graph edges
         ready: dict[str, list[GraphEdge]] = {}
         still_pending = []
-        torch.cuda.default_stream().synchronize()
 
         for ep in self.pending:
-            if ep.event.query():
-                # TODO: the system sometimes hangs under many requests unless we have this,
-                # but we don't want to wait for unrelated copies before proceeding...
-                self.copy_stream.synchronize()
+            if ep.future is None or ep.future.done():
+                if ep.future is not None:
+                    ep.future.result()
                 for edge in ep.graph_edges:
                     ready.setdefault(ep.request_id, []).append(edge)
                     logger.debug(
@@ -436,15 +509,14 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
         return ready
 
     def start_read_tensors(
-        self, request_id: str, graph_edges: list[GraphEdge],
-        device: str="cuda"
+        self, request_id: str,
+        graph_edges: list[GraphEdge],
     ):
         """
         For each edge with tensor_info (RDMA source): allocate dst tensor,
         register memory, call engine.transfer_read_on_cuda(), record CUDA event.
         For each edge WITHOUT tensor_info (signal-only): no data to transfer.
         """
-        stream = self.copy_stream
         for graph_edge in graph_edges:
             if len(graph_edge.tensor_info) == 0:
                 continue  # signal-only edge, no data to transfer
@@ -454,6 +526,7 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
                 len(graph_edge.tensor_info), graph_edge.name, graph_edge.next_node
             )
 
+            read_info = []
             for info in graph_edge.tensor_info:
                 if info.source_entity == self.my_entity_id or self.tensor_store.check_uuid_presence(
                     request_id, info.uuid
@@ -462,9 +535,9 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
                         request_id, info.uuid, 1 # increment reference while it is being read
                     )
                     continue
-                buffer = torch.empty(info.dims, dtype=info.dtype, device=device).as_strided(
-                    info.dims, stride=info.stride
-                )
+                buffer = torch.empty(
+                    info.dims, dtype=info.dtype, device=self.device
+                ).as_strided(info.dims, stride=info.stride)
                 self.tensor_store.put_tensor(
                     request_id=request_id, uuid=info.uuid, tensor=buffer
                 )
@@ -482,30 +555,17 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
                         )
                     self.engine.register_memory(buffer.data_ptr(), info.nbytes)
 
-
-                if hasattr(self.engine, "transfer_read_on_cuda"):
-                    with torch.cuda.stream(stream):
-                        self.engine.transfer_read_on_cuda(
-                            info.source_session_id,
-                            buffer.data_ptr(),
-                            info.address,
-                            info.nbytes,
-                            stream.cuda_stream,
-                        )
-                else:
-                    # TODO: maybe replace both transfer read paths with a thread-based mechanism
-                    self.engine.transfer_sync_read(
-                        info.source_session_id,
-                        buffer.data_ptr(),
-                        info.address,
-                        info.nbytes,
-                    )
+                read_info.append(TransferReadInfo(
+                    source_session_id=info.source_session_id,
+                    local_ptr=buffer.data_ptr(),
+                    remote_ptr=info.address,
+                    nbytes=info.nbytes,
+                ))
                 logger.debug("Started transfer read for uuid %s", info.uuid)
-            # For now, have one cuda event for all tensors in this graph edge
-            event = torch.cuda.Event()
-            event.record(stream)
+            fut = self._async_reader.submit(read_info)
             self.pending.append(
-                EventAndPointers(
-                    event=event, graph_edges=[graph_edge], request_id=request_id
+                FutureAndPointers(
+                    future=fut, graph_edges=[graph_edge],
+                    request_id=request_id
                 )
             )

--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -193,8 +193,9 @@ class AsyncMooncakeReader:
     The default stream is never blocked by store writes.
     """
 
-    def __init__(self, engine, device, max_workers: int = 1):
+    def __init__(self, engine, device, max_workers: int = 1, max_batch_size=500):
         self._engine = engine
+        self.max_batch_size = max_batch_size
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self._pending: list[Future] = []
         if device != "cpu":
@@ -222,16 +223,23 @@ class AsyncMooncakeReader:
         self._copy_stream.wait_event(event)
         self._copy_stream.synchronize()
 
-        # TODO: batch sync read (must have same source session ID)
+        # group read_info by session id for batch read
+        grouped_read = {}
         for info in read_info:
-            status = self._engine.transfer_sync_read(
-                info.source_session_id,
-                info.local_ptr,
-                info.remote_ptr,
-                info.nbytes,
-            )
-            if status < 0:
-                raise RuntimeError(f"Mooncake read failed. Status: {status}")
+            grouped_read.setdefault(info.source_session_id, []).append(info)
+
+        for (session_id, infos) in grouped_read.items():
+            for start in range(0, len(infos), self.max_batch_size):
+                end = min(start + self.max_batch_size, len(infos))
+            
+                status = self._engine.batch_transfer_sync_read(
+                    session_id,
+                    [infos[i].local_ptr for i in range(start, end)],
+                    [infos[i].remote_ptr for i in range(start, end)],
+                    [infos[i].nbytes for i in range(start, end)],
+                )
+                if status < 0:
+                    raise RuntimeError(f"Mooncake read failed. Status: {status}")
 
     def wait_all(self):
         """Block until all pending writes complete. Re-raises exceptions."""

--- a/mminf/engine/__init__.py
+++ b/mminf/engine/__init__.py
@@ -1,4 +1,5 @@
 import torch
 torch._dynamo.config.recompile_limit = 32
 torch._dynamo.config.allow_unspec_int_on_nn_module = True
+torch._dynamo.config.specialize_int = False
 torch.set_float32_matmul_precision('high')

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -185,22 +185,6 @@ class AREngine(BaseEngine):
 
         return output
 
-    def _can_batch(self, batch: NodeBatch) -> bool:
-        """Only batch when all requests share a batchable graph_walk path.
-
-        image_gen with 3-pass CFG is too complex to batch initially due to
-        multi-label switching and snapshot operations within the forward pass.
-        """
-        if len(batch.request_ids) <= 1:
-            return False
-        if batch.graph_walk not in ("decode", "prefill_text"):
-            return False
-        # Ensure the submodule supports batched forward
-        submodule = self.submodules.get(batch.node_name)
-        if submodule is None or not hasattr(submodule, "forward_batched"):
-            return False
-        return True
-
     def _execute_batched(self, batch: NodeBatch, submodule) -> NodeOutput:
         """Execute batch with BatchedCacheManager for true vectorized batching."""
         from mminf.engine.kv_store import StoreWritePolicy
@@ -371,7 +355,7 @@ class AREngine(BaseEngine):
                     # Priority: CUDA graph > batched > sequential
                     if self._can_use_cuda_graph(batch):
                         return self._execute_with_cuda_graph(batch, submodule)
-                    elif self._can_batch(batch):
+                    elif submodule.can_batch(batch):
                         return self._execute_batched(batch, submodule)
                     else:
                         return self._execute_sequential(batch, submodule)

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -50,7 +50,6 @@ class AREngine(BaseEngine):
         submodules: dict[str, torch.nn.Module],
         model_config: dict,
         device: torch.device,
-        mooncake_cfg: MooncakeStoreConfig,
         transfer_engine_info: TransferEngineInfo,
         kv_cache_type=torch.bfloat16,
     ) -> None:
@@ -78,7 +77,6 @@ class AREngine(BaseEngine):
         self.alloc_manager = PagedAllocationManager(
             config=cfg,
             kv_cache=self.kv_cache,
-            mooncake_cfg=mooncake_cfg,
             transfer_engine_info=transfer_engine_info
         )
 
@@ -332,21 +330,14 @@ class AREngine(BaseEngine):
             return output
 
         try:
-            # Filter to only retrieve cache labels this node actually needs
-            needed_labels = None
-            if hasattr(submodule, 'get_needed_cache_labels'):
-                needed = submodule.get_needed_cache_labels(
-                    batch.graph_walk, batch.per_request_info
-                )
-                if needed is not None:
-                    needed_labels = set(needed)
-
+            needed_labels = self._get_needed_labels(
+                batch.node_name, batch.graph_walk, batch.per_request_info
+            )
             for req_id, info in batch.per_request_info.items():
-                per_label_seq_info = info.per_label_seq_info
-                for label, seq_info in per_label_seq_info.items():
-                    if needed_labels is not None and label not in needed_labels:
+                for label, seq_info in info.per_label_seq_info.items():
+                    if needed_labels is None or label not in needed_labels:
                         continue
-                    self.alloc_manager.retrieve_from_store(
+                    self.alloc_manager.sync_retrieve(
                         req_id, label, seq_info
                     )
 
@@ -366,6 +357,40 @@ class AREngine(BaseEngine):
             if self.enable_nvtx:
                 range_pop()
 
+    def _get_needed_labels(
+        self, node_name: str, graph_walk: str,
+        request_info: dict[str, CurrentForwardPassInfo]
+    ):
+        submodule = self.submodules.get(node_name)
+        needed_labels = None
+        if hasattr(submodule, 'get_needed_cache_labels'):
+            needed = submodule.get_needed_cache_labels(
+                graph_walk, request_info)
+            if needed is not None:
+                needed_labels = set(needed)
+        return needed_labels
+
+    def check_ready(
+        self, node_name: str, request_id: str,
+        request_info: CurrentForwardPassInfo,
+    ):
+        needed_labels = self._get_needed_labels(
+            node_name, request_info.graph_walk, {
+                    request_id: request_info
+            }
+        )
+
+        for label, seq_info in request_info.per_label_seq_info.items():
+            if needed_labels is None or label not in needed_labels:
+                continue
+            self.alloc_manager.start_aysnc_retrieve(
+                request_id, label, seq_info
+            )
+        return all([
+            self.alloc_manager.check_retrieve_ready(request_id, label) \
+                for label in needed_labels
+        ])
+        
     def add_request(
         self, request_id: str, cache_labels: list[str] | None = None,
     ) -> None:

--- a/mminf/engine/base.py
+++ b/mminf/engine/base.py
@@ -71,6 +71,12 @@ class BaseEngine(ABC):
     @abstractmethod
     def remove_request(self, request_id: str) -> None:
         ...
+    
+    def check_ready(
+        self, node_name: str, request_id: str,
+        request_info: CurrentForwardPassInfo,
+    ):
+        return True
 
     def warmup(self) -> None:
         """Optional CUDA graph capture. Override in subclasses."""

--- a/mminf/engine/cache_manager.py
+++ b/mminf/engine/cache_manager.py
@@ -169,7 +169,6 @@ class BatchedCacheManager:
             state = self._get_state(rid, effective_label)
             sl = seq_lens[i]
             total_len = state.seq_len + sl
-            state.local_cache_seq_len = total_len
 
             self.alloc_manager.alloc(
                 rid, label=effective_label, seq_len=total_len
@@ -346,7 +345,6 @@ class BatchedCacheManager:
                 state = self._get_state(rid, label)
                 sl = seq_lens[i]
                 total_len = state.seq_len + sl
-                state.local_cache_seq_len = total_len
 
                 self.alloc_manager.alloc(rid, label=label, seq_len=total_len)
 
@@ -609,7 +607,7 @@ class BatchedCacheManager:
             from_state = self._get_state(rid, from_label)
 
             if realloc:
-                self.alloc_manager.reset_label(rid, to_label, clear_store=True)
+                self.alloc_manager.reset_label(rid, to_label)
 
             to_state = self._get_state(rid, to_label)
             start_pos =  to_state.seq_len // self.kv_cache_config.page_size
@@ -619,7 +617,6 @@ class BatchedCacheManager:
 
             to_state.seq_len = from_state.seq_len
             to_state.position_id_start = from_state.position_id_start
-            to_state.local_cache_seq_len = from_state.local_cache_seq_len
 
             for src_page, dst_page in zip(
                 from_state.page_indices[start_pos:],

--- a/mminf/engine/cuda_graph_runner.py
+++ b/mminf/engine/cuda_graph_runner.py
@@ -478,7 +478,6 @@ class CudaGraphRunner:
             for label in config_labels:
                 self.alloc_manager.reset_label(
                     rid, label, free=i>=batch_size,
-                    clear_store=False # there should be nothing with the dummy rid in the store
                 )
         for rid in request_ids:
             for label in config_labels:

--- a/mminf/engine/enc_dec_engine.py
+++ b/mminf/engine/enc_dec_engine.py
@@ -42,39 +42,6 @@ class EncoderDecoderEngine(BaseEngine):
         self.submodules = submodules
         self.device = device
 
-    def _can_batch_inputs(self, batch: NodeBatch) -> bool:
-        """Check if all requests have same-shaped inputs for stacking."""
-        if len(batch.request_ids) <= 1:
-            return False
-
-        # Get reference shapes from first request
-        first_rid = batch.request_ids[0]
-        first_inputs = batch.per_request_input_tensors.get(first_rid, {})
-        if not first_inputs:
-            return False
-
-        ref_shapes = {}
-        for name, tensor_list in first_inputs.items():
-            if not tensor_list:
-                continue
-            ref_shapes[name] = [t.shape for t in tensor_list]
-
-        # Check all other requests match
-        for rid in batch.request_ids[1:]:
-            inputs = batch.per_request_input_tensors.get(rid, {})
-            if set(inputs.keys()) != set(first_inputs.keys()):
-                return False
-            for name, tensor_list in inputs.items():
-                if name not in ref_shapes:
-                    continue
-                if len(tensor_list) != len(ref_shapes[name]):
-                    return False
-                for t, ref_shape in zip(tensor_list, ref_shapes[name]):
-                    if t.shape != ref_shape:
-                        return False
-
-        return True
-
     def _execute_batched(self, batch: NodeBatch, submodule) -> NodeOutput:
         """Stack same-shaped inputs and run a single forward pass."""
         request_ids = batch.request_ids
@@ -152,7 +119,7 @@ class EncoderDecoderEngine(BaseEngine):
         try:
             with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
                 with torch.no_grad():
-                    if self._can_batch_inputs(batch):
+                    if submodule.can_batch(batch):
                         return self._execute_batched(batch, submodule)
                     else:
                         return self._execute_sequential(batch, submodule)

--- a/mminf/engine/kv_store.py
+++ b/mminf/engine/kv_store.py
@@ -1,25 +1,17 @@
 import logging
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future
 from dataclasses import dataclass, field
 from enum import Enum
 import queue
-# from mooncake.store import MooncakeDistributedStore
 from mooncake.engine import TransferEngine
 
 import torch
 
 from mminf.communication.communicator import CommProtocol
+from mminf.communication.tensors import AsyncMooncakeReader, TransferReadInfo
 from mminf.conductor.request_info import SequenceInfo
 
 logger = logging.getLogger(__name__)
-
-
-# NOTE: when this is changed to be different from the page size (or perhaps when
-# it is made too small), writing large amounts of data to the mooncake store is 
-# sometimes very slow.
-KV_STORE_CHUNK_SIZE = 128
-
-MAX_TRANSFERS = 1000
 
 
 class PageAllocator:
@@ -67,13 +59,12 @@ class KVCacheConfig:
 class KVRequestState:
     """Per-request KV cache state for the AR engine."""
     page_indices: list[int] = field(default_factory=list)
-    seq_len: int = 0
+    seq_len: int = 0 # includes read in progress
     position_id_start: int = 0
 
-    # this must be properly set by the BatchedCacheManager
-    local_cache_seq_len: int = 0
+    read_in_progress: bool = False
+
     # sequence length of the in-distributed-store KV cache
-    store_seq_len_per_layer: list | None = None
     is_paused: bool = False
 
 
@@ -108,70 +99,11 @@ class StoreWritePolicy(Enum):
     NEVER = "never"     # non-disaggregated: all AR graph walks on same worker
 
 
-# class AsyncStoreWriter:
-#     """Background thread for non-blocking mooncake PUT operations.
-
-#     Follows SGLang's pattern: caller records CUDA event on default stream,
-#     submits write task to thread pool. Worker thread waits on event via
-#     dedicated CUDA stream, then does blocking mooncake PUTs.
-#     The default stream is never blocked by store writes.
-#     """
-
-#     def __init__(self, mooncake_store: MooncakeDistributedStore, device, max_workers: int = 1):
-#         self._store = mooncake_store
-#         self._executor = ThreadPoolExecutor(max_workers=max_workers)
-#         self._pending: list[Future] = []
-#         self._write_stream = torch.cuda.Stream(device=device)
-
-#     def submit(self, alloc_info: list["StoreAllocInfo"]):
-#         """Non-blocking: enqueue a batch of PUTs.
-
-#         Records a CUDA event on the current stream to ensure GPU data
-#         is ready before the background thread reads it.
-#         """
-#         if not alloc_info:
-#             return
-#         event = torch.cuda.current_stream().record_event()
-#         future = self._executor.submit(self._do_write, alloc_info, event)
-#         self._pending.append(future)
-#         # Prune completed futures to avoid unbounded growth
-#         self._pending = [f for f in self._pending if not f.done()]
-
-#     def _do_write(self, alloc_info: list["StoreAllocInfo"], event: torch.cuda.Event):
-#         """Worker thread: wait for GPU data via CUDA event, then PUT."""
-#         return
-#         self._write_stream.wait_event(event)
-#         self._write_stream.synchronize()
-#         for start in range(0, len(alloc_info), MAX_TRANSFERS):
-#             end = min(start + MAX_TRANSFERS, len(alloc_info))
-#             status = self._store.batch_put_from_multi_buffers(
-#                 keys=[a.key for a in alloc_info[start:end]],
-#                 all_buffer_ptrs=[a.ptr for a in alloc_info[start:end]],
-#                 all_sizes=[a.nbytes for a in alloc_info[start:end]],
-#             )
-#             if any(s < 0 for s in status):
-#                 raise RuntimeError(
-#                     f"Mooncake async write failed: {status}"
-#                 )
-
-#     def wait_all(self):
-#         """Block until all pending writes complete. Re-raises exceptions."""
-#         for f in self._pending:
-#             f.result()
-#         self._pending.clear()
-
-#     def shutdown(self):
-#         """Wait for pending writes and shut down the thread pool."""
-#         self.wait_all()
-#         self._executor.shutdown(wait=True)
-
-
 class PagedAllocationManager:
     def __init__(
         self,
         config: KVCacheConfig,
         kv_cache: torch.Tensor,
-        mooncake_cfg: MooncakeStoreConfig,
         transfer_engine_info: TransferEngineInfo
     ):
         self.config = config
@@ -180,33 +112,26 @@ class PagedAllocationManager:
         self.kv_cache = kv_cache
         self.write_policy = StoreWritePolicy.ALWAYS
     
-        # self.mooncake_store = MooncakeDistributedStore()
         self.engine = transfer_engine_info.transfer_engine
+        self._async_reader = AsyncMooncakeReader(
+            engine=self.engine, device=kv_cache.device
+        )
 
-        # self.mooncake_store.setup(
-        #     mooncake_cfg.hostname,
-        #     mooncake_cfg.metadata_server,
-        #     mooncake_cfg.segment_size,
-        #     mooncake_cfg.local_buff_size,
-        #     mooncake_cfg.protocol.value.lower(),
-        #     "",
-        #     mooncake_cfg.master_service
-        # )
         self.engine.register_memory(
             self.kv_cache.data_ptr(), self.kv_cache.nbytes
         )
         self.my_entity_id = transfer_engine_info.my_entity_id
         self.my_session_id = transfer_engine_info.my_session_id
 
-        # self._async_writer = AsyncStoreWriter(
-        #     self.mooncake_store, device=kv_cache.device
-        # )
+        # {req_id: {label: futures}}
+        self.pending_reads: dict[str, dict[str, list[Future]]] = {}
 
     def _key(self, request_id: str, label: str, pos: int, layer: int):
         return f"{request_id}_{label}_{pos}_{layer}"
 
     def _get_ptr_nbytes(
-        self, layer, page_idx, token_start, token_end,
+        self, layer, page_idx,
+        token_start, token_end,
         base_ptr=None
     ):
         token_stride = self.kv_cache.stride(3)
@@ -230,31 +155,7 @@ class PagedAllocationManager:
                 ) * element_size for kv_idx in [0, 1]
         ]
 
-        return ptrs, [nbytes, nbytes]
-    
-    # def _read_from_store(self, alloc_info: list[StoreAllocInfo]):
-    #     """Synchronous mooncake GET. Used by retrieve_from_store only.
-
-    #     No pre-transfer sync needed: destination pages are freshly allocated
-    #     and not in use by any GPU kernel. Post-transfer sync ensures DMA
-    #     writes are visible to subsequent GPU kernels.
-    #     """
-    #     if not alloc_info:
-    #         return
-    #     for start in range(0, len(alloc_info), MAX_TRANSFERS):
-    #         end = min(start + MAX_TRANSFERS, len(alloc_info))
-    #         keys = [alloc_info[i].key for i in range(start, end)]
-    #         status = self.mooncake_store.batch_get_into_multi_buffers(
-    #             keys=keys,
-    #             all_buffer_ptrs=[alloc_info[i].ptr for i in range(start, end)],
-    #             all_sizes=[alloc_info[i].nbytes for i in range(start, end)]
-    #         )
-    #         if any(s < 0 for s in status):
-    #             bad_key_status = str({
-    #                 keys[i]: s for i, s in enumerate(status) if s < 0
-    #             })
-    #             raise RuntimeError("Mooncake read failed: " + bad_key_status[:1000] + ("..." if len(bad_key_status) > 1000 else ""))
-    #     torch.cuda.default_stream().synchronize()
+        return ptrs, nbytes
 
     def flush_to_store(
         self, request_id: str, label: str, layers: int | list[int] | None = None
@@ -263,61 +164,9 @@ class PagedAllocationManager:
         # this function will posibly send ZMQ requests to potential receivers, who can do
         # RDMA reads on this Engine's KV cache
         return
-        # if self.write_policy == StoreWritePolicy.NEVER:
-        #     return
-        # assert self.config.page_size % KV_STORE_CHUNK_SIZE == 0, (
-        #     f"page_size ({self.config.page_size}) must be a multiple of "
-        #     f"KV_STORE_CHUNK_SIZE ({KV_STORE_CHUNK_SIZE})"
-        # )
-        # tokens_per_chunk = KV_STORE_CHUNK_SIZE
-        # chunks_per_page = self.config.page_size // tokens_per_chunk
-
-        # if isinstance(layers, int):
-        #     layers = [layers]
-        # if layers is None:
-        #     layers = list(range(self.config.num_layers))
-
-        # state = self.request_states[request_id][label]
-
-        # # Only flush complete chunks — drop any trailing partial chunk
-        # num_complete_chunks = state.local_cache_seq_len // tokens_per_chunk
-        # flush_up_to = num_complete_chunks * tokens_per_chunk  # token boundary
-
-        # alloc_info: list[StoreAllocInfo] = []
-
-        # for layer in layers:
-        #     if state.store_seq_len_per_layer[layer] >= flush_up_to:
-        #         continue
-
-        #     first_chunk = state.store_seq_len_per_layer[layer] // tokens_per_chunk
-        #     last_chunk = num_complete_chunks  # exclusive
-
-        #     state.store_seq_len_per_layer[layer] = flush_up_to
-
-        #     for chunk_idx in range(first_chunk, last_chunk):
-        #         page_pos = chunk_idx // chunks_per_page
-        #         chunk_within_page = chunk_idx % chunks_per_page
-
-        #         page_idx = state.page_indices[page_pos]
-
-        #         # Slice the chunk out of the page tensor
-        #         token_start = chunk_within_page * tokens_per_chunk
-        #         token_end = token_start + tokens_per_chunk
-
-        #         ptr, nbytes = self._get_ptr_nbytes(
-        #             layer, page_idx, token_start, token_end
-        #         )
-        #         alloc_info.append(StoreAllocInfo(
-        #             key=self._key(request_id, label, chunk_idx, layer),
-        #             ptr=ptr,
-        #             nbytes=nbytes
-        #         ))
-        
-        # self._async_writer.submit(alloc_info)
 
     def _new_state(self):
         state = KVRequestState()
-        state.store_seq_len_per_layer = [0] * self.config.num_layers
         return state
 
     def get_state(self, request_id: str, label: str):
@@ -335,37 +184,59 @@ class PagedAllocationManager:
         if num_new_pages > 0:
             new_pages = self.page_allocator.allocate(num_new_pages)
             state.page_indices.extend(new_pages)
+    
+    def wait_for_retrieves(
+        self, request_id: str, label: str
+    ):
+        for future in self.pending_reads[request_id].get(label, []):
+            future.result()
+        state = self.get_state(request_id, label)
+        state.read_in_progress = False
+        self.pending_reads[request_id][label] = []
 
-    def retrieve_from_store(
+    def check_retrieve_ready(
+        self, request_id: str, label: str
+    ) -> bool:
+        """
+        Returns true if all retrieves are done
+        """
+        state = self.get_state(request_id, label)
+        if not state.read_in_progress:
+            return True
+        futures = [
+            fut for fut in self.pending_reads[request_id].get(label, []) \
+                if not fut.done()
+        ]
+        in_progress = (len(futures) > 0)
+        state.read_in_progress = in_progress
+        self.pending_reads[request_id][label] = futures
+        return not in_progress
+
+    def sync_retrieve(
         self, request_id: str, label: str, seq_info: SequenceInfo
     ):
-        assert self.config.page_size % KV_STORE_CHUNK_SIZE == 0, (
-            f"page_size ({self.config.page_size}) must be a multiple of "
-            f"KV_STORE_CHUNK_SIZE ({KV_STORE_CHUNK_SIZE})"
-        )
-        tokens_per_chunk = KV_STORE_CHUNK_SIZE
-        chunks_per_page = self.config.page_size // tokens_per_chunk
+        self.start_aysnc_retrieve(request_id, label, seq_info)
+        self.wait_for_retrieves(request_id, label)
 
+    def start_aysnc_retrieve(
+        self, request_id: str, label: str, seq_info: SequenceInfo
+    ):
         seq_len = seq_info.seq_len
         state = self.get_state(request_id, label)
         if state.seq_len >= seq_len:
             return  # nothing to do
 
-        num_complete_chunks = seq_len // tokens_per_chunk
-        trailing_tokens = seq_len % tokens_per_chunk
-        first_chunk = state.seq_len // tokens_per_chunk
-        total_chunks = num_complete_chunks + (1 if trailing_tokens > 0 else 0)
+        first_page = state.seq_len // self.config.page_size
+        last_page = (seq_len - 1) // self.config.page_size
 
         self.alloc(request_id, label, seq_len)
 
-        local_addrs, remote_addrs, nbytes_list = [], [], []
+        read_info = []
 
-        for chunk_idx in range(first_chunk, total_chunks):
-            page_pos = chunk_idx // chunks_per_page
-            chunk_within_page = chunk_idx % chunks_per_page
-            token_start = chunk_within_page * tokens_per_chunk
-            token_end = token_start + (
-                trailing_tokens if chunk_idx == num_complete_chunks else tokens_per_chunk
+        for page_pos in range(first_page, last_page + 1):
+            token_start = 0 if page_pos > 0 else (state.seq_len % self.config.page_size)
+            token_end = self.config.page_size if page_pos != last_page else (
+                seq_len % self.config.page_size
             )
 
             local_page_idx = state.page_indices[page_pos]
@@ -379,37 +250,24 @@ class PagedAllocationManager:
                     layer, remote_page_idx, token_start, token_end,
                     base_ptr=seq_info.kv_cache_addr
                 )
-                local_addrs.extend(local_ptrs)
-                remote_addrs.extend(remote_ptrs)
-                nbytes_list.extend(nbytes)
 
-        for batch_start in range(0, len(local_addrs), MAX_TRANSFERS):
-            batch_end = batch_start + MAX_TRANSFERS
-            status = self.engine.batch_transfer_sync_read(
-                seq_info.latest_session_id,
-                local_addrs[batch_start:batch_end],
-                remote_addrs[batch_start:batch_end],
-                nbytes_list[batch_start:batch_end],
-            )
-            if status < 0:
-                raise RuntimeError("Mooncake retrieve failed")
-
-        if local_addrs:
-            torch.cuda.default_stream().synchronize()
-
+                read_info.extend([
+                    TransferReadInfo(
+                        seq_info.latest_session_id,
+                        local_ptr, remote_ptr, nbytes
+                    ) for local_ptr, remote_ptr in zip(local_ptrs, remote_ptrs)
+                ])
+        future = self._async_reader.submit(read_info)
+        self.pending_reads[request_id].setdefault(label, []).append(future)
         state.seq_len = seq_len
-        state.store_seq_len_per_layer = [
-            num_complete_chunks * tokens_per_chunk for _ in range(self.config.num_layers)
-        ]
-        state.local_cache_seq_len = seq_len
         state.position_id_start = seq_info.pos_id
+        state.read_in_progress = True
     
-    def get_per_label_seq_info(
-        self, request_id: str,
-    ):
-        # self._async_writer.wait_all()
+    def get_per_label_seq_info(self, request_id: str):
         per_label_seq_info: dict[str, SequenceInfo] = {}
         for label, state in self.request_states.get(request_id, {}).items():
+            self.wait_for_retrieves(request_id, label)
+
             state = self.get_state(request_id, label)
             per_label_seq_info[label] = SequenceInfo(
                 seq_len = state.seq_len,
@@ -421,16 +279,16 @@ class PagedAllocationManager:
             )
         return per_label_seq_info
     
-    def reset_label(self, request_id: str, label: str, free: bool=True, clear_store=True):
+    def reset_label(self, request_id: str, label: str, free: bool=True):
+        self.wait_for_retrieves(request_id, label)
         if label in self.request_states[request_id] and free:
             state = self.request_states[request_id][label]
             self.page_allocator.free(state.page_indices)
-        # if clear_store:
-        #     self.mooncake_store.remove_by_regex(f"^{request_id}_{label}.*")
         self.request_states[request_id][label] = self._new_state()
 
     def cleanup(self):
-        # self._async_writer.shutdown()
+        # wait for reads to finish before registering memory!
+        self._async_reader.shutdown()
         self.engine.unregister_memory(
             self.kv_cache.data_ptr()
         )
@@ -441,15 +299,15 @@ class PagedAllocationManager:
         self.request_states[request_id] = {
             label: self._new_state() for label in labels
         }
+        self.pending_reads[request_id] = {
+            label: [] for label in labels
+        }
     
     def remove_request(self, request_id: str):
-        # self._async_writer.wait_all()
         for label in self.request_states[request_id]:
+            self.wait_for_retrieves(request_id, label)
             state = self.request_states[request_id][label]
             self.page_allocator.free(state.page_indices)
         del self.request_states[request_id]
+        del self.pending_reads[request_id]
 
-        # count = self.mooncake_store.remove_by_regex(f"^{request_id}_.*")
-        # # TODO error handling
-        # if count < 0:
-        #     raise RuntimeError("Mooncake remove failed")

--- a/mminf/model/bagel/submodules.py
+++ b/mminf/model/bagel/submodules.py
@@ -11,6 +11,7 @@ from torch import nn
 
 from mminf.communication.tensors import NameToTensorList
 from mminf.conductor.request_info import CurrentForwardPassInfo
+from mminf.engine.base import NodeBatch
 from mminf.engine.cache_manager import BatchedCacheManager
 from mminf.model.bagel.components.language_model import BagelForCausalLM
 from mminf.model.bagel.components.modeling_utils import (
@@ -1066,6 +1067,11 @@ class LLMSubmodule(NodeSubmodule):
             boi_emb = self.embed_tokens(boi_ids).to(emb.dtype)
             eoi_emb = self.embed_tokens(eoi_ids).to(emb.dtype)
         return torch.cat([boi_emb, emb, eoi_emb], dim=0)
+
+    def can_batch(
+        self, batch: NodeBatch
+    ):
+        return batch.graph_walk in ["decode", "prefill_text"]
 
 
 class VAEDecoderSubmodule(NodeSubmodule):

--- a/mminf/model/bagel/submodules.py
+++ b/mminf/model/bagel/submodules.py
@@ -427,10 +427,10 @@ class LLMSubmodule(NodeSubmodule):
         """
         device = next(self.parameters()).device
 
-        has_cfg = self._batch_get_requires_cfg(
-            per_request_info, request_ids
+        requires_cfg = self._batch_get_requires_cfg(
+            per_request_info
         )
-        labels = self._get_active_labels(graph_walk, has_cfg)
+        labels = self._get_active_labels(graph_walk, requires_cfg)
 
          # these will get filled in
         seq_lens = []
@@ -504,7 +504,7 @@ class LLMSubmodule(NodeSubmodule):
                 **self._get_text_vae_idxs(seq_lens, device)
             }
 
-        if graph_walk == "image_gen" and has_cfg:
+        if graph_walk == "image_gen" and requires_cfg:
             # Batched CFG: plan a single FlashInfer batch across all 3 labels
             # so that image_gen can run one forward pass instead of 3.
             cache_manager.plan_attention_batched_cfg(
@@ -527,7 +527,7 @@ class LLMSubmodule(NodeSubmodule):
                     "prefill_text", "decode"
                 ],
                 labels=labels,
-                snapshots=[("main", "cfg_text")] if graph_walk == "prefill_text" and has_cfg else [],
+                snapshots=[("main", "cfg_text")] if graph_walk == "prefill_text" and requires_cfg else [],
                 write_cache=graph_walk not in ("image_gen", "image_gen_cfg")
             )
 
@@ -537,6 +537,7 @@ class LLMSubmodule(NodeSubmodule):
             ) else val for (key, val) in result.items()
         }
         result["seq_lens"] = seq_lens
+        result["requires_cfg"] =  requires_cfg
 
         return result
 
@@ -949,11 +950,10 @@ class LLMSubmodule(NodeSubmodule):
             result["time_index"] = [time_index]
         return result
 
-    @torch.compiler.disable
-    def _batch_get_requires_cfg(self, per_request_info: dict[str, CurrentForwardPassInfo], request_ids):
+    def _batch_get_requires_cfg(self, per_request_info: dict[str, CurrentForwardPassInfo]):
         return any(
-            per_request_info[rid].requires_cfg
-            for rid in request_ids
+            info.requires_cfg
+            for info in per_request_info.values()
         )
 
     def forward_batched(
@@ -969,21 +969,19 @@ class LLMSubmodule(NodeSubmodule):
         Concatenates inputs across requests, runs a single LLM forward with
         the BatchedCacheManager, then splits outputs back per-request.
         """
-        has_cfg = self._batch_get_requires_cfg(
-            per_request_info, request_ids
-        )
+        requires_cfg = packed_inputs.get("requires_cfg", True)
 
         if graph_walk == "decode":
             return self._forward_decode_batched(
                 cache_manager=cache_manager,
                 request_ids=request_ids,
                 packed_inputs=packed_inputs,
-                has_cfg=has_cfg,
+                requires_cfg=requires_cfg,
             )
         elif graph_walk == "prefill_text":
             self._forward_prefill_text(
                 cache_handle=cache_manager,
-                requires_cfg=has_cfg, **packed_inputs
+                **packed_inputs
             ) # prefill is the same batched and unbatched
             return {rid: [] for rid in request_ids}
         else:
@@ -994,7 +992,7 @@ class LLMSubmodule(NodeSubmodule):
         cache_manager: BatchedCacheManager,
         request_ids: list[str],
         packed_inputs: dict[str, torch.Tensor],
-        has_cfg: bool = False,
+        requires_cfg: bool = False,
         per_request_info: dict[str, CurrentForwardPassInfo] | None=None
     ) -> dict[str, NameToTensorList]:
         """Batched decode: all requests generate 1 token each.
@@ -1009,8 +1007,6 @@ class LLMSubmodule(NodeSubmodule):
 
         plan_attention/plan_rope are called in preprocess_batched.
         """
-        request_ids = cache_manager.request_ids
-
         # 1. Embed and concatenate
         embs = self.embed_tokens(packed_inputs["text_inputs"])
 
@@ -1022,7 +1018,7 @@ class LLMSubmodule(NodeSubmodule):
         )
 
         # 3. CFG sync pass for cfg_img if needed (already planned)
-        if has_cfg:
+        if requires_cfg:
             cache_manager.set_active_label("cfg_img")
             self.language_model(
                 embs, mode="und",

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -11,7 +11,7 @@ import yaml
 from mminf.communication.tensors import NameToTensorList
 from mminf.conductor.request_info import CurrentForwardConductorMetadata, CurrentForwardPassInfo
 from mminf.engine.cache_manager import BatchedCacheManager
-from mminf.engine.base import EngineType
+from mminf.engine.base import EngineType, NodeBatch
 from mminf.engine.kv_store import KVCacheConfig
 from mminf.graph.base import GraphEdge, GraphNode, GraphSection, Loop, Parallel, Sequential, TensorPointerInfo
 
@@ -75,6 +75,11 @@ class NodeSubmodule(torch.nn.Module):
         Compilable + CUDA-graphable.
         """
         ...
+    
+    def can_batch(
+        self, batch: NodeBatch
+    ):
+        return False
 
 
 @dataclass

--- a/mminf/worker/dummy_worker.py
+++ b/mminf/worker/dummy_worker.py
@@ -63,6 +63,7 @@ class DummyWorker:
             hostname=hostname,
             communicator=self.communicator,
             protocol=tensor_comm_protocol,
+            device="cpu"
         )
 
     def _add_new_request(

--- a/mminf/worker/engine_manager.py
+++ b/mminf/worker/engine_manager.py
@@ -31,7 +31,6 @@ class EngineManager:
         cls,
         engine_configs: list[dict],
         device: torch.device,
-        mooncake_cfg: MooncakeStoreConfig,
         transfer_engine_info: TransferEngineInfo,
         enable_nvtx: bool = False,
         model: Model | None = None,
@@ -83,7 +82,6 @@ class EngineManager:
 
             engine.load_model(
                 submodules, model_config, device,
-                mooncake_cfg=mooncake_cfg,
                 transfer_engine_info=transfer_engine_info
             )
             logger.info("Engine %s loaded in on device %s", cfg["engine_type"], str(device))

--- a/mminf/worker/micro_scheduler.py
+++ b/mminf/worker/micro_scheduler.py
@@ -67,7 +67,13 @@ class MicroScheduler:
                 if request_id not in worker_graphs_manager.per_request_info:
                     continue  # request was removed between scheduling cycles
                 graph_walk = worker_graphs_manager.get_graph_walk(request_id)
+                fwd_info = worker_graphs_manager.get_fwd_info(request_id)
                 for sname in node_names:
+                    # check if the node is ready on the engine level
+                    # (e.g., for AR, whether the kv cache is read in)
+                    engine = self.engine_manager.get_engine(sname)
+                    if not engine.check_ready(sname, request_id, fwd_info):
+                        continue
                     node_name_to_requests.setdefault(sname, []).append(
                         ReadyNodeEntry(request_id, worker_graph_id, graph_walk)
                     )

--- a/mminf/worker/micro_scheduler.py
+++ b/mminf/worker/micro_scheduler.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import logging
 from dataclasses import dataclass
 
@@ -34,6 +35,10 @@ PRIORITY = {
     EngineType.AUDIO_CODEC: 3,
 }
 
+class SchedulingType(Enum):
+    PRIORITY = "priority"
+    ROUND_ROBIN = "round_robin"
+
 
 class MicroScheduler:
     """
@@ -41,8 +46,62 @@ class MicroScheduler:
     groups by node name, returns the highest-priority group.
     """
 
-    def __init__(self, engine_manager: EngineManager):
+    def __init__(
+        self, engine_manager: EngineManager,
+        sched_type=SchedulingType.ROUND_ROBIN
+    ):
         self.engine_manager = engine_manager
+        self.batch_number = 0
+        self.sched_type = sched_type
+        self.node_and_walk_to_last_batch_num = {}
+    
+    def _select_node_priority(
+        self, node_name_to_requests: dict[str, list[ReadyNodeEntry]]
+    ):
+        # Pick the node name with highest priority (lowest PRIORITY value)
+        best_node_name = None
+        best_priority = float("inf")
+
+        for node_name in node_name_to_requests:
+            if node_name not in self.engine_manager.node_to_engine:
+                continue
+            engine = self.engine_manager.get_engine(node_name)
+            prio = PRIORITY.get(engine.engine_type(), 99)
+            if prio < best_priority:
+                best_priority = prio
+                best_node_name = node_name
+        if best_node_name is None:
+            return None, None
+        entries = node_name_to_requests[best_node_name]
+
+        # Enforce same graph_walk for the entire batch.
+        # Pick the most common graph_walk to maximize batch size;
+        # remaining requests stay in the queue for the next cycle.
+        walk_counts: dict[str, int] = {}
+        for e in entries:
+            walk_counts[e.graph_walk] = walk_counts.get(e.graph_walk, 0) + 1
+        graph_walk = max(walk_counts, key=walk_counts.get)
+
+        return node_name, graph_walk
+
+    def _select_node_rr(
+        self, node_name_to_requests: dict[str, list[ReadyNodeEntry]]
+    ):
+        best_node_name = None
+        best_graph_walk = None
+        least_recent_step = float('inf')
+
+        for node_name, reqs in node_name_to_requests.items():
+            for req in reqs:
+                step = self.node_and_walk_to_last_batch_num.get((
+                    node_name, req.graph_walk
+                ), 0)
+                if step < least_recent_step:
+                    least_recent_step = step
+                    best_node_name = node_name
+                    best_graph_walk = req.graph_walk
+        return best_node_name, best_graph_walk
+
 
     def get_next_batch(
         self,
@@ -81,33 +140,19 @@ class MicroScheduler:
         if not node_name_to_requests:
             return None
 
-        # Pick the node name with highest priority (lowest PRIORITY value)
-        best_node_name = None
-        best_priority = float("inf")
-
-        for node_name in node_name_to_requests:
-            if node_name not in self.engine_manager.node_to_engine:
-                continue
-            engine = self.engine_manager.get_engine(node_name)
-            prio = PRIORITY.get(engine.engine_type(), 99)
-            if prio < best_priority:
-                best_priority = prio
-                best_node_name = node_name
+        if self.sched_type == SchedulingType.PRIORITY:
+            best_node_name, graph_walk = self._select_node_priority(node_name_to_requests)
+        elif self.sched_type == SchedulingType.ROUND_ROBIN:
+            best_node_name, graph_walk = self._select_node_rr(node_name_to_requests)
+        else:
+            raise NotImplementedError(f"Unkown scheduling type {self.sched_type}")
 
         if best_node_name is None:
             return None
 
         # Pop ready nodes for all requests of this node name
-        entries = node_name_to_requests[best_node_name]
-
-        # Enforce same graph_walk for the entire batch.
-        # Pick the most common graph_walk to maximize batch size;
-        # remaining requests stay in the queue for the next cycle.
-        walk_counts: dict[str, int] = {}
-        for e in entries:
-            walk_counts[e.graph_walk] = walk_counts.get(e.graph_walk, 0) + 1
-        graph_walk = max(walk_counts, key=walk_counts.get)
-        entries = [e for e in entries if e.graph_walk == graph_walk]
+        entries = [e for e in node_name_to_requests[best_node_name] \
+                   if e.graph_walk == graph_walk]
 
         # Limit batch size if requested (e.g., for CUDA graph compatibility)
         if max_batch_size is not None and len(entries) > max_batch_size:
@@ -129,6 +174,10 @@ class MicroScheduler:
             "MicroScheduler scheduling node %s with graph walk %s for %d requests",
             best_node_name, graph_walk, len(node_objects)
         )
+        self.batch_number += 1
+        self.node_and_walk_to_last_batch_num[(
+            best_node_name, graph_walk
+        )] = self.batch_number
 
         return ScheduledBatch(
             node_name=best_node_name,

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -91,6 +91,7 @@ class Worker:
             communicator=self.communicator,
             protocol=tensor_comm_protocol,
             tcp_transfer_device=tcp_transfer_device,
+            device=self.device
         )
 
         self.engine_manager = EngineManager.from_config(
@@ -193,7 +194,6 @@ class Worker:
         # Start RDMA reads for tensors that have tensor_info
         self.tensor_manager.start_read_tensors(
             body.request_id, body.initial_inputs,
-            device=self.device
         )
 
         # Signal-only edges (tensor_info is None) can be processed immediately
@@ -235,7 +235,6 @@ class Worker:
         # Start RDMA reads for tensors with tensor_info
         self.tensor_manager.start_read_tensors(
             body.request_id, body.inputs,
-            device=self.device
         )
 
         # Signal-only edges can be processed immediately

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -482,6 +482,7 @@ class Worker:
                 # 3. Pick next batch via MicroScheduler
                 batch = self.scheduler.get_next_batch(self.worker_graphs_manager)
                 if batch is None:
+                    sleep(0.001) # added this (with my original original code) and it works!
                     continue
 
                 # 4. Gather input tensors for the batch

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -96,12 +96,6 @@ class Worker:
 
         self.engine_manager = EngineManager.from_config(
             engine_configs=engine_configs, device=device,
-            mooncake_cfg=MooncakeStoreConfig(
-                hostname=hostname,
-                metadata_server=f"http://localhost:{mooncake_port}/metadata",
-                protocol=tensor_comm_protocol,
-                master_service=master_service
-            ),
             transfer_engine_info=TransferEngineInfo(
                 my_entity_id=worker_id,
                 my_session_id=self.tensor_manager.my_session_id,

--- a/perf_testing/offline_homogenous.sh
+++ b/perf_testing/offline_homogenous.sh
@@ -35,6 +35,8 @@ for bs in "${BATCH_SIZES[@]}"; do
   NUM_REQUESTS=$NUM_REQUESTS TASK=text_to_image BATCH_SIZE=$bs benchmark/run_benchmark.sh
 done
 
+BATCH_SIZES=(1 2 4 8)
+
 # image_to_image
 for bs in "${BATCH_SIZES[@]}"; do
   NUM_REQUESTS=$(compute_num_requests $bs)

--- a/perf_testing/offline_homogenous.sh
+++ b/perf_testing/offline_homogenous.sh
@@ -2,28 +2,41 @@
 
 #!/bin/bash
 
-NUM_REQUESTS="${NUM_REQUESTS:-128}"
+#!/bin/bash
 
 BATCH_SIZES=(1 2 4 8 16)
+NUM_BATCHES="${NUM_BATCHES:-10}"
+MIN_NUM_REQUESTS="${MIN_NUM_REQUESTS:-20}"
+
+compute_num_requests() {
+  local bs=$1
+  local req=$((NUM_BATCHES * bs))
+  if [ "$req" -lt "$MIN_NUM_REQUESTS" ]; then
+    req=$MIN_NUM_REQUESTS
+  fi
+  echo $req
+}
 
 # text_to_text (with DATASET=text)
 for bs in "${BATCH_SIZES[@]}"; do
+  NUM_REQUESTS=$(compute_num_requests $bs)
   NUM_REQUESTS=$NUM_REQUESTS TASK=text_to_text DATASET=text BATCH_SIZE=$bs benchmark/run_benchmark.sh
 done
 
 # image_to_text
 for bs in "${BATCH_SIZES[@]}"; do
+  NUM_REQUESTS=$(compute_num_requests $bs)
   NUM_REQUESTS=$NUM_REQUESTS TASK=image_to_text BATCH_SIZE=$bs benchmark/run_benchmark.sh
 done
 
-NUM_REQUESTS="${NUM_REQUESTS_GEN:-64}"
-
 # text_to_image
 for bs in "${BATCH_SIZES[@]}"; do
+  NUM_REQUESTS=$(compute_num_requests $bs)
   NUM_REQUESTS=$NUM_REQUESTS TASK=text_to_image BATCH_SIZE=$bs benchmark/run_benchmark.sh
 done
 
 # image_to_image
 for bs in "${BATCH_SIZES[@]}"; do
+  NUM_REQUESTS=$(compute_num_requests $bs)
   NUM_REQUESTS=$NUM_REQUESTS TASK=image_to_image BATCH_SIZE=$bs benchmark/run_benchmark.sh
 done

--- a/perf_testing/offline_homogenous.sh
+++ b/perf_testing/offline_homogenous.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#!/bin/bash
+
+NUM_REQUESTS="${NUM_REQUESTS:-128}"
+
+BATCH_SIZES=(1 2 4 8 16)
+
+# text_to_text (with DATASET=text)
+for bs in "${BATCH_SIZES[@]}"; do
+  NUM_REQUESTS=$NUM_REQUESTS TASK=text_to_text DATASET=text BATCH_SIZE=$bs benchmark/run_benchmark.sh
+done
+
+# image_to_text
+for bs in "${BATCH_SIZES[@]}"; do
+  NUM_REQUESTS=$NUM_REQUESTS TASK=image_to_text BATCH_SIZE=$bs benchmark/run_benchmark.sh
+done
+
+NUM_REQUESTS="${NUM_REQUESTS_GEN:-64}"
+
+# text_to_image
+for bs in "${BATCH_SIZES[@]}"; do
+  NUM_REQUESTS=$NUM_REQUESTS TASK=text_to_image BATCH_SIZE=$bs benchmark/run_benchmark.sh
+done
+
+# image_to_image
+for bs in "${BATCH_SIZES[@]}"; do
+  NUM_REQUESTS=$NUM_REQUESTS TASK=image_to_image BATCH_SIZE=$bs benchmark/run_benchmark.sh
+done


### PR DESCRIPTION
**Added:**
- "Offline" mode (send a fixed-size batch to the server, wait for all results, and then send another batch) for benchmarking
- Simple text->text dataset
- Performance testing shell script

**Changes**:
- Replaced Mooncake `transfer_read_on_cuda` (which was unstable) with an async threadpool reader
- Added async support for KV reads
- Short sleep in the worker loop if no batches are found (prevents "busy waiting")
- Round robin scheduling to avoid HoL blocking (with priority-based as an option that can be theoretically passed in if we want)
- Avoid computing `requires_cfg` in the forward pass (pass it in via preprocess) to avoid some unnecessary torch recompiles / graph breaks