### PR TITLE
[WIP] Cuda IPC tensor transport

### DIFF
--- a/mminf/api_server/data_worker.py
+++ b/mminf/api_server/data_worker.py
@@ -170,6 +170,11 @@ class PreprocessWorkerThread:
             tcp_transfer_device=tcp_transfer_device,
         )
 
+        self.final_device = self.device
+        if tensor_comm_protocol == CommProtocol.IPC:
+            # cuda IPC needs GPU tensors
+            self.final_device = "cuda:0"
+
     def _process_input(
         self, input: PreprocessInput
     ):
@@ -227,6 +232,10 @@ class PreprocessWorkerThread:
             tensors["text_inputs"] = [torch.tensor(
                 list(byte_data), dtype=torch.uint8, device=self.device
             )]
+        
+        if self.final_device != self.device:
+            for key in tensors:
+                tensors[key] = [tensor.to(self.final_device) for tensor in tensors[key]]
 
         initial_signals = self.tensor_manager.store_and_return_tensor_info(
             request_id=input.request_id,

--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -271,13 +271,12 @@ class MooncakeTransferEngine(TensorTransferEngine):
         )
         self._session_id = f"{hostname}:{self._engine.get_rpc_port()}"
 
-    def register_memory(self, tensor: torch.Tensor) -> int:
-        ptr, nbytes = tensor.data_ptr(), tensor.nbytes
+    def register_memory(self, ptr: int, nbytes: int) -> int:
         return self._engine.register_memory(ptr, nbytes)
     
     def get_source_info(self, tensor: torch.Tensor) -> TransferSourceInfo:
         return MooncakeTransferInfo(
-            address=tensor.data_ptr(), source_entity_id=self._session_id,
+            address=tensor.data_ptr(), source_session_id=self._session_id,
         )
 
     def unregister_memory(self, ptr: int) -> int:
@@ -708,10 +707,9 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
                         )
 
                 read_info.append(TransferReadInfo(
-                    source_session_id=info.source_info.source_session_id,
                     local_ptr=buffer.data_ptr(),
-                    remote_ptr=info.source_info.address,
                     nbytes=info.nbytes,
+                    transfer_info=info.source_info
                 ))
                 logger.debug("Started transfer read for uuid %s", info.uuid)
             fut = self._async_reader.submit(read_info)

--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from uuid import uuid4
+from torch.multiprocessing.reductions import rebuild_cuda_tensor
 
 from mminf.graph.special_destinations import EMPTY_DESTINATION
 
@@ -109,6 +110,18 @@ class TensorStore:
 # TensorTransferEngine abstraction
 # ---------------------------------------------------------------------------
 
+@dataclass
+class TransferSourceInfo:
+    address: int
+
+
+@dataclass
+class TransferReadInfo:
+    local_ptr: int
+    nbytes: int
+    transfer_info: TransferSourceInfo
+
+
 class TensorTransferEngine(ABC):
     """Abstract interface for low-level memory registration and async reads.
 
@@ -121,6 +134,9 @@ class TensorTransferEngine(ABC):
     def register_memory(self, ptr: int, nbytes: int) -> int:
         """Register a memory region for remote access. Returns 0 on success."""
         ...
+    
+    def get_source_info(self, tensor: torch.Tensor) -> TransferSourceInfo:
+        return TransferSourceInfo(address=tensor.data_ptr())
 
     @abstractmethod
     def unregister_memory(self, ptr: int) -> int:
@@ -143,12 +159,9 @@ class TensorTransferEngine(ABC):
 # ---------------------------------------------------------------------------
 
 @dataclass
-class TransferReadInfo:
+class MooncakeTransferInfo(TransferSourceInfo):
     source_session_id: str
-    local_ptr: int
-    remote_ptr: int
-    nbytes: int
-
+    
 
 class AsyncMooncakeReader:
     """Background thread for non-blocking mooncake READ operations.
@@ -190,9 +203,9 @@ class AsyncMooncakeReader:
         self._copy_stream.synchronize()
 
         # group read_info by session id for batch read
-        grouped_read = {}
+        grouped_read: dict[str, list[TransferReadInfo]] = {}
         for info in read_info:
-            grouped_read.setdefault(info.source_session_id, []).append(info)
+            grouped_read.setdefault(info.transfer_info.source_session_id, []).append(info)
 
         for (session_id, infos) in grouped_read.items():
             for start in range(0, len(infos), self.max_batch_size):
@@ -201,7 +214,7 @@ class AsyncMooncakeReader:
                 status = self._engine.batch_transfer_sync_read(
                     session_id,
                     [infos[i].local_ptr for i in range(start, end)],
-                    [infos[i].remote_ptr for i in range(start, end)],
+                    [infos[i].transfer_info.address for i in range(start, end)],
                     [infos[i].nbytes for i in range(start, end)],
                 )
                 if status < 0:
@@ -258,8 +271,14 @@ class MooncakeTransferEngine(TensorTransferEngine):
         )
         self._session_id = f"{hostname}:{self._engine.get_rpc_port()}"
 
-    def register_memory(self, ptr: int, nbytes: int) -> int:
+    def register_memory(self, tensor: torch.Tensor) -> int:
+        ptr, nbytes = tensor.data_ptr(), tensor.nbytes
         return self._engine.register_memory(ptr, nbytes)
+    
+    def get_source_info(self, tensor: torch.Tensor) -> TransferSourceInfo:
+        return MooncakeTransferInfo(
+            address=tensor.data_ptr(), source_entity_id=self._session_id,
+        )
 
     def unregister_memory(self, ptr: int) -> int:
         return self._engine.unregister_memory(ptr)
@@ -270,6 +289,91 @@ class MooncakeTransferEngine(TensorTransferEngine):
     def get_session_id(self) -> str:
         return self._session_id
 
+
+# ---------------------------------------------------------------------------
+# CUDA IPC implementation
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CudaIPCTransferInfo(TransferSourceInfo):
+    cuda_share: tuple
+    size: tuple
+    stride: tuple
+    offset: int
+    dtype: str
+    requires_grad: bool
+
+
+class CudaIPCTransferEngine(TensorTransferEngine):
+    """No-op engine for SHM / single-node — data is already in local GPU memory."""
+
+    def register_memory(self, ptr, nbytes):
+        return 0 # no memory registration required
+    
+    def get_source_info(self, tensor):
+        storage = tensor.untyped_storage()
+        cuda_share = storage._share_cuda_()
+        return CudaIPCTransferInfo(
+            address=tensor.data_ptr(),
+            cuda_share=cuda_share,
+            size=tensor.size(),
+            stride=tensor.stride(),
+            offset=tensor.storage_offset(),
+            dtype=str(tensor.dtype),
+            requires_grad=tensor.requires_grad
+        )
+
+    def rebuild_tensor(
+        self, source_info: CudaIPCTransferInfo,
+        device: torch.device | None = None
+    ):
+        (
+            storage_device,
+            storage_handle,
+            storage_size_bytes,
+            storage_offset_bytes,
+            ref_counter_handle,
+            ref_counter_offset,
+            event_handle,
+            event_sync_required,
+        ) = source_info.cuda_share
+
+        
+        tensor = rebuild_cuda_tensor(
+            torch.Tensor,
+            source_info.size,
+            source_info.stride,
+            source_info.offset,
+            torch.UntypedStorage,
+            source_info.dtype,
+            storage_device,
+            storage_handle,
+            storage_size_bytes,
+            storage_offset_bytes,
+            source_info.requires_grad,
+            ref_counter_handle,
+            ref_counter_offset,
+            event_handle,
+            event_sync_required,
+        )
+
+        if device is not None:
+            tensor = tensor.to(device)
+        return tensor
+
+    def unregister_memory(self, ptr: int) -> int:
+        return 0  # no-op
+
+    def get_async_reader(self, device) -> None:
+        return None  # TODO: make async reader
+
+    def get_session_id(self) -> str:
+        return "" # session ID is not applicable here
+
+
+# ---------------------------------------------------------------------------
+# No-op transfer engine
+# ---------------------------------------------------------------------------
 
 class LocalTransferEngine(TensorTransferEngine):
     """No-op engine for SHM / single-node — data is already in local GPU memory."""
@@ -340,10 +444,9 @@ class TensorCommunicationManager(ABC):
                     dtype=tensor.dtype,
                     stride=tensor.stride(),
                     nbytes=tensor.nbytes,
-                    address=tensor.data_ptr(),
                     uuid=tensor_uuid,
-                    source_session_id=self.my_session_id,
-                    source_entity=self.my_entity_id,
+                    source_entity_id=self.my_entity_id,
+                    source_info=self.transfer_engine.get_source_info(tensor)
                 ))
         return tensor_info
 
@@ -408,9 +511,9 @@ class TensorCommunicationManager(ABC):
         acks: dict[str, dict[str, int]] = {}
         for edge in graph_edges:
             for info in edge.tensor_info:
-                if info.source_entity not in acks:
-                    acks[info.source_entity] = {}
-                acks[info.source_entity][info.uuid] = acks[info.source_entity].get(
+                if info.source_entity_id not in acks:
+                    acks[info.source_entity_id] = {}
+                acks[info.source_entity_id][info.uuid] = acks[info.source_entity_id].get(
                     info.uuid, 0) + 1
         for source_entity, tensors in acks.items():
             if source_entity == self.my_entity_id:
@@ -573,7 +676,7 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
 
             read_info = []
             for info in graph_edge.tensor_info:
-                if info.source_entity == self.my_entity_id or self.tensor_store.check_uuid_presence(
+                if info.source_entity_id == self.my_entity_id or self.tensor_store.check_uuid_presence(
                     request_id, info.uuid
                 ):
                     self.tensor_store.increment_ref(
@@ -596,12 +699,18 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
                 )
 
                 if self.protocol == CommProtocol.RDMA:
-                    self.transfer_engine.register_memory(buffer.data_ptr(), info.nbytes)
+                    success = self.transfer_engine.register_memory(
+                        buffer.data_ptr(), info.nbytes
+                    ) == 0
+                    if not success:
+                        raise RuntimeError(
+                            f"Mooncake memory registration failed for request id {request_id}, uuid {info.uuid} on read."
+                        )
 
                 read_info.append(TransferReadInfo(
-                    source_session_id=info.source_session_id,
+                    source_session_id=info.source_info.source_session_id,
                     local_ptr=buffer.data_ptr(),
-                    remote_ptr=info.address,
+                    remote_ptr=info.source_info.address,
                     nbytes=info.nbytes,
                 ))
                 logger.debug("Started transfer read for uuid %s", info.uuid)
@@ -613,6 +722,83 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
                 )
             )
 
+
+# ---------------------------------------------------------------------------
+# CudaIPCCommunicationManager
+# ---------------------------------------------------------------------------
+
+class CudaIPCCommunicationManager(TensorCommunicationManager):
+    def __init__(
+        self,
+        my_entity_id: str,
+        device: str,
+        communicator: BaseCommunicator,
+    ):
+        self.engine = CudaIPCTransferEngine()
+        super().__init__(
+            my_entity_id=my_entity_id,
+            my_session_id=self.engine.get_session_id(),
+            device=device,
+            communicator=communicator,
+            transfer_engine=self.engine,
+        )
+
+    def register_for_send(self, request_id, uuids, skip_cuda_sync=False):
+        if not skip_cuda_sync:
+            torch.cuda.default_stream().synchronize()
+        for uuid in uuids:
+            self.tensor_store.set_metadata(
+                request_id, uuid, mem_registered=True
+            )
+
+    def _cleanup_by_uuid(self, request_id: str, uuid: str):
+        logger.debug("Deleting tensor uuid %s", uuid)
+        if not self.tensor_store.check_uuid_presence(request_id, uuid):
+            logger.warning("Trying to cleanup tensor %s, but uuid not found", uuid)
+            return
+        self.tensor_store.remove_tensor(request_id, uuid)
+
+    def start_read_tensors(
+        self, request_id: str, graph_edges: list[GraphEdge],
+    ):
+        for graph_edge in graph_edges:
+            if len(graph_edge.tensor_info) == 0:
+                continue
+
+            logger.debug(
+                "Starting to read in %d tensors %s for graph node %s",
+                len(graph_edge.tensor_info), graph_edge.name, graph_edge.next_node
+            )
+
+            for info in graph_edge.tensor_info:
+                if info.source_entity_id == self.my_entity_id or self.tensor_store.check_uuid_presence(
+                    request_id, info.uuid
+                ):
+                    self.tensor_store.increment_ref(
+                        request_id, info.uuid, 1
+                    )
+                    continue
+
+                # TODO: async reader
+                buffer = self.engine.rebuild_tensor(
+                    source_info=info.source_info, device=self.device
+                )
+                self.tensor_store.put_tensor(
+                    request_id=request_id, uuid=info.uuid, tensor=buffer
+                )
+                self.tensor_store.set_metadata(
+                    request_id, info.uuid, mem_registered=True
+                )
+                self.tensor_store.increment_ref(
+                    request_id, info.uuid, 1
+                )
+            # needed downstream for get_ready_tensors
+            self.pending.append(
+                FutureAndPointers(
+                    future=None, graph_edges=[graph_edge],
+                    request_id=request_id
+                )
+            )
 
 # ---------------------------------------------------------------------------
 # Shared-memory tensor serialization helpers
@@ -759,11 +945,11 @@ class SharedMemoryCommunicationManager(TensorCommunicationManager):
                 len(graph_edge.tensor_info), graph_edge.name, graph_edge.next_node,
             )
             for info in graph_edge.tensor_info:
-                if info.source_entity == self.my_entity_id or \
+                if info.source_entity_id == self.my_entity_id or \
                    self.tensor_store.check_uuid_presence(request_id, info.uuid):
                     self.tensor_store.increment_ref(request_id, info.uuid, 1)
                     continue
-                path = self._shm_path(info.source_entity, info.uuid)
+                path = self._shm_path(info.source_entity_id, info.uuid)
                 with open(path, "rb") as f:
                     data = f.read()
                 tensor = _deserialize_tensor(data, self.device)
@@ -817,6 +1003,12 @@ def create_tensor_communication_manager(
             device=device,
             communicator=communicator,
             shm_dir=shm_dir,
+        )
+    if protocol == CommProtocol.IPC:
+        return CudaIPCCommunicationManager(
+            my_entity_id=my_entity_id,
+            device=device,
+            communicator=communicator,
         )
     return MooncakeCommunicationManager(
         my_entity_id=my_entity_id,

--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -1,3 +1,4 @@
+import ctypes
 import logging
 import os
 import platform
@@ -197,7 +198,7 @@ class AsyncMooncakeReader:
         self._pending = [f for f in self._pending if not f.done()]
         return future
 
-    def _do_read(self, read_info: list["TransferReadInfo"], event: torch.cuda.Event):
+    def _do_read(self, read_info: list[TransferReadInfo], event: torch.cuda.Event):
         """Worker thread: wait for GPU data via CUDA event, then PUT."""
         self._copy_stream.wait_event(event)
         self._copy_stream.synchronize()
@@ -303,6 +304,73 @@ class CudaIPCTransferInfo(TransferSourceInfo):
     requires_grad: bool
 
 
+@dataclass
+class CudaIPCTransferReadInfo:
+    local_tensor: torch.Tensor
+    transfer_info: TransferSourceInfo
+
+
+class AsyncCudaIPCReader:
+    """Background thread for non-blocking CUDA IPC tensor reconstruction.
+
+    Similar to AsyncMooncakeReader, but instead of issuing RDMA reads,
+    we rebuild tensors from CUDA IPC handles and optionally copy slices.
+
+    The default stream is never blocked.
+    """
+
+    def __init__(self, engine, device, max_workers: int = 3):
+        self._engine = engine
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._pending: list[Future] = []
+
+        self._device = device
+        if device != "cpu":
+            self._copy_stream = torch.cuda.Stream(device=device)
+        else:
+            self._copy_stream = torch.cuda.Stream()
+
+    def submit(self, read_info: list[CudaIPCTransferReadInfo]) -> Future:
+        if not read_info:
+            return
+
+        event = torch.cuda.current_stream().record_event()
+        future = self._executor.submit(self._do_read, read_info, event)
+        self._pending.append(future)
+
+        # prune
+        self._pending = [f for f in self._pending if not f.done()]
+        return future
+
+    def _do_read(self, read_info: list[CudaIPCTransferReadInfo], event: torch.cuda.Event):
+        # wait for producer writes
+        self._copy_stream.wait_event(event)
+        self._copy_stream.synchronize()
+
+        for info in read_info:
+            src_info: CudaIPCTransferInfo = info.transfer_info
+            remote_tensor = self._engine.rebuild_tensor(
+                src_info,
+                device=None,  # keep on original device first
+            )
+
+            # async copy on copy stream
+            with torch.cuda.stream(self._copy_stream):
+                info.local_tensor.copy_(remote_tensor, non_blocking=True)
+
+        # ensure copies finish before thread exits
+        self._copy_stream.synchronize()
+
+    def wait_all(self):
+        for f in self._pending:
+            f.result()
+        self._pending.clear()
+
+    def shutdown(self):
+        self.wait_all()
+        self._executor.shutdown(wait=True)
+
+
 class CudaIPCTransferEngine(TensorTransferEngine):
     """No-op engine for SHM / single-node — data is already in local GPU memory."""
 
@@ -318,7 +386,7 @@ class CudaIPCTransferEngine(TensorTransferEngine):
             size=tensor.size(),
             stride=tensor.stride(),
             offset=tensor.storage_offset(),
-            dtype=str(tensor.dtype),
+            dtype=tensor.dtype,
             requires_grad=tensor.requires_grad
         )
 
@@ -337,7 +405,6 @@ class CudaIPCTransferEngine(TensorTransferEngine):
             event_sync_required,
         ) = source_info.cuda_share
 
-        
         tensor = rebuild_cuda_tensor(
             torch.Tensor,
             source_info.size,
@@ -356,15 +423,25 @@ class CudaIPCTransferEngine(TensorTransferEngine):
             event_sync_required,
         )
 
+        if device == tensor.device:
+            # same device, different process. Cloning to avoid race conditions;
+            # the expected behavior for tensor transport is that the sender and
+            # receiver process do not point to the same tensor
+            tensor = tensor.clone()
         if device is not None:
             tensor = tensor.to(device)
+        # device = None is used for more complicated access patterns like KV cache
+        # reading, where we want to only copy over slices of the full KV cache. In
+        # that case, moving the slices to the right device is delegated to the caller.
         return tensor
 
     def unregister_memory(self, ptr: int) -> int:
         return 0  # no-op
 
     def get_async_reader(self, device) -> None:
-        return None  # TODO: make async reader
+        return AsyncCudaIPCReader(
+            engine=self, device=device
+        )
 
     def get_session_id(self) -> str:
         return "" # session ID is not applicable here
@@ -621,9 +698,7 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
             transfer_engine=engine,
         )
         self.protocol = protocol
-        self._async_reader = AsyncMooncakeReader(
-            engine._engine, device=device
-        )
+        self._async_reader = engine.get_async_reader(device)
 
     def register_for_send(self, request_id, uuids, skip_cuda_sync=False):
         if not skip_cuda_sync:
@@ -740,6 +815,7 @@ class CudaIPCCommunicationManager(TensorCommunicationManager):
             communicator=communicator,
             transfer_engine=self.engine,
         )
+        self._async_reader = self.engine.get_async_reader(device)
 
     def register_for_send(self, request_id, uuids, skip_cuda_sync=False):
         if not skip_cuda_sync:
@@ -768,6 +844,7 @@ class CudaIPCCommunicationManager(TensorCommunicationManager):
                 len(graph_edge.tensor_info), graph_edge.name, graph_edge.next_node
             )
 
+            read_info = []
             for info in graph_edge.tensor_info:
                 if info.source_entity_id == self.my_entity_id or self.tensor_store.check_uuid_presence(
                     request_id, info.uuid
@@ -777,23 +854,30 @@ class CudaIPCCommunicationManager(TensorCommunicationManager):
                     )
                     continue
 
-                # TODO: async reader
-                buffer = self.engine.rebuild_tensor(
-                    source_info=info.source_info, device=self.device
-                )
+                buffer = torch.empty(
+                    info.dims, dtype=info.dtype, device=self.device
+                ).as_strided(info.dims, stride=info.stride)
                 self.tensor_store.put_tensor(
                     request_id=request_id, uuid=info.uuid, tensor=buffer
                 )
                 self.tensor_store.set_metadata(
                     request_id, info.uuid, mem_registered=True
                 )
+                # +1 for transit (released by get_ready_tensors)
+                # +1 for graph-node usage (released by _cleanup_consumed_inputs)
                 self.tensor_store.increment_ref(
-                    request_id, info.uuid, 1
+                    request_id, info.uuid, 2
                 )
-            # needed downstream for get_ready_tensors
+
+                read_info.append(CudaIPCTransferReadInfo(
+                    local_tensor=buffer,
+                    transfer_info=info.source_info
+                ))
+                logger.debug("Started transfer read for uuid %s", info.uuid)
+            fut = self._async_reader.submit(read_info)
             self.pending.append(
                 FutureAndPointers(
-                    future=None, graph_edges=[graph_edge],
+                    future=fut, graph_edges=[graph_edge],
                     request_id=request_id
                 )
             )

--- a/mminf/communication/tensors.py
+++ b/mminf/communication/tensors.py
@@ -1,4 +1,5 @@
 import ctypes
+import gc
 import logging
 import os
 import platform
@@ -310,65 +311,71 @@ class CudaIPCTransferReadInfo:
     transfer_info: TransferSourceInfo
 
 
-class AsyncCudaIPCReader:
-    """Background thread for non-blocking CUDA IPC tensor reconstruction.
+# this async reader doesn't actually speed things up, so commenting it out for now
+# class AsyncCudaIPCReader:
+#     """Background thread for non-blocking CUDA IPC tensor reconstruction.
 
-    Similar to AsyncMooncakeReader, but instead of issuing RDMA reads,
-    we rebuild tensors from CUDA IPC handles and optionally copy slices.
+#     Similar to AsyncMooncakeReader, but instead of issuing RDMA reads,
+#     we rebuild tensors from CUDA IPC handles and optionally copy slices.
 
-    The default stream is never blocked.
-    """
+#     The default stream is never blocked.
+#     """
 
-    def __init__(self, engine, device, max_workers: int = 3):
-        self._engine = engine
-        self._executor = ThreadPoolExecutor(max_workers=max_workers)
-        self._pending: list[Future] = []
+#     def __init__(self, engine, device, max_workers: int = 3):
+#         self._engine = engine
+#         self._executor = ThreadPoolExecutor(max_workers=max_workers)
+#         self._pending: list[Future] = []
 
-        self._device = device
-        if device != "cpu":
-            self._copy_stream = torch.cuda.Stream(device=device)
-        else:
-            self._copy_stream = torch.cuda.Stream()
+#         self._device = device
+#         if device != "cpu":
+#             self._copy_stream = torch.cuda.Stream(device=device)
+#         else:
+#             self._copy_stream = torch.cuda.Stream()
 
-    def submit(self, read_info: list[CudaIPCTransferReadInfo]) -> Future:
-        if not read_info:
-            return
+#     def submit(self, read_info: list[CudaIPCTransferReadInfo]) -> Future:
+#         if not read_info:
+#             return
 
-        event = torch.cuda.current_stream().record_event()
-        future = self._executor.submit(self._do_read, read_info, event)
-        self._pending.append(future)
+#         event = torch.cuda.current_stream().record_event()
+#         future = self._executor.submit(self._do_read, read_info, event)
+#         self._pending.append(future)
 
-        # prune
-        self._pending = [f for f in self._pending if not f.done()]
-        return future
+#         # prune
+#         self._pending = [f for f in self._pending if not f.done()]
+#         return future
 
-    def _do_read(self, read_info: list[CudaIPCTransferReadInfo], event: torch.cuda.Event):
-        # wait for producer writes
-        self._copy_stream.wait_event(event)
-        self._copy_stream.synchronize()
+#     def _do_read(self, read_info: list[CudaIPCTransferReadInfo], event):
+#         self._copy_stream.wait_event(event)
 
-        for info in read_info:
-            src_info: CudaIPCTransferInfo = info.transfer_info
-            remote_tensor = self._engine.rebuild_tensor(
-                src_info,
-                device=None,  # keep on original device first
-            )
+#         cache = {}
 
-            # async copy on copy stream
-            with torch.cuda.stream(self._copy_stream):
-                info.local_tensor.copy_(remote_tensor, non_blocking=True)
+#         with torch.cuda.stream(self._copy_stream):
+#             for info in read_info:
+#                 src_info: CudaIPCTransferInfo = info.transfer_info
 
-        # ensure copies finish before thread exits
-        self._copy_stream.synchronize()
+#                 key = src_info.cuda_share
+#                 if key not in cache:
+#                     cache[key] = self._engine.rebuild_tensor(
+#                         src_info,
+#                         device=None,
+#                     ).contiguous()
 
-    def wait_all(self):
-        for f in self._pending:
-            f.result()
-        self._pending.clear()
+#                 remote_tensor = cache[key]
+#                 info.local_tensor.copy_(remote_tensor, non_blocking=True)
 
-    def shutdown(self):
-        self.wait_all()
-        self._executor.shutdown(wait=True)
+#         self._copy_stream.synchronize()
+
+#         # drop references after sync
+#         cache.clear()
+
+#     def wait_all(self):
+#         for f in self._pending:
+#             f.result()
+#         self._pending.clear()
+
+#     def shutdown(self):
+#         self.wait_all()
+#         self._executor.shutdown(wait=True)
 
 
 class CudaIPCTransferEngine(TensorTransferEngine):
@@ -439,9 +446,7 @@ class CudaIPCTransferEngine(TensorTransferEngine):
         return 0  # no-op
 
     def get_async_reader(self, device) -> None:
-        return AsyncCudaIPCReader(
-            engine=self, device=device
-        )
+        return None
 
     def get_session_id(self) -> str:
         return "" # session ID is not applicable here
@@ -815,7 +820,6 @@ class CudaIPCCommunicationManager(TensorCommunicationManager):
             communicator=communicator,
             transfer_engine=self.engine,
         )
-        self._async_reader = self.engine.get_async_reader(device)
 
     def register_for_send(self, request_id, uuids, skip_cuda_sync=False):
         if not skip_cuda_sync:
@@ -844,40 +848,28 @@ class CudaIPCCommunicationManager(TensorCommunicationManager):
                 len(graph_edge.tensor_info), graph_edge.name, graph_edge.next_node
             )
 
-            read_info = []
             for info in graph_edge.tensor_info:
+                self.tensor_store.increment_ref(
+                    request_id, info.uuid, 1
+                )
                 if info.source_entity_id == self.my_entity_id or self.tensor_store.check_uuid_presence(
                     request_id, info.uuid
                 ):
-                    self.tensor_store.increment_ref(
-                        request_id, info.uuid, 1
-                    )
                     continue
 
-                buffer = torch.empty(
-                    info.dims, dtype=info.dtype, device=self.device
-                ).as_strided(info.dims, stride=info.stride)
+                buffer = self.engine.rebuild_tensor(
+                    info.source_info, device=self.device
+                )
                 self.tensor_store.put_tensor(
                     request_id=request_id, uuid=info.uuid, tensor=buffer
                 )
                 self.tensor_store.set_metadata(
                     request_id, info.uuid, mem_registered=True
                 )
-                # +1 for transit (released by get_ready_tensors)
-                # +1 for graph-node usage (released by _cleanup_consumed_inputs)
-                self.tensor_store.increment_ref(
-                    request_id, info.uuid, 2
-                )
 
-                read_info.append(CudaIPCTransferReadInfo(
-                    local_tensor=buffer,
-                    transfer_info=info.source_info
-                ))
-                logger.debug("Started transfer read for uuid %s", info.uuid)
-            fut = self._async_reader.submit(read_info)
             self.pending.append(
                 FutureAndPointers(
-                    future=fut, graph_edges=[graph_edge],
+                    future=None, graph_edges=[graph_edge],
                     request_id=request_id
                 )
             )

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -351,7 +351,7 @@ class Conductor:
         uuids = []
         for info in tensor_info:
             uuid_to_ref_count = entity_id_to_msg.setdefault(
-                info.source_entity, UnpersistTensors(
+                info.source_entity_id, UnpersistTensors(
                     request_id=request_id, uuid_to_ref_count={}
                 )
             ).uuid_to_ref_count

--- a/mminf/engine/kv_store.py
+++ b/mminf/engine/kv_store.py
@@ -171,7 +171,7 @@ class MooncakeKVTransferEngine(KVTransferEngine):
         )
         self._transfer_info = MooncakeTransferInfo(
             address=kv_cache.data_ptr(),
-            session_id=transfer_engine.get_session_id(),
+            source_session_id=transfer_engine.get_session_id(),
         )
         self._async_reader = transfer_engine.get_async_reader(
             kv_cache.device

--- a/mminf/engine/kv_store.py
+++ b/mminf/engine/kv_store.py
@@ -7,9 +7,8 @@ from enum import Enum
 from typing import Any
 
 import torch
-from torch.multiprocessing.reductions import rebuild_cuda_tensor
 
-from mminf.communication.tensors import LocalTransferEngine, MooncakeTransferEngine, TensorTransferEngine, TransferReadInfo
+from mminf.communication.tensors import CudaIPCTransferEngine, CudaIPCTransferInfo, LocalTransferEngine, MooncakeTransferEngine, MooncakeTransferInfo, TensorTransferEngine, TransferReadInfo, TransferSourceInfo
 from mminf.conductor.request_info import SequenceInfo
 
 logger = logging.getLogger(__name__)
@@ -151,19 +150,12 @@ class KVTransferEngine(ABC):
         pass
 
     @abstractmethod
-    def get_kv_transfer_info(self) -> Any:
+    def get_kv_transfer_info(self) -> TransferSourceInfo:
         pass
 
     @abstractmethod
     def shutdown(self):
         pass
-
-
-@dataclass
-class MooncakeKVTransferInfo:
-    entity_id: str
-    session_id: str
-    data_ptr: int
 
 
 class MooncakeKVTransferEngine(KVTransferEngine):
@@ -177,16 +169,15 @@ class MooncakeKVTransferEngine(KVTransferEngine):
         self._transfer_engine.register_memory(
             kv_cache.data_ptr(), kv_cache.nbytes
         )
-        self._transfer_info = MooncakeKVTransferInfo(
-            entity_id=entity_id,
+        self._transfer_info = MooncakeTransferInfo(
+            address=kv_cache.data_ptr(),
             session_id=transfer_engine.get_session_id(),
-            data_ptr=kv_cache.data_ptr()
         )
         self._async_reader = transfer_engine.get_async_reader(
             kv_cache.device
         )
     
-    def get_kv_transfer_info(self) -> MooncakeKVTransferInfo:
+    def get_kv_transfer_info(self) -> MooncakeTransferInfo:
         return self._transfer_info
     
     def _get_ptr_nbytes(
@@ -218,7 +209,7 @@ class MooncakeKVTransferEngine(KVTransferEngine):
         return ptrs, nbytes
 
     def read_batched_async(
-        self, remote_kv_info: MooncakeKVTransferInfo,
+        self, remote_kv_info: MooncakeTransferInfo,
         read_info: list[KVReadInfo]
     ) -> Future | None:
         mooncake_read_info: list[TransferReadInfo] = []
@@ -228,12 +219,15 @@ class MooncakeKVTransferEngine(KVTransferEngine):
             )
             remote_ptrs, _ = self._get_ptr_nbytes(
                 kv_read_info=info, is_local=False,
-                base_ptr=remote_kv_info.data_ptr
+                base_ptr=remote_kv_info.address
             )
             mooncake_read_info.extend([
                 TransferReadInfo(
-                    remote_kv_info.session_id,
-                    local_ptr, remote_ptr, nbytes
+                    local_ptr=local_ptr,
+                    nbytes=nbytes,
+                    transfer_info=TransferSourceInfo(
+                        address=remote_ptr
+                    )
                 ) for local_ptr, remote_ptr in zip(local_ptrs, remote_ptrs, strict=True)
             ])
         return self._async_reader.submit(mooncake_read_info)
@@ -245,43 +239,24 @@ class MooncakeKVTransferEngine(KVTransferEngine):
         )
 
 
-@dataclass
-class CudaIpcKVTransferInfo:
-    cuda_share: tuple
-    size: tuple
-    stride: tuple
-    offset: int
-    dtype: str
-    requires_grad: bool
-
-
-# TODO: this can also become a regular tensor transport method
 class CudaIpcKVTransferEngine(KVTransferEngine):
     def __init__(
         self, kv_cache: torch.Tensor,
         max_workers=3
     ):
-        storage = kv_cache.untyped_storage()
-        cuda_share = storage._share_cuda_()
-        self._transfer_info = CudaIpcKVTransferInfo(
-            cuda_share=cuda_share,
-            size=kv_cache.size(),
-            stride=kv_cache.stride(),
-            offset=kv_cache.storage_offset(),
-            dtype=str(kv_cache.dtype),
-            requires_grad=kv_cache.requires_grad
-        )
+        self._transfer_engine = CudaIPCTransferEngine()
+        self._transfer_info = self._transfer_engine.get_source_info(kv_cache)
         self._device = kv_cache.device
         self._kv_cache = kv_cache
 
         self._pending: list[Future] = []
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
     
-    def get_kv_transfer_info(self) -> CudaIpcKVTransferInfo:
+    def get_kv_transfer_info(self) -> CudaIPCTransferInfo:
         return self._transfer_info
 
     def read_batched_async(
-        self, remote_kv_info: CudaIpcKVTransferInfo,
+        self, remote_kv_info: CudaIPCTransferInfo,
         read_info: list[KVReadInfo]
     ):
         if not read_info:
@@ -294,46 +269,19 @@ class CudaIpcKVTransferEngine(KVTransferEngine):
         return future
 
     def _do_read(
-        self, remote_kv_info: CudaIpcKVTransferInfo,
+        self, remote_kv_info: CudaIPCTransferInfo,
         read_info: list[KVReadInfo],
         event: torch.Event=None
     ):
         event.synchronize()
-        dtype = getattr(torch, remote_kv_info.dtype.split(".")[-1])
-        (
-            storage_device,
-            storage_handle,
-            storage_size_bytes,
-            storage_offset_bytes,
-            ref_counter_handle,
-            ref_counter_offset,
-            event_handle,
-            event_sync_required,
-        ) = remote_kv_info.cuda_share
-
+        
         # Note: as this is a zero-copy operation and not allocating memory
         # (just building a reference to underlying storage on the sending device),
         # it is ok that this is rebuilding the whole kv cache. What matters is that,
         # in the rest of the function, we are only copying the right pages to
         # self._device. In fact, in testing, we see it is faster to call
         # rebuild_cuda_tensor on the whole KV cache instead of just the slice we need. 
-        tensor = rebuild_cuda_tensor(
-            torch.Tensor,
-            remote_kv_info.size,
-            remote_kv_info.stride,
-            remote_kv_info.offset,
-            torch.UntypedStorage,
-            dtype,
-            storage_device,
-            storage_handle,
-            storage_size_bytes,
-            storage_offset_bytes,
-            remote_kv_info.requires_grad,
-            ref_counter_handle,
-            ref_counter_offset,
-            event_handle,
-            event_sync_required,
-        )
+        tensor = self._transfer_engine.rebuild_tensor(remote_kv_info)
 
         for info in read_info:
             slice = tensor[
@@ -373,7 +321,9 @@ class PagedAllocationManager:
             )
         elif isinstance(
             transfer_engine_info.transfer_engine, LocalTransferEngine
-        ):
+        ) or isinstance(
+            transfer_engine_info.transfer_engine, CudaIPCTransferEngine
+        ): 
             self._kv_transfer_engine = CudaIpcKVTransferEngine(kv_cache)
         else:
             raise ValueError(f"Unsupported transfer engine type: {type(transfer_engine_info.transfer_engine)}")

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -40,11 +40,10 @@ class TensorPointerInfo:
     dims: list[int]
     dtype: str
     nbytes: int
-    address: int
     stride: list[int]
     uuid: str  # for indexing storage
-    source_session_id: str  # "{HOSTNAME}:{client_engine.get_rpc_port()}"
-    source_entity: str  # which {worker, api_server} the tensor is on
+    source_entity_id: str # for sending ACKs
+    source_info: Any # TransferSourceInfo
 
 
 @dataclass

--- a/test/modular/test_loop_accumulated.py
+++ b/test/modular/test_loop_accumulated.py
@@ -13,6 +13,7 @@ import sys
 
 sys.path.insert(0, ".")
 
+from mminf.communication.tensors import TransferSourceInfo
 import pytest
 
 from mminf.graph.base import (
@@ -51,11 +52,12 @@ def _make_info(uuid_str: str) -> TensorPointerInfo:
         dims=[1],
         dtype="float32",
         nbytes=4,
-        address=0,
         stride=[1],
         uuid=uuid_str,
-        source_session_id="test",
-        source_entity="worker",
+        source_entity_id="worker",
+        source_info=TransferSourceInfo(
+            address=0
+        )
     )
 
 


### PR DESCRIPTION
Cuda IPC support for tensor transport. With this enabled, here are the bagel T2I benchmarking numbers on coriander:
```
--- Benchmark Results (wall time: 84.85s) ---
Offline Benchmark Results (10 requests, batch=1)
──────────────────────────────────────────────────
Request type breakdown: text_to_image=10
Requests : 10/10 succeeded
TTFT (image)  : mean=8.468s  p50=8.166s  p95=9.364s  p99=9.615s
E2E           : mean=8.474s  p50=8.173s  p95=9.369s  p99=9.621s
```
