### PR TITLE
update persist ref counts AFTER splitting inputs to workers

### DIFF
--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -662,7 +662,6 @@ class Conductor:
             self._set_partition_worker_graph_ids(
                 body.request_id, p.name, fwd_args.full_metadata.graph_walk,
             )
-            self._update_persist_ref_counts(body.request_id, fwd_args.inputs)
             partition_fwd_args[p.name] = fwd_args
 
         # Send NewRequest to each worker with the appropriate partition's inputs
@@ -677,6 +676,11 @@ class Conductor:
                     sharding_config=request_data.sharding_config,
                     inputs=fwd_args.inputs,
                     graph_walk=fwd_args.full_metadata.graph_walk,
+                )
+
+                self._update_persist_ref_counts(
+                    body.request_id,
+                    inputs_per_worker.get(worker_id, [])
                 )
 
                 message = NewRequest(

--- a/mminf/conductor/conductor.py
+++ b/mminf/conductor/conductor.py
@@ -913,8 +913,6 @@ class Conductor:
         request_data = self.requests[request_id]
         pstate = request_data.partition_states[partition_name]
 
-        self._update_persist_ref_counts(request_id, fwd_args.inputs)
-
         inputs_per_worker = self._split_inputs_to_workers(
             sharding_config=request_data.sharding_config,
             inputs=fwd_args.inputs,
@@ -922,6 +920,7 @@ class Conductor:
         )
 
         for worker, inputs in inputs_per_worker.items():
+            self._update_persist_ref_counts(request_id, inputs)
             message = WorkerMessage(
                 message_type=WorkerMessageType.INPUT_SIGNALS,
                 body=InputSignals(

--- a/mminf/utils/sampling.py
+++ b/mminf/utils/sampling.py
@@ -177,15 +177,16 @@ def fused_temperature_softmax(
     mask_stride_v = seen_mask.stride(1) if apply_penalty else 0
     grid = (B,)
     # BLOCK_SIZE is picked by @triton.autotune (not passed here).
-    _fused_sampling_prep_kernel[grid](
-        logits, temperature, pen_ptr, mask_ptr, probs,
-        V,
-        logits.stride(0), logits.stride(1),
-        probs.stride(0), probs.stride(1),
-        mask_stride_b, mask_stride_v,
-        APPLY_PENALTY=apply_penalty,
-        INCLUDE_GREEDY=include_greedy,
-    )
+    with torch.cuda.device(logits.device):
+        _fused_sampling_prep_kernel[grid](
+            logits, temperature, pen_ptr, mask_ptr, probs,
+            V,
+            logits.stride(0), logits.stride(1),
+            probs.stride(0), probs.stride(1),
+            mask_stride_b, mask_stride_v,
+            APPLY_PENALTY=apply_penalty,
+            INCLUDE_GREEDY=include_greedy,
+        )
     return probs
 
 

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -135,6 +135,9 @@ class Worker:
         self.device = device
         self.enable_nvtx = enable_nvtx
 
+        if self.device.type == "cuda" and self.device.index is not None:
+            torch.cuda.set_device(self.device)
+
         # ``dist_init_method`` is normally provided by the conductor — it
         # picks a free TCP port at startup so multiple ``mminf`` runs on
         # the same host don't collide. The ``tcp://{hostname}:29500``


### PR DESCRIPTION
Also fixes an existing bug where the worker was never calling ` torch.cuda.set_device(self.device)`, causing the sampling triton kernel to try to run on the wrong device.