### PR TITLE
Pi0.5 optimization

### DIFF
--- a/mminf/model/pi05/components/action_expert.py
+++ b/mminf/model/pi05/components/action_expert.py
@@ -58,16 +58,22 @@ class Pi05AdaRMSNorm(nn.Module):
     def forward(
         self, x: torch.Tensor, cond: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        # reshape instead of flattening early
+        BS = cond.shape[0]
+        AH = x.shape[0] // BS
+        x = x.view(BS, AH, -1)
+
         normed = self._rms_normalize(x)
-        modulation = self.dense(cond)
-        if modulation.dim() == 1:
-            # cond was a single vector (e.g., [hidden]); broadcast to the seq.
-            scale, shift, gate = modulation.chunk(3, dim=-1)
-        else:
-            # cond was [B, hidden] -> modulation [B, 3*hidden]; add seq dim.
-            modulation = modulation.unsqueeze(-2)  # [B, 1, 3*hidden]
-            scale, shift, gate = modulation.chunk(3, dim=-1)
+
+        modulation = self.dense(cond)[:, None, :]  # [BS, 1, 3*emb_dim]
+        scale, shift, gate = modulation.chunk(3, dim=-1)
+
         normed = normed * (1.0 + scale) + shift
+
+        # flatten back if needed
+        normed = normed.view(BS * AH, -1)
+        gate = gate.expand(BS, AH, -1).reshape(BS * AH, -1)
+
         return normed, gate
 
 

--- a/mminf/model/pi05/components/flow_matching.py
+++ b/mminf/model/pi05/components/flow_matching.py
@@ -8,6 +8,8 @@ import torch
 def sincos_timestep_embedding(
     t: torch.Tensor,
     dim: int,
+    fraction: torch.Tensor,
+    output_buffer: torch.Tensor,
     min_period: float = 4e-3,
     max_period: float = 4.0,
 ) -> torch.Tensor:
@@ -25,16 +27,19 @@ def sincos_timestep_embedding(
         raise ValueError(f"sincos embedding requires even dim, got {dim}")
     if t.dim() == 0:
         t = t[None]
-    half = dim // 2
-    # Geometric progression of frequencies between min_period and max_period.
-    # Use float64 for the frequency computation to match the openpi reference;
-    # bf16 has only ~3 digits of precision and rounds higher-frequency
-    # components, which compounds through time_mlp -> adaRMS -> 18 layers.
-    fraction = torch.linspace(0.0, 1.0, half, device=t.device, dtype=torch.float64)
-    period = min_period * (max_period / min_period) ** fraction
-    omega = (2.0 * math.pi / period).to(t.dtype)
-    angles = t[..., None] * omega
-    return torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+    
+    period = min_period * torch.pow(max_period / min_period, fraction)
+    omega = (2.0 * torch.pi / period).to(t.dtype)
+
+    K = dim // 2
+    # angles: (N, K)
+    angles = t.unsqueeze(-1) * omega  # omega should be (K,)
+
+    # Fill in-place instead of cat
+    output_buffer[:, :K] = torch.sin(angles)
+    output_buffer[:, K:] = torch.cos(angles)
+
+    return output_buffer
 
 
 def euler_step(

--- a/mminf/model/pi05/submodules.py
+++ b/mminf/model/pi05/submodules.py
@@ -204,7 +204,7 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
     )
 
     # TODO: check what numbers to actually use here
-    PREFILL_TOKEN_BUCKETS = [512, 1024, 2048]
+    PREFILL_TOKEN_BUCKETS = [512, 1024, 1800] # 2048 was giving OOM
     PREFILL_CAPTURE_BATCH_SIZES = [1, 2, 4]
 
     def __init__(
@@ -357,7 +357,7 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
                         "ts": torch.zeros(1, device=device, dtype=torch.long)
                     }
                 ),
-                capture_batch_sizes=[1, 2, 4, 8, 16]
+                capture_batch_sizes=[1, 2, 4]
             ),
             FlashInferPackedCudaGraphConfig(
                 capture_graph_walk="prefill",
@@ -472,8 +472,6 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         per_request_seqs = [inp.input_embeds for inp in inputs]
         prefix_embs = torch.cat(per_request_seqs, dim=0)
         seq_lens = [inp.input_seq_len for inp in inputs]
-
-        print("Prefill seq lens", seq_lens)
         
         # Bidirectional attention over the prefix; PaliGemma is a prefix-LM.
         cache_manager.plan_attention(

--- a/mminf/model/pi05/submodules.py
+++ b/mminf/model/pi05/submodules.py
@@ -204,7 +204,7 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
     )
 
     # TODO: check what numbers to actually use here
-    PREFILL_TOKEN_BUCKETS = [128, 256, 512, 1024, 2048, 4096]
+    PREFILL_TOKEN_BUCKETS = [512, 1024, 2048]
     PREFILL_CAPTURE_BATCH_SIZES = [1, 2, 4]
 
     def __init__(
@@ -351,7 +351,7 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
                 single_request_inputs=ARNodeInputs(
                     input_seq_len=self.config.action_horizon,
                     tensor_inputs={
-                        "noisy": torch.zeros(
+                        "noisy_actions": torch.zeros(
                             self.config.action_horizon, self.config.action_dim, device=device
                         ),
                         "ts": torch.zeros(1, device=device, dtype=torch.long)
@@ -520,7 +520,7 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
             "seq_lens": seq_lens,
             "fraction": self._get_timestep_emb_fraction(),
             "time_emb_buffer": torch.zeros(
-                (len(inputs), self.config.action_dim),
+                (len(inputs), self.config.action_hidden_size),
                 device=self.get_device(),
                 dtype=cat_noisy.dtype
             )
@@ -574,16 +574,16 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
 
     def _forward_prefill_batched(
         self,
-        cache_handle: BatchedCacheManager,
+        cache_manager: BatchedCacheManager,
         request_ids: list[str],
         prefix_embs: torch.Tensor,
         **kwargs,
     ) -> dict[str, NameToTensorList]:
         """Batched prefill: single PaliGemma forward over concatenated prefixes."""
-        cache_handle.set_active_label("main")
+        cache_manager.set_active_label("main")
         self.paligemma(
             query_sequence=prefix_embs,
-            cache_handle=cache_handle,
+            cache_handle=cache_manager,
             write_cache=True,
         )
         # Prefill produces no graph-edge outputs.
@@ -617,7 +617,7 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
             end = start + horizon
             result[rid] = {
                 "noisy_actions": [next_actions[start:end]],
-                "timestep_index": [next_index[i]],
+                "timestep_index": [next_index[i:i+1]],
             }
         return result
 

--- a/mminf/model/pi05/submodules.py
+++ b/mminf/model/pi05/submodules.py
@@ -20,6 +20,7 @@ from mminf.communication.tensors import NameToTensorList
 from mminf.conductor.request_info import CurrentForwardPassInfo
 from mminf.engine.base import NodeBatch
 from mminf.engine.cache_manager import BatchedCacheManager
+from mminf.engine.cuda_graph_config import BasicBatchedCudaGraphConfig, FlashInferPackedCudaGraphConfig
 from mminf.model.submodule_base import ARNodeInputs, ARNodeSubmodule, ModelInputsFromEngine, NodeInputs, NodeSubmodule
 from mminf.model.pi05.components.action_expert import Pi05ActionExpert, Pi05TimeMLP
 from mminf.model.pi05.components.flow_matching import sincos_timestep_embedding
@@ -202,6 +203,10 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         ".norm.",   # final RMSNorm / adaRMS norm
     )
 
+    # TODO: check what numbers to actually use here
+    PREFILL_TOKEN_BUCKETS = [128, 256, 512, 1024, 2048, 4096]
+    PREFILL_CAPTURE_BATCH_SIZES = [1, 2, 4]
+
     def __init__(
         self,
         embed_tokens: nn.Embedding,
@@ -242,6 +247,9 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         self._image_embed_scale = math.sqrt(config.hidden_size)
         self._text_embed_scale = float(config.hidden_size)
 
+        # cached on first action Euler step
+        self._fraction: torch.Tensor | None = None
+
     def to(self, *args, **kwargs):
         """Apply standard ``to()`` then upcast norm parameters back to fp32.
 
@@ -269,14 +277,8 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         - ``action_gen``: all requests in a batch are at the same Euler
           iteration (guaranteed by the Loop primitive), so their suffix tokens
           can be concatenated and processed in a single action expert forward.
-
-        NOTE: Batching is disabled for now pending investigation of a
-        deadlock in the batched prefill path. The forward_batched()
-        implementation is ready and tested in-process; the issue is in
-        the interaction with the AREngine's _execute_batched flow.
         """
-        # TODO: re-enable once the deadlock is resolved.
-        return False
+        return True
 
     def get_needed_cache_labels(
         self,
@@ -288,6 +290,22 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
     # ------------------------------------------------------------------
     # preprocess
     # ------------------------------------------------------------------
+
+    def _get_timestep_emb_fraction(self) -> torch.Tensor:
+        if self._fraction is not None:
+            return self._fraction
+        device = self.get_device()
+        dim = self.config.action_hidden_size
+        half = dim // 2
+        # Geometric progression of frequencies between min_period and max_period.
+        # Use float64 for the frequency computation to match the openpi reference;
+        # bf16 has only ~3 digits of precision and rounds higher-frequency
+        # components, which compounds through time_mlp -> adaRMS -> 18 layers.
+        self._fraction = torch.linspace(
+            0.0, 1.0, half, device=device,
+            dtype=torch.float64
+        )
+        return self._fraction
 
     def preprocess(
         self,
@@ -315,6 +333,42 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
     def _embed_tokens_scaled(self, ids: torch.Tensor) -> torch.Tensor:
         emb = self.embed_tokens(ids)
         return emb * self._text_embed_scale
+    
+    def get_cuda_graph_configs(
+        self, device: torch.device,
+    ) -> list[BasicBatchedCudaGraphConfig | FlashInferPackedCudaGraphConfig]:
+        prefill_packed = {
+            num_tokens: {
+                "prefix_embs": torch.zeros(num_tokens, self.config.hidden_size, device=device)
+            }
+            for num_tokens in self.PREFILL_TOKEN_BUCKETS
+        }
+        return [
+            # Action generation always has latents of the same size, so it is a similar
+            # paradigm to AR decode and can use the batched cuda graphs
+            BasicBatchedCudaGraphConfig(
+                capture_graph_walk="action_gen", requires_cfg=False, labels=["main"],
+                single_request_inputs=ARNodeInputs(
+                    input_seq_len=self.config.action_horizon,
+                    tensor_inputs={
+                        "noisy": torch.zeros(
+                            self.config.action_horizon, self.config.action_dim, device=device
+                        ),
+                        "ts": torch.zeros(1, device=device, dtype=torch.long)
+                    }
+                ),
+                capture_batch_sizes=[1, 2, 4, 8, 16]
+            ),
+            FlashInferPackedCudaGraphConfig(
+                capture_graph_walk="prefill",
+                packed_seq_len_to_inputs=prefill_packed,
+                requires_cfg=False,
+                labels=["main"],
+                compile=True,
+                causal_attention=False,
+                capture_batch_sizes=self.PREFILL_CAPTURE_BATCH_SIZES,
+            ),
+        ]
     
     def prepare_inputs(
         self,
@@ -379,7 +433,7 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
             noisy = torch.randn(
                 action_horizon, action_dim, device=device, generator=generator
             )
-            ts = torch.zeros((), device=device, dtype=torch.long)
+            ts = torch.zeros(1, device=device, dtype=torch.long)
         else:
             noisy = inputs["noisy_actions"][0]
             ts = inputs["timestep_index"][0]
@@ -412,12 +466,14 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         
     def _preprocess_prefill(
         self,
-        inputs: list[NameToTensorList],
+        inputs: list[ARNodeInputs],
         cache_manager: BatchedCacheManager,
     ) -> dict[str, torch.Tensor | Any]:
         per_request_seqs = [inp.input_embeds for inp in inputs]
         prefix_embs = torch.cat(per_request_seqs, dim=0)
         seq_lens = [inp.input_seq_len for inp in inputs]
+
+        print("Prefill seq lens", seq_lens)
         
         # Bidirectional attention over the prefix; PaliGemma is a prefix-LM.
         cache_manager.plan_attention(
@@ -425,16 +481,13 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         )
         cache_manager.plan_rope(seq_lens=seq_lens, pos_ids=None, label="main")
 
-        return {"prefix_embs": prefix_embs, "seq_lens": seq_lens}
+        return {"prefix_embs": prefix_embs}
 
     def _preprocess_action_gen(
         self,
-        inputs: list[NameToTensorList],
+        inputs: list[ARNodeInputs],
         cache_manager: BatchedCacheManager,
     ) -> dict[str, torch.Tensor | Any]:
-
-        all_noisy = [inp.tensor_inputs["noisy_actions"] for inp in inputs]
-        all_ts = [inp.tensor_inputs["ts"] for inp in inputs]
         seq_lens = [inp.input_seq_len for inp in inputs]
 
         # The action suffix attends to the frozen prefix KV cache. We pass
@@ -450,10 +503,27 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
             seq_lens=seq_lens, pos_ids=None, label="main"
         )
 
+        # Concatenate noisy_actions across requests for a single forward.
+        cat_noisy = torch.cat(
+            [inp.tensor_inputs["noisy_actions"] for inp in inputs],
+            dim=0
+        ) # [N * horizon, action_dim]
+
+        all_ts = torch.cat(
+            [inp.tensor_inputs["ts"] for inp in inputs],
+            dim=0
+        )
+
         return {
-            "noisy_actions": all_noisy,
+            "noisy_actions": cat_noisy,
             "timestep_index": all_ts,
             "seq_lens": seq_lens,
+            "fraction": self._get_timestep_emb_fraction(),
+            "time_emb_buffer": torch.zeros(
+                (len(inputs), self.config.action_dim),
+                device=self.get_device(),
+                dtype=cat_noisy.dtype
+            )
         }
 
     # ------------------------------------------------------------------
@@ -467,7 +537,7 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
     ) -> NameToTensorList:
         cache_handle=engine_inputs.cache_manager
 
-        if graph_walk == "prefill": #NOTE: may need to rename prefix_embs (bacame input_embeds)
+        if graph_walk == "prefill":
             return self._forward_prefill(cache_handle=cache_handle, **kwargs)
         if graph_walk == "action_gen":
             return self._forward_action_gen(cache_handle=cache_handle, **kwargs)
@@ -504,15 +574,16 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
 
     def _forward_prefill_batched(
         self,
-        cache_manager: BatchedCacheManager,
+        cache_handle: BatchedCacheManager,
         request_ids: list[str],
         prefix_embs: torch.Tensor,
+        **kwargs,
     ) -> dict[str, NameToTensorList]:
         """Batched prefill: single PaliGemma forward over concatenated prefixes."""
-        cache_manager.set_active_label("main")
+        cache_handle.set_active_label("main")
         self.paligemma(
             query_sequence=prefix_embs,
-            cache_handle=cache_manager,
+            cache_handle=cache_handle,
             write_cache=True,
         )
         # Prefill produces no graph-edge outputs.
@@ -522,19 +593,21 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         self,
         cache_manager: BatchedCacheManager,
         request_ids: list[str],
-        noisy_actions: list[torch.Tensor],
-        timestep_index: list[torch.Tensor],
+        noisy_actions: torch.Tensor,
+        timestep_index: torch.Tensor,
+        fraction: torch.Tensor,
+        time_emb_buffer: torch.Tensor,
+        **kwargs
     ) -> dict[str, NameToTensorList]:
         """Batched action_gen: single action expert forward, then split per-request."""
 
-        horizon = self.config.action_horizon
-
-        # All requests share the same timestep (Loop iterates in lockstep).
-        # Concatenate noisy_actions across requests for a single forward.
-        cat_noisy = torch.cat(noisy_actions, dim=0)  # [N * horizon, action_dim]
+        horizon = self.config.action_horizon        
 
         next_actions, next_index = self._euler_step(
-            cat_noisy, timestep_index[0], cache_manager
+            noisy_actions, timestep_index,
+            fraction=fraction,
+            time_emb_buffer=time_emb_buffer,
+            cache_handle=cache_manager
         )
 
         # Split back per-request by horizon.
@@ -544,7 +617,7 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
             end = start + horizon
             result[rid] = {
                 "noisy_actions": [next_actions[start:end]],
-                "timestep_index": [next_index],
+                "timestep_index": [next_index[i]],
             }
         return result
 
@@ -567,6 +640,8 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         self,
         noisy_actions,
         timestep_index,
+        fraction,
+        time_emb_buffer,
         cache_handle: BatchedCacheManager,
         **kwargs,
     ) -> NameToTensorList:
@@ -584,7 +659,10 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
             timestep_index = timestep_index[0]
 
         next_actions, next_index = self._euler_step(
-            noisy_actions, timestep_index, cache_handle
+            noisy_actions, timestep_index,
+            fraction=fraction,
+            time_emb_buffer=time_emb_buffer,
+            cache_handle=cache_handle
         )
         # We ALWAYS return both loop-back edges, even on the final iteration.
         # The Loop primitive (mminf/graph/base.py:Loop) handles the final-iter
@@ -602,6 +680,8 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         self,
         noisy_actions: torch.Tensor,
         timestep_index: torch.Tensor,
+        fraction: torch.Tensor,
+        time_emb_buffer: torch.Tensor,
         cache_handle: BatchedCacheManager,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """One Euler flow-matching step. Shared by sequential and batched paths.
@@ -615,6 +695,9 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         Returns:
             (next_actions, next_timestep_index) with same shapes as inputs.
         """
+        # noisy_actions: [N * horizon, action_dim]
+        # timestep_index: [N]
+
         config = self.config
         num_steps = config.num_flow_steps
 
@@ -624,9 +707,11 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         time_emb = sincos_timestep_embedding(
             t,
             dim=config.action_hidden_size,
+            fraction=fraction,
+            output_buffer=time_emb_buffer,
             min_period=config.timestep_min_period,
             max_period=config.timestep_max_period,
-        ).squeeze(0)
+        )
         adarms_cond = self.time_mlp(time_emb)
 
         suffix = self.action_in_proj(noisy_actions)

--- a/mminf/model/pi05/submodules.py
+++ b/mminf/model/pi05/submodules.py
@@ -203,7 +203,7 @@ class Pi05LLMSubmodule(ARNodeSubmodule):
         ".norm.",   # final RMSNorm / adaRMS norm
     )
 
-    # TODO: check what numbers to actually use here
+    # For the default image size and a simple text prompt, one request is about 400 tokens
     PREFILL_TOKEN_BUCKETS = [512, 1024, 1800] # 2048 was giving OOM
     PREFILL_CAPTURE_BATCH_SIZES = [1, 2, 4]
 

--- a/test/pi05/batch_test.py
+++ b/test/pi05/batch_test.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Pi0.5 batch benchmark.
+
+Sends a fixed pool of requests across batch sizes [1, 2, 3, 4], enforcing
+concurrency via a semaphore. Reports per-request and aggregate latency stats.
+
+Usage::
+
+    # Run with defaults (server on localhost:20002, 24 requests, all batch sizes)
+    python benchmark_pi05.py
+
+    # Custom port / pool size / batch sizes
+    python benchmark_pi05.py --port 20002 --pool 24 --batch-sizes 1 2 4 8
+
+    # Specify server URL directly
+    python benchmark_pi05.py --url http://my-robot-server:20002/infer
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import io
+import json
+import statistics
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import aiohttp
+import numpy as np
+from PIL import Image
+
+from _env import get_server_url
+
+# ── constants matching Pi0.5 defaults ────────────────────────────────────────
+ACTION_HORIZON = 50
+ACTION_DIM = 32
+IMAGE_SIZE = 224  # model expects 224×224 3-channel RGB
+
+DEFAULT_BATCH_SIZES = [1, 2, 3, 4]
+DEFAULT_POOL_SIZE = 24
+DEFAULT_TEXT = "pick up the block"
+
+
+# ── image helpers ─────────────────────────────────────────────────────────────
+
+def _make_random_png(seed: int) -> bytes:
+    """Deterministic 224×224 RGB PNG (fast, small, reproducible)."""
+    rng = np.random.default_rng(seed)
+    arr = rng.integers(0, 255, (IMAGE_SIZE, IMAGE_SIZE, 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr, mode="RGB").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# Pre-generate a small palette of images so we're not regenerating every call.
+_IMAGE_PALETTE: List[bytes] = [_make_random_png(s) for s in range(32)]
+
+
+def _get_image(idx: int) -> bytes:
+    return _IMAGE_PALETTE[idx % len(_IMAGE_PALETTE)]
+
+
+# ── request builder ───────────────────────────────────────────────────────────
+
+def _build_form_data(request_idx: int, text: str = DEFAULT_TEXT) -> aiohttp.FormData:
+    """Build the multipart/form-data body expected by the Pi0.5 inference server."""
+    form = aiohttp.FormData()
+
+    # Three camera images: base, left wrist, right wrist
+    for cam_idx in range(3):
+        seed_offset = request_idx * 3 + cam_idx
+        form.add_field(
+            "files",
+            _get_image(seed_offset),
+            filename=f"cam{cam_idx}_{request_idx}.png",
+            content_type="image/png",
+        )
+
+    form.add_field("text", text)
+    form.add_field("input_modalities", "image,text")
+    form.add_field("output_modalities", "action")
+    form.add_field("streaming", "false")
+    form.add_field(
+        "model_kwargs",
+        json.dumps({"robot_state": [0.0] * ACTION_DIM}),
+    )
+    return form
+
+
+# ── result dataclass ──────────────────────────────────────────────────────────
+
+@dataclass
+class RequestResult:
+    request_idx: int
+    batch_size: int          # concurrency level this request ran under
+    latency_s: float
+    success: bool
+    status_code: Optional[int] = None
+    error: Optional[str] = None
+    action_shape: Optional[tuple] = None
+
+
+# ── async worker ─────────────────────────────────────────────────────────────
+
+async def _send_one(
+    session: aiohttp.ClientSession,
+    semaphore: asyncio.Semaphore,
+    url: str,
+    request_idx: int,
+    batch_size: int,
+) -> RequestResult:
+    async with semaphore:
+        form = _build_form_data(request_idx)
+        t0 = time.perf_counter()
+        try:
+            async with session.post(url, data=form) as resp:
+                latency = time.perf_counter() - t0
+                body = await resp.read()
+                if not resp.ok:
+                    return RequestResult(
+                        request_idx=request_idx,
+                        batch_size=batch_size,
+                        latency_s=latency,
+                        success=False,
+                        status_code=resp.status,
+                        error=body[:200].decode(errors="replace"),
+                    )
+                payload = json.loads(body)
+                chunks = payload.get("outputs", {}).get("action", [])
+                shape = None
+                if chunks:
+                    raw = base64.b64decode(chunks[0]["data"])
+                    arr = np.frombuffer(raw, dtype=np.float32)
+                    n_steps = arr.size // ACTION_DIM
+                    shape = (n_steps, ACTION_DIM)
+                return RequestResult(
+                    request_idx=request_idx,
+                    batch_size=batch_size,
+                    latency_s=latency,
+                    success=True,
+                    status_code=resp.status,
+                    action_shape=shape,
+                )
+        except Exception as exc:
+            latency = time.perf_counter() - t0
+            return RequestResult(
+                request_idx=request_idx,
+                batch_size=batch_size,
+                latency_s=latency,
+                success=False,
+                error=str(exc),
+            )
+
+
+# ── benchmark runner ──────────────────────────────────────────────────────────
+
+async def run_batch_benchmark(
+    url: str,
+    pool_size: int,
+    batch_sizes: List[int],
+    timeout_s: float = 120.0,
+) -> dict[int, List[RequestResult]]:
+    """
+    For each batch_size, fire ``pool_size`` requests with at most
+    ``batch_size`` in-flight concurrently and record E2E latencies.
+    """
+    connector = aiohttp.TCPConnector(limit=max(batch_sizes) * 2)
+    timeout = aiohttp.ClientTimeout(total=timeout_s)
+    all_results: dict[int, List[RequestResult]] = {}
+
+    async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
+        for bs in batch_sizes:
+            print(f"\n{'─'*60}")
+            print(f"  Batch size = {bs}  ({pool_size} requests, ≤{bs} concurrent)")
+            print(f"{'─'*60}")
+            semaphore = asyncio.Semaphore(bs)
+            tasks = [
+                _send_one(session, semaphore, url, idx, bs)
+                for idx in range(pool_size)
+            ]
+            wall_t0 = time.perf_counter()
+            results: List[RequestResult] = await asyncio.gather(*tasks)
+            wall_elapsed = time.perf_counter() - wall_t0
+            all_results[bs] = results
+
+            # ── per-batch-size summary ────────────────────────────────────
+            ok = [r for r in results if r.success]
+            fail = [r for r in results if not r.success]
+            latencies = [r.latency_s for r in ok]
+
+            if latencies:
+                print(f"  Requests : {len(results)} total, {len(ok)} ok, {len(fail)} failed")
+                print(f"  Wall time: {wall_elapsed:.3f}s  |  "
+                      f"Throughput: {len(ok)/wall_elapsed:.2f} req/s")
+                print(f"  Latency  : "
+                      f"min={min(latencies):.3f}s  "
+                      f"p50={statistics.median(latencies):.3f}s  "
+                      f"p95={_percentile(latencies, 95):.3f}s  "
+                      f"p99={_percentile(latencies, 99):.3f}s  "
+                      f"max={max(latencies):.3f}s")
+                print(f"  Mean±std : {statistics.mean(latencies):.3f}s ± "
+                      f"{statistics.stdev(latencies) if len(latencies) > 1 else 0:.3f}s")
+                # Show action shape from first successful result
+                for r in ok:
+                    if r.action_shape:
+                        print(f"  Action   : shape={r.action_shape}")
+                        break
+            else:
+                print("  All requests FAILED.")
+
+            if fail:
+                print(f"\n  Sample errors ({min(3, len(fail))} of {len(fail)}):")
+                for r in fail[:3]:
+                    print(f"    req#{r.request_idx:02d}  "
+                          f"status={r.status_code}  err={r.error}")
+
+    return all_results
+
+
+def _percentile(data: List[float], p: int) -> float:
+    if not data:
+        return float("nan")
+    sorted_data = sorted(data)
+    idx = (p / 100) * (len(sorted_data) - 1)
+    lo, hi = int(idx), min(int(idx) + 1, len(sorted_data) - 1)
+    frac = idx - lo
+    return sorted_data[lo] * (1 - frac) + sorted_data[hi] * frac
+
+
+# ── summary table ─────────────────────────────────────────────────────────────
+
+def print_summary(all_results: dict[int, List[RequestResult]], pool_size: int) -> None:
+    print(f"\n{'═'*72}")
+    print("  BENCHMARK SUMMARY")
+    print(f"{'═'*72}")
+    header = f"{'Batch':>6}  {'OK':>4}  {'Fail':>4}  {'min':>7}  {'p50':>7}  {'p95':>7}  {'p99':>7}  {'max':>7}  {'req/s':>7}"
+    print(header)
+    print(f"{'─'*72}")
+    for bs in sorted(all_results.keys()):
+        results = all_results[bs]
+        ok = [r for r in results if r.success]
+        fail = [r for r in results if not r.success]
+        latencies = [r.latency_s for r in ok]
+        if latencies:
+            # Estimate wall time: sum of latencies / batch_size approximation
+            # (better: use per-batch wall time, but we store results only)
+            # Use sum/bs as a proxy for throughput
+            throughput = len(ok) / (sum(latencies) / bs) if latencies else 0
+            print(
+                f"{bs:>6}  {len(ok):>4}  {len(fail):>4}  "
+                f"{min(latencies):>7.3f}  "
+                f"{statistics.median(latencies):>7.3f}  "
+                f"{_percentile(latencies, 95):>7.3f}  "
+                f"{_percentile(latencies, 99):>7.3f}  "
+                f"{max(latencies):>7.3f}  "
+                f"{throughput:>7.2f}"
+            )
+        else:
+            print(f"{bs:>6}  {'0':>4}  {len(fail):>4}  {'ALL FAILED':>51}")
+    print(f"{'═'*72}")
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pi0.5 batch benchmark — measures E2E latency at varying concurrency levels."
+    )
+    parser.add_argument(
+        "--pool", type=int, default=DEFAULT_POOL_SIZE,
+        help=f"Total requests to send per batch size (default: {DEFAULT_POOL_SIZE}).",
+    )
+    parser.add_argument(
+        "--batch-sizes", type=int, nargs="+", default=DEFAULT_BATCH_SIZES,
+        help=f"Concurrency levels to test (default: {DEFAULT_BATCH_SIZES}).",
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=120.0,
+        help="Per-request timeout in seconds (default: 120).",
+    )
+    parser.add_argument(
+        "--text", default=DEFAULT_TEXT,
+        help=f"Task prompt sent with every request (default: '{DEFAULT_TEXT}').",
+    )
+    args = parser.parse_args()
+
+    url = get_server_url()
+    batch_sizes = sorted(set(args.batch_sizes))
+
+    print("Pi0.5 Batch Benchmark")
+    print(f"  Server  : {url}")
+    print(f"  Pool    : {args.pool} requests per batch size")
+    print(f"  Batches : {batch_sizes}")
+    print(f"  Prompt  : {args.text!r}")
+    print(f"  Images  : {IMAGE_SIZE}×{IMAGE_SIZE} random RGB PNGs (3 per request)")
+
+    all_results = asyncio.run(
+        run_batch_benchmark(url, args.pool, batch_sizes, args.timeout)
+    )
+
+    print_summary(all_results, args.pool)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added cuda graphs and continuous batching for pi0.5.

Based on quick performance smoke tests in `test/pi05/batch_test.py`:
```
════════════════════════════════════════════════════════════════════════
  BENCHMARK SUMMARY
════════════════════════════════════════════════════════════════════════
 Batch    OK  Fail      min      p50      p95      p99      max    req/s
────────────────────────────────────────────────────────────────────────
     1    24     0    0.069    0.073    0.086    0.087    0.087    13.51
     2    24     0    0.077    0.090    0.100    0.100    0.100    22.33
     3    24     0    0.090    0.107    0.141    0.145    0.146    27.58
     4    24     0    0.102    0.119    0.137    0.141    0.142    33.14
════════════════════════════════════════════════════════════════════════

```

vs. our current main (without continuous batching or cuda graphs):

```
════════════════════════════════════════════════════════════════════════
  BENCHMARK SUMMARY
════════════════════════════════════════════════════════════════════════
 Batch    OK  Fail      min      p50      p95      p99      max    req/s
────────────────────────────────────────────────────────────────────────
     1    24     0    0.186    0.192    0.210    0.213    0.214     5.14
     2    24     0    0.329    0.340    0.356    0.357    0.357     5.82
     3    24     0    0.408    0.519    0.540    0.543    0.544     5.98
     4    24     0    0.586    0.664    0.704    0.705    0.705     6.05
════════════════════════════════════════════════════════════════════════
```