### PR TITLE
two fixes for vjepa2

### DIFF
--- a/mstar/model/vjepa2/submodules.py
+++ b/mstar/model/vjepa2/submodules.py
@@ -152,25 +152,31 @@ class VJepa2EncoderSubmodule(NodeSubmodule):
         )
         return {"pixel_values_videos": stacked}
 
-    def _encode(self, pixel_values_videos: torch.Tensor) -> torch.Tensor:
+    def _encode(self, graph_walk: str, pixel_values_videos: torch.Tensor) -> torch.Tensor:
         """Encode a video clip into the ``encoder_hidden`` context.
 
-        Two distinct schemes, keyed on ``config.predictor_kind``:
+        Two distinct schemes:
 
-        * **AC** (``predictor_kind == "ac"``): upstream's self-tubelet
-          replication + post-encoder LayerNorm, sliced to the first frame's
-          tokens — see :meth:`_encode_self_tubelet`.  The AC rollout uses a
-          single-frame context (``z_hat = z[:, :tokens_per_frame]``).
+        * **AC rollout** (``predictor_kind == "ac"`` *and* a ``*_rollout*``
+          walk): upstream's self-tubelet replication + post-encoder LayerNorm,
+          sliced to the first frame's tokens — see :meth:`_encode_self_tubelet`.
+          The AC rollout grows context from a single frame
+          (``z_hat = z[:, :tokens_per_frame]``).
 
-        * **Masked / anticipative** (non-AC): the natural encoder forward over
-          the full ``[B, T, C, H, W]`` clip, yielding
-          ``[B, grid_depth * grid_size**2, D]``.  The anticipative rollout
-          predictor attends over this full multi-frame context, so it must
-          NOT be collapsed to a single frame — doing so makes
-          ``n_ctxt == n_pred`` and trips the rollout's
-          ``n_pred >= n_ctxt`` guard.
+        * **Everything else** (masked/anticipative; AC single-pass, encoder-only,
+          and MPC walks): the natural encoder forward over the full
+          ``[B, T, C, H, W]`` clip, yielding ``[B, grid_depth * grid_size**2,
+          D]``.  These predictors attend over the full multi-frame context and
+          must NOT have it collapsed to a single frame:
+
+          - the masked anticipative rollout would get ``n_ctxt == n_pred`` and
+            trip its ``n_pred >= n_ctxt`` guard;
+          - the single-pass AC predictor interleaves per-frame context tokens
+            with the per-timestep ``actions``/``states`` (T_action = grid_depth),
+            so a single-frame context (t=1) mismatches T_action and fails the
+            ``torch.cat([a, s, x], dim=2)`` in ``_prepare_sequence``.
         """
-        if self.config.predictor_kind == "ac":
+        if self.config.predictor_kind == "ac" and "rollout" in graph_walk:
             return self._encode_self_tubelet(pixel_values_videos)
         return self.encoder(pixel_values_videos)
 
@@ -224,7 +230,7 @@ class VJepa2EncoderSubmodule(NodeSubmodule):
             pixel_values_videos.dtype,
             pixel_values_videos.device,
         )
-        hidden = self._encode(pixel_values_videos)
+        hidden = self._encode(graph_walk, pixel_values_videos)
         logger.info("VJepa2EncoderSubmodule.forward: output shape=%s", tuple(hidden.shape))
         return {"encoder_hidden": [hidden]}
 
@@ -255,7 +261,7 @@ class VJepa2EncoderSubmodule(NodeSubmodule):
                 f"pixel_values_videos batch dim {b_in} does not match "
                 f"request count {len(request_ids)}."
             )
-        hidden = self._encode(pixel_values_videos)  # [B, N, D]
+        hidden = self._encode(graph_walk, pixel_values_videos)  # [B, N, D]
         return {
             rid: {"encoder_hidden": [hidden[i : i + 1]]}
             for i, rid in enumerate(request_ids)

--- a/mstar/model/vjepa2/submodules.py
+++ b/mstar/model/vjepa2/submodules.py
@@ -152,6 +152,28 @@ class VJepa2EncoderSubmodule(NodeSubmodule):
         )
         return {"pixel_values_videos": stacked}
 
+    def _encode(self, pixel_values_videos: torch.Tensor) -> torch.Tensor:
+        """Encode a video clip into the ``encoder_hidden`` context.
+
+        Two distinct schemes, keyed on ``config.predictor_kind``:
+
+        * **AC** (``predictor_kind == "ac"``): upstream's self-tubelet
+          replication + post-encoder LayerNorm, sliced to the first frame's
+          tokens — see :meth:`_encode_self_tubelet`.  The AC rollout uses a
+          single-frame context (``z_hat = z[:, :tokens_per_frame]``).
+
+        * **Masked / anticipative** (non-AC): the natural encoder forward over
+          the full ``[B, T, C, H, W]`` clip, yielding
+          ``[B, grid_depth * grid_size**2, D]``.  The anticipative rollout
+          predictor attends over this full multi-frame context, so it must
+          NOT be collapsed to a single frame — doing so makes
+          ``n_ctxt == n_pred`` and trips the rollout's
+          ``n_pred >= n_ctxt`` guard.
+        """
+        if self.config.predictor_kind == "ac":
+            return self._encode_self_tubelet(pixel_values_videos)
+        return self.encoder(pixel_values_videos)
+
     def _encode_self_tubelet(self, pixel_values_videos: torch.Tensor) -> torch.Tensor:
         """Encode video via upstream's self-tubelet pattern + post-encoder LayerNorm.
 
@@ -202,7 +224,7 @@ class VJepa2EncoderSubmodule(NodeSubmodule):
             pixel_values_videos.dtype,
             pixel_values_videos.device,
         )
-        hidden = self._encode_self_tubelet(pixel_values_videos)
+        hidden = self._encode(pixel_values_videos)
         logger.info("VJepa2EncoderSubmodule.forward: output shape=%s", tuple(hidden.shape))
         return {"encoder_hidden": [hidden]}
 
@@ -233,7 +255,7 @@ class VJepa2EncoderSubmodule(NodeSubmodule):
                 f"pixel_values_videos batch dim {b_in} does not match "
                 f"request count {len(request_ids)}."
             )
-        hidden = self._encode_self_tubelet(pixel_values_videos)  # [B, N, D]
+        hidden = self._encode(pixel_values_videos)  # [B, N, D]
         return {
             rid: {"encoder_hidden": [hidden[i : i + 1]]}
             for i, rid in enumerate(request_ids)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ bagel = [
     "safetensors",
     "torchvision",
     "torchaudio",
-    "torchcodec",
+    "torchcodec==0.8.*",
     "transformers",
 ]
 
@@ -70,7 +70,7 @@ qwen3_omni = [
     "qwen-omni-utils",
     "torchvision",
     "torchaudio",
-    "torchcodec",
+    "torchcodec==0.8.*",
     "transformers",
     "datasets",
     "sgl-kernel",
@@ -98,7 +98,7 @@ vjepa2 = [
     "huggingface-hub",
     "mooncake-transfer-engine",
     "safetensors",
-    "torchcodec",
+    "torchcodec==0.8.*",
 ]
 
 vjepa2_ac = [
@@ -106,7 +106,7 @@ vjepa2_ac = [
     "huggingface-hub",
     "mooncake-transfer-engine",
     "safetensors",
-    "torchcodec",
+    "torchcodec==0.8.*",
 ]
 
 all = [
@@ -122,7 +122,7 @@ all = [
     "safetensors",
     "torchvision",
     "torchaudio",
-    "torchcodec",
+    "torchcodec==0.8.*",
     "transformers",
     "safetensors",
     "triton",


### PR DESCRIPTION
(1) vjepa video encoder was encoding the wrong num frame for non-AC, (2) need to pin torchcodec version in pyproject.toml