### PR TITLE
Cpu offload

### DIFF
--- a/configs/bagel_cfg_parallel.yaml
+++ b/configs/bagel_cfg_parallel.yaml
@@ -1,6 +1,6 @@
 model: "bagel"
 max_seq_len: 32768
-max_concurrent_requests: 16
+max_concurrent_requests: 32
 
 kv_cache:
   cpu_offload_pages: 2048

--- a/configs/bagel_cfg_parallel.yaml
+++ b/configs/bagel_cfg_parallel.yaml
@@ -1,6 +1,6 @@
 model: "bagel"
 max_seq_len: 32768
-max_concurrent_requests: 32
+max_concurrent_requests: 16
 
 kv_cache:
   cpu_offload_pages: 2048

--- a/configs/bagel_cfg_parallel.yaml
+++ b/configs/bagel_cfg_parallel.yaml
@@ -1,6 +1,6 @@
 model: "bagel"
 max_seq_len: 32768
-max_concurrent_requests: 8
+max_concurrent_requests: 16
 
 kv_cache:
   cpu_offload_pages: 2048

--- a/configs/bagel_cfg_parallel.yaml
+++ b/configs/bagel_cfg_parallel.yaml
@@ -3,8 +3,7 @@ max_seq_len: 32768
 max_concurrent_requests: 8
 
 kv_cache:
-  max_num_pages: 4096
-  cpu_offload_pages: 4096
+  cpu_offload_pages: 2048
 
 node_groups:
   - node_names:

--- a/configs/bagel_cfg_parallel.yaml
+++ b/configs/bagel_cfg_parallel.yaml
@@ -1,5 +1,10 @@
 model: "bagel"
 max_seq_len: 32768
+max_concurrent_requests: 8
+
+kv_cache:
+  max_num_pages: 4096
+  cpu_offload_pages: 4096
 
 node_groups:
   - node_names:

--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -193,7 +193,7 @@ class AsyncMooncakeReader:
     The default stream is never blocked by store writes.
     """
 
-    def __init__(self, engine, device, max_workers: int = 1, max_batch_size=500):
+    def __init__(self, engine, device, max_workers: int = 3, max_batch_size=500):
         self._engine = engine
         self.max_batch_size = max_batch_size
         self._executor = ThreadPoolExecutor(max_workers=max_workers)

--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -193,7 +193,7 @@ class AsyncMooncakeReader:
     The default stream is never blocked by store writes.
     """
 
-    def __init__(self, engine, device, max_workers: int = 2, max_batch_size=500):
+    def __init__(self, engine, device, max_workers: int = 3, max_batch_size=500):
         self._engine = engine
         self.max_batch_size = max_batch_size
         self._executor = ThreadPoolExecutor(max_workers=max_workers)

--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -193,7 +193,7 @@ class AsyncMooncakeReader:
     The default stream is never blocked by store writes.
     """
 
-    def __init__(self, engine, device, max_workers: int = 3, max_batch_size=500):
+    def __init__(self, engine, device, max_workers: int = 2, max_batch_size=500):
         self._engine = engine
         self.max_batch_size = max_batch_size
         self._executor = ThreadPoolExecutor(max_workers=max_workers)

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -147,9 +147,13 @@ class Conductor:
         self.tcp_transfer_device = tcp_transfer_device
 
         self._worker_processes: list[mp.Process] = []
+        self.waiting_queue: list[NewRequestConductor] = []
 
         with open(model_config_file, "r") as f:
             self.model_config = yaml.safe_load(f)
+        self.max_concurrent_requests: int = self.model_config.get(
+            "max_concurrent_requests", None
+        )
         assert "max_seq_len" in self.model_config
         assert "node_groups" in self.model_config
 
@@ -341,6 +345,20 @@ class Conductor:
                 )
             )
 
+    def _try_admit_waiting(self):
+        """Drain the waiting queue up to the concurrency cap."""
+        while self.waiting_queue:
+            if (self.max_concurrent_requests is not None
+                    and len(self.requests) >= self.max_concurrent_requests):
+                break
+            body = self.waiting_queue.pop(0)
+            logger.info(
+                "Admitting queued request %s (%d/%s in-flight)",
+                body.request_id, len(self.requests),
+                str(self.max_concurrent_requests),
+            )
+            self._do_ingest_request(body)
+
     def _ingest_request(
         self, body: NewRequestConductor
     ):
@@ -350,6 +368,21 @@ class Conductor:
         and notify the workers that the request has arrived + provide the appropriate
         workers with the appropriate initial inputs for the forward pass.
         """
+        if (self.max_concurrent_requests is not None
+                and len(self.requests) >= self.max_concurrent_requests):
+            logger.info(
+                "Request %s queued (at capacity: %d/%d)",
+                body.request_id, len(self.requests),
+                self.max_concurrent_requests,
+            )
+            self.waiting_queue.append(body)
+            return
+        self._do_ingest_request(body)
+
+    def _do_ingest_request(
+        self, body: NewRequestConductor
+    ):
+        """Actually dispatch a request to workers (no admission check)."""
         logger.debug("Conductor ingesting request %s", body.request_id)
         worker_graph_to_worker = self._assign_worker_graphs_to_workers()
 
@@ -445,6 +478,7 @@ class Conductor:
             )
         )
         del self.requests[request_id]
+        self._try_admit_waiting()
 
     def _process_done_forward(
         self, request_id: str

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -189,8 +189,18 @@ class Conductor:
         self._per_worker_graphs: dict[str, list[WorkerGraph]] = {}
         self._per_worker_engine_configs: dict[str, list[dict]] = {}
 
+        kv_cache_config = self.model.get_kv_cache_config()
+        # Apply any KV cache overrides from the YAML config
+        yaml_kv_overrides = self.model_config.get("kv_cache", {})
+        if yaml_kv_overrides:
+            from dataclasses import fields
+            for f in fields(kv_cache_config):
+                if f.name in yaml_kv_overrides:
+                    setattr(kv_cache_config, f.name, yaml_kv_overrides[f.name])
+            logger.info("KV cache config after YAML overrides: %s", kv_cache_config)
+
         engine_model_cfg = {
-            "kv_cache": self.model.get_kv_cache_config(),
+            "kv_cache": kv_cache_config,
             "autocast_dtype": self.model.get_autocast_dtype()
         }
         for rank in self._sorted_ranks:

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -4,6 +4,7 @@ import torch
 
 from mminf.engine.base import BaseEngine, EngineType, NodeBatch, NodeOutput
 from mminf.engine.cache_manager import BatchedCacheManager, WorkspaceBufferManager
+from mminf.engine.cpu_page_pool import CPUPagePool
 from mminf.engine.cuda_graph_runner import CudaGraphRunner
 from mminf.engine.kv_store import KVCacheConfig, MooncakeStoreConfig, PagedAllocationManager, TransferEngineInfo
 from mminf.conductor.request_info import CurrentForwardPassInfo, SequenceInfo
@@ -38,6 +39,7 @@ class AREngine(BaseEngine):
         self.kv_cache = None  # [num_layers, max_pages, 2, page_size, num_kv_heads, head_dim]
         self.alloc_manager: PagedAllocationManager | None = None
         self.buffer_manager = None
+        self.cpu_page_pool: CPUPagePool | None = None
 
         # CUDA graph runners (initialized in warmup())
         self.cuda_graph_runners: dict[str, "CudaGraphRunner"] = {}
@@ -84,6 +86,18 @@ class AREngine(BaseEngine):
         self.buffer_manager = WorkspaceBufferManager(
             256 * 1024 * 1024, device=device
         )
+
+        # CPU page pool for KV cache offloading
+        if cfg.cpu_offload_pages > 0:
+            self.cpu_page_pool = CPUPagePool(
+                kv_cache_config=cfg,
+                max_cpu_pages=cfg.cpu_offload_pages,
+                kv_cache_dtype=kv_cache_type,
+            )
+            logger.info(
+                "AREngine: CPU page pool initialized with %d pages",
+                cfg.cpu_offload_pages,
+            )
 
     def _create_cache_manager(self, request_id: str) -> BatchedCacheManager:
         """Create a CacheHandle for a single request."""
@@ -333,13 +347,29 @@ class AREngine(BaseEngine):
             needed_labels = self._get_needed_labels(
                 batch.node_name, batch.graph_walk, batch.per_request_info
             )
-            for req_id, info in batch.per_request_info.items():
-                for label, seq_info in info.per_label_seq_info.items():
-                    if needed_labels is not None and label not in needed_labels:
-                        continue
-                    self.alloc_manager.sync_retrieve(
-                        req_id, label, seq_info
+            try:
+                for req_id, info in batch.per_request_info.items():
+                    for label, seq_info in info.per_label_seq_info.items():
+                        if needed_labels is not None and label not in needed_labels:
+                            continue
+                        self.alloc_manager.sync_retrieve(
+                            req_id, label, seq_info
+                        )
+            except RuntimeError as e:
+                if "Not enough free pages" in str(e):
+                    logger.warning(
+                        "KV cache page allocation failed for batch "
+                        "(node=%s, walk=%s, requests=%s): %s",
+                        batch.node_name, batch.graph_walk,
+                        batch.request_ids, e,
                     )
+                    return NodeOutput(
+                        per_request_output_tensors={
+                            rid: {} for rid in batch.request_ids
+                        },
+                        allocation_failed=True,
+                    )
+                raise
 
             with torch.no_grad():
                 with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
@@ -374,6 +404,14 @@ class AREngine(BaseEngine):
         self, node_name: str, request_id: str,
         request_info: CurrentForwardPassInfo,
     ):
+        # If this request was offloaded to CPU, try reloading first
+        if self.cpu_page_pool is not None and self.cpu_page_pool.is_offloaded(request_id):
+            try:
+                self.alloc_manager.reload_request(request_id, self.cpu_page_pool)
+                logger.info("Reloaded offloaded request %s from CPU", request_id)
+            except RuntimeError:
+                return False  # can't reload yet, not ready
+
         needed_labels = self._get_needed_labels(
             node_name, request_info.graph_walk, {
                     request_id: request_info
@@ -399,6 +437,8 @@ class AREngine(BaseEngine):
         self.alloc_manager.add_request(request_id, cache_labels or ["main"])
 
     def remove_request(self, request_id: str) -> None:
+        if self.cpu_page_pool is not None:
+            self.cpu_page_pool.remove_request(request_id)
         self.alloc_manager.remove_request(request_id)
 
     def pause_request(

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -425,13 +425,18 @@ class AREngine(BaseEngine):
         )
 
         labels_to_check = []
-        for label, seq_info in request_info.per_label_seq_info.items():
-            if needed_labels is not None and label not in needed_labels:
-                continue
-            self.alloc_manager.start_async_retrieve(
-                request_id, label, seq_info
-            )
-            labels_to_check.append(label)
+        try:
+            for label, seq_info in request_info.per_label_seq_info.items():
+                if needed_labels is not None and label not in needed_labels:
+                    continue
+                self.alloc_manager.start_async_retrieve(
+                    request_id, label, seq_info
+                )
+                labels_to_check.append(label)
+        except RuntimeError:
+            # Not enough pages to allocate for retrieval — not ready
+            return False
+
         return all([
             self.alloc_manager.check_retrieve_ready(request_id, label) \
                 for label in labels_to_check

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -347,6 +347,7 @@ class AREngine(BaseEngine):
             needed_labels = self._get_needed_labels(
                 batch.node_name, batch.graph_walk, batch.per_request_info
             )
+            self.alloc_manager.alloc_status.reset()
             try:
                 for req_id, info in batch.per_request_info.items():
                     for label, seq_info in info.per_label_seq_info.items():
@@ -355,19 +356,24 @@ class AREngine(BaseEngine):
                         self.alloc_manager.sync_retrieve(
                             req_id, label, seq_info
                         )
-            except RuntimeError as e:
-                if "Not enough free pages" in str(e):
+            except RuntimeError:
+                if not self.alloc_manager.alloc_status.success:
+                    status = self.alloc_manager.alloc_status
                     logger.warning(
                         "KV cache page allocation failed for batch "
-                        "(node=%s, walk=%s, requests=%s): %s",
+                        "(node=%s, walk=%s, request=%s, label=%s, "
+                        "pages_short=%d)",
                         batch.node_name, batch.graph_walk,
-                        batch.request_ids, e,
+                        status.request_id, status.label,
+                        status.pages_short,
                     )
                     return NodeOutput(
                         per_request_output_tensors={
                             rid: {} for rid in batch.request_ids
                         },
                         allocation_failed=True,
+                        alloc_pages_short=status.pages_short,
+                        alloc_failed_request_id=status.request_id,
                     )
                 raise
 

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -356,6 +356,16 @@ class AREngine(BaseEngine):
                         self.alloc_manager.sync_retrieve(
                             req_id, label, seq_info
                         )
+
+                with torch.no_grad():
+                    with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
+                        # Priority: CUDA graph > batched > sequential
+                        if self._can_use_cuda_graph(batch):
+                            return self._execute_with_cuda_graph(batch, submodule)
+                        elif submodule.can_batch(batch):
+                            return self._execute_batched(batch, submodule)
+                        else:
+                            return self._execute_sequential(batch, submodule)
             except RuntimeError:
                 if not self.alloc_manager.alloc_status.success:
                     status = self.alloc_manager.alloc_status
@@ -376,16 +386,6 @@ class AREngine(BaseEngine):
                         alloc_failed_request_id=status.request_id,
                     )
                 raise
-
-            with torch.no_grad():
-                with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
-                    # Priority: CUDA graph > batched > sequential
-                    if self._can_use_cuda_graph(batch):
-                        return self._execute_with_cuda_graph(batch, submodule)
-                    elif submodule.can_batch(batch):
-                        return self._execute_batched(batch, submodule)
-                    else:
-                        return self._execute_sequential(batch, submodule)
         finally:
             for req_id in batch.request_ids:
                 batch.per_request_info[req_id].per_label_seq_info = \

--- a/mminf/engine/base.py
+++ b/mminf/engine/base.py
@@ -37,6 +37,9 @@ class NodeOutput:
     per_request_output_tensors: dict[str, NameToTensorList]
     # Set to True when page allocation failed; worker should hold and retry.
     allocation_failed: bool = False
+    # When allocation_failed=True, details about the failure:
+    alloc_pages_short: int = 0
+    alloc_failed_request_id: str | None = None
 
 
 class BaseEngine(ABC):

--- a/mminf/engine/base.py
+++ b/mminf/engine/base.py
@@ -35,6 +35,8 @@ class NodeOutput:
     """Output from an engine's execute_batch()."""
     # {request_id: {output_name: [tensor]}}
     per_request_output_tensors: dict[str, NameToTensorList]
+    # Set to True when page allocation failed; worker should hold and retry.
+    allocation_failed: bool = False
 
 
 class BaseEngine(ABC):

--- a/mminf/engine/cpu_page_pool.py
+++ b/mminf/engine/cpu_page_pool.py
@@ -1,0 +1,141 @@
+"""CPU-side page pool for KV cache offloading.
+
+When GPU pages are exhausted, cold requests' KV cache pages can be swapped to
+CPU pinned memory here, freeing GPU pages for active requests. Pages are
+reloaded back to GPU when the request is re-scheduled.
+"""
+import logging
+from dataclasses import dataclass, field
+
+import torch
+
+from mminf.engine.kv_store import KVCacheConfig, PageAllocator
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OffloadedState:
+    """Tracks a single (request, label) that has been offloaded to CPU."""
+    cpu_page_indices: list[int]
+    seq_len: int
+    position_id_start: int
+
+
+class CPUPagePool:
+    """CPU-side mirror of the GPU paged KV cache for offloading."""
+
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        max_cpu_pages: int,
+        kv_cache_dtype: torch.dtype = torch.bfloat16,
+    ):
+        self.config = kv_cache_config
+        self.page_allocator = PageAllocator(max_cpu_pages)
+
+        # Same shape as the GPU KV cache but on pinned CPU memory
+        self.cpu_kv_cache = torch.zeros(
+            kv_cache_config.num_layers,
+            max_cpu_pages,
+            2,  # K and V
+            kv_cache_config.page_size,
+            kv_cache_config.num_kv_heads,
+            kv_cache_config.head_dim,
+            dtype=kv_cache_dtype,
+            device="cpu",
+        ).pin_memory()
+
+        # {request_id: {label: OffloadedState}}
+        self.offloaded: dict[str, dict[str, OffloadedState]] = {}
+
+        # Dedicated CUDA stream for async GPU↔CPU copies
+        self._stream: torch.cuda.Stream | None = None
+
+    def _get_stream(self) -> torch.cuda.Stream:
+        if self._stream is None:
+            self._stream = torch.cuda.Stream()
+        return self._stream
+
+    def is_offloaded(self, request_id: str) -> bool:
+        return request_id in self.offloaded and len(self.offloaded[request_id]) > 0
+
+    def offload_pages(
+        self,
+        request_id: str,
+        label: str,
+        gpu_kv_cache: torch.Tensor,
+        gpu_page_indices: list[int],
+        seq_len: int,
+        position_id_start: int,
+    ) -> None:
+        """Copy GPU pages → CPU pages (async on dedicated stream)."""
+        n_pages = len(gpu_page_indices)
+        if n_pages == 0:
+            return
+
+        cpu_pages = self.page_allocator.try_allocate(n_pages)
+        if cpu_pages is None:
+            logger.warning(
+                "CPU page pool exhausted: cannot offload %d pages for %s/%s",
+                n_pages, request_id, label,
+            )
+            return
+
+        stream = self._get_stream()
+        with torch.cuda.stream(stream):
+            for gpu_idx, cpu_idx in zip(gpu_page_indices, cpu_pages):
+                # Copy all layers at once: cpu[:, cpu_idx] = gpu[:, gpu_idx]
+                self.cpu_kv_cache[:, cpu_idx].copy_(
+                    gpu_kv_cache[:, gpu_idx], non_blocking=True
+                )
+
+        self.offloaded.setdefault(request_id, {})[label] = OffloadedState(
+            cpu_page_indices=cpu_pages,
+            seq_len=seq_len,
+            position_id_start=position_id_start,
+        )
+
+    def reload_pages(
+        self,
+        request_id: str,
+        label: str,
+        gpu_kv_cache: torch.Tensor,
+        gpu_page_indices: list[int],
+    ) -> tuple[int, int]:
+        """Copy CPU pages → GPU pages (async), free CPU pages.
+
+        Returns (seq_len, position_id_start) that were saved during offload.
+        """
+        state = self.offloaded[request_id][label]
+
+        stream = self._get_stream()
+        with torch.cuda.stream(stream):
+            for cpu_idx, gpu_idx in zip(state.cpu_page_indices, gpu_page_indices):
+                gpu_kv_cache[:, gpu_idx].copy_(
+                    self.cpu_kv_cache[:, cpu_idx], non_blocking=True
+                )
+
+        self.page_allocator.free(state.cpu_page_indices)
+        seq_len, pos_id = state.seq_len, state.position_id_start
+        del self.offloaded[request_id][label]
+        if not self.offloaded[request_id]:
+            del self.offloaded[request_id]
+        return seq_len, pos_id
+
+    def sync(self) -> None:
+        """Wait for all pending GPU↔CPU copies to complete."""
+        if self._stream is not None:
+            torch.cuda.current_stream().wait_stream(self._stream)
+
+    def remove_request(self, request_id: str) -> None:
+        """Free any CPU pages held by this request (e.g., on request removal)."""
+        if request_id not in self.offloaded:
+            return
+        for label, state in self.offloaded[request_id].items():
+            self.page_allocator.free(state.cpu_page_indices)
+        del self.offloaded[request_id]
+
+    @property
+    def num_free_pages(self) -> int:
+        return self.page_allocator.num_free

--- a/mminf/engine/kv_store.py
+++ b/mminf/engine/kv_store.py
@@ -31,6 +31,12 @@ class PageAllocator:
             )
         return [self.free_pages.get() for _ in range(n)]
 
+    def try_allocate(self, n: int) -> list[int] | None:
+        """Like allocate() but returns None instead of raising on failure."""
+        if self.free_pages.qsize() < n:
+            return None
+        return [self.free_pages.get() for _ in range(n)]
+
     def free(self, pages: list[int]) -> None:
         for page in pages:
             self.free_pages.put(page)
@@ -49,6 +55,7 @@ class KVCacheConfig:
     max_num_pages: int = 2048
     page_size: int = 128
     num_qo_heads: int | None = None  # Optional, defaults to num_kv_heads
+    cpu_offload_pages: int = 0  # >0 enables CPU offloading with this many CPU pages
 
     def __post_init__(self):
         if self.num_qo_heads is None:
@@ -123,8 +130,19 @@ class PagedAllocationManager:
         self.my_entity_id = transfer_engine_info.my_entity_id
         self.my_session_id = transfer_engine_info.my_session_id
 
+        # Stream for async GPU↔CPU page copies (Feature 3: CPU offloading)
+        self._offload_stream: torch.cuda.Stream | None = None
+
         # {req_id: {label: futures}}
         self.pending_reads: dict[str, dict[str, list[Future]]] = {}
+
+    @property
+    def num_free_pages(self) -> int:
+        return self.page_allocator.num_free
+
+    @property
+    def total_pages(self) -> int:
+        return self.config.max_num_pages
 
     def _key(self, request_id: str, label: str, pos: int, layer: int):
         return f"{request_id}_{label}_{pos}_{layer}"
@@ -311,4 +329,41 @@ class PagedAllocationManager:
             self.page_allocator.free(state.page_indices)
         del self.request_states[request_id]
         del self.pending_reads[request_id]
+
+    # ----- CPU offloading helpers -----
+
+    def offload_request(self, request_id: str, cpu_pool) -> int:
+        """Offload all labels for a request to *cpu_pool*, free GPU pages.
+
+        Returns the total number of GPU pages freed.
+        """
+        freed = 0
+        for label, state in self.request_states[request_id].items():
+            if not state.page_indices:
+                continue
+            self.wait_for_retrieves(request_id, label)
+            cpu_pool.offload_pages(
+                request_id, label, self.kv_cache,
+                state.page_indices, state.seq_len, state.position_id_start,
+            )
+            freed += len(state.page_indices)
+            self.page_allocator.free(state.page_indices)
+            state.page_indices = []
+            state.seq_len = 0
+        return freed
+
+    def reload_request(self, request_id: str, cpu_pool) -> None:
+        """Reload all labels for a request from *cpu_pool* back to GPU."""
+        for label in list(cpu_pool.offloaded.get(request_id, {}).keys()):
+            offloaded = cpu_pool.offloaded[request_id][label]
+            n_pages = len(offloaded.cpu_page_indices)
+            gpu_pages = self.page_allocator.allocate(n_pages)
+            state = self.get_state(request_id, label)
+            state.page_indices = gpu_pages
+            seq_len, pos_id = cpu_pool.reload_pages(
+                request_id, label, self.kv_cache, gpu_pages,
+            )
+            state.seq_len = seq_len
+            state.position_id_start = pos_id
+        cpu_pool.sync()
 

--- a/mminf/engine/kv_store.py
+++ b/mminf/engine/kv_store.py
@@ -77,6 +77,22 @@ class KVRequestState:
 
 LabelToState = dict[str, KVRequestState]
 
+
+@dataclass
+class AllocationStatus:
+    """Tracks the outcome of the most recent page allocation attempt."""
+    success: bool = True
+    pages_short: int = 0       # how many pages we couldn't allocate
+    request_id: str | None = None  # which request failed
+    label: str | None = None       # which cache label failed
+
+    def reset(self):
+        self.success = True
+        self.pages_short = 0
+        self.request_id = None
+        self.label = None
+
+
 @dataclass
 class StoreAllocInfo:
     key: str
@@ -132,6 +148,10 @@ class PagedAllocationManager:
 
         # Stream for async GPU↔CPU page copies (Feature 3: CPU offloading)
         self._offload_stream: torch.cuda.Stream | None = None
+
+        # Tracks the outcome of the most recent allocation attempt per batch.
+        # Reset at the start of each batch by the engine.
+        self.alloc_status = AllocationStatus()
 
         # {req_id: {label: futures}}
         self.pending_reads: dict[str, dict[str, list[Future]]] = {}
@@ -200,7 +220,18 @@ class PagedAllocationManager:
         num_pages_needed = (seq_len + self.config.page_size - 1) // self.config.page_size
         num_new_pages = num_pages_needed - len(state.page_indices)
         if num_new_pages > 0:
-            new_pages = self.page_allocator.allocate(num_new_pages)
+            new_pages = self.page_allocator.try_allocate(num_new_pages)
+            if new_pages is None:
+                self.alloc_status = AllocationStatus(
+                    success=False,
+                    pages_short=num_new_pages - self.page_allocator.num_free,
+                    request_id=request_id,
+                    label=label,
+                )
+                raise RuntimeError(
+                    f"Not enough free pages: requested {num_new_pages}, "
+                    f"available {self.page_allocator.num_free}"
+                )
             state.page_indices.extend(new_pages)
     
     def wait_for_retrieves(

--- a/mminf/worker/engine_manager.py
+++ b/mminf/worker/engine_manager.py
@@ -129,6 +129,13 @@ class EngineManager:
                 return engine.alloc_manager
         return None
 
+    def get_ar_engine(self) -> "AREngine | None":
+        """Return the first AR engine instance, if any."""
+        for engine in self.node_to_engine.values():
+            if isinstance(engine, AREngine):
+                return engine
+        return None
+
     def shutdown(self) -> None:
         seen = set()
         for engine in self.node_to_engine.values():

--- a/mminf/worker/micro_scheduler.py
+++ b/mminf/worker/micro_scheduler.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import logging
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 
 from mminf.engine.base import EngineType
 from mminf.graph.base import GraphNode
@@ -24,6 +25,8 @@ class ScheduledBatch:
     node_name: str
     graph_walk: str
     node_objects: dict[str,GraphNode]
+    # request_id -> worker_graph_id (for push-back on OOM)
+    request_to_worker_graph: dict[str, str] = None
 
 
 # Priority: lower value = higher priority
@@ -46,6 +49,9 @@ class MicroScheduler:
     groups by node name, returns the highest-priority group.
     """
 
+    # Seconds to wait before retrying a held request after OOM
+    HOLD_BACKOFF_SECONDS = 0.05
+
     def __init__(
         self, engine_manager: EngineManager,
         sched_type=SchedulingType.ROUND_ROBIN
@@ -54,6 +60,8 @@ class MicroScheduler:
         self.batch_number = 0
         self.sched_type = sched_type
         self.node_and_walk_to_last_batch_num = {}
+        # request_id -> monotonic time until which the request is held
+        self.held_until: dict[str, float] = {}
     
     def _select_node_priority(
         self, node_name_to_requests: dict[str, list[ReadyNodeEntry]]
@@ -102,6 +110,11 @@ class MicroScheduler:
                     best_graph_walk = req.graph_walk
         return best_node_name, best_graph_walk
 
+    def hold_requests(self, request_ids: list[str]) -> None:
+        """Put requests on hold for a brief backoff period after OOM."""
+        deadline = time.monotonic() + self.HOLD_BACKOFF_SECONDS
+        for rid in request_ids:
+            self.held_until[rid] = deadline
 
     def get_next_batch(
         self,
@@ -119,12 +132,21 @@ class MicroScheduler:
         # Collect all ready (node_name, request_id, graph_walk) tuples
         # grouped by node name
         node_name_to_requests: dict[str, list[ReadyNodeEntry]] = {}
+        now = time.monotonic()
+
+        # Expire stale hold entries
+        self.held_until = {
+            rid: t for rid, t in self.held_until.items() if t > now
+        }
 
         for worker_graph_id, queue in worker_graphs_manager.queues.items():
             ready_map = queue.get_ready_node_names()
             for request_id, node_names in ready_map.items():
                 if request_id not in worker_graphs_manager.per_request_info:
                     continue  # request was removed between scheduling cycles
+                # Skip requests in OOM backoff
+                if request_id in self.held_until:
+                    continue
                 graph_walk = worker_graphs_manager.get_graph_walk(request_id)
                 fwd_info = worker_graphs_manager.get_fwd_info(request_id)
                 for sname in node_names:
@@ -159,6 +181,7 @@ class MicroScheduler:
             entries = entries[:max_batch_size]
 
         node_objects = {}
+        request_to_worker_graph = {}
 
         for entry in entries:
             queue = worker_graphs_manager.queues[entry.worker_graph_id]
@@ -166,6 +189,7 @@ class MicroScheduler:
             if popped:
                 assert len(popped) == 1
                 node_objects[entry.request_id] = popped[0]
+                request_to_worker_graph[entry.request_id] = entry.worker_graph_id
 
         if not node_objects:
             return None
@@ -182,5 +206,6 @@ class MicroScheduler:
         return ScheduledBatch(
             node_name=best_node_name,
             graph_walk=graph_walk,
-            node_objects=node_objects
+            node_objects=node_objects,
+            request_to_worker_graph=request_to_worker_graph,
         )

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -99,6 +99,13 @@ class WorkerGraphQueues:
             q.ready = [node for i, node in enumerate(q.ready) if i not in pop_idxs]
         return nodes
 
+    def push_back_node(
+        self, request_id: str, node: GraphNode
+    ) -> None:
+        """Push a previously popped node back onto the ready queue (e.g., after OOM hold)."""
+        if request_id in self.per_request_queues:
+            self.per_request_queues[request_id].ready.append(node)
+
     def reset(self, request_id):
         """
         At the end of a worker graph, reset the queues for a request so it can

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -132,7 +132,7 @@ class Worker:
 
         # CPU offloading: LRU tracking and eviction policy
         self._last_active: dict[str, float] = {}  # request_id -> monotonic timestamp
-        self.eviction_policy = EvictionPolicy.LRU
+        self.eviction_policy = EvictionPolicy.MOST_PAGES
 
     def _compute_store_write_policy(
         self,

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -289,6 +289,54 @@ class Worker:
             )
 
     # ------------------------------------------------------------------
+    # CPU offloading
+    # ------------------------------------------------------------------
+
+    def _try_offload_cold_request(self, exclude_ids: set[str]) -> bool:
+        """Offload the request with the most GPU pages (not in *exclude_ids*) to CPU.
+
+        Returns True if a request was offloaded, False otherwise.
+        """
+        ar_engine = self.engine_manager.get_ar_engine()
+        if ar_engine is None or ar_engine.cpu_page_pool is None:
+            return False
+        alloc = ar_engine.alloc_manager
+        # Pick the request with the most allocated GPU pages
+        candidates = []
+        for rid, labels in alloc.request_states.items():
+            if rid in exclude_ids:
+                continue
+            total_pages = sum(len(s.page_indices) for s in labels.values())
+            if total_pages > 0:
+                candidates.append((rid, total_pages))
+        if not candidates:
+            return False
+        victim_id = max(candidates, key=lambda x: x[1])[0]
+        freed = alloc.offload_request(victim_id, ar_engine.cpu_page_pool)
+        logger.info(
+            "Offloaded request %s to CPU (%d GPU pages freed)", victim_id, freed
+        )
+        return freed > 0
+
+    def _try_reload_request(self, request_id: str) -> bool:
+        """Reload an offloaded request back to GPU. Returns True if reloaded."""
+        ar_engine = self.engine_manager.get_ar_engine()
+        if ar_engine is None or ar_engine.cpu_page_pool is None:
+            return False
+        if not ar_engine.cpu_page_pool.is_offloaded(request_id):
+            return False
+        try:
+            ar_engine.alloc_manager.reload_request(
+                request_id, ar_engine.cpu_page_pool
+            )
+            logger.info("Reloaded request %s from CPU to GPU", request_id)
+            return True
+        except RuntimeError:
+            # Not enough GPU pages to reload; will retry later
+            logger.debug("Cannot reload request %s yet (insufficient GPU pages)", request_id)
+            return False
+
+    # ------------------------------------------------------------------
     # Batch building
     # ------------------------------------------------------------------
 
@@ -501,7 +549,26 @@ class Worker:
                 finally:
                     if self.enable_nvtx:
                         range_pop(synchronize=False)
-                
+
+                # 5a. Handle allocation failure: push nodes back, try offload, backoff
+                if output.allocation_failed:
+                    # Try to offload a cold request to free GPU pages
+                    self._try_offload_cold_request(
+                        exclude_ids=set(batch.node_objects.keys())
+                    )
+                    for request_id, node in batch.node_objects.items():
+                        wg_id = batch.request_to_worker_graph[request_id]
+                        self.worker_graphs_manager.queues[wg_id].push_back_node(
+                            request_id, node
+                        )
+                    self.scheduler.hold_requests(list(batch.node_objects.keys()))
+                    logger.warning(
+                        "Batch held (OOM): node=%s walk=%s requests=%s",
+                        batch.node_name, batch.graph_walk,
+                        list(batch.node_objects.keys()),
+                    )
+                    continue
+
                 for rid, req_info in node_batch.per_request_info.items():
                     self.worker_graphs_manager.update_request_info(
                         rid, per_label_seq_info=req_info.per_label_seq_info

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -1,4 +1,6 @@
 import logging
+import time as _time
+from enum import Enum
 from time import sleep
 
 import torch
@@ -33,6 +35,12 @@ from mminf.worker.node_manager_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class EvictionPolicy(Enum):
+    """Strategy for choosing which request to offload to CPU on OOM."""
+    LRU = "lru"              # least-recently-used (by execution time)
+    MOST_PAGES = "most_pages"  # request holding the most GPU pages
 
 
 class Worker:
@@ -122,6 +130,10 @@ class Worker:
 
         self._unprocessed_messages = {} # req_id -> messages for requests that are not in the queue
 
+        # CPU offloading: LRU tracking and eviction policy
+        self._last_active: dict[str, float] = {}  # request_id -> monotonic timestamp
+        self.eviction_policy = EvictionPolicy.LRU
+
     def _compute_store_write_policy(
         self,
         my_worker_graphs: list[WorkerGraph],
@@ -177,6 +189,7 @@ class Worker:
 
     def _add_new_request(self, body: NewRequest) -> None:
         logger.debug("Worker %s received request %s", self.worker_id, body.request_id)
+        self._last_active[body.request_id] = _time.monotonic()
         self.worker_graphs_manager.add_request(
             request_id=body.request_id,
             worker_graph_ids=body.worker_graph_ids,
@@ -208,6 +221,7 @@ class Worker:
         self.engine_manager.remove_request(body.request_id)
         self.worker_graphs_manager.remove_request(body.request_id)
         self.tensor_manager.cleanup_request(body.request_id)
+        self._last_active.pop(body.request_id, None)
 
     def _handle_tensor_received(self, body: TensorReceived) -> None:
         """Sender-side cleanup: receiver confirmed RDMA read, free source buffers."""
@@ -295,11 +309,11 @@ class Worker:
     def _try_offload_cold_request(
         self, batch_ids: set[str]
     ) -> str | None:
-        """Offload the request with the most GPU pages to CPU.
+        """Offload one request's KV pages to CPU using the configured eviction policy.
 
         Prefers requests outside *batch_ids*. If none exist, falls back to
-        offloading the largest request *within* the batch (the caller should
-        then exclude it from execution).
+        picking a victim *within* the batch (the caller should then exclude
+        it from execution).
 
         Returns the victim request_id, or None if offloading wasn't possible.
         """
@@ -308,7 +322,7 @@ class Worker:
             return None
         alloc = ar_engine.alloc_manager
 
-        # Gather all candidates, split into external vs in-batch
+        # Gather all candidates with (rid, total_pages), split by location
         external: list[tuple[str, int]] = []
         in_batch: list[tuple[str, int]] = []
         for rid, labels in alloc.request_states.items():
@@ -325,13 +339,35 @@ class Worker:
         if not candidates:
             return None
 
-        victim_id = max(candidates, key=lambda x: x[1])[0]
+        victim_id = self._select_eviction_victim(candidates)
         freed = alloc.offload_request(victim_id, ar_engine.cpu_page_pool)
         logger.info(
-            "Offloaded request %s to CPU (%d GPU pages freed, in_batch=%s)",
-            victim_id, freed, victim_id in batch_ids,
+            "Offloaded request %s to CPU (%d GPU pages freed, "
+            "policy=%s, in_batch=%s)",
+            victim_id, freed, self.eviction_policy.value,
+            victim_id in batch_ids,
         )
         return victim_id if freed > 0 else None
+
+    def _select_eviction_victim(
+        self, candidates: list[tuple[str, int]]
+    ) -> str:
+        """Pick a victim from *candidates* based on ``self.eviction_policy``.
+
+        Each candidate is ``(request_id, total_gpu_pages)``.
+        """
+        if self.eviction_policy == EvictionPolicy.MOST_PAGES:
+            return max(candidates, key=lambda x: x[1])[0]
+
+        # LRU: pick the request with the oldest last_active timestamp.
+        # Ties (or missing entries) broken by most pages.
+        return min(
+            candidates,
+            key=lambda x: (
+                self._last_active.get(x[0], 0.0),  # oldest first
+                -x[1],                               # then most pages
+            ),
+        )[0]
 
     def _try_reload_request(self, request_id: str) -> bool:
         """Reload an offloaded request back to GPU. Returns True if reloaded."""
@@ -595,6 +631,11 @@ class Worker:
                             batch.node_name, batch.graph_walk, len(batch_ids),
                         )
                     continue
+
+                # Update LRU timestamps for successfully executed requests
+                now = _time.monotonic()
+                for rid in batch.node_objects:
+                    self._last_active[rid] = now
 
                 for rid, req_info in node_batch.per_request_info.items():
                     self.worker_graphs_manager.update_request_info(

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -292,31 +292,46 @@ class Worker:
     # CPU offloading
     # ------------------------------------------------------------------
 
-    def _try_offload_cold_request(self, exclude_ids: set[str]) -> bool:
-        """Offload the request with the most GPU pages (not in *exclude_ids*) to CPU.
+    def _try_offload_cold_request(
+        self, batch_ids: set[str]
+    ) -> str | None:
+        """Offload the request with the most GPU pages to CPU.
 
-        Returns True if a request was offloaded, False otherwise.
+        Prefers requests outside *batch_ids*. If none exist, falls back to
+        offloading the largest request *within* the batch (the caller should
+        then exclude it from execution).
+
+        Returns the victim request_id, or None if offloading wasn't possible.
         """
         ar_engine = self.engine_manager.get_ar_engine()
         if ar_engine is None or ar_engine.cpu_page_pool is None:
-            return False
+            return None
         alloc = ar_engine.alloc_manager
-        # Pick the request with the most allocated GPU pages
-        candidates = []
+
+        # Gather all candidates, split into external vs in-batch
+        external: list[tuple[str, int]] = []
+        in_batch: list[tuple[str, int]] = []
         for rid, labels in alloc.request_states.items():
-            if rid in exclude_ids:
-                continue
             total_pages = sum(len(s.page_indices) for s in labels.values())
-            if total_pages > 0:
-                candidates.append((rid, total_pages))
+            if total_pages == 0:
+                continue
+            if rid in batch_ids:
+                in_batch.append((rid, total_pages))
+            else:
+                external.append((rid, total_pages))
+
+        # Prefer external victims; fall back to in-batch
+        candidates = external or in_batch
         if not candidates:
-            return False
+            return None
+
         victim_id = max(candidates, key=lambda x: x[1])[0]
         freed = alloc.offload_request(victim_id, ar_engine.cpu_page_pool)
         logger.info(
-            "Offloaded request %s to CPU (%d GPU pages freed)", victim_id, freed
+            "Offloaded request %s to CPU (%d GPU pages freed, in_batch=%s)",
+            victim_id, freed, victim_id in batch_ids,
         )
-        return freed > 0
+        return victim_id if freed > 0 else None
 
     def _try_reload_request(self, request_id: str) -> bool:
         """Reload an offloaded request back to GPU. Returns True if reloaded."""
@@ -550,23 +565,35 @@ class Worker:
                     if self.enable_nvtx:
                         range_pop(synchronize=False)
 
-                # 5a. Handle allocation failure: push nodes back, try offload, backoff
+                # 5a. Handle allocation failure: offload a victim, retry the rest
                 if output.allocation_failed:
-                    # Try to offload a cold request to free GPU pages
-                    self._try_offload_cold_request(
-                        exclude_ids=set(batch.node_objects.keys())
-                    )
+                    batch_ids = set(batch.node_objects.keys())
+                    victim_id = self._try_offload_cold_request(batch_ids)
+
+                    # Push all batch nodes back to their queues
                     for request_id, node in batch.node_objects.items():
                         wg_id = batch.request_to_worker_graph[request_id]
                         self.worker_graphs_manager.queues[wg_id].push_back_node(
                             request_id, node
                         )
-                    self.scheduler.hold_requests(list(batch.node_objects.keys()))
-                    logger.warning(
-                        "Batch held (OOM): node=%s walk=%s requests=%s",
-                        batch.node_name, batch.graph_walk,
-                        list(batch.node_objects.keys()),
-                    )
+
+                    if victim_id is not None:
+                        # Only hold the offloaded victim (needs CPU→GPU reload)
+                        self.scheduler.hold_requests([victim_id])
+                        logger.warning(
+                            "OOM on node=%s walk=%s: offloaded victim=%s, "
+                            "retrying %d remaining requests",
+                            batch.node_name, batch.graph_walk, victim_id,
+                            len(batch_ids) - (1 if victim_id in batch_ids else 0),
+                        )
+                    else:
+                        # No offloading possible; hold all requests briefly
+                        self.scheduler.hold_requests(list(batch_ids))
+                        logger.warning(
+                            "OOM on node=%s walk=%s: no offload possible, "
+                            "holding %d requests",
+                            batch.node_name, batch.graph_walk, len(batch_ids),
+                        )
                     continue
 
                 for rid, req_info in node_batch.per_request_info.items():

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -132,7 +132,7 @@ class Worker:
 
         # CPU offloading: LRU tracking and eviction policy
         self._last_active: dict[str, float] = {}  # request_id -> monotonic timestamp
-        self.eviction_policy = EvictionPolicy.MOST_PAGES
+        self.eviction_policy = EvictionPolicy.LRU
 
     def _compute_store_write_policy(
         self,


### PR DESCRIPTION
**Feature 1: Conductor Admission Control**                                           

-   conductor.py: Added max_concurrent_requests config (from YAML, default None = unlimited), waiting_queue for excess requests, _try_admit_waiting() to drain queue when requests complete. _ingest_request() now gates on capacity and delegates  to _do_ingest_request().                                                                                                                                                                                                                          

**Feature 2: Graceful OOM Handling**                             
-   kv_store.py: Added try_allocate() (returns None instead of RuntimeError), num_free_pages/total_pages properties                                                                                                                                 
-   base.py: Added allocation_failed: bool = False to NodeOutput                                                                                                                                                                                    
-   ar_engine.py: Catches RuntimeError("Not enough free pages") in execute_batch(), returns NodeOutput(allocation_failed=True)                                                                                                                     
-   micro_scheduler.py: Added held_until dict with configurable backoff (50ms), hold_requests() method, and filtering of held requests in get_next_batch()                                                                                          
-   node_manager_utils.py: Added push_back_node() to re-queue nodes after OOM                                                                                                                                                                       
-   worker.py: On allocation_failed, pushes nodes back, calls scheduler.hold_requests(), and continues main loop                                                                                                                                    

**Feature 3: CPU Offloading**                                                                                                                                                                                                            

-   cpu_page_pool.py (new): CPUPagePool with pinned CPU memory matching GPU KV cache layout. offload_pages() / reload_pages() with async CUDA streams. OffloadedState tracking per (request, label).                                                
-   kv_store.py: Added cpu_offload_pages to KVCacheConfig, offload_request() / reload_request() on PagedAllocationManager
-   ar_engine.py: Creates CPUPagePool in load_model() when cpu_offload_pages > 0. check_ready() auto-reloads offloaded requests. remove_request() cleans up CPU pool.                                                                               
-   engine_manager.py: Added get_ar_engine() helper                                                                                                                                                                                                 
-   worker.py: Added _try_offload_cold_request() (picks victim with most pages) and _try_reload_request(). Offload trigger integrated into OOM handler.                                            


**Configuration (YAML)**              
                                                                                                                                                                                                                                                                                                                                                                                                         
```
  max_concurrent_requests: 8   # Feature 1: admission cap (omit for unlimited)                                                                                                                                                                      
  # In kv_cache config or model config:                                                                                                                                                                                                             
  # cpu_offload_pages: 4096    # Feature 3: CPU page pool size (0 = disabled)  
```