### PR TITLE
Qwen3 Omni Bug Fixes

### DIFF
--- a/mminf/api_server/entrypoint.py
+++ b/mminf/api_server/entrypoint.py
@@ -299,10 +299,10 @@ class APIServer:
                                 self.pending_requests[rid]["final_outputs"] = \
                                     message.body.final_outputs
                         elif rid in self.recently_completed:
-                            logger.debug("Late message for completed %s", rid)
+                            logger.debug("Late message for completed %s: %s", rid, message.message_type)
                         else:
                             logger.warning(
-                                "Message for unknown request %s", rid
+                                "Message for unknown request %s: %s", rid, message.message_type
                             )
                 for result_chunk in self.preprocess_worker.get_result_chunks():
                     logger.debug(

--- a/mminf/engine/base.py
+++ b/mminf/engine/base.py
@@ -42,6 +42,9 @@ class NodeBatch:
     per_request_input_tensors: dict[str, NameToTensorList]
     per_request_info: dict[str, CurrentForwardPassInfo] = field(default_factory=dict)
     metadata: dict = field(default_factory=dict)
+    # rids whose consumed streaming input was the final chunk — this pass
+    # reports the partition done (see worker._postprocess_batch)
+    final_stream_rids: set[str] = field(default_factory=set)
 
 
 @dataclass

--- a/mminf/graph/base.py
+++ b/mminf/graph/base.py
@@ -63,6 +63,9 @@ class GraphEdge:
     # only for EMIT_TO_CLIENT
     output_modality: str = field(default="")  # text | image | video | audio
     _persist_for_loop: bool = field(default=False)
+    # set on a synthetic streaming-input edge carrying the final chunk, so the
+    # consuming pass (not the earlier ingest) reports the partition done
+    _final_stream_chunk: bool = field(default=False)
 
     # Set for sharded configurations
     _total_fanin: int = 1
@@ -77,7 +80,8 @@ class GraphEdge:
             conductor_new_token=self.conductor_new_token,
             is_streaming=self.is_streaming,
             output_modality=self.output_modality,
-            _persist_for_loop=self._persist_for_loop
+            _persist_for_loop=self._persist_for_loop,
+            _final_stream_chunk=self._final_stream_chunk,
         )
 
 

--- a/mminf/model/qwen3_omni/qwen3_omni_model.py
+++ b/mminf/model/qwen3_omni/qwen3_omni_model.py
@@ -933,36 +933,19 @@ class Qwen3OmniModel(Model):
         there are more codec tokens to process.
         """
         chunk_size = self.config.code2wav.codec_chunk_frames
-        token_count = conn.token_count if conn else 0
-        consumed = conn.consumed_count if conn else 0
-        producer_done = conn.producer_done if conn else False
-
         metadata.graph_walk = "code2wav_chunk"
-
-        available = token_count - consumed
-
-        # Nothing left to decode
-        if available <= 0 and producer_done:
-            return ForwardPassArgs(
-                full_metadata=metadata,
-                inputs=[],
-                unpersist_tensors=[],
-                request_done=True,
-            )
-
         step_metadata = {"consumed_tokens": chunk_size}
 
-        # Check if this is the last chunk
-        new_consumed = consumed + chunk_size
-        remaining_after = token_count - new_consumed
-        is_last = producer_done and remaining_after < chunk_size
-
+        # Don't predict the last chunk from token counts: LeftContextChunkPolicy
+        # emits an extra flush pass for the retained overlap, so a count-based
+        # guess completes the request before that final chunk is emitted. The
+        # `available <= 0` check above fires once consumption actually catches up.
         return ForwardPassArgs(
             full_metadata=metadata,
             inputs=[],
             unpersist_tensors=[],
             step_metadata=step_metadata,
-            request_done=is_last,
+            request_done=False,
         )
 
     # -----------------------------------------------------------------------

--- a/mminf/model/qwen3_omni/qwen3_omni_model.py
+++ b/mminf/model/qwen3_omni/qwen3_omni_model.py
@@ -595,6 +595,7 @@ class Qwen3OmniModel(Model):
         )
 
         first_walk = schedule[0][0] if schedule else "thinker_decode"
+        is_last_prefill = (schedule and len(schedule) == 1)
 
         full_metadata = CurrentForwardConductorMetadata(
             input_modalities=input_modalities,
@@ -623,7 +624,7 @@ class Qwen3OmniModel(Model):
                 # Tell the Thinker whether to emit thinker_states.  Text only
                 # requests skip it to save cross-partition bandwidth.
                 "audio_output": audio_output,
-                "is_last_prefill": len(schedule) == 1
+                "is_last_prefill": is_last_prefill
             },
         )
 

--- a/mminf/streaming/chunk_policy.py
+++ b/mminf/streaming/chunk_policy.py
@@ -39,8 +39,8 @@ class ChunkPolicy(ABC):
         """Whether the buffer should keep producing (empty) chunks after the
         producer signals done and all buffered items have been consumed.
 
-        Default ``False``: the buffer sets ``reached_final_chunk`` after the
-        last item is flushed, which propagates partition-done to the conductor.
+        Default ``False``: partition-done is propagated to the conductor after
+        the last item is flushed.
 
         Set to ``True`` for connections where the consumer must keep running
         after the producer finishes (e.g., Thinker→Talker: the Talker

--- a/mminf/streaming/stream_buffer.py
+++ b/mminf/streaming/stream_buffer.py
@@ -39,7 +39,6 @@ class StreamBuffer:
     _id_to_tensor: dict = field(default_factory=dict)
     _consumed: int = 0
     _chunks_popped: int = 0
-    reached_final_chunk: bool = False
     producer_done: bool = False
 
     _num_tensors_registered = 0
@@ -121,7 +120,6 @@ class StreamBuffer:
         # consumer decides when it's done via its own model logic.
         if self.policy.continue_after_producer_done():
             is_final = False
-        self.reached_final_chunk = is_final
 
         chunk = StreamChunk(
             data=self._collate(items),

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -622,6 +622,7 @@ class Worker:
                     next_node=consumer_node,
                     name=edge_name,
                     tensor_info=[],
+                    _final_stream_chunk=chunk.is_final,
                 )
             else:
                 # Normal chunk — store tensor and create edge with tensor_info.
@@ -639,6 +640,7 @@ class Worker:
                     next_node=consumer_node,
                     name=edge_name,
                     tensor_info=tensor_infos.get(edge_name, []),
+                    _final_stream_chunk=chunk.is_final,
                 )
         return synthetic_edge
 
@@ -672,23 +674,23 @@ class Worker:
         """Check all active StreamBuffers; when a chunk is ready, feed it as a normal input."""
         for request_id, req_info in list(self.worker_graphs_manager.per_request_info.items()):
             for edge_name, sbuf in req_info.stream_buffers.items():
-                consumer_node = self._consumer_node_cache.get(edge_name, "")
-                partition_name = self.worker_graphs_manager.get_partition_for_node(consumer_node)
                 synthetic_edge = self._pop_streaming_edge(sbuf, edge_name, request_id)
 
                 if synthetic_edge is not None:
                     # Streaming edges go through the same path as regular ones —
                     # ReadySignals.is_ready_for_streaming flips on as soon as
                     # the streaming inputs are the only ones missing. Empty
-                    # leftover list means the edge was claimed.
+                    # leftover list means the edge was claimed. The final-chunk
+                    # signal rides the synthetic edge to the consuming pass,
+                    # which reports the partition done in _postprocess_batch —
+                    # NOT here, where an earlier in-flight pass's WGD could read
+                    # it before the final output chunk is emitted.
                     leftovers = self.worker_graphs_manager.process_new_streaming_inputs(
                         request_id=request_id, inputs=[synthetic_edge],
                         can_buffer=False # important: only ingest for this loop iter only!
                     )
                     if leftovers:
                         sbuf.store_uningested_edge(synthetic_edge)
-                    elif sbuf.reached_final_chunk:
-                        req_info.per_partition_info[partition_name].stream_partition_done = True
 
 
     def _check_ready_tensors(self) -> None:
@@ -805,6 +807,7 @@ class Worker:
         """Gather input tensors from tensor_manager for all requests in the batch."""
         per_request_inputs: dict[str, NameToTensorList] = {}
         per_request_info: dict[CurrentForwardPassInfo] = {}
+        final_stream_rids: set[str] = set()
         batch_partition = self.worker_graphs_manager.get_partition_for_node(batch.node_name)
 
         for request_id, node in batch.node_objects.items():
@@ -816,6 +819,8 @@ class Worker:
                         request_id=request_id, uuid=info.uuid
                     ) for info in edge.tensor_info
                 ]
+                if edge.is_streaming and edge._final_stream_chunk:
+                    final_stream_rids.add(request_id)
             per_request_inputs[request_id] = tensors
             per_request_info[request_id] = self.worker_graphs_manager.get_fwd_info(request_id, batch_partition)
 
@@ -824,7 +829,8 @@ class Worker:
             graph_walk=batch.graph_walk,
             request_ids=list(batch.node_objects.keys()),
             per_request_input_tensors=per_request_inputs,
-            per_request_info=per_request_info
+            per_request_info=per_request_info,
+            final_stream_rids=final_stream_rids,
         )
     
     def maybe_send_zmq_to_tp_followers(
@@ -897,6 +903,7 @@ class Worker:
         graph_walk: str | None = None,
         partition_name: str | None = None,
         prematerialized_new_tokens: dict[str, list[int]] | None = None,
+        node_speculatively_scheduled: bool=False
     ) -> None:
         """
         Send outputs to other workers and to the conductor.
@@ -1002,8 +1009,10 @@ class Worker:
             if partition_name is None:
                 partition_name = getattr(fwd_info, 'partition_name', 'default')
             req_info = self.worker_graphs_manager.per_request_info.get(request_id)
-            p_done = req_info.per_partition_info[partition_name].stream_partition_done \
-                if req_info else False
+            p_done = (
+                req_info.per_partition_info[partition_name].stream_partition_done \
+                    and not node_speculatively_scheduled
+            ) if req_info else False
 
             # Collect stream consumption info
             stream_consumed = {}
@@ -1471,6 +1480,10 @@ class Worker:
                     rid, partition_N
                 ) for rid in request_ids
             },
+            final_stream_rids={
+                rid for rid, edges in consumed_streaming_edges.items()
+                if any(e._final_stream_chunk for e in edges)
+            },
         )
 
         logger.debug(f"Speculating: {spec_node_info.node_name} {spec_node_batch.request_ids}")
@@ -1718,6 +1731,13 @@ class Worker:
             range_pop(synchronize=False)
             range_push("worker.send_outputs", synchronize=False)
 
+        # The consuming pass (not the earlier ingest) reports the partition
+        # done, so it rides this pass's WGD with the final output loop index.
+        for rid in batch_N.node_batch.final_stream_rids:
+            req_info = self.worker_graphs_manager.per_request_info.get(rid)
+            if req_info is not None:
+                req_info.per_partition_info[batch_N.partition].stream_partition_done = True
+
         # TODO: wire up the new token path (currently unused for any of the models)
         for rid, routing in routing_per_request.items():
             self._send_outputs(
@@ -1725,6 +1745,7 @@ class Worker:
                 nested_loop_indices=per_req_nested_idxs[rid],
                 graph_walk=batch_N.graph_walk,
                 partition_name=batch_N.partition,
+                node_speculatively_scheduled=batch_N.batch.node_objects[rid]._speculatively_scheduled
             )
 
         if self.enable_nvtx:

--- a/mminf/worker/worker.py
+++ b/mminf/worker/worker.py
@@ -819,7 +819,7 @@ class Worker:
                         request_id=request_id, uuid=info.uuid
                     ) for info in edge.tensor_info
                 ]
-                if edge.is_streaming and edge._final_stream_chunk:
+                if edge._final_stream_chunk:
                     final_stream_rids.add(request_id)
             per_request_inputs[request_id] = tensors
             per_request_info[request_id] = self.worker_graphs_manager.get_fwd_info(request_id, batch_partition)


### PR DESCRIPTION
1. The thinker's `is_last_prefill` was not being set in the initial forward pass inputs, so a token is never sampled in prefill for T2T or T2S, leading to the subsequent decode not having a text input.
2. We were occasionally getting "Message for unknown request". This was due to having two conflicting signals for when the code2wav is  done: one from the conductor (which apparently could undercount chunks by 1), and one from the actual stream buffer. This PR removes the conductor-level signal.
3. Related to the above "message for unknown request" issue, added a defensive guard to only mark a streaming partition as done upon _completion_ of the last chunk, not upon it being popped off of the stream buffer. 

**Tested**: I tested this out on qwen3omi {default config, thinker TP 2, colocated} for BS=8 on all modalities, Orpheus colocated, bagel default config (LLM on rank 1)