### PR TITLE
Dynamic loop control

### DIFF
--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -372,6 +372,7 @@ class TensorCommunicationManager(ABC):
                 )
             for edge in edges:
                 edge.tensor_info = graph_node_info[name]
+        return graph_node_info
 
     # ---- abstract: transport-specific ----
 

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -472,9 +472,10 @@ class Conductor:
         # Send NewRequest to each worker with the appropriate partition's inputs
         for worker_id, worker_graph_ids in worker_to_worker_graph_ids.items():
             # Determine which partition this worker serves
-            for partition_name, fwd_args in self._resolve_worker_partition(
-                worker_graph_ids, partitions, partition_fwd_args,
+            for partition_name, partition_wg_ids in self._resolve_worker_partition(
+                worker_graph_ids, partitions,
             ).items():
+                fwd_args = partition_fwd_args[partition_name]
                 pstate = partition_states[partition_name]
                 inputs_per_worker = self._split_inputs_to_workers(
                     worker_graph_to_worker=worker_graph_to_worker,
@@ -484,7 +485,7 @@ class Conductor:
 
                 message = NewRequest(
                     request_id=body.request_id,
-                    worker_graph_ids=worker_graph_ids,
+                    worker_graph_ids=partition_wg_ids,
                     worker_graph_to_worker=worker_graph_to_worker,
                     initial_inputs=inputs_per_worker.get(worker_id, []),
                     request_info=CurrentForwardPassInfo(
@@ -507,16 +508,15 @@ class Conductor:
     def _resolve_worker_partition(
         self, worker_graph_ids: list[str],
         partitions: list[PartitionDefinition],
-        partition_fwd_args: dict[str, ForwardPassArgs],
-    ) -> dict[str, ForwardPassArgs]:
+    ) -> dict[str, set[str]]:
         """Find which partition(s) a set of worker graphs belongs to."""
-        args = {}
+        partition_wg_ids = {}
         for wg_id in worker_graph_ids:
             wg_walks = self._all_worker_graph_ids_to_graph_walks.get(wg_id, set())
             for p in partitions:
                 if wg_walks & p.graph_walks:
-                    args[p.name] = partition_fwd_args[p.name]
-        return args
+                    partition_wg_ids.setdefault(p.name, set()).add(wg_id)
+        return partition_wg_ids
 
     def _set_partition_worker_graph_ids(
         self, request_id: str, partition_name: str, graph_walk: str,
@@ -678,7 +678,7 @@ class Conductor:
             for conn in request_data.streaming_connections.values():
                 if conn.from_partition == partition_name:
                     conn.producer_done = True
-                    self._send_producer_done(request_id, conn.to_partition)
+                    self._send_producer_done(request_id, conn.from_partition, conn.to_partition)
         elif fwd_args.inputs:
             # Partition has inputs to send — conductor-driven
             self._send_partition_inputs(request_id, partition_name, fwd_args)
@@ -736,7 +736,10 @@ class Conductor:
             )
             self.communicator.send(worker, message)
 
-    def _send_producer_done(self, request_id: str, consumer_partition_name: str):
+    def _send_producer_done(
+        self, request_id: str, producer_partition: str,
+        consumer_partition_name: str
+    ):
         """Send producer_done signal to the consumer partition's worker(s)."""
         request_data = self.requests[request_id]
         pstate = request_data.partition_states[consumer_partition_name]
@@ -764,7 +767,7 @@ class Conductor:
                         max_tokens=request_data.max_output_tokens
                     ),
                     partition_name=consumer_partition_name,
-                    producer_done=True,
+                    producer_done=set([producer_partition]),
                 ),
             )
             self.communicator.send(worker_id, message)

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 
 import numpy as np
+import torch
 import yaml
 
 from mminf.api_server.request_types import APIServerMessage, RequestComplete
@@ -57,6 +58,7 @@ def _worker_process_target(
     worker_ids: list[str],
     my_worker_graphs: list[WorkerGraph],
     kv_config: list[KVCacheConfig],
+    model_config: dict,
     all_worker_graph_ids_to_graph_walks: dict[str, set[str]],
     all_worker_graph_ids_to_nodes: dict[str, set[str]],
     all_worker_graph_ids_to_dyn_loops: dict[str, set[str]],
@@ -87,6 +89,7 @@ def _worker_process_target(
         worker_ids=worker_ids,
         my_worker_graphs=my_worker_graphs,
         kv_config=kv_config,
+        model_config=model_config,
         all_worker_graph_ids_to_graph_walks=all_worker_graph_ids_to_graph_walks,
         all_worker_graph_ids_to_nodes=all_worker_graph_ids_to_nodes,
         all_worker_graph_ids_to_dyn_loops=all_worker_graph_ids_to_dyn_loops,
@@ -250,6 +253,7 @@ class Conductor:
                     "worker_ids": self.worker_ids,
                     "my_worker_graphs": self._per_worker_graphs[worker_id],
                     "kv_config": self._get_kv_config(),
+                    "model_config": self.model_config,
                     "all_worker_graph_ids_to_graph_walks": self._all_worker_graph_ids_to_graph_walks,
                     "all_worker_graph_ids_to_nodes": self._all_worker_graph_ids_to_nodes,
                     "all_worker_graph_ids_to_dyn_loops": self._all_worker_graph_ids_to_dyn_loops,

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -487,6 +487,7 @@ class Conductor:
                         random_seed=pstate.random_seed,
                         requires_cfg=fwd_args.full_metadata.requires_cfg,
                         partition_name=partition_name,
+                        max_tokens=request_data.max_output_tokens
                     ),
                 )
                 self.communicator.send(
@@ -721,6 +722,7 @@ class Conductor:
                         per_label_seq_info=pstate.per_label_seq_info,
                         requires_cfg=fwd_args.full_metadata.requires_cfg,
                         partition_name=partition_name,
+                        max_tokens=request_data.max_output_tokens
                     ),
                     partition_name=partition_name
                 ),
@@ -752,6 +754,7 @@ class Conductor:
                         random_seed=pstate.random_seed,
                         requires_cfg=False,
                         partition_name=consumer_partition_name,
+                        max_tokens=request_data.max_output_tokens
                     ),
                     partition_name=consumer_partition_name,
                     producer_done=True,

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -59,6 +59,7 @@ def _worker_process_target(
     kv_config: list[KVCacheConfig],
     all_worker_graph_ids_to_graph_walks: dict[str, set[str]],
     all_worker_graph_ids_to_nodes: dict[str, set[str]],
+    all_worker_graph_ids_to_dyn_loops: dict[str, set[str]],
     hostname: str,
     socket_path_prefix: str,
     enable_nvtx: bool = False,
@@ -88,6 +89,7 @@ def _worker_process_target(
         kv_config=kv_config,
         all_worker_graph_ids_to_graph_walks=all_worker_graph_ids_to_graph_walks,
         all_worker_graph_ids_to_nodes=all_worker_graph_ids_to_nodes,
+        all_worker_graph_ids_to_dyn_loops=all_worker_graph_ids_to_dyn_loops,
         hostname=hostname,
         socket_path_prefix=socket_path_prefix,
         enable_nvtx=enable_nvtx,
@@ -232,6 +234,10 @@ class Conductor:
             worker_graph_id: worker_graph.section.get_node_names()
             for worker_graph_id, worker_graph in self.worker_graphs.items()
         }
+        self._all_worker_graph_ids_to_dyn_loops = {
+            worker_graph_id: worker_graph.section.get_dyn_loop_names()
+            for worker_graph_id, worker_graph in self.worker_graphs.items()
+        }
 
     def _launch_workers(self):
         """Spawn one process per worker rank using spawn context."""
@@ -246,6 +252,7 @@ class Conductor:
                     "kv_config": self._get_kv_config(),
                     "all_worker_graph_ids_to_graph_walks": self._all_worker_graph_ids_to_graph_walks,
                     "all_worker_graph_ids_to_nodes": self._all_worker_graph_ids_to_nodes,
+                    "all_worker_graph_ids_to_dyn_loops": self._all_worker_graph_ids_to_dyn_loops,
                     "hostname": self.hostname,
                     "socket_path_prefix": self.socket_path_prefix,
                     "model": self.model,

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -79,7 +79,7 @@ def _worker_process_target(
 
     from mminf.worker.worker import Worker
     logger.debug("Launching worker %s with graph nodes %s", worker_id, str(
-        sum([wg.section.get_node_names() for wg in my_worker_graphs], start=[])
+        [wg.section.get_node_names() for wg in my_worker_graphs]
     ))
     worker = Worker(
         worker_id=worker_id,

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -87,6 +87,7 @@ def _worker_process_target(
     worker = Worker(
         worker_id=worker_id,
         worker_ids=worker_ids,
+        model=model,
         my_worker_graphs=my_worker_graphs,
         kv_config=kv_config,
         model_config=model_config,
@@ -97,7 +98,6 @@ def _worker_process_target(
         socket_path_prefix=socket_path_prefix,
         enable_nvtx=enable_nvtx,
         device=torch.device(device),
-        model=model,
         mooncake_port=mooncake_port,
         tensor_comm_protocol=tensor_comm_protocol,
         tcp_transfer_device=tcp_transfer_device,
@@ -489,7 +489,7 @@ class Conductor:
 
                 message = NewRequest(
                     request_id=body.request_id,
-                    worker_graph_ids=partition_wg_ids,
+                    partition_worker_graph_ids=partition_wg_ids,
                     worker_graph_to_worker=worker_graph_to_worker,
                     initial_inputs=inputs_per_worker.get(worker_id, []),
                     request_info=CurrentForwardPassInfo(

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -58,7 +58,7 @@ def _worker_process_target(
     my_worker_graphs: list[WorkerGraph],
     kv_config: list[KVCacheConfig],
     all_worker_graph_ids_to_graph_walks: dict[str, set[str]],
-    all_worker_graph_ids_to_nodes: dict[str, list[str]],
+    all_worker_graph_ids_to_nodes: dict[str, set[str]],
     hostname: str,
     socket_path_prefix: str,
     enable_nvtx: bool = False,
@@ -228,7 +228,7 @@ class Conductor:
         self._all_worker_graph_ids_to_graph_walks: dict[str, set[str]] = {
             worker_graph_id: worker_graph.graph_walks for worker_graph_id, worker_graph in self.worker_graphs.items()
         }
-        self._all_worker_graph_ids_to_nodes: dict[str, list[str]] = {
+        self._all_worker_graph_ids_to_nodes: dict[str, set[str]] = {
             worker_graph_id: worker_graph.section.get_node_names()
             for worker_graph_id, worker_graph in self.worker_graphs.items()
         }

--- a/mminf/conductor/request_info.py
+++ b/mminf/conductor/request_info.py
@@ -71,6 +71,7 @@ class CurrentForwardPassInfo:
     # set of names of loops to stop
     dynamic_loop_stop_signals: set[str] = field(default_factory=set)
     loop_stop_times: dict[str, IterIndexTree] = field(default_factory=dict)
+    dynamic_loop_iter_counts: dict[str, int] = field(default_factory=dict)
 
     def register_loop_stop(self, loop_name: str):
         self.dynamic_loop_stop_signals.add(loop_name)
@@ -78,6 +79,7 @@ class CurrentForwardPassInfo:
     def clear_loop_stop_info(self):
         self.loop_stop_times.clear()
         self.dynamic_loop_stop_signals.clear()
+        self.dynamic_loop_iter_counts.clear()
 
 # ---------------------------------------------------------------------------
 # Partition types for async graph partitions

--- a/mminf/conductor/request_info.py
+++ b/mminf/conductor/request_info.py
@@ -61,9 +61,21 @@ class CurrentForwardPassInfo:
     requires_cfg: bool
     fwd_index: int
     random_seed: int
+    max_tokens: int
     step_metadata: dict = field(default_factory=dict)
     per_label_seq_info: PerLabelSeqInfo = field(default_factory=PerLabelSeqInfo)
     partition_name: str = field(default="default")
+
+    # set of names of loops to stop
+    dynamic_loop_stop_signals: set[str] = field(default_factory=set)
+    dynamic_loop_iter_counts: dict[str, int] = field(default_factory=dict)
+
+    def register_loop_stop(self, loop_name: str):
+        self.dynamic_loop_stop_signals.add(loop_name)
+    
+    def reset_dyn_loop_info(self):
+        self.dynamic_loop_stop_signals.clear()
+        self.dynamic_loop_iter_counts.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/mminf/conductor/request_info.py
+++ b/mminf/conductor/request_info.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 
+from mminf.graph.loop_index import IterIndexTree
+
 
 @dataclass
 class CurrentForwardConductorMetadata:
@@ -68,15 +70,14 @@ class CurrentForwardPassInfo:
 
     # set of names of loops to stop
     dynamic_loop_stop_signals: set[str] = field(default_factory=set)
-    dynamic_loop_iter_counts: dict[str, int] = field(default_factory=dict)
+    loop_stop_times: dict[str, IterIndexTree] = field(default_factory=dict)
 
     def register_loop_stop(self, loop_name: str):
         self.dynamic_loop_stop_signals.add(loop_name)
     
-    def reset_dyn_loop_info(self):
+    def clear_loop_stop_info(self):
+        self.loop_stop_times.clear()
         self.dynamic_loop_stop_signals.clear()
-        self.dynamic_loop_iter_counts.clear()
-
 
 # ---------------------------------------------------------------------------
 # Partition types for async graph partitions

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -390,11 +390,17 @@ class AREngine(BaseEngine):
                     with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
                         # Priority: CUDA graph > batched > sequential
                         if self._can_use_cuda_graph(batch):
-                            return self._execute_with_cuda_graph(batch, submodule)
+                            output = self._execute_with_cuda_graph(batch, submodule)
                         elif submodule.can_batch(batch):
-                            return self._execute_batched(batch, submodule)
+                            output = self._execute_batched(batch, submodule)
                         else:
-                            return self._execute_sequential(batch, submodule)
+                            output = self._execute_sequential(batch, submodule)
+                        for rid, info in batch.per_request_info.items():
+                            submodule.postprocess(
+                                request_info=info,
+                                outputs=output.per_request_output_tensors[rid]
+                            )
+                        return output
             except RuntimeError:
                 if not cache_mgmt.alloc_manager.alloc_status.success:
                     status = cache_mgmt.alloc_manager.alloc_status

--- a/mminf/engine/ar_engine.py
+++ b/mminf/engine/ar_engine.py
@@ -398,7 +398,7 @@ class AREngine(BaseEngine):
                         for rid, info in batch.per_request_info.items():
                             submodule.postprocess(
                                 request_info=info,
-                                outputs=output.per_request_output_tensors[rid]
+                                outputs=output.per_request_output_tensors.get(rid, {})
                             )
                         return output
             except RuntimeError:

--- a/mminf/engine/audio_codec_engine.py
+++ b/mminf/engine/audio_codec_engine.py
@@ -77,6 +77,11 @@ class AudioCodecEngine(BaseEngine):
                             outputs[rid] = {"output": [result]}
                         else:
                             outputs[rid] = {}
+                for rid, info in batch.per_request_info.items():
+                    submodule.postprocess(
+                        request_info=info,
+                        outputs=outputs[rid]
+                    )
                 return NodeOutput(per_request_output_tensors=outputs)
         finally:
             if self.enable_nvtx:

--- a/mminf/engine/cuda_graph_runner.py
+++ b/mminf/engine/cuda_graph_runner.py
@@ -254,6 +254,7 @@ class CudaGraphRunner:
                     requires_cfg=config.requires_cfg,
                     fwd_index=0,
                     random_seed=0,
+                    max_tokens=1,
                 ) for rid in dummy_rids
             }
 

--- a/mminf/engine/enc_dec_engine.py
+++ b/mminf/engine/enc_dec_engine.py
@@ -119,9 +119,15 @@ class EncoderDecoderEngine(BaseEngine):
             with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
                 with torch.no_grad():
                     if submodule.can_batch(batch):
-                        return self._execute_batched(batch, submodule)
+                        output = self._execute_batched(batch, submodule)
                     else:
-                        return self._execute_sequential(batch, submodule)
+                        output = self._execute_sequential(batch, submodule)
+                    for rid, info in batch.per_request_info.items():
+                        submodule.postprocess(
+                            request_info=info,
+                            outputs=output.per_request_output_tensors[rid]
+                        )
+                    return output
         finally:
             if self.enable_nvtx:
                 range_pop()

--- a/mminf/engine/enc_dec_engine.py
+++ b/mminf/engine/enc_dec_engine.py
@@ -125,7 +125,7 @@ class EncoderDecoderEngine(BaseEngine):
                     for rid, info in batch.per_request_info.items():
                         submodule.postprocess(
                             request_info=info,
-                            outputs=output.per_request_output_tensors[rid]
+                            outputs=output.per_request_output_tensors.get(rid, {})
                         )
                     return output
         finally:

--- a/mminf/engine/flow_engine.py
+++ b/mminf/engine/flow_engine.py
@@ -78,7 +78,13 @@ class FlowEngine(BaseEngine):
         try:
             with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
                 with torch.no_grad():
-                    return self._execute_sequential(batch, submodule)
+                    output = self._execute_sequential(batch, submodule)
+                for rid, info in batch.per_request_info.items():
+                    submodule.postprocess(
+                        request_info=info,
+                        outputs=output.per_request_output_tensors[rid]
+                    )
+                return output
         finally:
             if self.enable_nvtx:
                 range_pop()

--- a/mminf/engine/flow_engine.py
+++ b/mminf/engine/flow_engine.py
@@ -79,11 +79,11 @@ class FlowEngine(BaseEngine):
             with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
                 with torch.no_grad():
                     output = self._execute_sequential(batch, submodule)
-                for rid, info in batch.per_request_info.items():
-                    submodule.postprocess(
-                        request_info=info,
-                        outputs=output.per_request_output_tensors[rid]
-                    )
+                    for rid, info in batch.per_request_info.items():
+                        submodule.postprocess(
+                            request_info=info,
+                            outputs=output.per_request_output_tensors.get(rid, {})
+                        )
                 return output
         finally:
             if self.enable_nvtx:

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -58,7 +58,7 @@ class GraphEdge:
 
     # Flags
     persist: bool = field(default=False) # previously back_to_conductor
-    is_new_token: bool = field(default=False)
+    conductor_new_token: bool = field(default=False)
     is_streaming: bool = field(default=False) # streaming edge: tokens accumulate at destination buffer
     # only for EMIT_TO_CLIENT
     output_modality: str = field(default="") # text | image | video | audio
@@ -376,7 +376,7 @@ class Parallel(GraphSection):
 class Loop(GraphSection):
     section: GraphSection # this is used to populate next_section and
                           # in-progress section; it remains "clean"
-    n_iters: int
+    max_iters: int
     outputs: list[GraphEdge]
     curr_iter: int = field(default=0)
     _external_inputs: list[GraphEdge] = field(default=None)
@@ -456,7 +456,7 @@ class Loop(GraphSection):
         ingested += self._nxt_iter_section.ingest_inputs(node_to_inputs)
         update_list_dicts(node_to_inputs, external_inputs)
 
-        if self.curr_iter != self.n_iters - 1:
+        if self.curr_iter != self.max_iters - 1:
             for graph_edge in ingested:
                 if (graph_edge.name, graph_edge.next_node) in my_external_inputs:
                     my_external_inputs[(
@@ -489,29 +489,6 @@ class Loop(GraphSection):
             edge for edge in outputs if (edge.name, edge.next_node) in input_names_dests
         ]
 
-    # def _replace_outputs_for_final_iter(
-    #     self, section: GraphSection,
-    # ):
-    #     """
-    #     For the final iteration, we want to: remove all loop-back signals
-    #     from the graph.
-    #     """
-    #     loop_back_signals = self._loop_back_signals
-    #     loop_back_name_dests = set([
-    #         (edge.name, edge.next_node) for edge in loop_back_signals
-    #     ])
-
-    #     def replace_outputs(node_outputs: list[GraphEdge]):
-    #         return [
-    #             edge for edge in node_outputs \
-    #                 if (edge.name, edge.next_node) not in loop_back_name_dests
-    #         ]
-    #     if isinstance(section, GraphNode) or isinstance(section, Loop):
-    #         section.outputs = replace_outputs(section.outputs)
-    #     elif isinstance(section, Sequential) or isinstance(section, Parallel):
-    #         for sec in section.sections:
-    #             self._replace_outputs_for_final_iter(sec)
-
     def __post_init__(self):
         # In the disaggregated case, we need filter self.outputs for outputs
         # that this subgraph actually produces
@@ -529,32 +506,36 @@ class Loop(GraphSection):
             self._external_inputs = self._get_external_inputs()
         if self._loop_back_signals is None:
             self._loop_back_signals = self._get_loop_back_signals()
-        
-        # if self.n_iters == self.curr_iter + 1:
-        #     self._replace_outputs_for_final_iter(self._curr_iter_section)
+
+    def _get_advanced_loop(
+        self, curr_iter_section, nxt_iter_section
+    ):
+        return Loop(
+            section=self.section,
+            _curr_iter_section=curr_iter_section,
+            _nxt_iter_section=nxt_iter_section,
+            curr_iter=self.curr_iter + 1,
+            max_iters=self.max_iters,
+            outputs=self.outputs,
+            _external_inputs=self._external_inputs,
+            _loop_back_signals=self._loop_back_signals,
+            _tensor_manager=self._tensor_manager,
+            _request_id=self._request_id,
+        )
 
     def _advance_one_iter(self) -> "Loop":
         self._uncache_outputs()
         curr_iter_section = self._nxt_iter_section
         nxt_iter_section = deepcopy(self.section)
 
-        logger.info(
+        logger.debug(
             "Advancing loop with nodes %s from iter %d -> %d (out of %d)",
             str(self.section.get_node_names()), self.curr_iter,
-            self.curr_iter + 1, self.n_iters
+            self.curr_iter + 1, self.max_iters
         )
 
-        loop = Loop(
-            section=self.section,
-            _curr_iter_section=curr_iter_section,
-            _nxt_iter_section=nxt_iter_section,
-            curr_iter=self.curr_iter + 1,
-            n_iters=self.n_iters,
-            outputs=self.outputs,
-            _external_inputs=self._external_inputs,
-            _loop_back_signals=self._loop_back_signals,
-            _tensor_manager=self._tensor_manager,
-            _request_id=self._request_id,
+        loop = self._get_advanced_loop(
+            curr_iter_section, nxt_iter_section
         )
         loop.ingest_inputs(get_node_to_inputs_mapping(
             self._external_inputs
@@ -562,7 +543,7 @@ class Loop(GraphSection):
         return loop
     
     def _is_done(self):
-        return (self.n_iters == self.curr_iter + 1) and (self._curr_iter_section is None)
+        return (self.max_iters == self.curr_iter + 1) and (self._curr_iter_section is None)
 
     def split_off_ready(self):
         loop = self
@@ -611,3 +592,33 @@ class Loop(GraphSection):
             loop_back_name_dests_to_remove=loop_back_name_dests
         )
 
+
+@dataclass
+class DynamicLoop(Loop):
+    name: str = field(default="loop")
+    _finished: bool = field(default=False)
+
+    def register_finished(self):
+        self._finished = True
+    
+    def _is_done(self):
+        return (
+            (self.max_iters == self.curr_iter + 1) or self._finished) \
+                and (self._curr_iter_section is None)
+
+    def _get_advanced_loop(
+        self, curr_iter_section, nxt_iter_section
+    ):
+        return DynamicLoop(
+            section=self.section,
+            name=self.name,
+            _curr_iter_section=curr_iter_section,
+            _nxt_iter_section=nxt_iter_section,
+            curr_iter=self.curr_iter + 1,
+            max_iters=self.max_iters,
+            outputs=self.outputs,
+            _external_inputs=self._external_inputs,
+            _loop_back_signals=self._loop_back_signals,
+            _tensor_manager=self._tensor_manager,
+            _request_id=self._request_id,
+        )

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -2,8 +2,15 @@ import logging
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LoopCompletionOutput:
+    new_waiting: "GraphSection"
+    outputs: list["GraphEdge"] = field(default_factory=list)
 
 
 def update_list_dicts(signals: dict[str, list], new_signals: dict[str, list]):
@@ -24,7 +31,6 @@ class TensorPointerInfo:
     uuid: str # for indexing storage
     source_session_id: str # "{HOSTNAME}:{client_engine.get_rpc_port()}"
     source_entity: str # which {worker, api_server} the tensor is on
-
 
 @dataclass
 class GraphEdge:
@@ -91,6 +97,27 @@ class GraphSection(ABC):
         """
         pass
 
+    @abstractmethod
+    def cache_outputs(
+        self, tensor_info: dict[str, list[TensorPointerInfo]],
+    ):
+        pass
+
+    @abstractmethod
+    def complete_loops(self) -> LoopCompletionOutput:
+        """
+        Checks if any loops have completed, and returns their cached output edges,
+        if any
+        """
+        pass
+
+    @abstractmethod
+    def register_communication_info(
+        self, communication_manager,
+        request_id: str
+    ):
+        pass
+
 
 @dataclass
 class GraphNode(GraphSection):
@@ -151,6 +178,20 @@ class GraphNode(GraphSection):
         if self.is_ready():
             return [self], None
         return [], self
+    
+    def cache_outputs(
+        self, tensor_info: dict[str, list[TensorPointerInfo]],
+    ):
+        return
+    
+    def complete_loops(self) -> LoopCompletionOutput:
+        return LoopCompletionOutput(self)
+    
+    def register_communication_info(
+        self, communication_manager,
+        request_id: str
+    ):
+        return
 
 
 @dataclass
@@ -208,6 +249,32 @@ class Sequential(GraphSection):
         if len(waiting) == 0:
             return first_ready, None
         return first_ready, Sequential(sections=waiting)
+    
+    def cache_outputs(
+        self, tensor_info: dict[str, list[TensorPointerInfo]],
+    ):
+        for sec in self.sections:
+            sec.cache_outputs(tensor_info)
+    
+    def complete_loops(self) -> LoopCompletionOutput:
+        output = self.sections[0].complete_loops()
+        if output.new_waiting is None:
+            waiting = self.sections[1:]
+        else:
+            waiting = [output.new_waiting] + self.sections[1:]
+        
+        if len(waiting) > 0:
+            output.new_waiting = Sequential(sections=waiting)
+        return output
+    
+    def register_communication_info(
+        self, communication_manager,
+        request_id: str
+    ):
+        for sec in self.sections:
+            sec.register_communication_info(
+                communication_manager, request_id
+            )
 
 
 @dataclass
@@ -248,6 +315,40 @@ class Parallel(GraphSection):
             return ready, None
         return ready, Parallel(sections=waiting)
 
+    def cache_outputs(
+        self, tensor_info: dict[str, list[TensorPointerInfo]],
+    ):
+        for sec in self.sections:
+            sec.cache_outputs(tensor_info)
+    
+    def complete_loops(self) -> LoopCompletionOutput:
+        outputs = []
+        waiting = []
+        for sec in self.sections:
+            out = sec.complete_loops()
+            outputs += out.outputs
+            if out.new_waiting is not None:
+                waiting.append(out.new_waiting)
+        
+        if len(waiting) > 0:
+            return LoopCompletionOutput(
+                new_waiting=Parallel(sections=waiting),
+                outputs=outputs
+            )
+        return LoopCompletionOutput(
+            new_waiting=None,
+            outputs=outputs
+        )
+    
+    def register_communication_info(
+        self, communication_manager,
+        request_id: str
+    ):
+        for sec in self.sections:
+            sec.register_communication_info(
+                communication_manager, request_id
+            )
+
 
 @dataclass
 class Loop(GraphSection):
@@ -256,10 +357,17 @@ class Loop(GraphSection):
     n_iters: int
     outputs: list[GraphEdge]
     curr_iter: int = field(default=0)
-    external_inputs: list[GraphEdge] = field(default=None)
-    loop_back_signals: list[GraphEdge] = field(default=None)
-    curr_iter_section: GraphSection = field(default=None)
-    nxt_iter_section: GraphSection = field(default=None)
+    _external_inputs: list[GraphEdge] = field(default=None)
+    _loop_back_signals: list[GraphEdge] = field(default=None)
+    _curr_iter_section: GraphSection = field(default=None)
+    _nxt_iter_section: GraphSection = field(default=None)
+    _cached_outputs: dict[str, list[TensorPointerInfo]] = field(default_factory=dict)
+    _output_names: set[str] = field(default_factory=set)
+
+    # For handling tensor reference counting of loop outputs
+    _tensor_manager: Any | None = field(default=None) # no type annotation because 
+                                                      # of circular imports
+    _request_id: str | None = field(default=None)
 
     def get_outputs(self):
         return self.outputs
@@ -269,20 +377,48 @@ class Loop(GraphSection):
 
     def get_node_names(self):
         return self.section.get_node_names()
+    
+    def register_communication_info(
+        self, communication_manager,
+        request_id: str
+    ):
+        self._tensor_manager = communication_manager
+        self._request_id = request_id
+        self.section.register_communication_info(
+            communication_manager, request_id
+        )
+    
+    def cache_outputs(
+        self, tensor_info: dict[str, list[TensorPointerInfo]],
+    ):
+        names = [key for key in tensor_info if key in self._output_names]
+        for out_name in names:
+            tensor_infos = tensor_info[out_name]
+            for info in tensor_infos:
+                self._tensor_manager.increment_ref(self._request_id, info.uuid)
+            self._cached_outputs.setdefault(out_name, []).extend(tensor_infos)
+        if self._curr_iter_section is not None:
+            self._curr_iter_section.cache_outputs(tensor_info)
+    
+    def _uncache_outputs(self):
+        for tensor_infos in self._cached_outputs.values():
+            for info in tensor_infos:
+                self._tensor_manager.dereference(self._request_id, info.uuid) 
+        self._cached_outputs.clear()
 
     def ingest_inputs(self, node_to_inputs: DestToGraphEdges):
         # Populate the current iteration first, then populate the next iteration
         # if there are any leftover inputs (which would signal either inputs that
         # are not for this section, or loop-back inputs)
         ingested: list[GraphEdge] = []
-        if self.curr_iter_section is not None:
-            ingested += self.curr_iter_section.ingest_inputs(node_to_inputs)
+        if self._curr_iter_section is not None:
+            ingested += self._curr_iter_section.ingest_inputs(node_to_inputs)
 
         # we should only be populating the nxt_iter_section with loop-back inputs,
         # so exclude external inputs from populating nxt_iter_section. This logic
         # is required to make nested loops work.
         my_external_inputs = {
-            (edge.name, edge.next_node): edge for edge in self.external_inputs
+            (edge.name, edge.next_node): edge for edge in self._external_inputs
         }
         external_inputs = {
             dest: [
@@ -295,7 +431,7 @@ class Loop(GraphSection):
                 if i not in external_inputs[dest]
             ]
 
-        ingested += self.nxt_iter_section.ingest_inputs(node_to_inputs)
+        ingested += self._nxt_iter_section.ingest_inputs(node_to_inputs)
         update_list_dicts(node_to_inputs, external_inputs)
 
         if self.curr_iter != self.n_iters - 1:
@@ -335,24 +471,16 @@ class Loop(GraphSection):
         self, section: GraphSection,
     ):
         """
-        For the final iteration, we want to: (1) remove all loop-back signals
-        from the graph, and (2) add in self.outputs where appropriate
+        For the final iteration, we want to: remove all loop-back signals
+        from the graph.
         """
-        loop_back_signals = self.loop_back_signals
+        loop_back_signals = self._loop_back_signals
         loop_back_name_dests = set([
             (edge.name, edge.next_node) for edge in loop_back_signals
         ])
-        full_outputs = self.outputs
 
         def replace_outputs(node_outputs: list[GraphEdge]):
-            node_output_names = set([
-                edge.name for edge in node_outputs
-            ])
-            outputs_to_add = [
-                edge for edge in full_outputs if edge.name in node_output_names
-            ]
-
-            return outputs_to_add + [
+            return [
                 edge for edge in node_outputs \
                     if (edge.name, edge.next_node) not in loop_back_name_dests
             ]
@@ -363,20 +491,29 @@ class Loop(GraphSection):
                 self._replace_outputs_for_final_iter(sec)
 
     def __post_init__(self):
-        if self.curr_iter_section is None:
-            self.curr_iter_section = deepcopy(self.section)
-        if self.nxt_iter_section is None:
-            self.nxt_iter_section = deepcopy(self.section)
-        if self.external_inputs is None:
-            self.external_inputs = self._get_external_inputs()
-        if self.loop_back_signals is None:
-            self.loop_back_signals = self._get_loop_back_signals()
+        # In the disaggregated case, we need filter self.outputs for outputs
+        # that this subgraph actually produces
+        outputs_we_produce = set([
+            edge.name for edge in self.section.get_outputs()
+        ])
+        self.outputs = [edge for edge in self.outputs if edge.name in outputs_we_produce]
 
+        self._output_names = set([edge.name for edge in self.outputs])
+        if self._curr_iter_section is None:
+            self._curr_iter_section = deepcopy(self.section)
+        if self._nxt_iter_section is None:
+            self._nxt_iter_section = deepcopy(self.section)
+        if self._external_inputs is None:
+            self._external_inputs = self._get_external_inputs()
+        if self._loop_back_signals is None:
+            self._loop_back_signals = self._get_loop_back_signals()
+        
         if self.n_iters == self.curr_iter + 1:
-            self._replace_outputs_for_final_iter(self.curr_iter_section)
+            self._replace_outputs_for_final_iter(self._curr_iter_section)
 
     def _advance_one_iter(self) -> "Loop":
-        curr_iter_section = self.nxt_iter_section
+        self._uncache_outputs()
+        curr_iter_section = self._nxt_iter_section
         nxt_iter_section = deepcopy(self.section)
 
         logger.info(
@@ -387,27 +524,56 @@ class Loop(GraphSection):
 
         loop = Loop(
             section=self.section,
-            curr_iter_section=curr_iter_section,
-            nxt_iter_section=nxt_iter_section,
+            _curr_iter_section=curr_iter_section,
+            _nxt_iter_section=nxt_iter_section,
             curr_iter=self.curr_iter + 1,
             n_iters=self.n_iters,
             outputs=self.outputs,
-            external_inputs=self.external_inputs,
-            loop_back_signals=self.loop_back_signals
+            _external_inputs=self._external_inputs,
+            _loop_back_signals=self._loop_back_signals,
+            _tensor_manager=self._tensor_manager,
+            _request_id=self._request_id,
         )
         loop.ingest_inputs(get_node_to_inputs_mapping(
-            self.external_inputs
+            self._external_inputs
         ))
         return loop
 
     def split_off_ready(self):
-        loop = self if self.curr_iter_section is not None \
-            else self._advance_one_iter()
-        first_ready, first_waiting = loop.curr_iter_section.split_off_ready()
-        loop.curr_iter_section = first_waiting
+        loop = self
+        if self._curr_iter_section is None:
+            if self.n_iters == self.curr_iter + 1:
+                return [], None
+            loop = self._advance_one_iter()
 
-        if loop.n_iters == loop.curr_iter + 1: # last iteration
-            return first_ready, first_waiting
-
-        loop.curr_iter_section = first_waiting
+        first_ready, first_waiting = loop._curr_iter_section.split_off_ready()
+        loop._curr_iter_section = first_waiting
         return first_ready, loop
+    
+    def complete_loops(self) -> LoopCompletionOutput:
+        output_signals = []
+
+        # recursive call
+        if self._curr_iter_section is not None:
+            recursive_output = self._curr_iter_section.complete_loops()
+            output_signals += recursive_output.outputs
+            self._curr_iter_section = recursive_output.new_waiting
+        
+        # check if the loop is done after the recursive call updates _curr_iter_section
+        done = (self.n_iters == self.curr_iter + 1) and (self._curr_iter_section is None)
+        if not done:
+            return LoopCompletionOutput(
+                new_waiting=self,
+                outputs=output_signals
+            )
+        
+        # if done, new_waiting is None and also need to collect our outputs
+        for output in self.outputs:
+            if output.name in self._cached_outputs:
+                output.tensor_info = self._cached_outputs[output.name]
+                output_signals.append(output)
+
+        return LoopCompletionOutput(
+            new_waiting=None,
+            outputs=output_signals
+        )

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -11,6 +11,13 @@ logger = logging.getLogger(__name__)
 class LoopCompletionOutput:
     new_waiting: "GraphSection"
     outputs: list["GraphEdge"] = field(default_factory=list)
+    loop_back_name_dests_to_remove: set[tuple[str, str]] = field(default_factory=set)
+
+    def filter_out_loop_back(self, edges: list["GraphEdge"]) -> list["GraphEdge"]:
+        return [
+            edge for edge in edges \
+                if (edge.name, edge.next_node) not in self.loop_back_name_dests_to_remove
+        ]
 
 
 def update_list_dicts(signals: dict[str, list], new_signals: dict[str, list]):
@@ -323,21 +330,25 @@ class Parallel(GraphSection):
     
     def complete_loops(self) -> LoopCompletionOutput:
         outputs = []
+        loop_back_name_dests = set()
         waiting = []
         for sec in self.sections:
             out = sec.complete_loops()
             outputs += out.outputs
+            loop_back_name_dests.update(out.loop_back_name_dests_to_remove)
             if out.new_waiting is not None:
                 waiting.append(out.new_waiting)
         
         if len(waiting) > 0:
             return LoopCompletionOutput(
                 new_waiting=Parallel(sections=waiting),
-                outputs=outputs
+                outputs=outputs,
+                loop_back_name_dests_to_remove=loop_back_name_dests
             )
         return LoopCompletionOutput(
             new_waiting=None,
-            outputs=outputs
+            outputs=outputs,
+            loop_back_name_dests_to_remove=loop_back_name_dests
         )
     
     def register_communication_info(
@@ -467,28 +478,28 @@ class Loop(GraphSection):
             edge for edge in outputs if (edge.name, edge.next_node) in input_names_dests
         ]
 
-    def _replace_outputs_for_final_iter(
-        self, section: GraphSection,
-    ):
-        """
-        For the final iteration, we want to: remove all loop-back signals
-        from the graph.
-        """
-        loop_back_signals = self._loop_back_signals
-        loop_back_name_dests = set([
-            (edge.name, edge.next_node) for edge in loop_back_signals
-        ])
+    # def _replace_outputs_for_final_iter(
+    #     self, section: GraphSection,
+    # ):
+    #     """
+    #     For the final iteration, we want to: remove all loop-back signals
+    #     from the graph.
+    #     """
+    #     loop_back_signals = self._loop_back_signals
+    #     loop_back_name_dests = set([
+    #         (edge.name, edge.next_node) for edge in loop_back_signals
+    #     ])
 
-        def replace_outputs(node_outputs: list[GraphEdge]):
-            return [
-                edge for edge in node_outputs \
-                    if (edge.name, edge.next_node) not in loop_back_name_dests
-            ]
-        if isinstance(section, GraphNode) or isinstance(section, Loop):
-            section.outputs = replace_outputs(section.outputs)
-        elif isinstance(section, Sequential) or isinstance(section, Parallel):
-            for sec in section.sections:
-                self._replace_outputs_for_final_iter(sec)
+    #     def replace_outputs(node_outputs: list[GraphEdge]):
+    #         return [
+    #             edge for edge in node_outputs \
+    #                 if (edge.name, edge.next_node) not in loop_back_name_dests
+    #         ]
+    #     if isinstance(section, GraphNode) or isinstance(section, Loop):
+    #         section.outputs = replace_outputs(section.outputs)
+    #     elif isinstance(section, Sequential) or isinstance(section, Parallel):
+    #         for sec in section.sections:
+    #             self._replace_outputs_for_final_iter(sec)
 
     def __post_init__(self):
         # In the disaggregated case, we need filter self.outputs for outputs
@@ -508,8 +519,8 @@ class Loop(GraphSection):
         if self._loop_back_signals is None:
             self._loop_back_signals = self._get_loop_back_signals()
         
-        if self.n_iters == self.curr_iter + 1:
-            self._replace_outputs_for_final_iter(self._curr_iter_section)
+        # if self.n_iters == self.curr_iter + 1:
+        #     self._replace_outputs_for_final_iter(self._curr_iter_section)
 
     def _advance_one_iter(self) -> "Loop":
         self._uncache_outputs()
@@ -538,11 +549,14 @@ class Loop(GraphSection):
             self._external_inputs
         ))
         return loop
+    
+    def _is_done(self):
+        return (self.n_iters == self.curr_iter + 1) and (self._curr_iter_section is None)
 
     def split_off_ready(self):
         loop = self
         if self._curr_iter_section is None:
-            if self.n_iters == self.curr_iter + 1:
+            if self._is_done():
                 return [], None
             loop = self._advance_one_iter()
 
@@ -552,19 +566,22 @@ class Loop(GraphSection):
     
     def complete_loops(self) -> LoopCompletionOutput:
         output_signals = []
+        loop_back_name_dests = set()
 
         # recursive call
         if self._curr_iter_section is not None:
             recursive_output = self._curr_iter_section.complete_loops()
-            output_signals += recursive_output.outputs
+            output_signals = recursive_output.outputs
+            loop_back_name_dests = recursive_output.loop_back_name_dests_to_remove
             self._curr_iter_section = recursive_output.new_waiting
         
         # check if the loop is done after the recursive call updates _curr_iter_section
-        done = (self.n_iters == self.curr_iter + 1) and (self._curr_iter_section is None)
+        done = self._is_done()
         if not done:
             return LoopCompletionOutput(
                 new_waiting=self,
-                outputs=output_signals
+                outputs=output_signals,
+                loop_back_name_dests_to_remove=loop_back_name_dests
             )
         
         # if done, new_waiting is None and also need to collect our outputs
@@ -572,8 +589,14 @@ class Loop(GraphSection):
             if output.name in self._cached_outputs:
                 output.tensor_info = self._cached_outputs[output.name]
                 output_signals.append(output)
+        
+        loop_back_name_dests.update([
+            (edge.name, edge.next_node) for edge in self._loop_back_signals
+        ])
 
         return LoopCompletionOutput(
             new_waiting=None,
-            outputs=output_signals
+            outputs=output_signals,
+            loop_back_name_dests_to_remove=loop_back_name_dests
         )
+

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -86,6 +86,10 @@ class GraphSection(ABC):
         pass
 
     @abstractmethod
+    def get_dyn_loop_names(self) -> set[str]:
+        pass
+
+    @abstractmethod
     def get_inputs(self) -> list[GraphEdge]:
         """
         All external or "loop-back" inputs into a worker graph
@@ -162,6 +166,9 @@ class GraphNode(GraphSection):
 
     def get_node_names(self) -> set[str]:
         return {self.name}
+    
+    def get_dyn_loop_names(self) -> set[str]:
+        return set()
 
     def get_inputs(self) -> list[GraphEdge]:
         return [
@@ -221,6 +228,12 @@ class Sequential(GraphSection):
         res = set()
         for s in self.sections:
             res.update(s.get_node_names())
+        return res
+    
+    def get_dyn_loop_names(self) -> set[str]:
+        res = set()
+        for s in self.sections:
+            res.update(s.get_dyn_loop_names())
         return res
 
     def _get_inputs_outputs(self):
@@ -305,6 +318,12 @@ class Parallel(GraphSection):
         res = set()
         for s in self.sections:
             res.update(s.get_node_names())
+        return res
+
+    def get_dyn_loop_names(self) -> set[str]:
+        res = set()
+        for s in self.sections:
+            res.update(s.get_dyn_loop_names())
         return res
 
     def get_inputs(self):
@@ -403,6 +422,9 @@ class Loop(GraphSection):
 
     def get_node_names(self):
         return self.section.get_node_names()
+
+    def get_dyn_loop_names(self) -> set[str]:
+        return self.section.get_dyn_loop_names()
     
     def register_communication_info(
         self, communication_manager,
@@ -605,6 +627,11 @@ class DynamicLoop(Loop):
 
     def register_finished(self):
         self._finished = True
+
+    def get_dyn_loop_names(self) -> set[str]:
+        res = super().get_dyn_loop_names()
+        res.add(self.name)
+        return res
     
     def _is_done(self):
         return (

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -121,13 +121,17 @@ class GraphSection(ABC):
         pass
 
     @abstractmethod
+    def split_off_ready_for_streaming(self) -> list["GraphNode"]:
+        pass
+
+    @abstractmethod
     def cache_outputs(
         self, tensor_info: dict[str, list[TensorPointerInfo]],
     ):
         pass
 
     @abstractmethod
-    def complete_loops(self) -> LoopCompletionOutput:
+    def complete_loops(self, done_node: str) -> LoopCompletionOutput:
         """
         Checks if any loops have completed, and returns their cached output edges,
         if any
@@ -153,6 +157,7 @@ class GraphNode(GraphSection):
     outputs: list[GraphEdge]
     consumes_stream: bool = field(default=False)
     _streaming_inputs: set[str] = field(default_factory=set)
+    _split_off_for_streaming: bool = field(default=False)
 
     # Populated as previous nodes complete
     # This will also include, e.g., tensor UUIDs associated with these inputs
@@ -163,10 +168,10 @@ class GraphNode(GraphSection):
         self.input_ids = set(self.input_ids)
 
     def is_ready(self):
-        return self.input_ids.issubset(set(self.ready_inputs.keys()).union(self._streaming_inputs))
-    
-    def is_ready_including_streaming(self):
         return self.input_ids.issubset(set(self.ready_inputs.keys()))
+    
+    def is_ready_except_streaming(self):
+        return self.input_ids.issubset(set(self.ready_inputs.keys()).union(self._streaming_inputs))
 
     def get_node_names(self) -> set[str]:
         return {self.name}
@@ -209,12 +214,20 @@ class GraphNode(GraphSection):
             return [self], None
         return [], self
     
+    def split_off_ready_for_streaming(self):
+        if self._split_off_for_streaming:
+            return []
+        if self.is_ready_except_streaming():
+            self._split_off_for_streaming = True
+            return [self]
+        return []
+    
     def cache_outputs(
         self, tensor_info: dict[str, list[TensorPointerInfo]],
     ):
         return
     
-    def complete_loops(self) -> LoopCompletionOutput:
+    def complete_loops(self, done_node) -> LoopCompletionOutput:
         return LoopCompletionOutput(self)
     
     def register_communication_info(
@@ -225,6 +238,7 @@ class GraphNode(GraphSection):
     
     def reset(self):
         self.ready_inputs.clear()
+        self._split_off_for_streaming = False
     
     def clear_outputs(self):
         for edge in self.outputs:
@@ -294,14 +308,17 @@ class Sequential(GraphSection):
             return first_ready, None
         return first_ready, Sequential(sections=waiting)
     
+    def split_off_ready_for_streaming(self):
+        return self.sections[0].split_off_ready_for_streaming()
+    
     def cache_outputs(
         self, tensor_info: dict[str, list[TensorPointerInfo]],
     ):
         for sec in self.sections:
             sec.cache_outputs(tensor_info)
     
-    def complete_loops(self) -> LoopCompletionOutput:
-        output = self.sections[0].complete_loops()
+    def complete_loops(self, done_node) -> LoopCompletionOutput:
+        output = self.sections[0].complete_loops(done_node)
         if output.new_waiting is None:
             waiting = self.sections[1:]
         else:
@@ -369,6 +386,12 @@ class Parallel(GraphSection):
         if len(waiting) == 0:
             return ready, None
         return ready, Parallel(sections=waiting)
+    
+    def split_off_ready_for_streaming(self):
+        return sum(
+            [sec.split_off_ready_for_streaming() for sec in self.sections],
+            start=[]
+        )
 
     def cache_outputs(
         self, tensor_info: dict[str, list[TensorPointerInfo]],
@@ -376,12 +399,12 @@ class Parallel(GraphSection):
         for sec in self.sections:
             sec.cache_outputs(tensor_info)
     
-    def complete_loops(self) -> LoopCompletionOutput:
+    def complete_loops(self, done_node) -> LoopCompletionOutput:
         outputs = []
         loop_back_name_dests = set()
         waiting = []
         for sec in self.sections:
-            out = sec.complete_loops()
+            out = sec.complete_loops(done_node)
             outputs += out.outputs
             loop_back_name_dests.update(out.loop_back_name_dests_to_remove)
             if out.new_waiting is not None:
@@ -415,7 +438,7 @@ class Parallel(GraphSection):
 
 @dataclass
 class Loop(GraphSection):
-    curr_section_replica: GraphSection # this is used to populate next_section and
+    section: GraphSection # this is used to populate next_section and
                           # in-progress section; it remains "clean"
     max_iters: int
     outputs: list[GraphEdge]
@@ -432,18 +455,19 @@ class Loop(GraphSection):
     _tensor_manager: Any | None = field(default=None) # no type annotation because 
                                                       # of circular imports
     _request_id: str | None = field(default=None)
+    _waiting_for_execution: set[str] = field(default_factory=set)
 
     def get_outputs(self):
         return self.outputs
 
     def get_inputs(self):
-        return self.curr_section_replica.get_inputs()
+        return self.section.get_inputs()
 
     def get_node_names(self):
-        return self.curr_section_replica.get_node_names()
+        return self.section.get_node_names()
 
     def get_dyn_loop_names(self) -> set[str]:
-        return self.curr_section_replica.get_dyn_loop_names()
+        return self.section.get_dyn_loop_names()
     
     def register_communication_info(
         self, communication_manager,
@@ -451,7 +475,7 @@ class Loop(GraphSection):
     ):
         self._tensor_manager = communication_manager
         self._request_id = request_id
-        self.curr_section_replica.register_communication_info(
+        self.section.register_communication_info(
             communication_manager, request_id
         )
     
@@ -511,8 +535,8 @@ class Loop(GraphSection):
         return ingested
 
     def _get_external_inputs(self):
-        inputs = self.curr_section_replica.get_inputs()
-        internal_outputs = self.curr_section_replica.get_outputs()
+        inputs = self.section.get_inputs()
+        internal_outputs = self.section.get_outputs()
         output_names_dests = set([(edge.name, edge.next_node) for edge in internal_outputs])
 
         # compute "external inputs", i.e., ones that don't come from looping
@@ -524,11 +548,11 @@ class Loop(GraphSection):
     def _get_loop_back_signals(self) -> list[GraphEdge]:
         # these inputs and outputs only include external and loop-back signals;
         # they do not include signals that are purely internal to the section
-        inputs = self.curr_section_replica.get_inputs()
+        inputs = self.section.get_inputs()
         input_names_dests = [
             (edge.name, edge.next_node) for edge in inputs
         ]
-        outputs = self.curr_section_replica.get_outputs()
+        outputs = self.section.get_outputs()
 
         return [
             edge for edge in outputs if (edge.name, edge.next_node) in input_names_dests
@@ -538,15 +562,15 @@ class Loop(GraphSection):
         # In the disaggregated case, we need filter self.outputs for outputs
         # that this subgraph actually produces
         outputs_we_produce = set([
-            edge.name for edge in self.curr_section_replica.get_outputs()
+            edge.name for edge in self.section.get_outputs()
         ])
         self.outputs = [edge for edge in self.outputs if edge.name in outputs_we_produce]
 
         self._output_names = set([edge.name for edge in self.outputs])
         if self._curr_iter_section is None:
-            self._curr_iter_section = self.curr_section_replica
+            self._curr_iter_section = self.section
         if self._nxt_iter_section is None:
-            self._nxt_iter_section = deepcopy(self.curr_section_replica)
+            self._nxt_iter_section = deepcopy(self.section)
         if self._external_inputs is None:
             self._external_inputs = self._get_external_inputs()
         if self._loop_back_signals is None:
@@ -555,17 +579,17 @@ class Loop(GraphSection):
 
     def _advance_one_iter(self) -> "Loop":
         self._uncache_outputs()
-        self.curr_section_replica.reset()
+        self.section.reset()
 
-        new_curr, new_next = self._nxt_iter_section, self.curr_section_replica
+        new_curr, new_next = self._nxt_iter_section, self.section
         self._curr_iter_section = new_curr
         self._nxt_iter_section = new_next
-        self.curr_section_replica = new_curr
+        self.section = new_curr
         self.curr_iter += 1
 
         logger.debug(
             "Advancing loop with nodes %s from iter %d -> %d (out of %d)",
-            str(self.curr_section_replica.get_node_names()), self.curr_iter,
+            str(self.section.get_node_names()), self.curr_iter,
             self.curr_iter + 1, self.max_iters
         )
 
@@ -574,25 +598,40 @@ class Loop(GraphSection):
         ))
     
     def _is_done(self):
-        return (self.max_iters == self.curr_iter + 1) and (self._curr_iter_section is None)
+        return (self.max_iters == self.curr_iter + 1) and self._iter_done() 
+
+    def _iter_done(self):
+        return (self._curr_iter_section is None) and len(self._waiting_for_execution) == 0
 
     def split_off_ready(self):
-        if self._curr_iter_section is None:
+        if self._iter_done():
             if self._is_done():
                 return [], None
             self._advance_one_iter()
-
+        elif self._curr_iter_section is None:
+            return [], self
         first_ready, first_waiting = self._curr_iter_section.split_off_ready()
+        self._waiting_for_execution.update([
+            node.name for node in first_ready
+        ])
         self._curr_iter_section = first_waiting
         return first_ready, self
     
-    def complete_loops(self) -> LoopCompletionOutput:
+    def split_off_ready_for_streaming(self):
+        return (
+            self._curr_iter_section.split_off_ready_for_streaming() \
+                if self._curr_iter_section is not None else []
+        ) + self._nxt_iter_section.split_off_ready_for_streaming()
+    
+    def complete_loops(self, done_node: str) -> LoopCompletionOutput:
+        if done_node in self._waiting_for_execution:
+            self._waiting_for_execution.remove(done_node)
         output_signals = []
         loop_back_name_dests = set()
 
         # recursive call
         if self._curr_iter_section is not None:
-            recursive_output = self._curr_iter_section.complete_loops()
+            recursive_output = self._curr_iter_section.complete_loops(done_node)
             output_signals = recursive_output.outputs
             loop_back_name_dests = recursive_output.loop_back_name_dests_to_remove
             self._curr_iter_section = recursive_output.new_waiting
@@ -623,8 +662,8 @@ class Loop(GraphSection):
         )
     
     def reset(self):
-        self.curr_section_replica.reset()
-        self._curr_iter_section = self.curr_section_replica
+        self.section.reset()
+        self._curr_iter_section = self.section
         self._nxt_iter_section.reset()
         self.curr_iter = 0
 

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -8,16 +8,27 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
+class FilteredEdges:
+    kept: list["GraphEdge"]
+    filtered_out: list["GraphEdge"]
+
+@dataclass
 class LoopCompletionOutput:
     new_waiting: "GraphSection"
     outputs: list["GraphEdge"] = field(default_factory=list)
     loop_back_name_dests_to_remove: set[tuple[str, str]] = field(default_factory=set)
 
-    def filter_out_loop_back(self, edges: list["GraphEdge"]) -> list["GraphEdge"]:
-        return [
-            edge for edge in edges \
-                if (edge.name, edge.next_node) not in self.loop_back_name_dests_to_remove
-        ]
+    def filter_out_loop_back(self, edges: list["GraphEdge"]) -> FilteredEdges:
+        return FilteredEdges(
+            kept=[
+                edge for edge in edges \
+                    if (edge.name, edge.next_node) not in self.loop_back_name_dests_to_remove
+            ],
+            filtered_out=[
+                edge for edge in edges \
+                    if (edge.name, edge.next_node) in self.loop_back_name_dests_to_remove
+            ]
+        )
 
 
 def update_list_dicts(signals: dict[str, list], new_signals: dict[str, list]):

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -141,6 +141,10 @@ class GraphSection(ABC):
     ):
         pass
 
+    @abstractmethod
+    def reset(self):
+        pass
+
 
 @dataclass
 class GraphNode(GraphSection):
@@ -218,6 +222,13 @@ class GraphNode(GraphSection):
         request_id: str
     ):
         return
+    
+    def reset(self):
+        self.ready_inputs.clear()
+    
+    def clear_outputs(self):
+        for edge in self.outputs:
+            edge.tensor_info.clear()
 
 
 @dataclass
@@ -308,13 +319,17 @@ class Sequential(GraphSection):
             sec.register_communication_info(
                 communication_manager, request_id
             )
+    
+    def reset(self):
+        for sec in self.sections:
+            sec.reset()
 
 
 @dataclass
 class Parallel(GraphSection):
     sections: list[GraphSection]
 
-    def get_node_names(self) -> list[str]:
+    def get_node_names(self) -> set[str]:
         res = set()
         for s in self.sections:
             res.update(s.get_node_names())
@@ -392,11 +407,15 @@ class Parallel(GraphSection):
             sec.register_communication_info(
                 communication_manager, request_id
             )
+    
+    def reset(self):
+        for sec in self.sections:
+            sec.reset()
 
 
 @dataclass
 class Loop(GraphSection):
-    section: GraphSection # this is used to populate next_section and
+    curr_section_replica: GraphSection # this is used to populate next_section and
                           # in-progress section; it remains "clean"
     max_iters: int
     outputs: list[GraphEdge]
@@ -418,13 +437,13 @@ class Loop(GraphSection):
         return self.outputs
 
     def get_inputs(self):
-        return self.section.get_inputs()
+        return self.curr_section_replica.get_inputs()
 
     def get_node_names(self):
-        return self.section.get_node_names()
+        return self.curr_section_replica.get_node_names()
 
     def get_dyn_loop_names(self) -> set[str]:
-        return self.section.get_dyn_loop_names()
+        return self.curr_section_replica.get_dyn_loop_names()
     
     def register_communication_info(
         self, communication_manager,
@@ -432,7 +451,7 @@ class Loop(GraphSection):
     ):
         self._tensor_manager = communication_manager
         self._request_id = request_id
-        self.section.register_communication_info(
+        self.curr_section_replica.register_communication_info(
             communication_manager, request_id
         )
     
@@ -492,8 +511,8 @@ class Loop(GraphSection):
         return ingested
 
     def _get_external_inputs(self):
-        inputs = self.section.get_inputs()
-        internal_outputs = self.section.get_outputs()
+        inputs = self.curr_section_replica.get_inputs()
+        internal_outputs = self.curr_section_replica.get_outputs()
         output_names_dests = set([(edge.name, edge.next_node) for edge in internal_outputs])
 
         # compute "external inputs", i.e., ones that don't come from looping
@@ -505,11 +524,11 @@ class Loop(GraphSection):
     def _get_loop_back_signals(self) -> list[GraphEdge]:
         # these inputs and outputs only include external and loop-back signals;
         # they do not include signals that are purely internal to the section
-        inputs = self.section.get_inputs()
+        inputs = self.curr_section_replica.get_inputs()
         input_names_dests = [
             (edge.name, edge.next_node) for edge in inputs
         ]
-        outputs = self.section.get_outputs()
+        outputs = self.curr_section_replica.get_outputs()
 
         return [
             edge for edge in outputs if (edge.name, edge.next_node) in input_names_dests
@@ -519,69 +538,53 @@ class Loop(GraphSection):
         # In the disaggregated case, we need filter self.outputs for outputs
         # that this subgraph actually produces
         outputs_we_produce = set([
-            edge.name for edge in self.section.get_outputs()
+            edge.name for edge in self.curr_section_replica.get_outputs()
         ])
         self.outputs = [edge for edge in self.outputs if edge.name in outputs_we_produce]
 
         self._output_names = set([edge.name for edge in self.outputs])
         if self._curr_iter_section is None:
-            self._curr_iter_section = deepcopy(self.section)
+            self._curr_iter_section = self.curr_section_replica
         if self._nxt_iter_section is None:
-            self._nxt_iter_section = deepcopy(self.section)
+            self._nxt_iter_section = deepcopy(self.curr_section_replica)
         if self._external_inputs is None:
             self._external_inputs = self._get_external_inputs()
         if self._loop_back_signals is None:
             self._loop_back_signals = self._get_loop_back_signals()
 
-    def _get_advanced_loop(
-        self, curr_iter_section, nxt_iter_section
-    ):
-        return Loop(
-            section=self.section,
-            _curr_iter_section=curr_iter_section,
-            _nxt_iter_section=nxt_iter_section,
-            curr_iter=self.curr_iter + 1,
-            max_iters=self.max_iters,
-            outputs=self.outputs,
-            _external_inputs=self._external_inputs,
-            _loop_back_signals=self._loop_back_signals,
-            _tensor_manager=self._tensor_manager,
-            _request_id=self._request_id,
-            _uuid_label=self._uuid_label
-        )
 
     def _advance_one_iter(self) -> "Loop":
         self._uncache_outputs()
-        curr_iter_section = self._nxt_iter_section
-        nxt_iter_section = deepcopy(self.section)
+        self.curr_section_replica.reset()
+
+        new_curr, new_next = self._nxt_iter_section, self.curr_section_replica
+        self._curr_iter_section = new_curr
+        self._nxt_iter_section = new_next
+        self.curr_section_replica = new_curr
+        self.curr_iter += 1
 
         logger.debug(
             "Advancing loop with nodes %s from iter %d -> %d (out of %d)",
-            str(self.section.get_node_names()), self.curr_iter,
+            str(self.curr_section_replica.get_node_names()), self.curr_iter,
             self.curr_iter + 1, self.max_iters
         )
 
-        loop = self._get_advanced_loop(
-            curr_iter_section, nxt_iter_section
-        )
-        loop.ingest_inputs(get_node_to_inputs_mapping(
+        self.ingest_inputs(get_node_to_inputs_mapping(
             self._external_inputs
         ))
-        return loop
     
     def _is_done(self):
         return (self.max_iters == self.curr_iter + 1) and (self._curr_iter_section is None)
 
     def split_off_ready(self):
-        loop = self
         if self._curr_iter_section is None:
             if self._is_done():
                 return [], None
-            loop = self._advance_one_iter()
+            self._advance_one_iter()
 
-        first_ready, first_waiting = loop._curr_iter_section.split_off_ready()
-        loop._curr_iter_section = first_waiting
-        return first_ready, loop
+        first_ready, first_waiting = self._curr_iter_section.split_off_ready()
+        self._curr_iter_section = first_waiting
+        return first_ready, self
     
     def complete_loops(self) -> LoopCompletionOutput:
         output_signals = []
@@ -618,6 +621,12 @@ class Loop(GraphSection):
             outputs=output_signals,
             loop_back_name_dests_to_remove=loop_back_name_dests
         )
+    
+    def reset(self):
+        self.curr_section_replica.reset()
+        self._curr_iter_section = self.curr_section_replica
+        self._nxt_iter_section.reset()
+        self.curr_iter = 0
 
 
 @dataclass
@@ -637,20 +646,7 @@ class DynamicLoop(Loop):
         return (
             (self.max_iters == self.curr_iter + 1) or self._finished) \
                 and (self._curr_iter_section is None)
-
-    def _get_advanced_loop(
-        self, curr_iter_section, nxt_iter_section
-    ):
-        return DynamicLoop(
-            section=self.section,
-            name=self.name,
-            _curr_iter_section=curr_iter_section,
-            _nxt_iter_section=nxt_iter_section,
-            curr_iter=self.curr_iter + 1,
-            max_iters=self.max_iters,
-            outputs=self.outputs,
-            _external_inputs=self._external_inputs,
-            _loop_back_signals=self._loop_back_signals,
-            _tensor_manager=self._tensor_manager,
-            _request_id=self._request_id,
-        )
+    
+    def reset(self):
+        super().reset()
+        self._finished = False

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
+from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ def get_node_to_inputs_mapping(
 @dataclass
 class GraphSection(ABC):
     @abstractmethod
-    def get_node_names(self) -> list[str]:
+    def get_node_names(self) -> set[str]:
         pass
 
     @abstractmethod
@@ -159,8 +160,8 @@ class GraphNode(GraphSection):
     def is_ready_including_streaming(self):
         return self.input_ids.issubset(set(self.ready_inputs.keys()))
 
-    def get_node_names(self) -> list[str]:
-        return [self.name]
+    def get_node_names(self) -> set[str]:
+        return {self.name}
 
     def get_inputs(self) -> list[GraphEdge]:
         return [
@@ -216,10 +217,11 @@ class GraphNode(GraphSection):
 class Sequential(GraphSection):
     sections: list[GraphSection]
 
-    def get_node_names(self) -> list[str]:
-        return sum([
-            s.get_node_names() for s in self.sections
-        ], start=[])
+    def get_node_names(self) -> set[str]:
+        res = set()
+        for s in self.sections:
+            res.update(s.get_node_names())
+        return res
 
     def _get_inputs_outputs(self):
         # In the case that this section is part of a loop, "loop-back"
@@ -300,9 +302,10 @@ class Parallel(GraphSection):
     sections: list[GraphSection]
 
     def get_node_names(self) -> list[str]:
-        return sum([
-            s.get_node_names() for s in self.sections
-        ], start=[])
+        res = set()
+        for s in self.sections:
+            res.update(s.get_node_names())
+        return res
 
     def get_inputs(self):
         return sum(
@@ -385,6 +388,7 @@ class Loop(GraphSection):
     _nxt_iter_section: GraphSection = field(default=None)
     _cached_outputs: dict[str, list[TensorPointerInfo]] = field(default_factory=dict)
     _output_names: set[str] = field(default_factory=set)
+    _uuid_label: str = field(default_factory=lambda: str(uuid4()))
 
     # For handling tensor reference counting of loop outputs
     _tensor_manager: Any | None = field(default=None) # no type annotation because 
@@ -521,6 +525,7 @@ class Loop(GraphSection):
             _loop_back_signals=self._loop_back_signals,
             _tensor_manager=self._tensor_manager,
             _request_id=self._request_id,
+            _uuid_label=self._uuid_label
         )
 
     def _advance_one_iter(self) -> "Loop":

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -438,8 +438,10 @@ class Parallel(GraphSection):
 
 @dataclass
 class Loop(GraphSection):
-    section: GraphSection # this is used to populate next_section and
-                          # in-progress section; it remains "clean"
+    # "section" is used by users to specify the loop iterior.It is also
+    # used in the current copy-free "advance iter" logic; see "_advance_one_iter"
+    # for more information
+    section: GraphSection
     max_iters: int
     outputs: list[GraphEdge]
     curr_iter: int = field(default=0)
@@ -578,7 +580,30 @@ class Loop(GraphSection):
 
 
     def _advance_one_iter(self) -> "Loop":
+        """
+        Advance the iteration by essentially resetting the curr_iter_section
+        and swapping it with the next_iter_section. This allows loop iteration while
+        remaining copy-free. The overall logic is as follows:
+
+        1. Loop instantiation: _curr_iter_section is set to section ("obj A"), and
+        _nxt_iter_section is set to a copy ("obj B")
+
+        2. Advance iter 0 -> 1: reset self.section (obj A). Set _curr_iter_section
+        to obj B (which has possibly accumulated inputs in its tenure as
+        _nxt_iter_section), and _curr_iter_section is set to the newly-reset obj B.
+        We have to use self.section here because _curr_iter_section will be None before
+        calling _advance_one_iter.
+
+        3. Advance iter 1 -> 2: Same as (2), but sets _curr_iter_section to obj A,
+        and sets _nxt_iter_section to a freshly-reset obj B.
+        """
         self._uncache_outputs()
+
+        # TODO: maybe if we call node.reset right after running each node in the worker,
+        # so we know that all nodes in self.section have already been reset if
+        # self._iter_done() returns True, we don't have to call this here. But we
+        # will have to make sure to carefully reset the loop curr_iter in complete_loops(),
+        # so leaving this as a comment to think about later.
         self.section.reset()
 
         new_curr, new_next = self._nxt_iter_section, self.section
@@ -684,7 +709,7 @@ class DynamicLoop(Loop):
     def _is_done(self):
         return (
             (self.max_iters == self.curr_iter + 1) or self._finished) \
-                and (self._curr_iter_section is None)
+                and self._iter_done()
     
     def reset(self):
         super().reset()

--- a/mminf/graph/loop_index.py
+++ b/mminf/graph/loop_index.py
@@ -42,7 +42,9 @@ class IterIndexTree:
         return child.label_context_gt(other.children[child_name], target_label)
 
 
-def build_loop_index_tree(graph: GraphSection, fwd_idx: str):
+def build_loop_index_tree(
+    graph: GraphSection, fwd_idx: str
+) -> IterIndexTree:
     root = IterIndexTree(label="_fwd_idx", iter_index=fwd_idx)
     
     def _build(graph: GraphSection) -> dict[str, IterIndexTree]:

--- a/mminf/graph/loop_index.py
+++ b/mminf/graph/loop_index.py
@@ -39,6 +39,8 @@ class IterIndexTree:
             if label in other.children and target_label in child.descendent_labels:
                 child_name = label
                 break
+        if child_name is None:
+            return False
         return child.label_context_gt(other.children[child_name], target_label)
 
 
@@ -79,6 +81,7 @@ def update_loop_index_tree(
         if isinstance(graph, Sequential) or isinstance(graph, Parallel):
             for sec in graph.sections:
                 _update(tree, sec)
+                return
 
         # otherwise, this is a loop
         label = graph.name if isinstance(graph, DynamicLoop) else graph._uuid_label

--- a/mminf/graph/loop_index.py
+++ b/mminf/graph/loop_index.py
@@ -1,0 +1,88 @@
+
+from dataclasses import dataclass, field
+
+from mminf.graph.base import DynamicLoop, GraphNode, GraphSection, Loop, Parallel, Sequential
+
+
+@dataclass
+class IterIndexTree:
+    label: str
+    iter_index: int = 0
+    children: dict[str, "IterIndexTree"] = field(default_factory=dict)
+    descendent_labels: set[str] = field(default_factory=set)
+
+    def _set_desc_labels(self):
+        for child in self.children.values():
+            self.descendent_labels.add(child.label)
+            self.descendent_labels.update(child.descendent_labels)
+    
+    def label_context_gt(self, other: "IterIndexTree", target_label: str) -> bool:
+        """
+        Whether the iter indices of "self" are greater than the indices of
+        "other", specifically in the path leading up to (but not including)
+        "target_label".
+
+        For instance, if we are stopping the loop "target_label" but don't
+        want to double-stop it, we can keep track of the last time it was
+        stopped and only stop it again `new_time.label_context_gt(prev, label)`.
+        """
+        if self.label == target_label:
+            return False
+        assert self.label == other.label and target_label in self.descendent_labels
+        if self.iter_index != other.iter_index:
+            return self.iter_index > other.iter_index
+
+        # iter indices are equal, so have to recurse down the path
+        child_name = None
+        child = None
+        for label, child in self.children.items():
+            if label in other.children and target_label in child.descendent_labels:
+                child_name = label
+                break
+        return child.label_context_gt(other.children[child_name], target_label)
+
+
+def build_loop_index_tree(graph: GraphSection, fwd_idx: str):
+    root = IterIndexTree(label="_fwd_idx", iter_index=fwd_idx)
+    
+    def _build(graph: GraphSection) -> dict[str, IterIndexTree]:
+        if isinstance(graph, GraphNode) or graph is None:
+            return {}
+        if isinstance(graph, Sequential) or isinstance(graph, Parallel):
+            res = {}
+            for sec in graph.sections:
+                res.update(_build(sec))
+            return res
+        
+        # otherwise, this is a loop
+        label = graph.name if isinstance(graph, DynamicLoop) else graph._uuid_label
+        base_node = IterIndexTree(
+            label=label, iter_index=graph.curr_iter
+        )
+        base_node.children = _build(graph._curr_iter_section)
+        base_node._set_desc_labels()
+        return {label: base_node}
+    root.children = _build(graph)
+    root._set_desc_labels()
+    return root
+
+def update_loop_index_tree(
+    index_tree: IterIndexTree, graph: GraphSection, fwd_idx: str
+):
+    index_tree.iter_index = fwd_idx
+    
+    def _update(tree: IterIndexTree, graph: GraphSection) -> dict[str, IterIndexTree]:
+        if isinstance(graph, GraphNode) or graph is None:
+            return
+        if isinstance(graph, Sequential) or isinstance(graph, Parallel):
+            for sec in graph.sections:
+                _update(tree, sec)
+
+        # otherwise, this is a loop
+        label = graph.name if isinstance(graph, DynamicLoop) else graph._uuid_label
+        if label not in tree.children:
+            return
+        tree = tree.children[label]
+        tree.iter_index = graph.curr_iter
+        _update(tree, graph._curr_iter_section)
+    _update(index_tree, graph)

--- a/mminf/graph/request_queues.py
+++ b/mminf/graph/request_queues.py
@@ -2,6 +2,7 @@
 
 import logging
 from dataclasses import dataclass, field
+import time
 
 from mminf.graph.base import DestToGraphEdges, GraphEdge, GraphNode, GraphSection, get_node_to_inputs_mapping
 
@@ -28,10 +29,16 @@ class PerRequestNodeQueues:
     one of these queues.
     """
     waiting: GraphSection | None
+    full_section: GraphSection
     ready: list[GraphNode] = field(default_factory=list)
     # Nodes that have all non-streaming inputs ready
     waiting_for_stream: list[GraphNode] = field(default_factory=list)
     worker_graph_id: str = field(default="")
+
+    def reset(self):
+        self.full_section.reset()
+        self.waiting = self.full_section
+        self.ready.clear()
 
     def _update_ready_waiting(self):
         """
@@ -99,7 +106,6 @@ class PerRequestNodeQueues:
         external_outputs = sum(
             new_inputs.values(), start=[]
         )
-
         self._update_ready_waiting()
         logger.debug(
             ("Finished processing new graph inputs. Ready nodes: %s, waiting: %s.\n"

--- a/mminf/graph/request_queues.py
+++ b/mminf/graph/request_queues.py
@@ -39,6 +39,7 @@ class PerRequestNodeQueues:
         self.full_section.reset()
         self.waiting = self.full_section
         self.ready.clear()
+        self.waiting_for_stream.clear()
 
     def _update_ready_waiting(self):
         """
@@ -48,9 +49,7 @@ class PerRequestNodeQueues:
         if self.waiting is None:
             return
         new_ready, new_waiting = self.waiting.split_off_ready()
-        self.ready += [node for node in new_ready if node.is_ready_including_streaming()]
-        self.waiting_for_stream += [node for node in new_ready if not node.is_ready_including_streaming()]
-
+        self.ready += new_ready
         self.waiting = new_waiting
     
     def process_streaming_input(
@@ -60,19 +59,26 @@ class PerRequestNodeQueues:
         new_inputs: DestToGraphEdges = get_node_to_inputs_mapping(new_inputs)
         ingested = []
 
-        self._update_ready_waiting()
+        if self.waiting is None:
+            return ProcessedInputs(
+                for_other_worker_graphs=new_inputs,
+                routed_to_this_worker_graph=[],
+            )
+
+        self.waiting_for_stream.extend(
+            self.waiting.split_off_ready_for_streaming()
+        )
 
         new_waiting_for_stream = []
         for node in self.waiting_for_stream:
             ingested.extend(node.ingest_inputs(new_inputs))
-            if not node.is_ready_including_streaming():
+            if not node.is_ready():
                 new_waiting_for_stream.append(node)
-            else:
-                self.ready.append(node)
         self.waiting_for_stream = new_waiting_for_stream
         external_outputs = sum(
             new_inputs.values(), start=[]
         )
+        self._update_ready_waiting()
         return ProcessedInputs(
             for_other_worker_graphs=external_outputs,
             routed_to_this_worker_graph=ingested,

--- a/mminf/graph/request_queues.py
+++ b/mminf/graph/request_queues.py
@@ -56,14 +56,14 @@ class PerRequestNodeQueues:
         self,
         new_inputs: list[GraphEdge]
     ) -> ProcessedInputs:
-        new_inputs: DestToGraphEdges = get_node_to_inputs_mapping(new_inputs)
-        ingested = []
-
         if self.waiting is None:
             return ProcessedInputs(
                 for_other_worker_graphs=new_inputs,
                 routed_to_this_worker_graph=[],
             )
+
+        new_inputs: DestToGraphEdges = get_node_to_inputs_mapping(new_inputs)
+        ingested = []
 
         self.waiting_for_stream.extend(
             self.waiting.split_off_ready_for_streaming()

--- a/mminf/model/bagel/bagel_model.py
+++ b/mminf/model/bagel/bagel_model.py
@@ -493,7 +493,7 @@ class BagelModel(Model):
         # -- decode: single LLM node (embed + transformer + lm_head) --
         decode = DynamicLoop(
             name="decode_loop",
-            curr_section_replica=GraphNode(
+            section=GraphNode(
                 name="LLM",
                 input_ids=["text_inputs"],
                 outputs=[
@@ -518,7 +518,7 @@ class BagelModel(Model):
         # there are N-1 intervals, so N-1 Euler steps are needed.
         image_gen = Sequential([
             Loop(
-                curr_section_replica=GraphNode(
+                section=GraphNode(
                     name="LLM",
                     input_ids=["latents", "time_index"],
                     outputs=[
@@ -550,7 +550,7 @@ class BagelModel(Model):
         # combine_cfg applies the CFG formula + Euler step after each iteration.
         image_gen_cfg = Sequential([
             Loop(
-                curr_section_replica=Sequential([
+                section=Sequential([
                     Parallel([
                         GraphNode(
                             name="LLM",

--- a/mminf/model/bagel/bagel_model.py
+++ b/mminf/model/bagel/bagel_model.py
@@ -493,7 +493,7 @@ class BagelModel(Model):
         # -- decode: single LLM node (embed + transformer + lm_head) --
         decode = DynamicLoop(
             name="decode_loop",
-            section=GraphNode(
+            curr_section_replica=GraphNode(
                 name="LLM",
                 input_ids=["text_inputs"],
                 outputs=[
@@ -518,7 +518,7 @@ class BagelModel(Model):
         # there are N-1 intervals, so N-1 Euler steps are needed.
         image_gen = Sequential([
             Loop(
-                section=GraphNode(
+                curr_section_replica=GraphNode(
                     name="LLM",
                     input_ids=["latents", "time_index"],
                     outputs=[
@@ -550,7 +550,7 @@ class BagelModel(Model):
         # combine_cfg applies the CFG formula + Euler step after each iteration.
         image_gen_cfg = Sequential([
             Loop(
-                section=Sequential([
+                curr_section_replica=Sequential([
                     Parallel([
                         GraphNode(
                             name="LLM",

--- a/mminf/model/bagel/bagel_model.py
+++ b/mminf/model/bagel/bagel_model.py
@@ -44,6 +44,7 @@ from mminf.conductor.request_info import CurrentForwardConductorMetadata
 from mminf.engine.base import EngineType
 from mminf.engine.kv_store import KVCacheConfig
 from mminf.graph.base import (
+    DynamicLoop,
     GraphEdge,
     GraphNode,
     GraphSection,
@@ -490,18 +491,25 @@ class BagelModel(Model):
         ])
 
         # -- decode: single LLM node (embed + transformer + lm_head) --
-        decode = GraphNode(
-            name="LLM",
-            input_ids=["text_inputs"],
-            outputs=[
-                GraphEdge(
-                    next_node=EMIT_TO_CLIENT,
-                    name="new_token",
-                    output_modality="text",
-                    is_new_token=True,
-                    persist=True,
-                ),
-            ],
+        decode = DynamicLoop(
+            name="decode_loop",
+            section=GraphNode(
+                name="LLM",
+                input_ids=["text_inputs"],
+                outputs=[
+                    GraphEdge(
+                        next_node=EMIT_TO_CLIENT,
+                        name="new_token",
+                        output_modality="text",
+                    ),
+                    GraphEdge(
+                        next_node="LLM",
+                        name="text_inputs",
+                    ),
+                ],
+            ),
+            max_iters=self.get_max_output_tokens(),
+            outputs=[],
         )
 
         # -- image_gen: denoising loop (LLM does CFG+Euler) -> VAE decode --
@@ -518,7 +526,7 @@ class BagelModel(Model):
                         GraphEdge(next_node="LLM", name="time_index"),
                     ],
                 ),
-                n_iters=self.config.num_timesteps - 1,
+                max_iters=self.config.num_timesteps - 1,
                 outputs=[
                     GraphEdge(next_node="vae_decoder", name="latents"),
                 ],
@@ -584,7 +592,7 @@ class BagelModel(Model):
                         ],
                     ),
                 ]),
-                n_iters=self.config.num_timesteps - 1,
+                max_iters=self.config.num_timesteps - 1,
                 outputs=[
                     GraphEdge(next_node="vae_decoder", name="latents"),
                 ],
@@ -712,9 +720,8 @@ class BagelModel(Model):
             return [graph_edge]
 
         elif graph_walk == DECODE:
-            # Previous token feeds back as text_inputs
+            # The submodule automatically adds a BOS to start
             graph_edge = GraphEdge(next_node="LLM", name="text_inputs")
-            graph_edge.tensor_info = persist_signals.get("new_token", [])
             return [graph_edge]
 
         elif graph_walk == "image_gen":
@@ -865,17 +872,16 @@ class BagelModel(Model):
                     else:
                         metadata.graph_walk = self._image_gen_walk
         elif metadata.graph_walk == DECODE:
-            tokens = new_tokens.get("new_token", [])
-            if self.eos_token_id is not None and self.eos_token_id in tokens:
-                target = metadata.kwargs["target_output"]
-                if metadata.kwargs.get("think_mode", False) and target == "image":
-                    # Thinking graph walk complete — transition to image generation.
-                    metadata.graph_walk = self._image_gen_walk
-                else:
-                    request_done = True
+            target = metadata.kwargs["target_output"]
+            if metadata.kwargs.get("think_mode", False) and target == "image":
+                # Thinking graph walk complete — transition to image generation.
+                metadata.graph_walk = self._image_gen_walk
+            else:
+                request_done = True
 
         elif metadata.graph_walk in ("image_gen", "image_gen_cfg"):
-            # Image generation complete (one image per request)
+            # Image generation complete (one image per request), OR
+            # text generation complete (happens in a dynamic loop)
             request_done = True
 
         step_metadata =  self._get_step_metadata(metadata)

--- a/mminf/model/bagel/submodules.py
+++ b/mminf/model/bagel/submodules.py
@@ -1085,6 +1085,18 @@ class LLMSubmodule(NodeSubmodule):
         self, batch: NodeBatch
     ):
         return batch.graph_walk in ["decode", "prefill_text"]
+    
+    def postprocess(
+        self, request_info: CurrentForwardPassInfo,
+        outputs: dict[str, list[torch.Tensor]]
+    ):
+        if "new_token" not in outputs:
+            return
+        outputs["text_inputs"] = outputs["new_token"]
+        token = outputs["new_token"][0].item()
+        if (self.eos_token_id is not None and self.eos_token_id == token) or \
+                (request_info.dynamic_loop_iter_counts.get("decode_loop", 0) >= request_info.max_tokens):
+            request_info.register_loop_stop("decode_loop")
 
 
 class VAEDecoderSubmodule(NodeSubmodule):

--- a/mminf/model/bagel/submodules.py
+++ b/mminf/model/bagel/submodules.py
@@ -964,7 +964,6 @@ class LLMSubmodule(NodeSubmodule):
 
         result: NameToTensorList = {output_name: [hidden]}
         if self.node_name == "LLM":
-            result["latents"] = [latents]
             result["time_index"] = [time_index]
         return result
 

--- a/mminf/model/bagel/submodules.py
+++ b/mminf/model/bagel/submodules.py
@@ -1095,7 +1095,7 @@ class LLMSubmodule(NodeSubmodule):
         outputs["text_inputs"] = outputs["new_token"]
         token = outputs["new_token"][0].item()
         if (self.eos_token_id is not None and self.eos_token_id == token) or \
-                (request_info.dynamic_loop_iter_counts.get("decode_loop", 0) >= request_info.max_tokens):
+                (request_info.dynamic_loop_iter_counts.get("decode_loop", 0) + 1 >= request_info.max_tokens):
             request_info.register_loop_stop("decode_loop")
 
 

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -245,8 +245,8 @@ def _divide_into_worker_graphs(
                 section=s.section,
                 n_iters=graph.n_iters,
                 curr_iter=graph.curr_iter,
-                external_inputs=graph.external_inputs,
-                loop_back_signals=graph.loop_back_signals,
+                _external_inputs=graph._external_inputs,
+                _loop_back_signals=graph._loop_back_signals,
                 outputs=graph.outputs
             )
         return loop_section_worker_graphs

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -238,37 +238,33 @@ def _divide_into_worker_graphs(
 
     if isinstance(graph, Loop):
         loop_section_worker_graphs = _divide_into_worker_graphs(
-            graph.curr_section_replica,
+            graph.section,
             graph_walk=graph_walk,
             node_to_group_idx=node_to_group_idx,
             node_groups=node_groups,
             input_streams=input_streams
         )
-        if len(loop_section_worker_graphs) == 1:
-            # fully colocated case
-            loop_section_worker_graphs[0].section = graph
-            return loop_section_worker_graphs
-
-        # in the disaggregated case, we need to wrap all worker graphs in a loop
-        # with the external signals and loop-back signals pre-computed
+        ext_inps = [
+            inp for inp in graph._external_inputs if inp.name not in input_streams
+        ]
         for s in loop_section_worker_graphs:
             if isinstance(graph, DynamicLoop):
                 s.section = DynamicLoop(
-                    curr_section_replica=s.section,
+                    section=s.section,
                     name=graph.name,
                     max_iters=graph.max_iters,
                     curr_iter=graph.curr_iter,
-                    _external_inputs=graph._external_inputs,
+                    _external_inputs=ext_inps,
                     _loop_back_signals=graph._loop_back_signals,
                     outputs=graph.outputs,
                     _uuid_label=graph._uuid_label
                 )
             else:
                 s.section = Loop(
-                    curr_section_replica=s.section,
+                    section=s.section,
                     max_iters=graph.max_iters,
                     curr_iter=graph.curr_iter,
-                    _external_inputs=graph._external_inputs,
+                    _external_inputs=ext_inps,
                     _loop_back_signals=graph._loop_back_signals,
                     outputs=graph.outputs,
                     _uuid_label=graph._uuid_label

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -238,7 +238,7 @@ def _divide_into_worker_graphs(
 
     if isinstance(graph, Loop):
         loop_section_worker_graphs = _divide_into_worker_graphs(
-            graph.section,
+            graph.curr_section_replica,
             graph_walk=graph_walk,
             node_to_group_idx=node_to_group_idx,
             node_groups=node_groups,
@@ -254,7 +254,7 @@ def _divide_into_worker_graphs(
         for s in loop_section_worker_graphs:
             if isinstance(graph, DynamicLoop):
                 s.section = DynamicLoop(
-                    section=s.section,
+                    curr_section_replica=s.section,
                     name=graph.name,
                     max_iters=graph.max_iters,
                     curr_iter=graph.curr_iter,
@@ -265,7 +265,7 @@ def _divide_into_worker_graphs(
                 )
             else:
                 s.section = Loop(
-                    section=s.section,
+                    curr_section_replica=s.section,
                     max_iters=graph.max_iters,
                     curr_iter=graph.curr_iter,
                     _external_inputs=graph._external_inputs,

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -19,7 +19,7 @@ from mminf.engine.base import EngineType, NodeBatch
 from mminf.engine.cache_manager import BatchedCacheManager
 from mminf.engine.cuda_graph_runner import CudaGraphConfig
 from mminf.engine.kv_store import KVCacheConfig
-from mminf.graph.base import GraphEdge, GraphNode, GraphSection, Loop, Parallel, Sequential, TensorPointerInfo
+from mminf.graph.base import DynamicLoop, GraphEdge, GraphNode, GraphSection, Loop, Parallel, Sequential, TensorPointerInfo
 
 DECODE = "decode"
 MAX_OUTPUT_TOKENS = 2048
@@ -118,6 +118,17 @@ class NodeSubmodule(torch.nn.Module):
         self, batch: NodeBatch
     ):
         return False
+
+    def postprocess(
+        self, request_info: CurrentForwardPassInfo,
+        outputs: dict[str, list[torch.Tensor]]
+    ):
+        """
+        Performs any required postprocessing (after sampling from logits, if applicable)
+        on the submodule outputs (e.g., checking for EOS to stop the decode loop, as this
+        python-level control flow cannot happen in a cuda graph section).
+        """
+        return
 
 
 @dataclass
@@ -241,14 +252,25 @@ def _divide_into_worker_graphs(
         # in the disaggregated case, we need to wrap all worker graphs in a loop
         # with the external signals and loop-back signals pre-computed
         for s in loop_section_worker_graphs:
-            s.section = Loop(
-                section=s.section,
-                n_iters=graph.n_iters,
-                curr_iter=graph.curr_iter,
-                _external_inputs=graph._external_inputs,
-                _loop_back_signals=graph._loop_back_signals,
-                outputs=graph.outputs
-            )
+            if isinstance(graph, DynamicLoop):
+                s.section = DynamicLoop(
+                    section=s.section,
+                    name=graph.name,
+                    max_iters=graph.max_iters,
+                    curr_iter=graph.curr_iter,
+                    _external_inputs=graph._external_inputs,
+                    _loop_back_signals=graph._loop_back_signals,
+                    outputs=graph.outputs
+                )
+            else:
+                s.section = Loop(
+                    section=s.section,
+                    max_iters=graph.max_iters,
+                    curr_iter=graph.curr_iter,
+                    _external_inputs=graph._external_inputs,
+                    _loop_back_signals=graph._loop_back_signals,
+                    outputs=graph.outputs
+                )
         return loop_section_worker_graphs
 
 

--- a/mminf/model/base.py
+++ b/mminf/model/base.py
@@ -260,7 +260,8 @@ def _divide_into_worker_graphs(
                     curr_iter=graph.curr_iter,
                     _external_inputs=graph._external_inputs,
                     _loop_back_signals=graph._loop_back_signals,
-                    outputs=graph.outputs
+                    outputs=graph.outputs,
+                    _uuid_label=graph._uuid_label
                 )
             else:
                 s.section = Loop(
@@ -269,7 +270,8 @@ def _divide_into_worker_graphs(
                     curr_iter=graph.curr_iter,
                     _external_inputs=graph._external_inputs,
                     _loop_back_signals=graph._loop_back_signals,
-                    outputs=graph.outputs
+                    outputs=graph.outputs,
+                    _uuid_label=graph._uuid_label
                 )
         return loop_section_worker_graphs
 

--- a/mminf/model/dummy_model.py
+++ b/mminf/model/dummy_model.py
@@ -83,7 +83,7 @@ class DummyModel(Model):
         image_gen = Sequential([
             Parallel([self._get_text_emb(), self._get_img_emb()]),
             Loop(
-                curr_section_replica=Sequential([
+                section=Sequential([
                     GraphNode(
                         name="LLM",
                         input_ids=["text_emb", "img_emb", "latents"],

--- a/mminf/model/dummy_model.py
+++ b/mminf/model/dummy_model.py
@@ -74,7 +74,7 @@ class DummyModel(Model):
                         next_node=EMIT_TO_CLIENT,
                         output_modality="text",
                         name="new_token",
-                        is_new_token=True
+                        conductor_new_token=True
                     )
                 ]
             )
@@ -99,7 +99,7 @@ class DummyModel(Model):
                         ]
                     )
                 ]),
-                n_iters=10,
+                max_iters=10,
                 outputs=[
                     GraphEdge(next_node="VAE_dec", name="latents")
                 ]

--- a/mminf/model/dummy_model.py
+++ b/mminf/model/dummy_model.py
@@ -83,7 +83,7 @@ class DummyModel(Model):
         image_gen = Sequential([
             Parallel([self._get_text_emb(), self._get_img_emb()]),
             Loop(
-                section=Sequential([
+                curr_section_replica=Sequential([
                     GraphNode(
                         name="LLM",
                         input_ids=["text_emb", "img_emb", "latents"],

--- a/mminf/model/dummy_omni_model.py
+++ b/mminf/model/dummy_omni_model.py
@@ -26,7 +26,7 @@ class DummyOmniModel(Model):
                 outputs=[
                     GraphEdge(next_node="TalkerLLM", name="thinker_hidden"),
                     GraphEdge(
-                        next_node=EMIT_TO_CLIENT, name="thinker_token", is_new_token=True,
+                        next_node=EMIT_TO_CLIENT, name="thinker_token", conductor_new_token=True,
                         output_modality="text"
                     ),
                 ],
@@ -36,7 +36,7 @@ class DummyOmniModel(Model):
                 input_ids=["thinker_hidden"],
                 outputs=[
                     GraphEdge(next_node="MTP", name="codec_hidden"),
-                    GraphEdge(next_node=EMIT_TO_CLIENT, name="talker_token", is_new_token=True),
+                    GraphEdge(next_node=EMIT_TO_CLIENT, name="talker_token", conductor_new_token=True),
                 ],
             ),
             Loop(
@@ -45,10 +45,10 @@ class DummyOmniModel(Model):
                     input_ids=["codec_hidden"],
                     outputs=[
                         GraphEdge(next_node="MTP", name="codec_hidden"),
-                        GraphEdge(next_node=EMIT_TO_CLIENT, name="mtp_token", is_new_token=True),
+                        GraphEdge(next_node=EMIT_TO_CLIENT, name="mtp_token", conductor_new_token=True),
                     ],
                 ),
-                n_iters=16,
+                max_iters=16,
                 outputs=[
                     GraphEdge(next_node="AudioCodec", name="codec_hidden"),
                 ],

--- a/mminf/model/dummy_omni_model.py
+++ b/mminf/model/dummy_omni_model.py
@@ -40,7 +40,7 @@ class DummyOmniModel(Model):
                 ],
             ),
             Loop(
-                section=GraphNode(
+                curr_section_replica=GraphNode(
                     name="MTP",
                     input_ids=["codec_hidden"],
                     outputs=[

--- a/mminf/model/dummy_omni_model.py
+++ b/mminf/model/dummy_omni_model.py
@@ -40,7 +40,7 @@ class DummyOmniModel(Model):
                 ],
             ),
             Loop(
-                curr_section_replica=GraphNode(
+                section=GraphNode(
                     name="MTP",
                     input_ids=["codec_hidden"],
                     outputs=[

--- a/mminf/model/orpheus/orpheus_model.py
+++ b/mminf/model/orpheus/orpheus_model.py
@@ -288,37 +288,35 @@ class OrpheusModel(Model):
         which is updated from the worker's StreamBuffer via
         WorkerGraphsDone.stream_tokens_consumed.
         """
-        stride = self.config.snac_stride_tokens
+        # stride = self.config.snac_stride_tokens
 
         metadata.graph_walk = "snac_chunk"
 
-        available = token_buffer_count - consumed
+        # available = token_buffer_count - consumed
 
-        # Nothing left to decode
-        if available <= 0 and producer_done:
-            return ForwardPassArgs(
-                full_metadata=metadata,
-                inputs=[],
-                unpersist_tensors=[],
-                request_done=True,
-            )
+        # # Nothing left to decode
+        # if available <= 0 and producer_done:
+        #     return ForwardPassArgs(
+        #         full_metadata=metadata,
+        #         inputs=[],
+        #         unpersist_tensors=[],
+        #         request_done=True,
+        #     )
 
-        step_metadata = {"consumed_tokens": stride}
+        # step_metadata = {"consumed_tokens": stride}
 
-        # Check if this is the last chunk. Basically, the new_consumed = consumed + stride
-        # is only used to calculate is_last. it's asking "after the worker consumes another
-        # stride's worth of tokens, will there be enough left for another chunk?"
-        # It's not actually advancing any state.
-        new_consumed = consumed + stride
-        remaining_after = token_buffer_count - new_consumed
-        is_last = producer_done and remaining_after < stride
+        # # Check if this is the last chunk. Basically, the new_consumed = consumed + stride
+        # # is only used to calculate is_last. it's asking "after the worker consumes another
+        # # stride's worth of tokens, will there be enough left for another chunk?"
+        # # It's not actually advancing any state.
+        # new_consumed = consumed + stride
+        # remaining_after = token_buffer_count - new_consumed
+        # is_last = producer_done and remaining_after < stride
 
         return ForwardPassArgs(
             full_metadata=metadata,
             inputs=[],
             unpersist_tensors=[],
-            step_metadata=step_metadata,
-            request_done=is_last,
         )
 
     # -------------------------------------------------------------------

--- a/mminf/model/orpheus/orpheus_model.py
+++ b/mminf/model/orpheus/orpheus_model.py
@@ -127,7 +127,7 @@ class OrpheusModel(Model):
 
         decode = DynamicLoop(
             name="decode_loop",
-            section=GraphNode(
+            curr_section_replica=GraphNode(
                 name="LLM",
                 input_ids=["text_inputs"],
                 outputs=[

--- a/mminf/model/orpheus/orpheus_model.py
+++ b/mminf/model/orpheus/orpheus_model.py
@@ -127,7 +127,7 @@ class OrpheusModel(Model):
 
         decode = DynamicLoop(
             name="decode_loop",
-            curr_section_replica=GraphNode(
+            section=GraphNode(
                 name="LLM",
                 input_ids=["text_inputs"],
                 outputs=[
@@ -277,41 +277,10 @@ class OrpheusModel(Model):
         producer_done: bool,
         consumed: int = 0,
     ) -> ForwardPassArgs:
-        """SNAC partition: trigger one streaming chunk decode.
-
-        The SNAC submodule converts ALL buffered tokens to codes and takes
-        the last 28 valid codes (matching the reference decoder). The
-        conductor just needs to trigger it periodically and track whether
-        there are more tokens to process.
-
-        ``consumed`` comes from the StreamingConnectionState.consumed_count,
-        which is updated from the worker's StreamBuffer via
-        WorkerGraphsDone.stream_tokens_consumed.
+        """SNAC partition: the streaming decode loop is self-triggered,
+        so this function is basically a no-op.
         """
-        # stride = self.config.snac_stride_tokens
-
         metadata.graph_walk = "snac_chunk"
-
-        # available = token_buffer_count - consumed
-
-        # # Nothing left to decode
-        # if available <= 0 and producer_done:
-        #     return ForwardPassArgs(
-        #         full_metadata=metadata,
-        #         inputs=[],
-        #         unpersist_tensors=[],
-        #         request_done=True,
-        #     )
-
-        # step_metadata = {"consumed_tokens": stride}
-
-        # # Check if this is the last chunk. Basically, the new_consumed = consumed + stride
-        # # is only used to calculate is_last. it's asking "after the worker consumes another
-        # # stride's worth of tokens, will there be enough left for another chunk?"
-        # # It's not actually advancing any state.
-        # new_consumed = consumed + stride
-        # remaining_after = token_buffer_count - new_consumed
-        # is_last = producer_done and remaining_after < stride
 
         return ForwardPassArgs(
             full_metadata=metadata,

--- a/mminf/model/orpheus/orpheus_model.py
+++ b/mminf/model/orpheus/orpheus_model.py
@@ -114,7 +114,7 @@ class OrpheusModel(Model):
                 GraphEdge(
                     next_node=EMPTY_DESTINATION,
                     name="new_token",
-                    is_new_token=True,
+                    conductor_new_token=True,
                     persist=True,
                 ),
                 StreamingGraphEdge(
@@ -132,7 +132,7 @@ class OrpheusModel(Model):
                 GraphEdge(
                     next_node=EMPTY_DESTINATION,
                     name="new_token",
-                    is_new_token=True,
+                    conductor_new_token=True,
                     persist=True,
                 ),
                 StreamingGraphEdge(

--- a/mminf/model/orpheus/orpheus_model.py
+++ b/mminf/model/orpheus/orpheus_model.py
@@ -140,11 +140,11 @@ class OrpheusModel(Model):
                         name="new_token",
                         target_partition="SNAC",
                     ),
-                    GraphEdge(
-                        next_node=EMPTY_DESTINATION,
-                        name="new_token",
-                        conductor_new_token=True,
-                    ),
+                    # GraphEdge(
+                    #     next_node=EMPTY_DESTINATION,
+                    #     name="new_token",
+                    #     conductor_new_token=True,
+                    # ),
                 ],
             ),
             max_iters=self.get_max_output_tokens(),

--- a/mminf/model/orpheus/orpheus_model.py
+++ b/mminf/model/orpheus/orpheus_model.py
@@ -30,7 +30,7 @@ from mminf.communication.tensors import NameToTensorList
 from mminf.conductor.request_info import CurrentForwardConductorMetadata, PartitionDefinition, StreamingConnectionState
 from mminf.engine.ar_engine import KVCacheConfig
 from mminf.engine.base import EngineType
-from mminf.graph.base import GraphEdge, GraphNode, GraphSection, TensorPointerInfo
+from mminf.graph.base import DynamicLoop, GraphEdge, GraphNode, GraphSection, TensorPointerInfo
 from mminf.graph.special_destinations import EMIT_TO_CLIENT, EMPTY_DESTINATION
 from mminf.model.base import ForwardPassArgs, Model, NodeSubmodule
 from mminf.model.orpheus.config import OrpheusModelConfig
@@ -125,22 +125,30 @@ class OrpheusModel(Model):
             ],
         )
 
-        decode = GraphNode(
-            name="LLM",
-            input_ids=["text_inputs"],
-            outputs=[
-                GraphEdge(
-                    next_node=EMPTY_DESTINATION,
-                    name="new_token",
-                    conductor_new_token=True,
-                    persist=True,
-                ),
-                StreamingGraphEdge(
-                    next_node="snac_decoder",
-                    name="new_token",
-                    target_partition="SNAC",
-                ),
-            ],
+        decode = DynamicLoop(
+            name="decode_loop",
+            section=GraphNode(
+                name="LLM",
+                input_ids=["text_inputs"],
+                outputs=[
+                    GraphEdge(
+                        next_node="LLM",
+                        name="text_inputs",
+                    ),
+                    StreamingGraphEdge(
+                        next_node="snac_decoder",
+                        name="new_token",
+                        target_partition="SNAC",
+                    ),
+                    GraphEdge(
+                        next_node=EMPTY_DESTINATION,
+                        name="new_token",
+                        conductor_new_token=True,
+                    ),
+                ],
+            ),
+            max_iters=self.get_max_output_tokens(),
+            outputs=[],
         )
 
         snac_chunk = GraphNode(
@@ -232,18 +240,9 @@ class OrpheusModel(Model):
         if metadata.is_prefill:
             metadata.is_prefill = False
             metadata.graph_walk = "decode"
-            metadata.kwargs["audio_token_count"] = 0
-            metadata.kwargs["decode_finished"] = False
         elif metadata.graph_walk == "decode":
-            tokens = new_tokens.get("new_token", [])
-            count = metadata.kwargs["audio_token_count"]
-            for t in tokens:
-                if t == self.config.stop_token_id:
-                    request_done = True
-                    metadata.kwargs["decode_finished"] = True
-                    break
-                count += 1
-            metadata.kwargs["audio_token_count"] = count
+            request_done = True
+            metadata.kwargs["decode_finished"] = True
 
         if request_done:
             return ForwardPassArgs(

--- a/mminf/model/orpheus/submodules.py
+++ b/mminf/model/orpheus/submodules.py
@@ -84,7 +84,7 @@ class OrpheusLLMSubmodule(NodeSubmodule):
         token = outputs["new_token"][0].item()
         eos_token_id = self.config.stop_token_id
         if (eos_token_id is not None and eos_token_id == token) or \
-                (request_info.dynamic_loop_iter_counts.get("decode_loop", 0) >= request_info.max_tokens):
+                (request_info.dynamic_loop_iter_counts.get("decode_loop", 0) + 1 >= request_info.max_tokens):
             request_info.register_loop_stop("decode_loop")
 
     def _forward_prefill(

--- a/mminf/model/orpheus/submodules.py
+++ b/mminf/model/orpheus/submodules.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 
 from mminf.communication.tensors import NameToTensorList
+from mminf.conductor.request_info import CurrentForwardPassInfo
 from mminf.engine.ar_engine import BatchedCacheManager
 from mminf.engine.cuda_graph_runner import CudaGraphConfig
 from mminf.model.base import NodeSubmodule
@@ -72,6 +73,19 @@ class OrpheusLLMSubmodule(NodeSubmodule):
             return self._forward_decode(cache_handle=cache_handle, **kwargs)
         else:
             raise ValueError(f"Unknown graph walk for OrpheusLLM: {graph_walk!r}")
+
+    def postprocess(
+        self, request_info: CurrentForwardPassInfo,
+        outputs: dict[str, list[torch.Tensor]]
+    ):
+        if "new_token" not in outputs:
+            return
+        outputs["text_inputs"] = outputs["new_token"]
+        token = outputs["new_token"][0].item()
+        eos_token_id = self.config.stop_token_id
+        if (eos_token_id is not None and eos_token_id == token) or \
+                (request_info.dynamic_loop_iter_counts.get("decode_loop", 0) >= request_info.max_tokens):
+            request_info.register_loop_stop("decode_loop")
 
     def _forward_prefill(
         self,

--- a/mminf/model/pi05/pi05_model.py
+++ b/mminf/model/pi05/pi05_model.py
@@ -276,7 +276,7 @@ class Pi05Model(Model):
                     GraphEdge(next_node="LLM", name="timestep_index"),
                 ],
             ),
-            n_iters=self.config.num_flow_steps,
+            max_iters=self.config.num_flow_steps,
             outputs=[
                 GraphEdge(
                     next_node=EMIT_TO_CLIENT,

--- a/mminf/model/qwen3_omni/qwen3_omni_model.py
+++ b/mminf/model/qwen3_omni/qwen3_omni_model.py
@@ -42,7 +42,7 @@ from mminf.conductor.request_info import (
 )
 from mminf.engine.base import EngineType
 from mminf.engine.kv_store import KVCacheConfig
-from mminf.graph.base import GraphEdge, GraphNode, Sequential, TensorPointerInfo
+from mminf.graph.base import DynamicLoop, GraphEdge, GraphNode, Sequential, TensorPointerInfo
 from mminf.graph.special_destinations import EMIT_TO_CLIENT, EMPTY_DESTINATION
 from mminf.model.base import ForwardPassArgs, Model, NodeSubmodule, TensorAndMetadata
 from mminf.model.qwen3_omni.components.code2wav import Qwen3OmniCode2Wav
@@ -207,7 +207,6 @@ class Qwen3OmniModel(Model):
                     next_node=EMIT_TO_CLIENT,
                     name="new_token",
                     output_modality="text",
-                    is_new_token=True,
                     persist=True,
                 ),
                 StreamingGraphEdge(
@@ -243,7 +242,6 @@ class Qwen3OmniModel(Model):
                         next_node=EMIT_TO_CLIENT,
                         name="new_token",
                         output_modality="text",
-                        is_new_token=True,
                         persist=True,
                     ),
                     StreamingGraphEdge(
@@ -280,7 +278,6 @@ class Qwen3OmniModel(Model):
                         next_node=EMIT_TO_CLIENT,
                         name="new_token",
                         output_modality="text",
-                        is_new_token=True,
                         persist=True,
                     ),
                     StreamingGraphEdge(
@@ -299,28 +296,36 @@ class Qwen3OmniModel(Model):
 
         # -- Thinker decode: produces new_token (persist) + thinker_states
         #    (streaming to Talker) --
-        thinker_decode = GraphNode(
-            name="Thinker",
-            input_ids=["text_inputs"],
-            outputs=[
-                GraphEdge(
-                    next_node=EMIT_TO_CLIENT,
-                    name="new_token",
-                    output_modality="text",
-                    is_new_token=True,
-                    persist=True,
-                ),
-                StreamingGraphEdge(
-                    next_node="Talker",
-                    name="thinker_states",
-                    target_partition="Talker",
-                ),
-                StreamingGraphEdge(
-                    next_node="Talker",
-                    name="thinker_mask",
-                    target_partition="Talker",
-                ),
-            ],
+        thinker_decode = DynamicLoop(
+            name="thinker_decode_loop",
+            section=GraphNode(
+                name="Thinker",
+                input_ids=["text_inputs"],
+                outputs=[
+                    GraphEdge(
+                        next_node=EMIT_TO_CLIENT,
+                        name="new_token",
+                        output_modality="text",
+                    ),
+                    GraphEdge(
+                        next_node="Thinker",
+                        name="text_inputs",
+                        output_modality="text",
+                    ),
+                    StreamingGraphEdge(
+                        next_node="Talker",
+                        name="thinker_states",
+                        target_partition="Talker",
+                    ),
+                    StreamingGraphEdge(
+                        next_node="Talker",
+                        name="thinker_mask",
+                        target_partition="Talker",
+                    ),
+                ],
+            ),
+            max_iters=self.get_max_output_tokens(),
+            outputs=[],
         )
 
         # -- Talker prefill: receives thinker_states + talker_trigger --
@@ -331,12 +336,6 @@ class Qwen3OmniModel(Model):
             name="Talker",
             input_ids=["thinker_states", "thinker_mask", "talker_trigger"],
             outputs=[
-                GraphEdge(
-                    next_node=EMPTY_DESTINATION,
-                    name="new_token",
-                    is_new_token=True,
-                    persist=True,
-                ),
                 GraphEdge(
                     next_node=EMPTY_DESTINATION,
                     name="all_codes",
@@ -351,27 +350,25 @@ class Qwen3OmniModel(Model):
         )
 
         # -- Talker decode: autoregressive codec token generation --
-        talker_decode = GraphNode(
-            name="Talker",
-            input_ids=["all_codes", "thinker_states", "thinker_mask"],
-            outputs=[
-                GraphEdge(
-                    next_node=EMPTY_DESTINATION,
-                    name="new_token",
-                    is_new_token=True,
-                    persist=True,
-                ),
-                GraphEdge(
-                    next_node=EMPTY_DESTINATION,
-                    name="all_codes",
-                    persist=True,
-                ),
-                StreamingGraphEdge(
-                    next_node="Code2Wav",
-                    name="codec_tokens",
-                    target_partition="Code2Wav",
-                ),
-            ],
+        talker_decode = DynamicLoop(
+            name="talker_decode_loop",
+            section=GraphNode(
+                name="Talker",
+                input_ids=["all_codes", "thinker_states", "thinker_mask"],
+                outputs=[
+                    GraphEdge(
+                        next_node="Talker",
+                        name="all_codes",
+                    ),
+                    StreamingGraphEdge(
+                        next_node="Code2Wav",
+                        name="codec_tokens",
+                        target_partition="Code2Wav",
+                    ),
+                ],
+            ),
+            max_iters=self.get_max_output_tokens(),
+            outputs=[],
         )
 
         # -- Code2Wav chunk: vocoder streaming decode --
@@ -727,7 +724,6 @@ class Qwen3OmniModel(Model):
         4. Each decode step: check new_token for EOS (im_end_token_id)
         5. On EOS: request_done=True for Thinker
         """
-        request_done = False
 
         if metadata.is_prefill:
             # Advance prefill schedule
@@ -744,15 +740,7 @@ class Qwen3OmniModel(Model):
                 metadata.graph_walk = "thinker_decode"
 
         elif metadata.graph_walk == "thinker_decode":
-            # Check for EOS in newly generated tokens
-            tokens = new_tokens.get("new_token", [])
-            for t in tokens:
-                if t == self.config.im_end_token_id:
-                    request_done = True
-                    break
-
-        # Build inputs for next step
-        if request_done:
+            # if the decode loop returns to conductor, the thinker is fully done
             return ForwardPassArgs(
                 full_metadata=metadata,
                 inputs=[],
@@ -760,7 +748,7 @@ class Qwen3OmniModel(Model):
                 request_done=True,
             )
 
-        is_last_prefill = True
+
         if metadata.is_prefill:
             # Still in prefill -- delegate to _get_thinker_prefill_inputs
             # which handles the (walk_name, {input_name: tensor_info}) schedule
@@ -773,6 +761,7 @@ class Qwen3OmniModel(Model):
             inputs = self._get_thinker_prefill_inputs(metadata, persist_signals)
         else:
             # Decode: previous token feeds back as text_inputs
+            is_last_prefill = False
             edge = GraphEdge(next_node="Thinker", name="text_inputs")
             edge.tensor_info = persist_signals.get("new_token", [])
             inputs = [edge]
@@ -822,8 +811,6 @@ class Qwen3OmniModel(Model):
            - If codec_eos: request_done=True for Talker
            - Else: return all_codes as input again (loop)
         """
-        request_done = False
-
         if metadata.is_prefill:
             # Talker is in prefill mode, waiting for conductor triggers.
 
@@ -867,37 +854,12 @@ class Qwen3OmniModel(Model):
             )
 
         elif metadata.graph_walk == "talker_decode":
-            # Decode loop: check only the layer-0 code (first element) for
-            # codec EOS.  Higher codebook layers (1-31) are residual codes
-            # and should not be compared against the EOS token ID.
-            tokens = new_tokens["new_token"]
-            codec_eos = self.config.talker.codec_eos_token_id
-            if tokens and tokens[0] == codec_eos:
-                request_done = True
-
-            if request_done:
-                return ForwardPassArgs(
-                    full_metadata=metadata,
-                    inputs=[],
-                    unpersist_tensors=[],
-                    request_done=True,
-                )
-
-            # Feed all_codes back for next decode step
-            edge = GraphEdge(next_node="Talker", name="all_codes")
-            edge.tensor_info = persist_signals.get("all_codes", [])
-            inputs = [edge]
-            unpersist_tensors = sum(
-                [inp.tensor_info for inp in inputs], start=[]
-            )
-
+            # If the decode loop reaches the conductor, we can end the request.
             return ForwardPassArgs(
                 full_metadata=metadata,
-                inputs=inputs,
-                unpersist_tensors=unpersist_tensors,
-                step_metadata={
-                    "is_prefill": False,
-                },
+                inputs=[],
+                unpersist_tensors=[],
+                request_done=True,
             )
 
         raise ValueError(

--- a/mminf/model/qwen3_omni/submodules.py
+++ b/mminf/model/qwen3_omni/submodules.py
@@ -1483,8 +1483,6 @@ class TalkerSubmodule(NodeSubmodule):
         """
         cache_handle.set_active_label("main")
 
-        print("is_last_prefill", is_last_prefill)
-
         # Check for non-last prefill (KV-cache-only step)
         if graph_walk == "talker_prefill" and not is_last_prefill:
             self.model(input_embeds=input_embeds, cache_handle=cache_handle)
@@ -1772,7 +1770,6 @@ class TalkerSubmodule(NodeSubmodule):
             return
         token = outputs["new_token"][0].item()
         eos_token_id = self.config.talker.codec_eos_token_id
-        print(token, eos_token_id)
         if (eos_token_id is not None and eos_token_id == token) or \
                 (request_info.dynamic_loop_iter_counts.get("talker_decode_loop", 0) >= request_info.max_tokens):
             request_info.register_loop_stop("talker_decode_loop")

--- a/mminf/model/qwen3_omni/submodules.py
+++ b/mminf/model/qwen3_omni/submodules.py
@@ -884,6 +884,19 @@ class ThinkerSubmodule(NodeSubmodule):
         per_request_info: dict[str, CurrentForwardPassInfo],
     ) -> list[str]:
         return ["main"]
+    
+    def postprocess(
+        self, request_info: CurrentForwardPassInfo,
+        outputs: dict[str, list[torch.Tensor]]
+    ):
+        if "new_token" not in outputs:
+            return
+        outputs["text_inputs"] = outputs["new_token"]
+        token = outputs["new_token"][0].item()
+        eos_token_id = self.config.im_end_token_id
+        if (eos_token_id is not None and eos_token_id == token) or \
+                (request_info.dynamic_loop_iter_counts.get("thinker_decode_loop", 0) >= request_info.max_tokens):
+            request_info.register_loop_stop("thinker_decode_loop")
 
 
 # ===================================================================
@@ -1470,6 +1483,8 @@ class TalkerSubmodule(NodeSubmodule):
         """
         cache_handle.set_active_label("main")
 
+        print("is_last_prefill", is_last_prefill)
+
         # Check for non-last prefill (KV-cache-only step)
         if graph_walk == "talker_prefill" and not is_last_prefill:
             self.model(input_embeds=input_embeds, cache_handle=cache_handle)
@@ -1748,13 +1763,25 @@ class TalkerSubmodule(NodeSubmodule):
         per_request_info: dict[str, CurrentForwardPassInfo],
     ) -> list[str]:
         return ["main"]
+    
+    def postprocess(
+        self, request_info: CurrentForwardPassInfo,
+        outputs: dict[str, list[torch.Tensor]]
+    ):
+        if "new_token" not in outputs:
+            return
+        token = outputs["new_token"][0].item()
+        eos_token_id = self.config.talker.codec_eos_token_id
+        print(token, eos_token_id)
+        if (eos_token_id is not None and eos_token_id == token) or \
+                (request_info.dynamic_loop_iter_counts.get("talker_decode_loop", 0) >= request_info.max_tokens):
+            request_info.register_loop_stop("talker_decode_loop")
 
     # ---- cleanup ----
 
     def cleanup_request(self, request_id: str) -> None:
         """Remove per-request state when a request completes."""
         self._seen_layer0_mask.pop(request_id, None)
-        self._prefill_conv_tail.pop(request_id, None)
         self._eos_embed_sent.discard(request_id)
 
 

--- a/mminf/model/qwen3_omni/submodules.py
+++ b/mminf/model/qwen3_omni/submodules.py
@@ -895,7 +895,7 @@ class ThinkerSubmodule(NodeSubmodule):
         token = outputs["new_token"][0].item()
         eos_token_id = self.config.im_end_token_id
         if (eos_token_id is not None and eos_token_id == token) or \
-                (request_info.dynamic_loop_iter_counts.get("thinker_decode_loop", 0) >= request_info.max_tokens):
+                (request_info.dynamic_loop_iter_counts.get("thinker_decode_loop", 0) + 1 >= request_info.max_tokens):
             request_info.register_loop_stop("thinker_decode_loop")
 
 
@@ -1771,7 +1771,7 @@ class TalkerSubmodule(NodeSubmodule):
         token = outputs["new_token"][0].item()
         eos_token_id = self.config.talker.codec_eos_token_id
         if (eos_token_id is not None and eos_token_id == token) or \
-                (request_info.dynamic_loop_iter_counts.get("talker_decode_loop", 0) >= request_info.max_tokens):
+                (request_info.dynamic_loop_iter_counts.get("talker_decode_loop", 0) + 1 >= request_info.max_tokens):
             request_info.register_loop_stop("talker_decode_loop")
 
     # ---- cleanup ----

--- a/mminf/model/utils.py
+++ b/mminf/model/utils.py
@@ -271,11 +271,12 @@ def load_weights_from_hf_shards(
             if prefix + k in mod_key_to_hf_keys.keys():
                 mod_key_to_hf_keys[k] = mod_key_to_hf_keys[prefix + k]
                 all_hf_keys.update(mod_key_to_hf_keys[k].keys)
-                del mod_key_to_hf_keys[prefix + k]
+                if prefix:
+                    del mod_key_to_hf_keys[prefix + k]
             mod_key_to_idx[k] = i
         module_keys.append(mod.module.state_dict().keys())
         all_module_keys.update(module_keys[-1])
-    
+
     mod_key_to_hf_keys = {
         k: v for k, v in mod_key_to_hf_keys.items() if k in all_module_keys
     }

--- a/mminf/utils/ipc_format.py
+++ b/mminf/utils/ipc_format.py
@@ -74,8 +74,8 @@ class UnpersistTensors(MessageBody):
 class StopLoops(MessageBody):
     request_id: str
     loop_names: set[str]
-    loop_stop_times: dict[str, IterIndexTree] = field(default_factory=dict)
     partition_name: str
+    loop_stop_times: dict[str, IterIndexTree] = field(default_factory=dict)
 
 @dataclass
 class WorkerMessage:

--- a/mminf/utils/ipc_format.py
+++ b/mminf/utils/ipc_format.py
@@ -55,7 +55,7 @@ class InputSignals(MessageBody):
     inputs: list[GraphEdge]
     request_info: CurrentForwardPassInfo
     partition_name: str = "default"
-    producer_done: bool = False
+    producer_done: set = field(default_factory=set)
 
 
 @dataclass

--- a/mminf/utils/ipc_format.py
+++ b/mminf/utils/ipc_format.py
@@ -28,11 +28,10 @@ class MessageBody:
 class WorkerMessageType(Enum):
     NEW_REQUEST = "new_request"
     REMOVE_REQUEST = "remove_request"
-    KV_TRANSFER_LAYER = "kv_transfer_layer"
-    KV_TRANSFER_META = "kv_transfer_meta"
     INPUT_SIGNALS = "input_signals"
     UNPERSIST_TENSORS = "unpersist"
     TENSOR_RECEIVED = "tensor_received"
+    STOP_LOOPS = "stop_loops"
 
 
 @dataclass
@@ -69,6 +68,13 @@ class TensorReceived(MessageBody):
 class UnpersistTensors(MessageBody):
     request_id: str
     uuid_to_ref_count: dict[str, int]
+
+@dataclass
+class StopLoops(MessageBody):
+    request_id: str
+    loop_names: set[str]
+    fwd_index: int
+    partition_name: str
 
 @dataclass
 class WorkerMessage:

--- a/mminf/utils/ipc_format.py
+++ b/mminf/utils/ipc_format.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 from mminf.conductor.request_info import CurrentForwardPassInfo, PerLabelSeqInfo, SequenceInfo
 from mminf.graph.base import GraphEdge, TensorPointerInfo
+from mminf.graph.loop_index import IterIndexTree
 
 
 class Status(Enum):
@@ -73,7 +74,7 @@ class UnpersistTensors(MessageBody):
 class StopLoops(MessageBody):
     request_id: str
     loop_names: set[str]
-    fwd_index: int
+    loop_stop_times: dict[str, IterIndexTree] = field(default_factory=dict)
     partition_name: str
 
 @dataclass

--- a/mminf/utils/ipc_format.py
+++ b/mminf/utils/ipc_format.py
@@ -38,7 +38,7 @@ class WorkerMessageType(Enum):
 @dataclass
 class NewRequest(MessageBody):
     request_id: str
-    worker_graph_ids: list[str]
+    partition_worker_graph_ids: list[str]
     worker_graph_to_worker: dict[str, str]
     initial_inputs: list[GraphEdge]
     request_info: CurrentForwardPassInfo

--- a/mminf/worker/dummy_worker.py
+++ b/mminf/worker/dummy_worker.py
@@ -74,7 +74,7 @@ class DummyWorker:
         """
         self.worker_graphs_manager.add_request(
             request_id=body.request_id,
-            worker_graph_ids=body.worker_graph_ids,
+            partition_worker_graph_ids=body.partition_worker_graph_ids,
             worker_graph_to_worker=body.worker_graph_to_worker
         )
 

--- a/mminf/worker/engine_manager.py
+++ b/mminf/worker/engine_manager.py
@@ -32,6 +32,7 @@ class EngineManager:
         node_names: set[str],
         device: torch.device,
         kv_config: list[KVCacheConfig],
+        model_config: dict,
         transfer_engine_info: TransferEngineInfo,
         model: Model,
         enable_nvtx: bool = False,
@@ -51,22 +52,19 @@ class EngineManager:
 
         node_to_engine: dict[str, BaseEngine] = {}
 
+        # Resolve autocast dtype: explicit YAML config wins; otherwise we
+        # fall back to the Model's own preference (so models that need to
+        # match a reference numerically can override get_autocast_dtype
+        # without forcing every config file to set the same value).
+        autocast_dtype = model.get_autocast_dtype()
+        if "autocast_dtype" in model_config:
+            autocast_dtype = model_config["autocast_dtype"]
+
         for engine_type_str, node_names in type_to_nodes.items():
             engine_cls = ENGINE_TYPE_TO_CLASS[engine_type_str]
 
-            # Resolve autocast dtype: explicit YAML config wins; otherwise we
-            # fall back to the Model's own preference (so models that need to
-            # match a reference numerically can override get_autocast_dtype
-            # without forcing every config file to set the same value).
-            if "autocast_dtype" in model_config:
-                autocast_dtype = model_config["autocast_dtype"]
-            elif model is not None:
-                autocast_dtype = model.get_autocast_dtype()
-            else:
-                autocast_dtype = torch.bfloat16
-
             engine = engine_cls(
-                autocast_dtype=model.get_autocast_dtype(),
+                autocast_dtype=autocast_dtype,
                 enable_nvtx=enable_nvtx,
             )
 
@@ -79,7 +77,7 @@ class EngineManager:
                         if engine.has_autocast():
                             submodules[name] = submodule.to(
                                 device=device,
-                                dtype=model.get_autocast_dtype()
+                                dtype=autocast_dtype
                             )
                         else:
                             submodules[name] = submodule.to(
@@ -90,7 +88,8 @@ class EngineManager:
                 submodules,
                 kv_cache_config=kv_config,
                 device=device,
-                transfer_engine_info=transfer_engine_info
+                transfer_engine_info=transfer_engine_info,
+                kv_cache_type=autocast_dtype
             )
             logger.info("Engine %s loaded in on device %s", engine_type_str, str(device))
 

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -68,7 +68,7 @@ class WorkerGraphQueues:
 
     def is_done(self, request_id) -> bool:
         q = self.per_request_queues[request_id]
-        return q.waiting is None and len(q.ready) == 0
+        return q.waiting is None and len(q.ready) == 0 and len(q.waiting_for_stream) == 0
 
     def add_request(self, request_id: str):
         """
@@ -320,7 +320,7 @@ class WorkerGraphsManager:
 
     def complete_loops(
         self, request_id: str, worker_graph_id: str,
-        output_edges: list[GraphEdge]
+        output_edges: list[GraphEdge], done_node: str
     ) -> FilteredEdges:
         queue = self.queues[worker_graph_id].per_request_queues[request_id]
         if queue.waiting is None:
@@ -328,7 +328,7 @@ class WorkerGraphsManager:
                 kept=output_edges,
                 filtered_out=[]
             )
-        out = queue.waiting.complete_loops()
+        out = queue.waiting.complete_loops(done_node)
         queue.waiting = out.new_waiting
 
         filter_result = out.filter_out_loop_back(output_edges)
@@ -534,7 +534,7 @@ class WorkerGraphsManager:
 
         graph_walk = current_fwd_info.graph_walk
         my_worker_graph_ids = [gid for gid in worker_graph_ids if gid in self.queues]
-        partition_name = getattr(current_fwd_info, 'partition_name', 'default')
+        partition_name = current_fwd_info.partition_name
 
         if request_id not in self.per_request_info:
             self.per_request_info[request_id] = PerRequestInfo(
@@ -553,6 +553,7 @@ class WorkerGraphsManager:
             )
         else:
             req_info = self.per_request_info[request_id]
+            req_info.worker_graph_ids += my_worker_graph_ids
             req_info.per_partition_info[partition_name] = PerPartitionInfo(
                 graph_walk_worker_graph_ids=[
                     graph_id for graph_id in my_worker_graph_ids

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -2,6 +2,7 @@ import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
 
+from mminf.communication.tensors import TensorCommunicationManager
 from mminf.conductor.request_info import CurrentForwardPassInfo, PerLabelSeqInfo
 from mminf.graph.base import GraphEdge, GraphNode, TensorPointerInfo
 from mminf.graph.request_queues import (
@@ -48,6 +49,7 @@ class WorkerGraphQueues:
                           # but not the prefill graph walk
     worker_graph: WorkerGraph
     per_request_queues: dict[str, PerRequestNodeQueues] # request_id -> queue
+    tensor_manager: TensorCommunicationManager
 
     def process_new_inputs(self, request_id: str, inputs: list[GraphEdge]) -> ProcessedInputs:
         """
@@ -74,6 +76,9 @@ class WorkerGraphQueues:
         self.per_request_queues[request_id] = PerRequestNodeQueues(
             waiting=deepcopy(self.worker_graph.section),
             worker_graph_id=self.worker_graph_id
+        )
+        self.per_request_queues[request_id].waiting.register_communication_info(
+            self.tensor_manager, request_id
         )
 
     def remove_request(self, request_id: str):
@@ -122,6 +127,9 @@ class WorkerGraphQueues:
         be used for the next full model forward pass.
         """
         self.per_request_queues[request_id].waiting = deepcopy(self.worker_graph.section)
+        self.per_request_queues[request_id].waiting.register_communication_info(
+            self.tensor_manager, request_id
+        )
         self.per_request_queues[request_id].ready = []
 
 
@@ -257,6 +265,36 @@ class WorkerGraphsManager:
             for worker_graph_id in worker_graph_ids:
                 inputs = self.queues[worker_graph_id].process_new_streaming_inputs(request_id, inputs).for_other_worker_graphs
         return inputs
+
+
+    def get_worker_graph_id_for_node(
+        self, request_id: str, node_name: str
+    ) -> str:
+        partition = self.get_partition_for_node(node_name)
+        graph_walk = self.get_graph_walk(request_id, partition)
+        for gid in self.per_request_info[request_id].worker_graph_ids:
+            if (graph_walk in self.all_worker_graph_ids_to_graph_walks[gid]) and \
+                        (node_name in self.all_worker_graph_ids_to_nodes[gid]):
+                return gid
+        raise RuntimeError(f"Could not find worker graph for node {node_name}, request {request_id}")
+    
+
+    def get_waiting_node(
+        self, request_id: str, worker_graph_id: str
+    ):
+        return self.queues[worker_graph_id].per_request_queues[request_id].waiting
+
+
+    def complete_loops(
+        self, request_id: str, worker_graph_id: str
+    ) -> list[GraphEdge]:
+        queue = self.queues[worker_graph_id].per_request_queues[request_id]
+        if queue.waiting is None:
+            return []
+        out = queue.waiting.complete_loops()
+        queue.waiting = out.new_waiting
+        return out.outputs
+
 
     def process_node_outputs(
         self, request_id: str,

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -207,6 +207,7 @@ class PerRequestInfo:
     - tensors: TBD
     """
     node_to_worker: dict[NodeAndGraphWalk, str]  # for all nodes
+    dyn_loop_to_workers: dict[NodeAndGraphWalk, list[str]]
     worker_graph_ids: list[str] # for this worker
 
     pending_persist_signals: list[GraphEdge] = field(default_factory=list)
@@ -231,6 +232,7 @@ class WorkerGraphsManager:
     # The following two are for routing purposes:
     all_worker_graph_ids_to_graph_walks: dict[str, set[str]] # for worker graphs on different workers too
     all_worker_graph_ids_to_nodes: dict[str, set[str]] # for worker graphs on different workers too
+    all_worker_graph_ids_to_dyn_loops: dict[str, set[str]]
 
     # Maps node_name -> partition_name. Populated from the model's partitions
     # and graph walk definitions. Used to look up which partition a node belongs
@@ -525,6 +527,7 @@ class WorkerGraphsManager:
         is responsible for which nodes for this request (for output routing).
         """
         node_to_worker = {}
+        dyn_loop_to_workers = {}
         for graph_id in worker_graph_ids:
             if graph_id in self.queues:
                 self.queues[graph_id].add_request(request_id)
@@ -539,6 +542,14 @@ class WorkerGraphsManager:
                         graph_walk=graph_walk
                     ): worker_id for name in self.all_worker_graph_ids_to_nodes[worker_graph_id]
                 })
+
+                for loop_name in self.all_worker_graph_ids_to_dyn_loops[worker_graph_id]:
+                    dyn_loop_to_workers.setdefault(NodeAndGraphWalk(
+                        node=loop_name,
+                        graph_walk=graph_walk
+                    ), []).append(worker_id)
+
+                self.all_worker_graph_ids_to_dyn_loops
         graph_walk = current_fwd_info.graph_walk
         my_worker_graph_ids = [gid for gid in worker_graph_ids if gid in self.queues]
         partition_name = getattr(current_fwd_info, 'partition_name', 'default')
@@ -546,6 +557,7 @@ class WorkerGraphsManager:
         if request_id not in self.per_request_info:
             self.per_request_info[request_id] = PerRequestInfo(
                 node_to_worker=node_to_worker,
+                dyn_loop_to_workers=dyn_loop_to_workers,
                 worker_graph_ids=my_worker_graph_ids,
                 per_partition_info={
                     partition_name: PerPartitionInfo(
@@ -572,6 +584,11 @@ class WorkerGraphsManager:
             for queue_id in self.per_request_info[request_id].worker_graph_ids:
                 self.queues[queue_id].remove_request(request_id)
             del self.per_request_info[request_id]
+    
+    def get_dyn_loop_workers(self, request_id: str, partition_name: str, loop_name: str):
+        return self.per_request_info[request_id].dyn_loop_to_workers[NodeAndGraphWalk(
+            node=loop_name, graph_walk=self.get_graph_walk(request_id, partition_name)
+        )]
 
     def buffer_persist_signals(
             self, request_id: str,

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -161,6 +161,21 @@ class WorkerGraphQueues:
                 _get_iters(section._curr_iter_section)
         _get_iters(self.per_request_queues[request_id].waiting)
         return iter_dict
+    
+    def get_dynamic_loop_iters(self, request_id: str) -> dict[str, int]:
+        iter_dict = {}
+        def _get_iters(section: GraphSection):
+            if isinstance(section, Sequential) or isinstance(section, Parallel):
+                for sec in section.sections:
+                    _get_iters(sec)
+                return
+            if isinstance(section, DynamicLoop):
+                iter_dict[section.name] = section.curr_iter
+            if isinstance(section, Loop):
+                # including dynamic loops
+                _get_iters(section._curr_iter_section)
+        _get_iters(self.per_request_queues[request_id].waiting)
+        return iter_dict
 
 
 @dataclass
@@ -480,6 +495,20 @@ class WorkerGraphsManager:
                             graph=waiting,
                             fwd_idx=req_info.fwd_index
                         )
+    
+    def get_dynamic_loop_iters(
+        self, request_id: str,
+        partition: str,
+    ) -> dict[str, int]:
+        part_info = self.per_request_info[request_id].per_partition_info[partition]
+        worker_graph_ids = part_info.graph_walk_worker_graph_ids
+
+        iter_counts: dict[str, int] = {}
+        for worker_graph_id in worker_graph_ids:
+            iter_counts.update(
+                self.queues[worker_graph_id].get_dynamic_loop_iters(request_id)
+            )
+        return iter_counts
 
     def add_request(
         self, request_id: str,

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -74,12 +74,14 @@ class WorkerGraphQueues:
         """
         Initialize queues for a new request
         """
-        self.per_request_queues[request_id] = PerRequestNodeQueues(
-            waiting=deepcopy(self.worker_graph.section),
-            worker_graph_id=self.worker_graph_id
-        )
-        self.per_request_queues[request_id].waiting.register_communication_info(
+        section_copy = deepcopy(self.worker_graph.section)
+        section_copy.register_communication_info(
             self.tensor_manager, request_id
+        )
+        self.per_request_queues[request_id] = PerRequestNodeQueues(
+            waiting=section_copy,
+            full_section=section_copy,
+            worker_graph_id=self.worker_graph_id
         )
 
     def remove_request(self, request_id: str):
@@ -127,11 +129,7 @@ class WorkerGraphQueues:
         At the end of a worker graph, reset the queues for a request so it can
         be used for the next full model forward pass.
         """
-        self.per_request_queues[request_id].waiting = deepcopy(self.worker_graph.section)
-        self.per_request_queues[request_id].waiting.register_communication_info(
-            self.tensor_manager, request_id
-        )
-        self.per_request_queues[request_id].ready = []
+        self.per_request_queues[request_id].reset()
     
     def stop_loops(self, request_id: str, loop_names: set[str]):
         def _stop_loops(section: GraphSection):
@@ -146,21 +144,6 @@ class WorkerGraphQueues:
                 # including dynamic loops
                 _stop_loops(section._curr_iter_section)
         _stop_loops(self.per_request_queues[request_id].waiting)
-    
-    def get_dynamic_loop_iters(self, request_id: str) -> dict[str, int]:
-        iter_dict = {}
-        def _get_iters(section: GraphSection):
-            if isinstance(section, Sequential) or isinstance(section, Parallel):
-                for sec in section.sections:
-                    _get_iters(sec)
-                return
-            if isinstance(section, DynamicLoop):
-                iter_dict[section.name] = section.curr_iter
-            if isinstance(section, Loop):
-                # including dynamic loops
-                _get_iters(section._curr_iter_section)
-        _get_iters(self.per_request_queues[request_id].waiting)
-        return iter_dict
     
     def get_dynamic_loop_iters(self, request_id: str) -> dict[str, int]:
         iter_dict = {}
@@ -490,7 +473,7 @@ class WorkerGraphsManager:
             ):
                 for name in loop_names:
                     if name in req_info.loop_stop_times:
-                        req_info.loop_stop_times[name] = update_loop_index_tree(
+                        update_loop_index_tree(
                             index_tree=req_info.loop_stop_times[name],
                             graph=waiting,
                             fwd_idx=req_info.fwd_index
@@ -549,7 +532,6 @@ class WorkerGraphsManager:
                         graph_walk=graph_walk
                     ), []).append(worker_id)
 
-                self.all_worker_graph_ids_to_dyn_loops
         graph_walk = current_fwd_info.graph_walk
         my_worker_graph_ids = [gid for gid in worker_graph_ids if gid in self.queues]
         partition_name = getattr(current_fwd_info, 'partition_name', 'default')

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 from mminf.communication.tensors import TensorCommunicationManager
 from mminf.conductor.request_info import CurrentForwardPassInfo, PerLabelSeqInfo
-from mminf.graph.base import GraphEdge, GraphNode, TensorPointerInfo, FilteredEdges
+from mminf.graph.base import DynamicLoop, FilteredEdges, GraphEdge, GraphNode, GraphSection, Loop, Parallel, Sequential, TensorPointerInfo
 from mminf.graph.request_queues import (
     PerRequestNodeQueues,
     ProcessedInputs,
@@ -131,6 +131,35 @@ class WorkerGraphQueues:
             self.tensor_manager, request_id
         )
         self.per_request_queues[request_id].ready = []
+    
+    def stop_loops(self, request_id: str, loop_names: set[str]):
+        def _stop_loops(section: GraphSection):
+            if isinstance(section, Sequential) or isinstance(section, Parallel):
+                for sec in section.sections:
+                    _stop_loops(sec)
+                return
+            if isinstance(section, DynamicLoop):
+                if section.name in loop_names:
+                    section.register_finished()
+            if isinstance(section, Loop):
+                # including dynamic loops
+                _stop_loops(section._curr_iter_section)
+        _stop_loops(self.per_request_queues[request_id].waiting)
+    
+    def get_dynamic_loop_iters(self, request_id: str) -> dict[str, int]:
+        iter_dict = {}
+        def _get_iters(section: GraphSection):
+            if isinstance(section, Sequential) or isinstance(section, Parallel):
+                for sec in section.sections:
+                    _get_iters(sec)
+                return
+            if isinstance(section, DynamicLoop):
+                iter_dict[section.name] = section.curr_iter
+            if isinstance(section, Loop):
+                # including dynamic loops
+                _get_iters(section._curr_iter_section)
+        _get_iters(self.per_request_queues[request_id].waiting)
+        return iter_dict
 
 
 @dataclass
@@ -323,7 +352,7 @@ class WorkerGraphsManager:
 
         # (1) find back_to_conductor flags
         to_conductor = [edge for edge in non_streaming_outputs if edge.persist]
-        new_token_outputs = [edge for edge in non_streaming_outputs if edge.is_new_token]
+        new_token_outputs = [edge for edge in non_streaming_outputs if edge.conductor_new_token]
 
         # (2) process all internal-facing outputs
         worker_graph_ids = [
@@ -421,6 +450,31 @@ class WorkerGraphsManager:
             streaming_to_workers=streaming_to_workers,
             streaming_local=streaming_local,
         )
+    
+    def stop_loops(
+        self, request_id: str,
+        partition: str,
+        loop_names: set[str]
+    ):
+        part_info = self.per_request_info[request_id].per_partition_info[partition]
+        worker_graph_ids = part_info.graph_walk_worker_graph_ids
+        for worker_graph_id in worker_graph_ids:
+            self.queues[worker_graph_id].stop_loops(request_id, loop_names)
+    
+
+    def get_dynamic_loop_iters(
+        self, request_id: str,
+        partition: str,
+    ) -> dict[str, int]:
+        part_info = self.per_request_info[request_id].per_partition_info[partition]
+        worker_graph_ids = part_info.graph_walk_worker_graph_ids
+
+        iter_counts: dict[str, int] = {}
+        for worker_graph_id in worker_graph_ids:
+            iter_counts.update(
+                self.queues[worker_graph_id].get_dynamic_loop_iters(request_id)
+            )
+        return iter_counts
 
     def add_request(
         self, request_id: str,

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -286,14 +286,15 @@ class WorkerGraphsManager:
 
 
     def complete_loops(
-        self, request_id: str, worker_graph_id: str
+        self, request_id: str, worker_graph_id: str,
+        output_edges: list[GraphEdge]
     ) -> list[GraphEdge]:
         queue = self.queues[worker_graph_id].per_request_queues[request_id]
         if queue.waiting is None:
             return []
         out = queue.waiting.complete_loops()
         queue.waiting = out.new_waiting
-        return out.outputs
+        return out.outputs + out.filter_out_loop_back(output_edges)
 
 
     def process_node_outputs(

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 from mminf.communication.tensors import TensorCommunicationManager
 from mminf.conductor.request_info import CurrentForwardPassInfo, PerLabelSeqInfo
-from mminf.graph.base import GraphEdge, GraphNode, TensorPointerInfo
+from mminf.graph.base import GraphEdge, GraphNode, TensorPointerInfo, FilteredEdges
 from mminf.graph.request_queues import (
     PerRequestNodeQueues,
     ProcessedInputs,
@@ -288,13 +288,19 @@ class WorkerGraphsManager:
     def complete_loops(
         self, request_id: str, worker_graph_id: str,
         output_edges: list[GraphEdge]
-    ) -> list[GraphEdge]:
+    ) -> FilteredEdges:
         queue = self.queues[worker_graph_id].per_request_queues[request_id]
         if queue.waiting is None:
-            return output_edges
+            return FilteredEdges(
+                kept=output_edges,
+                filtered_out=[]
+            )
         out = queue.waiting.complete_loops()
         queue.waiting = out.new_waiting
-        return out.outputs + out.filter_out_loop_back(output_edges)
+
+        filter_result = out.filter_out_loop_back(output_edges)
+        filter_result.kept += out.outputs
+        return filter_result
 
 
     def process_node_outputs(

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -268,6 +268,9 @@ class WorkerGraphsManager:
 
     def get_fwd_number(self, request_id: str, partition_name: str):
         return self.get_fwd_info(request_id, partition_name).fwd_index
+    
+    def has_partition(self,  request_id: str, partition_name: str):
+        return partition_name in self.per_request_info[request_id].per_partition_info
 
     def get_fwd_info(self, request_id: str, partition_name: str):
         part_info = self.per_request_info[request_id].per_partition_info[partition_name]

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -291,7 +291,7 @@ class WorkerGraphsManager:
     ) -> list[GraphEdge]:
         queue = self.queues[worker_graph_id].per_request_queues[request_id]
         if queue.waiting is None:
-            return []
+            return output_edges
         out = queue.waiting.complete_loops()
         queue.waiting = out.new_waiting
         return out.outputs + out.filter_out_loop_back(output_edges)

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from mminf.communication.tensors import TensorCommunicationManager
 from mminf.conductor.request_info import CurrentForwardPassInfo, PerLabelSeqInfo
 from mminf.graph.base import DynamicLoop, FilteredEdges, GraphEdge, GraphNode, GraphSection, Loop, Parallel, Sequential, TensorPointerInfo
+from mminf.graph.loop_index import IterIndexTree, build_loop_index_tree, update_loop_index_tree
 from mminf.graph.request_queues import (
     PerRequestNodeQueues,
     ProcessedInputs,
@@ -214,7 +215,7 @@ class WorkerGraphsManager:
 
     # The following two are for routing purposes:
     all_worker_graph_ids_to_graph_walks: dict[str, set[str]] # for worker graphs on different workers too
-    all_worker_graph_ids_to_nodes: dict[str, str] # for worker graphs on different workers too
+    all_worker_graph_ids_to_nodes: dict[str, set[str]] # for worker graphs on different workers too
 
     # Maps node_name -> partition_name. Populated from the model's partitions
     # and graph walk definitions. Used to look up which partition a node belongs
@@ -454,27 +455,31 @@ class WorkerGraphsManager:
     def stop_loops(
         self, request_id: str,
         partition: str,
-        loop_names: set[str]
+        loop_names: set[str],
+        req_info: CurrentForwardPassInfo | None = None,
+        last_node_run: str | None = None
     ):
         part_info = self.per_request_info[request_id].per_partition_info[partition]
         worker_graph_ids = part_info.graph_walk_worker_graph_ids
         for worker_graph_id in worker_graph_ids:
             self.queues[worker_graph_id].stop_loops(request_id, loop_names)
-    
+            waiting = self.queues[worker_graph_id].per_request_queues[request_id].waiting
 
-    def get_dynamic_loop_iters(
-        self, request_id: str,
-        partition: str,
-    ) -> dict[str, int]:
-        part_info = self.per_request_info[request_id].per_partition_info[partition]
-        worker_graph_ids = part_info.graph_walk_worker_graph_ids
-
-        iter_counts: dict[str, int] = {}
-        for worker_graph_id in worker_graph_ids:
-            iter_counts.update(
-                self.queues[worker_graph_id].get_dynamic_loop_iters(request_id)
-            )
-        return iter_counts
+            if req_info is not None and (
+                last_node_run in self.all_worker_graph_ids_to_nodes[worker_graph_id]
+            ):
+                for name in loop_names:
+                    if name in req_info.loop_stop_times:
+                        req_info.loop_stop_times[name] = update_loop_index_tree(
+                            index_tree=req_info.loop_stop_times[name],
+                            graph=waiting,
+                            fwd_idx=req_info.fwd_index
+                        )
+                    else:
+                        req_info.loop_stop_times[name] = build_loop_index_tree(
+                            graph=waiting,
+                            fwd_idx=req_info.fwd_index
+                        )
 
     def add_request(
         self, request_id: str,
@@ -516,7 +521,7 @@ class WorkerGraphsManager:
                             graph_id for graph_id in my_worker_graph_ids
                             if graph_walk in self.all_worker_graph_ids_to_graph_walks[graph_id]
                         ],
-                        current_fwd_info=current_fwd_info
+                        current_fwd_info=current_fwd_info,
                     )
                 }
             )

--- a/mminf/worker/node_manager_utils.py
+++ b/mminf/worker/node_manager_utils.py
@@ -462,6 +462,10 @@ class WorkerGraphsManager:
         req_info: CurrentForwardPassInfo | None = None,
         last_node_run: str | None = None
     ):
+        """
+        Stops dynamic loops based on stop signals. If req_info is also passed in,
+        then this also updates req_info.loop_stop_times with the urrent loop indices.
+        """
         part_info = self.per_request_info[request_id].per_partition_info[partition]
         worker_graph_ids = part_info.graph_walk_worker_graph_ids
         for worker_graph_id in worker_graph_ids:
@@ -500,7 +504,7 @@ class WorkerGraphsManager:
 
     def add_request(
         self, request_id: str,
-        worker_graph_ids: list[str], # for this worker's worker graphs
+        partition_worker_graph_ids: list[str], # for this worker's worker graphs
         worker_graph_to_worker: dict[str, str], # for other / all worker graphs
         current_fwd_info: CurrentForwardPassInfo,
     ):
@@ -509,34 +513,39 @@ class WorkerGraphsManager:
         to the relevant worker graph queues, and updating the mapping of which worker
         is responsible for which nodes for this request (for output routing).
         """
-        node_to_worker = {}
-        dyn_loop_to_workers = {}
-        for graph_id in worker_graph_ids:
+
+        current_graph_walk = current_fwd_info.graph_walk
+        my_worker_graph_ids = [gid for gid in partition_worker_graph_ids if gid in self.queues]
+        partition_name = current_fwd_info.partition_name
+
+        for graph_id in partition_worker_graph_ids:
             if graph_id in self.queues:
                 self.queues[graph_id].add_request(request_id)
 
-        for worker_graph_id, worker_id in worker_graph_to_worker.items():
-            if worker_graph_id not in self.all_worker_graph_ids_to_graph_walks:
-                continue
-            for graph_walk in self.all_worker_graph_ids_to_graph_walks[worker_graph_id]:
-                node_to_worker.update({
-                    NodeAndGraphWalk(
-                        node=name,
-                        graph_walk=graph_walk
-                    ): worker_id for name in self.all_worker_graph_ids_to_nodes[worker_graph_id]
-                })
-
-                for loop_name in self.all_worker_graph_ids_to_dyn_loops[worker_graph_id]:
-                    dyn_loop_to_workers.setdefault(NodeAndGraphWalk(
-                        node=loop_name,
-                        graph_walk=graph_walk
-                    ), []).append(worker_id)
-
-        graph_walk = current_fwd_info.graph_walk
-        my_worker_graph_ids = [gid for gid in worker_graph_ids if gid in self.queues]
-        partition_name = current_fwd_info.partition_name
 
         if request_id not in self.per_request_info:
+            # Note: conductor.py passes the same worker_graph_to_worker dict
+            # on every NewRequest for a given request(i.e., for every partition).
+            # So the below logic only needs to be done once.
+            node_to_worker = {}
+            dyn_loop_to_workers = {}
+            for worker_graph_id, worker_id in worker_graph_to_worker.items():
+                if worker_graph_id not in self.all_worker_graph_ids_to_graph_walks:
+                    continue
+                for graph_walk in self.all_worker_graph_ids_to_graph_walks[worker_graph_id]:
+                    node_to_worker.update({
+                        NodeAndGraphWalk(
+                            node=name,
+                            graph_walk=graph_walk
+                        ): worker_id for name in self.all_worker_graph_ids_to_nodes[worker_graph_id]
+                    })
+
+                    for loop_name in self.all_worker_graph_ids_to_dyn_loops[worker_graph_id]:
+                        dyn_loop_to_workers.setdefault(NodeAndGraphWalk(
+                            node=loop_name,
+                            graph_walk=graph_walk
+                        ), []).append(worker_id)
+
             self.per_request_info[request_id] = PerRequestInfo(
                 node_to_worker=node_to_worker,
                 dyn_loop_to_workers=dyn_loop_to_workers,
@@ -545,19 +554,20 @@ class WorkerGraphsManager:
                     partition_name: PerPartitionInfo(
                         graph_walk_worker_graph_ids=[
                             graph_id for graph_id in my_worker_graph_ids
-                            if graph_walk in self.all_worker_graph_ids_to_graph_walks[graph_id]
+                            if current_graph_walk in self.all_worker_graph_ids_to_graph_walks[graph_id]
                         ],
                         current_fwd_info=current_fwd_info,
                     )
                 }
             )
         else:
+            # Just do partition-specific work: updating worker_graph_ids, instantiating PerPartitionInfo
             req_info = self.per_request_info[request_id]
             req_info.worker_graph_ids += my_worker_graph_ids
             req_info.per_partition_info[partition_name] = PerPartitionInfo(
                 graph_walk_worker_graph_ids=[
                     graph_id for graph_id in my_worker_graph_ids
-                    if graph_walk in self.all_worker_graph_ids_to_graph_walks[graph_id]
+                    if current_graph_walk in self.all_worker_graph_ids_to_graph_walks[graph_id]
                 ],
                 current_fwd_info=current_fwd_info
             )

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -11,7 +11,7 @@ from mminf.communication.tensors import NameToTensorList, create_tensor_communic
 from mminf.conductor.request_info import CurrentForwardPassInfo
 from mminf.engine.base import EngineType, NodeBatch, NodeOutput
 from mminf.engine.kv_store import KVCacheConfig, StoreWritePolicy, TransferEngineInfo
-from mminf.graph.base import GraphEdge
+from mminf.graph.base import FilteredEdges, GraphEdge
 from mminf.graph.request_queues import format_graph_edge_list
 from mminf.model.base import Model, WorkerGraph
 from mminf.streaming.stream_buffer import StreamBuffer
@@ -21,6 +21,7 @@ from mminf.utils.ipc_format import (
     InputSignals,
     NewRequest,
     RemoveRequest,
+    StopLoops,
     TensorReceived,
     UnpersistTensors,
     WorkerGraphsDone,
@@ -30,6 +31,7 @@ from mminf.utils.ipc_format import (
 from mminf.worker.engine_manager import EngineManager
 from mminf.worker.micro_scheduler import MicroScheduler, ScheduledBatch
 from mminf.worker.node_manager_utils import (
+    NodeAndGraphWalk,
     NodeOutputRouting,
     WorkerGraphQueues,
     WorkerGraphsManager,
@@ -378,11 +380,20 @@ class Worker:
             self.tensor_manager.set_persist(
                 body.request_id, uuid, persist=False
             )
+    
+    def _stop_loops(self, body: StopLoops):
+        fwd_info = self.worker_graphs_manager.get_fwd_info(
+            body.request_id, body.partition_name
+        ) 
+        if fwd_info.fwd_index != body.fwd_index:
+            # new forward pass has started already
+            return
 
     def _process_message_list(self, messages: list[WorkerMessage]):
         msg_types_needing_active_request = [
             WorkerMessageType.REMOVE_REQUEST,
             WorkerMessageType.INPUT_SIGNALS,
+            WorkerMessageType.STOP_LOOPS
         ]
         for message in messages:
             if (
@@ -632,7 +643,8 @@ class Worker:
         batch: ScheduledBatch,
         output: "NodeOutput",
         filtered_outputs_per_request: dict[str, list[GraphEdge]],
-    ) -> dict[str, list[GraphEdge]]:
+        output_edges: dict[str, list[GraphEdge]] = {}
+    ) -> dict[str, FilteredEdges]:
         """
         ``filtered_outputs_per_request`` contains, for each request, only the
         GraphNode output edges whose names are actually present in the
@@ -641,14 +653,18 @@ class Worker:
         audio_output=False which omits thinker_states) are excluded so that
         empty-tensor_info edges are not routed downstream.
         """
-        output_edges: dict[str, list[GraphEdge]] = {}
+        
+        output_edges: dict[str, FilteredEdges] = {}
         for request_id, node in batch.node_objects.items():
             # output name to list of tensors
             request_output_tensors = output.per_request_output_tensors.get(
                 request_id, {}
             ) # name -> list of tensors
             filtered_outputs = filtered_outputs_per_request.get(request_id, [])
-            output_edges[request_id] = filtered_outputs
+            output_edges[request_id] = FilteredEdges(
+                kept=filtered_outputs,
+                filtered_out=[]
+            )
 
             if not request_output_tensors:
                 continue  # Node produced no outputs (e.g., KV-cache-only prefill step)
@@ -665,13 +681,12 @@ class Worker:
             waiting_node = self.worker_graphs_manager.get_waiting_node(request_id, worker_graph_id)
             if waiting_node is not None:
                 waiting_node.cache_outputs(output_tensor_info)
-            filter_result = self.worker_graphs_manager.complete_loops(
-                request_id, worker_graph_id, output_edges[request_id]
+            output_edges[request_id] = self.worker_graphs_manager.complete_loops(
+                request_id, worker_graph_id, output_edges[request_id].kept
             )
-            output_edges[request_id] = filter_result.kept
 
             # if any outputs were filtered out, we must dereference them
-            for edge in filter_result.filtered_out:
+            for edge in output_edges[request_id].filtered_out:
                 for info in edge.tensor_info:
                     self.tensor_manager.dereference(request_id, info.uuid)
 
@@ -857,6 +872,14 @@ class Worker:
 
                 # 4. Gather input tensors for the batch
                 node_batch = self._build_node_batch(batch)
+                batch_partition = self.worker_graphs_manager.get_partition_for_node(batch.node_name)
+
+                for request_id, req_info in node_batch.per_request_info.items():
+                    req_info.dynamic_loop_iter_counts.update(
+                        self.worker_graphs_manager.get_dynamic_loop_iters(
+                            request_id, partition=batch_partition,
+                        )
+                    )
 
                 # 5. Execute via engine
                 engine = self.engine_manager.get_engine(batch.node_name)
@@ -908,13 +931,19 @@ class Worker:
                 for rid in batch.node_objects:
                     self._last_active[(rid, batch.node_name)] = now
 
-                batch_partition = self.worker_graphs_manager.get_partition_for_node(batch.node_name)
-
                 for rid, req_info in node_batch.per_request_info.items():
+                    if req_info.dynamic_loop_stop_signals:                        
+                        self.worker_graphs_manager.stop_loops(
+                            rid, partition=batch_partition,
+                            loop_names=req_info.dynamic_loop_stop_signals
+                        )
+
                     self.worker_graphs_manager.update_request_info(
-                        rid, per_label_seq_info=req_info.per_label_seq_info,
+                        rid, current_fwd_info=req_info,
+                        per_label_seq_info=req_info.per_label_seq_info,
                         partition_name=batch_partition,
                     )
+                    
 
                 # 5b. Free consumed input tensors
                 self._cleanup_consumed_inputs(batch)
@@ -940,9 +969,36 @@ class Worker:
                 routing_per_request: dict[str, NodeOutputRouting] = {}
                 for request_id in batch.node_objects:
                     routing = self.worker_graphs_manager.process_node_outputs(
-                        request_id, node_outputs[request_id], graph_walk=batch.graph_walk
+                        request_id, node_outputs[request_id].kept, graph_walk=batch.graph_walk
                     )
                     routing_per_request[request_id] = routing
+
+                    # 6b. If there are loop-back signals that were filtered out for different
+                    # workers, send "loop done" messages to the corresponding workers
+                    if node_batch.per_request_info[request_id].dynamic_loop_stop_signals:
+                        workers = set()
+                        for edge in node_outputs[request_id].filtered_out:
+                            workers.add(
+                                self.worker_graphs_manager.per_request_info[request_id].node_to_worker[NodeAndGraphWalk(
+                                    node=edge.next_node,
+                                    graph_walk=batch.graph_walk
+                                )]
+                            )
+                        for worker in workers:
+                            if worker == self.worker_id:
+                                continue
+                            self.communicator.send(
+                                entity_id=worker,
+                                msg=WorkerMessage(
+                                    message_type=WorkerMessageType.STOP_LOOPS,
+                                    body=StopLoops(
+                                        request_id=request_id,
+                                        loop_names=node_batch.per_request_info[request_id].dynamic_loop_stop_signals,
+                                        fwd_index=node_batch.per_request_info[request_id].fwd_index,
+                                        partition_name=batch_partition
+                                    )
+                                )
+                            )
 
                 # 7. Store output tensors, register RDMA if needed
                 self._register_outputs(batch, routing_per_request)
@@ -954,6 +1010,9 @@ class Worker:
                         graph_walk=batch.graph_walk,
                         partition_name=batch_partition,
                     )
+                
+                for rid, req_info in node_batch.per_request_info.items():
+                    req_info.dynamic_loop_stop_signals.clear()
             except Exception:
                 logger.exception("Worker %s error in main loop", self.worker_id)
                 sleep(0.01)

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -890,6 +890,13 @@ class Worker:
                 node_batch = self._build_node_batch(batch)
                 batch_partition = self.worker_graphs_manager.get_partition_for_node(batch.node_name)
 
+                for request_id, req_info in node_batch.per_request_info.items():
+                    req_info.dynamic_loop_iter_counts.update(
+                        self.worker_graphs_manager.get_dynamic_loop_iters(
+                            request_id, partition=batch_partition,
+                        )
+                    )
+
                 # 5. Execute via engine
                 engine = self.engine_manager.get_engine(batch.node_name)
                 logger.debug("Executing batch for node %s on engine %s", node_batch.node_name, str(type(engine)))

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -2,7 +2,6 @@ import logging
 import time as _time
 from enum import Enum
 from time import sleep
-import time
 
 import torch
 
@@ -431,6 +430,8 @@ class Worker:
                 self._handle_tensor_received(message.body)
             elif message.message_type == WorkerMessageType.UNPERSIST_TENSORS:
                 self._unpersist_tensors(message.body)
+            elif message.message_type == WorkerMessageType.STOP_LOOPS:
+                self._stop_loops(message.body)
 
     def _process_messages(self) -> None:
         self._process_message_list(self.communicator.get_all_new_messages())
@@ -895,6 +896,7 @@ class Worker:
                             request_id, partition=batch_partition,
                         )
                     )
+                    batch.node_objects[request_id].clear_outputs()
 
                 # 5. Execute via engine
                 engine = self.engine_manager.get_engine(batch.node_name)

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -60,6 +60,7 @@ class Worker:
         worker_ids: list[str],
         my_worker_graphs: list[WorkerGraph],
         kv_config: dict[str, KVCacheConfig],
+        model_config: dict,
         all_worker_graph_ids_to_graph_walks: dict[str, set[str]],
         all_worker_graph_ids_to_nodes: dict[str, set[str]],
         all_worker_graph_ids_to_dyn_loops: dict[str, set[str]],
@@ -110,6 +111,7 @@ class Worker:
             node_names,
             device=device,
             kv_config=kv_config,
+            model_config=model_config,
             transfer_engine_info=TransferEngineInfo(
                 my_entity_id=worker_id,
                 my_session_id=self.tensor_manager.my_session_id,

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -63,6 +63,7 @@ class Worker:
         kv_config: dict[str, KVCacheConfig],
         all_worker_graph_ids_to_graph_walks: dict[str, set[str]],
         all_worker_graph_ids_to_nodes: dict[str, set[str]],
+        all_worker_graph_ids_to_dyn_loops: dict[str, set[str]],
         hostname: str = "localhost",
         socket_path_prefix: str = "/tmp/mminf",
         tensor_comm_protocol: CommProtocol = CommProtocol.RDMA,
@@ -132,6 +133,7 @@ class Worker:
             },
             per_request_info={},
             all_worker_graph_ids_to_graph_walks=all_worker_graph_ids_to_graph_walks,
+            all_worker_graph_ids_to_dyn_loops=all_worker_graph_ids_to_dyn_loops,
             all_worker_graph_ids_to_nodes=all_worker_graph_ids_to_nodes,
             node_to_partition=node_to_partition,
         )
@@ -327,13 +329,6 @@ class Worker:
             format_graph_edge_list(body.inputs), self.worker_id, body.request_id
         )
         req_info = self.worker_graphs_manager.per_request_info.get(body.request_id)
-
-        self._stop_loops(StopLoops(
-            request_id=body.request_id,
-            loop_names=set(body.request_info.loop_stop_times.keys()),
-            loop_stop_times=body.request_info.loop_stop_times,
-            partition_name=body.partition_name
-        ))
 
         # Handle producer_done signal: mark all StreamBuffers for this request as done
         if body.producer_done:
@@ -993,32 +988,28 @@ class Worker:
                     )
                     routing_per_request[request_id] = routing
 
-                    # 6b. If there are loop-back signals that were filtered out for different
-                    # workers, send "loop done" messages to the corresponding workers
-                    if node_batch.per_request_info[request_id].dynamic_loop_stop_signals:
-                        workers = set()
-                        for edge in node_outputs[request_id].filtered_out:
-                            workers.add(
-                                self.worker_graphs_manager.per_request_info[request_id].node_to_worker[NodeAndGraphWalk(
-                                    node=edge.next_node,
-                                    graph_walk=batch.graph_walk
-                                )]
-                            )
-                        for worker in workers:
-                            if worker == self.worker_id:
-                                continue
-                            self.communicator.send(
-                                entity_id=worker,
-                                msg=WorkerMessage(
-                                    message_type=WorkerMessageType.STOP_LOOPS,
-                                    body=StopLoops(
-                                        request_id=request_id,
-                                        loop_names=node_batch.per_request_info[request_id].dynamic_loop_stop_signals,
-                                        fwd_index=node_batch.per_request_info[request_id].fwd_index,
-                                        partition_name=batch_partition
-                                    )
+                    # 6b. send "loop done" messages to the corresponding workers
+                    stop_loop_workers = {}
+                    for loop_name in node_batch.per_request_info[request_id].dynamic_loop_stop_signals:
+                        for worker in self.worker_graphs_manager.get_dyn_loop_workers(
+                            request_id,  batch_partition, loop_name
+                        ):
+                            stop_loop_workers.setdefault(worker, set()).add(loop_name)
+                    for worker, loop_names in stop_loop_workers.items():
+                        if worker == self.worker_id:
+                            continue
+                        self.communicator.send(
+                            entity_id=worker,
+                            msg=WorkerMessage(
+                                message_type=WorkerMessageType.STOP_LOOPS,
+                                body=StopLoops(
+                                    request_id=request_id,
+                                    loop_names=loop_names,
+                                    loop_stop_times=node_batch.per_request_info[request_id].loop_stop_times,
+                                    partition_name=batch_partition
                                 )
                             )
+                        )
 
                 # 7. Store output tensors, register RDMA if needed
                 self._register_outputs(batch, routing_per_request)

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -333,7 +333,10 @@ class Worker:
         if body.producer_done:
             if req_info:
                 for sbuf in req_info.stream_buffers.values():
-                    sbuf.signal_done()
+                    if sbuf.from_partition in body.producer_done:
+                        # If we have multiple consumer partitions colocated, we need to signal
+                        # the right one
+                        sbuf.signal_done()
 
         # Separate streaming edges — they'll be handled when tensors are ready
         # (streaming edges with tensor_info go through RDMA, handled in _check_ready_tensors)
@@ -698,7 +701,8 @@ class Worker:
             if waiting_node is not None:
                 waiting_node.cache_outputs(output_tensor_info)
             output_edges[request_id] = self.worker_graphs_manager.complete_loops(
-                request_id, worker_graph_id, output_edges[request_id].kept
+                request_id, worker_graph_id, output_edges[request_id].kept,
+                done_node=batch.node_name
             )
 
             # if any outputs were filtered out, we must dereference them

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -665,7 +665,9 @@ class Worker:
             waiting_node = self.worker_graphs_manager.get_waiting_node(request_id, worker_graph_id)
             if waiting_node is not None:
                 waiting_node.cache_outputs(output_tensor_info)
-            output_edges[request_id] += self.worker_graphs_manager.complete_loops(request_id, worker_graph_id)
+            output_edges[request_id] = self.worker_graphs_manager.complete_loops(
+                request_id, worker_graph_id, output_edges[request_id]
+            )
         return output_edges
         
 

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -84,23 +84,6 @@ class Worker:
                         for node_name in section.get_node_names():
                             node_to_partition[node_name] = pdef.name
 
-        self.worker_graphs_manager = WorkerGraphsManager(
-            queues={
-                worker_graph.worker_graph_id: WorkerGraphQueues(
-                    worker_graph_id=worker_graph.worker_graph_id,
-                    graph_walks=worker_graph.graph_walks,
-                    worker_graph=worker_graph,
-                    per_request_queues={},
-                )
-                for worker_graph in my_worker_graphs
-            },
-            per_request_info={},
-            all_worker_graph_ids_to_graph_walks=all_worker_graph_ids_to_graph_walks,
-            all_worker_graph_ids_to_nodes=all_worker_graph_ids_to_nodes,
-            node_to_partition=node_to_partition,
-        )
-
-
         self.communicator = ZMQCommunicator(
             my_id=worker_id,
             push_ids=worker_ids + ["conductor", "api_server", "api_server_preprocess_worker"],
@@ -118,6 +101,7 @@ class Worker:
         node_names = set(sum([
             wg.section.get_node_names() for wg in my_worker_graphs
         ], start=[]))
+
         self.engine_manager = EngineManager.build(
             node_names,
             device=device,
@@ -130,6 +114,24 @@ class Worker:
             model=model,
             enable_nvtx=self.enable_nvtx
         )
+
+        self.worker_graphs_manager = WorkerGraphsManager(
+            queues={
+                worker_graph.worker_graph_id: WorkerGraphQueues(
+                    worker_graph_id=worker_graph.worker_graph_id,
+                    graph_walks=worker_graph.graph_walks,
+                    worker_graph=worker_graph,
+                    per_request_queues={},
+                    tensor_manager=self.tensor_manager
+                )
+                for worker_graph in my_worker_graphs
+            },
+            per_request_info={},
+            all_worker_graph_ids_to_graph_walks=all_worker_graph_ids_to_graph_walks,
+            all_worker_graph_ids_to_nodes=all_worker_graph_ids_to_nodes,
+            node_to_partition=node_to_partition,
+        )
+
         self.scheduler = MicroScheduler(self.engine_manager)
 
         # Determine store write policy based on worker graph topology
@@ -625,19 +627,13 @@ class Worker:
     # Output handling
     # ------------------------------------------------------------------
 
-    def _store_outputs(
+    def _store_outputs_and_finish_loops(
         self,
         batch: ScheduledBatch,
         output: "NodeOutput",
-        routing_per_request: dict[str, NodeOutputRouting],
         filtered_outputs_per_request: dict[str, list[GraphEdge]],
     ) -> dict[str, list[GraphEdge]]:
         """
-        For outputs going to other workers: register tensors for RDMA send
-        and populate tensor_info on the GraphEdges.
-        For outputs staying local: store tensors in tensor_manager.
-        Returns the output edges per request (with tensor_info filled in).
-
         ``filtered_outputs_per_request`` contains, for each request, only the
         GraphNode output edges whose names are actually present in the
         submodule's returned output dict. Edges absent from the output dict
@@ -646,7 +642,6 @@ class Worker:
         empty-tensor_info edges are not routed downstream.
         """
         output_edges: dict[str, list[GraphEdge]] = {}
-
         for request_id, node in batch.node_objects.items():
             # output name to list of tensors
             request_output_tensors = output.per_request_output_tensors.get(
@@ -658,12 +653,34 @@ class Worker:
             if not request_output_tensors:
                 continue  # Node produced no outputs (e.g., KV-cache-only prefill step)
 
-            self.tensor_manager.store_and_populate_graph_edges(
+            output_tensor_info = self.tensor_manager.store_and_populate_graph_edges(
                 request_id=request_id,
                 tensors=request_output_tensors,
                 graph_edges=filtered_outputs
             )
+            
+            worker_graph_id = self.worker_graphs_manager.get_worker_graph_id_for_node(
+                request_id, node_name=node.name
+            )
+            waiting_node = self.worker_graphs_manager.get_waiting_node(request_id, worker_graph_id)
+            if waiting_node is not None:
+                waiting_node.cache_outputs(output_tensor_info)
+            output_edges[request_id] += self.worker_graphs_manager.complete_loops(request_id, worker_graph_id)
+        return output_edges
+        
 
+    def _register_outputs(
+        self,
+        batch: ScheduledBatch,
+        routing_per_request: dict[str, NodeOutputRouting],
+    ):
+        """
+        For outputs going to other workers: register tensors for RDMA send
+        and populate tensor_info on the GraphEdges.
+        For outputs staying local: store tensors in tensor_manager.
+        Returns the output edges per request (with tensor_info filled in).
+        """
+        for request_id, node in batch.node_objects.items():
             routing = routing_per_request[request_id]
             uuids = set()
             for edge in (
@@ -685,7 +702,6 @@ class Worker:
                         request_id=request_id, uuid=info.uuid, persist=True
                     )
 
-        return output_edges
 
     def _send_outputs(
         self, request_id: str, outputs: NodeOutputRouting,
@@ -901,7 +917,6 @@ class Worker:
                 # (which omits thinker_states). Without filtering, edges whose names are
                 # absent from the output dict would be routed with empty tensor_info.
                 filtered_outputs_per_request: dict[str, list[GraphEdge]] = {}
-                routing_per_request: dict[str, NodeOutputRouting] = {}
                 for request_id, node in batch.node_objects.items():
                     request_output_tensors = output.per_request_output_tensors.get(
                         request_id, {}
@@ -910,15 +925,18 @@ class Worker:
                         e for e in node.outputs if e.name in request_output_tensors
                     ]
                     filtered_outputs_per_request[request_id] = filtered_outputs
+
+                node_outputs = self._store_outputs_and_finish_loops(batch, output)
+                
+                routing_per_request: dict[str, NodeOutputRouting] = {}
+                for request_id in batch.node_objects:
                     routing = self.worker_graphs_manager.process_node_outputs(
-                        request_id, filtered_outputs, graph_walk=batch.graph_walk
+                        request_id, node_outputs[request_id], graph_walk=batch.graph_walk
                     )
                     routing_per_request[request_id] = routing
 
                 # 7. Store output tensors, register RDMA if needed
-                self._store_outputs(
-                    batch, output, routing_per_request, filtered_outputs_per_request
-                )
+                self._register_outputs(batch, routing_per_request)
 
                 # 8. Send outputs to other workers / conductor
                 for request_id in batch.node_objects.keys():

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -102,9 +102,9 @@ class Worker:
             tcp_transfer_device=tcp_transfer_device,
         )
 
-        node_names = set(sum([
-            wg.section.get_node_names() for wg in my_worker_graphs
-        ], start=[]))
+        node_names = set()
+        for wg in my_worker_graphs:
+            node_names.update(wg.section.get_node_names())
 
         self.engine_manager = EngineManager.build(
             node_names,
@@ -660,7 +660,6 @@ class Worker:
         batch: ScheduledBatch,
         output: "NodeOutput",
         filtered_outputs_per_request: dict[str, list[GraphEdge]],
-        output_edges: dict[str, list[GraphEdge]] = {}
     ) -> dict[str, FilteredEdges]:
         """
         ``filtered_outputs_per_request`` contains, for each request, only the
@@ -981,7 +980,10 @@ class Worker:
                     ]
                     filtered_outputs_per_request[request_id] = filtered_outputs
 
-                node_outputs = self._store_outputs_and_finish_loops(batch, output)
+                node_outputs = self._store_outputs_and_finish_loops(
+                    batch, output=output,
+                    filtered_outputs_per_request=filtered_outputs_per_request
+                )
                 
                 routing_per_request: dict[str, NodeOutputRouting] = {}
                 for request_id in batch.node_objects:

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -665,9 +665,16 @@ class Worker:
             waiting_node = self.worker_graphs_manager.get_waiting_node(request_id, worker_graph_id)
             if waiting_node is not None:
                 waiting_node.cache_outputs(output_tensor_info)
-            output_edges[request_id] = self.worker_graphs_manager.complete_loops(
+            filter_result = self.worker_graphs_manager.complete_loops(
                 request_id, worker_graph_id, output_edges[request_id]
             )
+            output_edges[request_id] = filter_result.kept
+
+            # if any outputs were filtered out, we must dereference them
+            for edge in filter_result.filtered_out:
+                for info in edge.tensor_info:
+                    self.tensor_manager.dereference(request_id, info.uuid)
+
         return output_edges
         
 

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -391,6 +391,10 @@ class Worker:
             )
     
     def _stop_loops(self, body: StopLoops):
+        if not self.worker_graphs_manager.has_partition(
+            body.request_id, body.partition_name
+        ):
+            return
         fwd_info = self.worker_graphs_manager.get_fwd_info(
             body.request_id, body.partition_name
         )

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -58,6 +58,7 @@ class Worker:
         self,
         worker_id: str,
         worker_ids: list[str],
+        model: Model,
         my_worker_graphs: list[WorkerGraph],
         kv_config: dict[str, KVCacheConfig],
         model_config: dict,
@@ -69,7 +70,6 @@ class Worker:
         tensor_comm_protocol: CommProtocol = CommProtocol.RDMA,
         device: torch.device = torch.device("cuda"),
         enable_nvtx: bool = False,
-        model: Model | None = None,
         mooncake_port: int=8080,
         tcp_transfer_device=""
     ):
@@ -271,7 +271,7 @@ class Worker:
 
         self.worker_graphs_manager.add_request(
             request_id=body.request_id,
-            worker_graph_ids=body.worker_graph_ids,
+            partition_worker_graph_ids=body.partition_worker_graph_ids,
             worker_graph_to_worker=body.worker_graph_to_worker,
             current_fwd_info=body.request_info
         )
@@ -888,7 +888,7 @@ class Worker:
                 # 3. Pick next batch via MicroScheduler
                 batch = self.scheduler.get_next_batch(self.worker_graphs_manager)
                 if batch is None:
-                    sleep(0.01)
+                    sleep(0.001)
                     continue
 
                 # 4. Gather input tensors for the batch
@@ -957,7 +957,10 @@ class Worker:
                     if req_info.dynamic_loop_stop_signals:                        
                         self.worker_graphs_manager.stop_loops(
                             rid, partition=batch_partition,
-                            loop_names=req_info.dynamic_loop_stop_signals
+                            loop_names=req_info.dynamic_loop_stop_signals,
+                            # Pass in req_info and last_node_run to update
+                            # req_info.loop_stop_times
+                            req_info=req_info, last_node_run=batch.node_name
                         )
 
                     self.worker_graphs_manager.update_request_info(

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -2,6 +2,7 @@ import logging
 import time as _time
 from enum import Enum
 from time import sleep
+import time
 
 import torch
 
@@ -12,6 +13,7 @@ from mminf.conductor.request_info import CurrentForwardPassInfo
 from mminf.engine.base import EngineType, NodeBatch, NodeOutput
 from mminf.engine.kv_store import KVCacheConfig, StoreWritePolicy, TransferEngineInfo
 from mminf.graph.base import FilteredEdges, GraphEdge
+from mminf.graph.loop_index import build_loop_index_tree
 from mminf.graph.request_queues import format_graph_edge_list
 from mminf.model.base import Model, WorkerGraph
 from mminf.streaming.stream_buffer import StreamBuffer
@@ -60,7 +62,7 @@ class Worker:
         my_worker_graphs: list[WorkerGraph],
         kv_config: dict[str, KVCacheConfig],
         all_worker_graph_ids_to_graph_walks: dict[str, set[str]],
-        all_worker_graph_ids_to_nodes: dict[str, list[str]],
+        all_worker_graph_ids_to_nodes: dict[str, set[str]],
         hostname: str = "localhost",
         socket_path_prefix: str = "/tmp/mminf",
         tensor_comm_protocol: CommProtocol = CommProtocol.RDMA,
@@ -208,7 +210,7 @@ class Worker:
         self,
         my_worker_graphs: list[WorkerGraph],
         all_worker_graph_ids_to_graph_walks: dict[str, set[str]],
-        all_worker_graph_ids_to_nodes: dict[str, list[str]],
+        all_worker_graph_ids_to_nodes: dict[str, set[str]],
         node_engine_types: dict[str, EngineType] | None = None,
     ) -> StoreWritePolicy:
         """Determine whether this worker needs to write KV to the mooncake store.
@@ -236,7 +238,7 @@ class Worker:
 
         # Collect all workers' AR graph walks
         for wg_id, walks in all_worker_graph_ids_to_graph_walks.items():
-            nodes = all_worker_graph_ids_to_nodes.get(wg_id, [])
+            nodes = all_worker_graph_ids_to_nodes.get(wg_id, set())
             for node_name in nodes:
                 if _is_ar(node_name):
                     all_ar_walks_nodes.update([(walk, node_name) for walk in walks])
@@ -326,6 +328,13 @@ class Worker:
         )
         req_info = self.worker_graphs_manager.per_request_info.get(body.request_id)
 
+        self._stop_loops(StopLoops(
+            request_id=body.request_id,
+            loop_names=set(body.request_info.loop_stop_times.keys()),
+            loop_stop_times=body.request_info.loop_stop_times,
+            partition_name=body.partition_name
+        ))
+
         # Handle producer_done signal: mark all StreamBuffers for this request as done
         if body.producer_done:
             if req_info:
@@ -384,10 +393,18 @@ class Worker:
     def _stop_loops(self, body: StopLoops):
         fwd_info = self.worker_graphs_manager.get_fwd_info(
             body.request_id, body.partition_name
-        ) 
-        if fwd_info.fwd_index != body.fwd_index:
-            # new forward pass has started already
-            return
+        )
+        loop_names = set()
+        for name, stop_time in body.loop_stop_times.items():
+            if name not in fwd_info.loop_stop_times or stop_time.label_context_gt(
+                fwd_info.loop_stop_times[name], name
+            ):
+                loop_names.add(name)
+            fwd_info.loop_stop_times[name] = stop_time
+        if loop_names:
+            self.worker_graphs_manager.stop_loops(
+                body.request_id, body.partition_name, loop_names
+            )
 
     def _process_message_list(self, messages: list[WorkerMessage]):
         msg_types_needing_active_request = [
@@ -813,7 +830,6 @@ class Worker:
                 ),
             )
             self.communicator.send(worker_id, message)
-
         if outputs.completed_worker_graph_ids:
             fwd_info = self.worker_graphs_manager.get_fwd_info(request_id, partition_name)
             if partition_name is None:
@@ -873,13 +889,6 @@ class Worker:
                 # 4. Gather input tensors for the batch
                 node_batch = self._build_node_batch(batch)
                 batch_partition = self.worker_graphs_manager.get_partition_for_node(batch.node_name)
-
-                for request_id, req_info in node_batch.per_request_info.items():
-                    req_info.dynamic_loop_iter_counts.update(
-                        self.worker_graphs_manager.get_dynamic_loop_iters(
-                            request_id, partition=batch_partition,
-                        )
-                    )
 
                 # 5. Execute via engine
                 engine = self.engine_manager.get_engine(batch.node_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,20 @@ bagel = [
     "transformers",
 ]
 
+qwen3_omni = [
+    "einops",
+    "flashinfer-python",
+    "huggingface-hub",
+    "mooncake-transfer-engine",
+    "Pillow",
+    "regex",
+    "qwen-omni-utils",
+    "torchvision",
+    "torchaudio",
+    "torchcodec",
+    "transformers",
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["mminf*"]

--- a/test/modular/test_phase1.py
+++ b/test/modular/test_phase1.py
@@ -300,7 +300,7 @@ class TestImageGenLoop:
         request_id = "test_req_1"
         manager.add_request(
             request_id=request_id,
-            worker_graph_ids=[worker_graph_id],
+            partition_worker_graph_ids=[worker_graph_id],
             worker_graph_to_worker={worker_graph_id: "worker_0"},
         )
         manager.update_graph_walk(request_id, "image_gen")
@@ -389,7 +389,7 @@ class TestImageGenLoop:
         request_id = "req_sched"
         manager.add_request(
             request_id=request_id,
-            worker_graph_ids=[worker_graph_id],
+            partition_worker_graph_ids=[worker_graph_id],
             worker_graph_to_worker={worker_graph_id: "w0"},
         )
         manager.update_graph_walk(request_id, "image_gen")

--- a/test/modular/test_pi05_model.py
+++ b/test/modular/test_pi05_model.py
@@ -86,7 +86,7 @@ def test_pi05_action_gen_is_loop_with_action_output_emission():
     walks = model.get_graph_walk_graphs()
     action_gen = walks[Pi05Model.ACTION_GEN_WALK]
     assert isinstance(action_gen, Loop)
-    assert action_gen.n_iters == model.config.num_flow_steps == 10
+    assert action_gen.max_iters== model.config.num_flow_steps == 10
     # The terminal output emits to the client with the action modality.
     # Its ``name`` must match one of the section's loop-back edge names so
     # that Loop._replace_outputs_for_final_iter can swap it in on the final

--- a/test/modular/test_request_queues.py
+++ b/test/modular/test_request_queues.py
@@ -77,16 +77,16 @@ if __name__ == "__main__":
                 section=loop.section.sections[0].sections[0],
                 n_iters=loop.n_iters,
                 curr_iter=loop.curr_iter,
-                external_inputs=loop.external_inputs,
-                loop_back_signals=loop.loop_back_signals,
+                _external_inputs=loop._external_inputs,
+                _loop_back_signals=loop._loop_back_signals,
                 outputs=loop.outputs
             ),
             Loop(
                 section=loop.section.sections[0].sections[1],
                 n_iters=loop.n_iters,
                 curr_iter=loop.curr_iter,
-                external_inputs=loop.external_inputs,
-                loop_back_signals=loop.loop_back_signals,
+                _external_inputs=loop._external_inputs,
+                _loop_back_signals=loop._loop_back_signals,
                 outputs=loop.outputs
             )
         ]),
@@ -94,8 +94,8 @@ if __name__ == "__main__":
             section=loop.section.sections[1],
             n_iters=loop.n_iters,
             curr_iter=loop.curr_iter,
-            external_inputs=loop.external_inputs,
-            loop_back_signals=loop.loop_back_signals,
+            _external_inputs=loop._external_inputs,
+            _loop_back_signals=loop._loop_back_signals,
             outputs=loop.outputs
         )
     ])

--- a/test/modular/test_request_queues.py
+++ b/test/modular/test_request_queues.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     # show-o2-style graph with weird stuff added to stress-test
 
     loop = Loop(
-        section=Parallel([
+        curr_section_replica=Parallel([
             Sequential([
                 GraphNode(
                     name="LLM",
@@ -23,7 +23,7 @@ if __name__ == "__main__":
                     ]
                 ),
                 Loop(
-                    section=Sequential([
+                    curr_section_replica=Sequential([
                         GraphNode(
                             name="flow",
                             input_ids=["hidden_states", "mystery", "mystery2"],
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     loop = Parallel([
         Sequential([
             Loop(
-                section=loop.section.sections[0].sections[0],
+                curr_section_replica=loop.curr_section_replica.sections[0].sections[0],
                 n_iters=loop.n_iters,
                 curr_iter=loop.curr_iter,
                 _external_inputs=loop._external_inputs,
@@ -82,7 +82,7 @@ if __name__ == "__main__":
                 outputs=loop.outputs
             ),
             Loop(
-                section=loop.section.sections[0].sections[1],
+                curr_section_replica=loop.curr_section_replica.sections[0].sections[1],
                 n_iters=loop.n_iters,
                 curr_iter=loop.curr_iter,
                 _external_inputs=loop._external_inputs,
@@ -91,7 +91,7 @@ if __name__ == "__main__":
             )
         ]),
         Loop(
-            section=loop.section.sections[1],
+            curr_section_replica=loop.curr_section_replica.sections[1],
             n_iters=loop.n_iters,
             curr_iter=loop.curr_iter,
             _external_inputs=loop._external_inputs,
@@ -121,7 +121,7 @@ if __name__ == "__main__":
             )
         ]),
         Loop(
-            section=Parallel([
+            curr_section_replica=Parallel([
                 Sequential([
                     GraphNode(
                         name="LLM",
@@ -132,7 +132,7 @@ if __name__ == "__main__":
                         ]
                     ),
                     Loop(
-                        section=Sequential([
+                        curr_section_replica=Sequential([
                             GraphNode(
                                 name="flow",
                                 input_ids=["hidden_states", "mystery", "mystery2"],

--- a/test/modular/test_request_queues.py
+++ b/test/modular/test_request_queues.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     # show-o2-style graph with weird stuff added to stress-test
 
     loop = Loop(
-        curr_section_replica=Parallel([
+        section=Parallel([
             Sequential([
                 GraphNode(
                     name="LLM",
@@ -23,7 +23,7 @@ if __name__ == "__main__":
                     ]
                 ),
                 Loop(
-                    curr_section_replica=Sequential([
+                    section=Sequential([
                         GraphNode(
                             name="flow",
                             input_ids=["hidden_states", "mystery", "mystery2"],
@@ -40,7 +40,7 @@ if __name__ == "__main__":
                             ]
                         ),
                     ]),
-                    n_iters=2,
+                    max_iters=2,
                     outputs=[
                         GraphEdge(name="latents", next_node="LLM")
                     ]
@@ -64,7 +64,7 @@ if __name__ == "__main__":
                 )
             ])
         ]),
-        n_iters=3,
+        max_iters=3,
         outputs=[
             GraphEdge(name="latents", next_node="VAE_decoder"),
             GraphEdge(name="some_random_external_output", next_node="EMIT_TO_CLIENT")
@@ -74,16 +74,16 @@ if __name__ == "__main__":
     loop = Parallel([
         Sequential([
             Loop(
-                curr_section_replica=loop.curr_section_replica.sections[0].sections[0],
-                n_iters=loop.n_iters,
+                section=loop.section.sections[0].sections[0],
+                max_iters=loop.max_iters,
                 curr_iter=loop.curr_iter,
                 _external_inputs=loop._external_inputs,
                 _loop_back_signals=loop._loop_back_signals,
                 outputs=loop.outputs
             ),
             Loop(
-                curr_section_replica=loop.curr_section_replica.sections[0].sections[1],
-                n_iters=loop.n_iters,
+                section=loop.section.sections[0].sections[1],
+                max_iters=loop.max_iters,
                 curr_iter=loop.curr_iter,
                 _external_inputs=loop._external_inputs,
                 _loop_back_signals=loop._loop_back_signals,
@@ -91,8 +91,8 @@ if __name__ == "__main__":
             )
         ]),
         Loop(
-            curr_section_replica=loop.curr_section_replica.sections[1],
-            n_iters=loop.n_iters,
+            section=loop.section.sections[1],
+            max_iters=loop.max_iters,
             curr_iter=loop.curr_iter,
             _external_inputs=loop._external_inputs,
             _loop_back_signals=loop._loop_back_signals,
@@ -121,7 +121,7 @@ if __name__ == "__main__":
             )
         ]),
         Loop(
-            curr_section_replica=Parallel([
+            section=Parallel([
                 Sequential([
                     GraphNode(
                         name="LLM",
@@ -132,7 +132,7 @@ if __name__ == "__main__":
                         ]
                     ),
                     Loop(
-                        curr_section_replica=Sequential([
+                        section=Sequential([
                             GraphNode(
                                 name="flow",
                                 input_ids=["hidden_states", "mystery", "mystery2"],
@@ -150,7 +150,7 @@ if __name__ == "__main__":
                                 ]
                             ),
                         ]),
-                        n_iters=2,
+                        max_iters=2,
                         outputs=[
                             GraphEdge(next_node="LLM", name="latents")
                         ]
@@ -174,7 +174,7 @@ if __name__ == "__main__":
                     )
                 ])
             ]),
-            n_iters=3,
+            max_iters=3,
             outputs=[
                 GraphEdge(next_node="VAE_decoder", name="latents"),
                 GraphEdge(next_node="EMIT_TO_CLIENT", name="some_random_external_output")

--- a/test/qwen3-omni/tts_request.py
+++ b/test/qwen3-omni/tts_request.py
@@ -50,7 +50,7 @@ def write_wav(pcm_data: bytes, path: str):
 def main():
     parser = argparse.ArgumentParser(description="Orpheus TTS client")
     parser.add_argument("--text", default="Hello, how are you doing today?", help="Text to synthesize")
-    parser.add_argument("--voice", default="tara", help="Voice name")
+    parser.add_argument("--voice", default="ethan", help="Voice name")
     parser.add_argument("--output", default="output.wav", help="Output WAV file path")
     parser.add_argument("--port", type=int, default=20001, help="Port number to connect to (localhost only)")
     args = parser.parse_args()


### PR DESCRIPTION
The `Loop` primitive can now have dynamic control, which a model implementation can set in the submodule via `CurrentForwardPassInfo.register_loop_stop(dynamic_loop_name)`.

For the bagel model, making the decode graph walk a dynamic loop reduced ITL from 9ms to 7ms.

This theoretically works for disaggregated/nested loops, but is largely untested because we don't have any models with diaggregated/nested loops. For those cases, we would have to communicate loop stops to other workers.

To avoid potential race conditions / double stops, we keep track of when each worker has last sent a stop signal to each dynamic loop. So, if we receive two stop signals from to different workers for the same loop, we don't try to stop the loop twice. I have implemented a data structure to keep track of "nested loop indices" (e.g., if we have loop B inside loop A, then `idx_A = 2, idx_B=0` is "later" than `idx_A=1, idx_B=3`). This logic should hopefully not be too much overhead, but maybe it is... or maybe it's too complicated/