### PR TITLE
[model] allocate submodule params in autocast_dtype to avoid fp32 weight-load OOM

### DIFF
--- a/mstar/model/bagel/bagel_model.py
+++ b/mstar/model/bagel/bagel_model.py
@@ -169,6 +169,7 @@ def _stacked_source_keys(
 def _load_into(
     module: nn.Module, source_path: Path, device: str,
     stacked_params: list[StackedParamRule] | None = None,
+    autocast_dtype: torch.dtype | None = None,
 ) -> None:
     """Materialise ``module`` on ``device`` and load every parameter from
     ``source_path``. Raises ``KeyError`` if any parameter is missing from
@@ -177,7 +178,12 @@ def _load_into(
     ``stacked_params`` routes per-shard checkpoint tensors into fused
     parameters (e.g. ``q/k/v_proj`` → ``qkv_proj``); pass it for modules
     that use ``FusedColumnLinear`` projections.
+    ``autocast_dtype`` (when not None) casts ``module`` on the meta device
+    before ``to_empty`` so storage is allocated directly in that dtype
+    instead of fp32-then-downcast (halves the load-time VRAM peak).
     """
+    if autocast_dtype is not None:
+        module = module.to(autocast_dtype)
     module.to_empty(device=device)
     expected = set(dict(module.named_parameters()).keys())
     read_keys = _stacked_source_keys(expected, stacked_params)
@@ -287,7 +293,7 @@ class BagelModel(Model):
         )
         self.repo = Path(local_dir)
 
-    def _init_language_model_components(self, device):
+    def _init_language_model_components(self, device, autocast_dtype=None):
         if self.llm_initialized:
             return
         self._download_hf()
@@ -302,6 +308,7 @@ class BagelModel(Model):
             _BagelLLMEMA(self.language_model, self.llm2vae),
             ema_path, device,
             stacked_params=LLAMA_STACKED_PARAMS,
+            autocast_dtype=autocast_dtype,
         )
 
         if not self.vae_initialized:
@@ -317,9 +324,10 @@ class BagelModel(Model):
                     self.vae2llm, self.time_embedder, self.latent_pos_embed,
                 ),
                 ema_path, device,
+                autocast_dtype=autocast_dtype,
             )
 
-    def _init_vae_components(self, device):
+    def _init_vae_components(self, device, autocast_dtype=None):
         self._download_hf()
         if self.vae_initialized:
             return
@@ -330,7 +338,7 @@ class BagelModel(Model):
 
         # Load in weights: VAE
         vae_path = self.repo / "ae.safetensors"
-        _load_into(self.vae_model, vae_path, device)
+        _load_into(self.vae_model, vae_path, device, autocast_dtype=autocast_dtype)
 
         if not self.llm_initialized:
             # LLM components also need these for image gen, so these
@@ -347,10 +355,11 @@ class BagelModel(Model):
                     self.vae2llm, self.time_embedder, self.latent_pos_embed,
                 ),
                 ema_path, device,
+                autocast_dtype=autocast_dtype,
             )
 
 
-    def _init_vit_components(self, device):
+    def _init_vit_components(self, device, autocast_dtype=None):
         self._download_hf()
         with torch.device("meta"):
             self.vit_model = BagelVisionModel(self.config.vit_config)
@@ -371,6 +380,7 @@ class BagelModel(Model):
         _load_into(
             _BagelViTEMA(self.vit_model, self.connector, self.vit_pos_embed),
             ema_path, device,
+            autocast_dtype=autocast_dtype,
         )
 
 
@@ -378,11 +388,14 @@ class BagelModel(Model):
     # Lazy submodule initialization
     # -----------------------------------------------------------------------
 
-    def _create_submodule(self, node_name: str, device: str) -> NodeSubmodule | None:
+    def _create_submodule(
+        self, node_name: str, device: str,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule | None:
         """Create a submodule wrapper on first access."""
         logger.debug("Creating submodule for BAGEL model node %s", node_name)
         if node_name in ("LLM", "LLM_cfg_text", "LLM_cfg_img"):
-            self._init_language_model_components(device)
+            self._init_language_model_components(device, autocast_dtype=autocast_dtype)
             return LLMSubmodule(
                 language_model=self.language_model,
                 llm2vae=self.llm2vae,
@@ -397,13 +410,13 @@ class BagelModel(Model):
                 node_name=node_name,
             )
         elif node_name == "combine_cfg":
-            self._init_language_model_components(device)
+            self._init_language_model_components(device, autocast_dtype=autocast_dtype)
             return CombineCFGSubmodule(
                 llm2vae=self.llm2vae,
                 config=self.config,
             )
         elif node_name == "vit_encoder":
-            self._init_vit_components(device)
+            self._init_vit_components(device, autocast_dtype=autocast_dtype)
             return ViTEncoderSubmodule(
                 vit_model=self.vit_model,
                 connector=self.connector,
@@ -412,7 +425,7 @@ class BagelModel(Model):
                 vit_max_num_patch_per_side=self.config.vit_max_num_patch_per_side
             )
         elif node_name == "vae_encoder":
-            self._init_vae_components(device)
+            self._init_vae_components(device, autocast_dtype=autocast_dtype)
             return VAEEncoderSubmodule(
                 vae_model=self.vae_model,
                 vae2llm=self.vae2llm,
@@ -424,7 +437,7 @@ class BagelModel(Model):
                 max_latent_size=self.config.max_latent_size,
             )
         elif node_name == "vae_decoder":
-            self._init_vae_components(device)
+            self._init_vae_components(device, autocast_dtype=autocast_dtype)
             return VAEDecoderSubmodule(
                 vae_model=self.vae_model,
                 latent_patch_size=self.config.latent_patch_size,
@@ -589,10 +602,13 @@ class BagelModel(Model):
             num_qo_heads=self.config.num_attention_heads,
         )]
 
-    def get_submodule(self, node_name: str, device: str = "cpu", tp_group=None) -> torch.nn.Module | None:
+    def get_submodule(
+        self, node_name: str, device: str = "cpu", tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> torch.nn.Module | None:
         if node_name in self._submodule_cache:
             return self._submodule_cache[node_name]
-        submodule = self._create_submodule(node_name, device)
+        submodule = self._create_submodule(node_name, device, autocast_dtype=autocast_dtype)
         logger.info(f"Successfully loaded in BAGEL submodule for {node_name}")
         self._submodule_cache[node_name] = submodule
         return submodule

--- a/mstar/model/base.py
+++ b/mstar/model/base.py
@@ -415,7 +415,10 @@ class Model(ABC):
         return output.cpu().numpy().tobytes()
 
     @abstractmethod
-    def get_submodule(self, node_name: str, device="cpu", tp_group=None) -> torch.nn.Module | None:
+    def get_submodule(
+        self, node_name: str, device="cpu", tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> torch.nn.Module | None:
         """Return the nn.Module for this node, or None for dummy mode.
 
         ``tp_group`` is the :class:`TPCommGroup` for this node on the
@@ -423,6 +426,15 @@ class Model(ABC):
         Models that support tensor parallelism should forward it to
         parallel-linear constructors so weight shapes are partitioned at
         init time and the weight loaders shard correctly.
+
+        ``autocast_dtype`` is the dtype this node's params should be
+        allocated in. Models that build on the meta device must cast the
+        meta module to this dtype *before* ``to_empty(device)`` so storage
+        is allocated directly in the target dtype — casting after
+        ``to_empty`` first materialises every param in the meta default
+        (float32), doubling the load-time VRAM peak. ``None`` means leave
+        the default (float32); the engine manager passes ``None`` for
+        nodes whose engine does not autocast.
         """
         pass
 

--- a/mstar/model/orpheus/orpheus_model.py
+++ b/mstar/model/orpheus/orpheus_model.py
@@ -412,22 +412,35 @@ class OrpheusModel(Model):
     # Model ABC: submodule loading
     # -------------------------------------------------------------------
 
-    def get_submodule(self, node_name: str, device: str = "cpu", tp_group=None) -> NodeSubmodule | None:
+    def get_submodule(
+        self, node_name: str, device: str = "cpu", tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule | None:
         if node_name in self._submodule_cache:
             return self._submodule_cache[node_name]
-        submodule = self._create_submodule(node_name, device, tp_group=tp_group)
+        submodule = self._create_submodule(
+            node_name, device, tp_group=tp_group, autocast_dtype=autocast_dtype,
+        )
         logger.info("Successfully loaded Orpheus submodule for %s", node_name)
         self._submodule_cache[node_name] = submodule
         return submodule
 
-    def _create_submodule(self, node_name: str, device: str, tp_group=None) -> NodeSubmodule | None:
+    def _create_submodule(
+        self, node_name: str, device: str, tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule | None:
         if node_name == "LLM":
-            return self._create_llm_submodule(device, tp_group=tp_group)
+            return self._create_llm_submodule(
+                device, tp_group=tp_group, autocast_dtype=autocast_dtype,
+            )
         elif node_name == "snac_decoder":
             return self._create_snac_submodule(device)
         return None
 
-    def _create_llm_submodule(self, device: str, tp_group=None) -> NodeSubmodule:
+    def _create_llm_submodule(
+        self, device: str, tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule:
         from mstar.model.loader import load_weights
         from mstar.model.orpheus.components.language_model import OrpheusForCausalLM
         from mstar.model.orpheus.submodules import OrpheusLLMSubmodule
@@ -439,6 +452,10 @@ class OrpheusModel(Model):
 
         with torch.device("meta"):
             language_model = OrpheusForCausalLM(self.config, comm_group=tp_group)
+        # Cast on meta (no allocation) so to_empty allocates directly in the
+        # target dtype instead of fp32-then-downcast.
+        if autocast_dtype is not None:
+            language_model = language_model.to(autocast_dtype)
         language_model.to_empty(device=device)
 
         load_weights(language_model, local_dir, device=device)

--- a/mstar/model/pi05/pi05_model.py
+++ b/mstar/model/pi05/pi05_model.py
@@ -590,25 +590,35 @@ class Pi05Model(Model):
         self, node_name: str, device: str = "cpu", tp_group=None,
         autocast_dtype: torch.dtype | None = None,
     ) -> torch.nn.Module | None:
+        # NOTE: ``autocast_dtype`` is accepted for interface parity but
+        # deliberately NOT applied at param allocation. Pi0.5's submodules
+        # (Pi05ViTEncoderSubmodule / Pi05LLMSubmodule) override ``to()`` to
+        # keep precision-sensitive params in fp32 — the SigLIP vision tower
+        # entirely, and the transformer norm params — matching lerobot's
+        # ``to_bfloat16_for_selected_params``. Meta-casting to bf16 before
+        # ``to_empty`` would load those weights into bf16 storage and lose
+        # precision that the post-load fp32 upcast cannot recover (~0.2 abs
+        # delta on final actions). So we load in fp32 and let the submodule
+        # ``to()`` overrides do the selective down-cast. Pi0.5 (~14 GB) does
+        # not hit the load-time OOM this hint addresses.
         if node_name in self._submodule_cache:
             return self._submodule_cache[node_name]
-        submodule = self._create_submodule(node_name, device, autocast_dtype=autocast_dtype)
+        submodule = self._create_submodule(node_name, device)
         self._submodule_cache[node_name] = submodule
         if submodule is not None:
             logger.info("Successfully loaded Pi0.5 submodule for %s", node_name)
         return submodule
 
     def _create_submodule(
-        self, node_name: str, device: str,
-        autocast_dtype: torch.dtype | None = None,
+        self, node_name: str, device: str
     ) -> NodeSubmodule | None:
         if node_name == "vit_encoder":
-            self._init_vit_components(device, autocast_dtype=autocast_dtype)
+            self._init_vit_components(device)
             return Pi05ViTEncoderSubmodule(
                 encoder=self.siglip, config=self.config
             )
         if node_name == "LLM":
-            self._init_llm_components(device, autocast_dtype=autocast_dtype)
+            self._init_llm_components(device)
             return Pi05LLMSubmodule(
                 embed_tokens=self.embed_tokens,
                 paligemma=self.paligemma,
@@ -620,7 +630,7 @@ class Pi05Model(Model):
             )
         return None
 
-    def _init_vit_components(self, device: str, autocast_dtype: torch.dtype | None = None):
+    def _init_vit_components(self, device: str):
         if self.siglip is not None:
             return
         # Construct on the "meta" device — a special PyTorch device that
@@ -634,10 +644,6 @@ class Pi05Model(Model):
         # pattern HuggingFace ``from_pretrained`` uses under the hood.
         with torch.device("meta" if not self.skip_weight_loading else "cpu"):
             self.siglip = Pi05SiglipEncoder(self.config)
-        # Cast before to_empty (no allocation on meta) so storage is allocated
-        # directly in the target dtype instead of fp32-then-downcast.
-        if autocast_dtype is not None:
-            self.siglip = self.siglip.to(autocast_dtype)
         if self.skip_weight_loading:
             self.siglip = self.siglip.to_empty(device=device)
             _reset_non_persistent_buffers(self.siglip, device)
@@ -664,7 +670,7 @@ class Pi05Model(Model):
         siglip_sd = self._extract_siglip_state_dict(flat)
         load_hf_weights(self.siglip, siglip_sd.items())
 
-    def _init_llm_components(self, device: str, autocast_dtype: torch.dtype | None = None):
+    def _init_llm_components(self, device: str):
         if self.embed_tokens is not None:
             return
         # See ``_init_vit_components`` for why we build on the meta device:
@@ -697,10 +703,6 @@ class Pi05Model(Model):
                 self.action_out_proj,
                 self.time_mlp,
             ):
-                # Cast before to_empty (no allocation on meta) so storage is
-                # allocated directly in the target dtype.
-                if autocast_dtype is not None:
-                    mod.to(autocast_dtype)
                 mod.to_empty(device=device)
             return
 
@@ -717,10 +719,6 @@ class Pi05Model(Model):
             action_out_proj=self.action_out_proj,
             time_mlp=self.time_mlp,
         )
-        # Cast before to_empty (no allocation on meta) so storage is allocated
-        # directly in the target dtype instead of fp32-then-downcast.
-        if autocast_dtype is not None:
-            wrapper = wrapper.to(autocast_dtype)
         wrapper.to_empty(device=device)
         load_hf_weights(
             wrapper,

--- a/mstar/model/pi05/pi05_model.py
+++ b/mstar/model/pi05/pi05_model.py
@@ -588,25 +588,27 @@ class Pi05Model(Model):
 
     def get_submodule(
         self, node_name: str, device: str = "cpu", tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
     ) -> torch.nn.Module | None:
         if node_name in self._submodule_cache:
             return self._submodule_cache[node_name]
-        submodule = self._create_submodule(node_name, device)
+        submodule = self._create_submodule(node_name, device, autocast_dtype=autocast_dtype)
         self._submodule_cache[node_name] = submodule
         if submodule is not None:
             logger.info("Successfully loaded Pi0.5 submodule for %s", node_name)
         return submodule
 
     def _create_submodule(
-        self, node_name: str, device: str
+        self, node_name: str, device: str,
+        autocast_dtype: torch.dtype | None = None,
     ) -> NodeSubmodule | None:
         if node_name == "vit_encoder":
-            self._init_vit_components(device)
+            self._init_vit_components(device, autocast_dtype=autocast_dtype)
             return Pi05ViTEncoderSubmodule(
                 encoder=self.siglip, config=self.config
             )
         if node_name == "LLM":
-            self._init_llm_components(device)
+            self._init_llm_components(device, autocast_dtype=autocast_dtype)
             return Pi05LLMSubmodule(
                 embed_tokens=self.embed_tokens,
                 paligemma=self.paligemma,
@@ -618,7 +620,7 @@ class Pi05Model(Model):
             )
         return None
 
-    def _init_vit_components(self, device: str):
+    def _init_vit_components(self, device: str, autocast_dtype: torch.dtype | None = None):
         if self.siglip is not None:
             return
         # Construct on the "meta" device — a special PyTorch device that
@@ -632,6 +634,10 @@ class Pi05Model(Model):
         # pattern HuggingFace ``from_pretrained`` uses under the hood.
         with torch.device("meta" if not self.skip_weight_loading else "cpu"):
             self.siglip = Pi05SiglipEncoder(self.config)
+        # Cast before to_empty (no allocation on meta) so storage is allocated
+        # directly in the target dtype instead of fp32-then-downcast.
+        if autocast_dtype is not None:
+            self.siglip = self.siglip.to(autocast_dtype)
         if self.skip_weight_loading:
             self.siglip = self.siglip.to_empty(device=device)
             _reset_non_persistent_buffers(self.siglip, device)
@@ -658,7 +664,7 @@ class Pi05Model(Model):
         siglip_sd = self._extract_siglip_state_dict(flat)
         load_hf_weights(self.siglip, siglip_sd.items())
 
-    def _init_llm_components(self, device: str):
+    def _init_llm_components(self, device: str, autocast_dtype: torch.dtype | None = None):
         if self.embed_tokens is not None:
             return
         # See ``_init_vit_components`` for why we build on the meta device:
@@ -691,6 +697,10 @@ class Pi05Model(Model):
                 self.action_out_proj,
                 self.time_mlp,
             ):
+                # Cast before to_empty (no allocation on meta) so storage is
+                # allocated directly in the target dtype.
+                if autocast_dtype is not None:
+                    mod.to(autocast_dtype)
                 mod.to_empty(device=device)
             return
 
@@ -707,6 +717,10 @@ class Pi05Model(Model):
             action_out_proj=self.action_out_proj,
             time_mlp=self.time_mlp,
         )
+        # Cast before to_empty (no allocation on meta) so storage is allocated
+        # directly in the target dtype instead of fp32-then-downcast.
+        if autocast_dtype is not None:
+            wrapper = wrapper.to(autocast_dtype)
         wrapper.to_empty(device=device)
         load_hf_weights(
             wrapper,

--- a/mstar/model/qwen3_omni/qwen3_omni_model.py
+++ b/mstar/model/qwen3_omni/qwen3_omni_model.py
@@ -1184,10 +1184,15 @@ class Qwen3OmniModel(Model):
     # Model ABC: submodule loading
     # -----------------------------------------------------------------------
 
-    def get_submodule(self, node_name: str, device: str = "cpu", tp_group=None) -> NodeSubmodule | None:
+    def get_submodule(
+        self, node_name: str, device: str = "cpu", tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule | None:
         if node_name in self._submodule_cache:
             return self._submodule_cache[node_name]
-        submodule = self._create_submodule(node_name, device, tp_group=tp_group)
+        submodule = self._create_submodule(
+            node_name, device, tp_group=tp_group, autocast_dtype=autocast_dtype,
+        )
         logger.info("Successfully loaded Qwen3-Omni submodule for %s", node_name)
         self._submodule_cache[node_name] = submodule
 
@@ -1211,11 +1216,18 @@ class Qwen3OmniModel(Model):
 
         return submodule
 
-    def _create_submodule(self, node_name: str, device: str, tp_group=None) -> NodeSubmodule | None:
+    def _create_submodule(
+        self, node_name: str, device: str, tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule | None:
         if node_name == "Thinker":
-            return self._create_thinker_submodule(device, tp_group=tp_group)
+            return self._create_thinker_submodule(
+                device, tp_group=tp_group, autocast_dtype=autocast_dtype,
+            )
         elif node_name == "Talker":
-            return self._create_talker_submodule(device, tp_group=tp_group)
+            return self._create_talker_submodule(
+                device, tp_group=tp_group, autocast_dtype=autocast_dtype,
+            )
         elif node_name == "Code2Wav":
             return self._create_code2wav_submodule(device)
         elif node_name == "audio_encoder":
@@ -1295,13 +1307,20 @@ class Qwen3OmniModel(Model):
         self._THINKER_STACKED_PARAMS = rules
         return rules
 
-    def _create_thinker_submodule(self, device: str, tp_group=None) -> NodeSubmodule:
+    def _create_thinker_submodule(
+        self, device: str, tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule:
         from mstar.model.loader import load_hf_weights
         from mstar.model.loader.iterators import iter_safetensors_shards
         from mstar.model.qwen3_omni.components.thinker import Qwen3OmniThinkerModel
 
         with torch.device("meta"):
             thinker_model = Qwen3OmniThinkerModel(self.config, comm_group=tp_group)
+        # Cast on meta (no allocation) so to_empty allocates directly in the
+        # target dtype instead of fp32-then-downcast.
+        if autocast_dtype is not None:
+            thinker_model = thinker_model.to(autocast_dtype)
         thinker_model.to_empty(device=device)
 
         weights = iter_safetensors_shards(
@@ -1325,7 +1344,10 @@ class Qwen3OmniModel(Model):
             config=self.config,
         )
 
-    def _create_talker_submodule(self, device: str, tp_group=None) -> NodeSubmodule:
+    def _create_talker_submodule(
+        self, device: str, tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule:
         from mstar.model.loader import load_hf_weights
         from mstar.model.loader.iterators import iter_safetensors_shards
         from mstar.model.qwen3_omni.components.talker import (
@@ -1340,6 +1362,10 @@ class Qwen3OmniModel(Model):
             # replication is cheaper than 150+ NCCL all-reduces per
             # decode step (5 layers x 15 unrolled iterations).
             talker_model = Qwen3OmniTalkerModel(self.config, comm_group=tp_group)
+        # Cast on meta (no allocation) so to_empty allocates directly in the
+        # target dtype instead of fp32-then-downcast.
+        if autocast_dtype is not None:
+            talker_model = talker_model.to(autocast_dtype)
         talker_model.to_empty(device=device)
 
         # Talker and CodePredictor share the "talker." prefix. We stream
@@ -1381,6 +1407,10 @@ class Qwen3OmniModel(Model):
 
         with torch.device("meta"):
             code_predictor = Qwen3OmniCodePredictor(self.config)
+        # Cast on meta (no allocation) so to_empty allocates directly in the
+        # target dtype instead of fp32-then-downcast.
+        if autocast_dtype is not None:
+            code_predictor = code_predictor.to(autocast_dtype)
         code_predictor.to_empty(device=device)
         load_hf_weights(
             code_predictor, iter(code_pred_weights),

--- a/mstar/model/vjepa2/vjepa2_model.py
+++ b/mstar/model/vjepa2/vjepa2_model.py
@@ -928,26 +928,32 @@ class VJepa2Model(Model):
     # Model ABC: submodule loading
     # ------------------------------------------------------------------
 
-    def get_submodule(self, node_name: str, device: str = "cpu", tp_group=None) -> torch.nn.Module | None:
+    def get_submodule(
+        self, node_name: str, device: str = "cpu", tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> torch.nn.Module | None:
         if node_name in self._submodule_cache:
             return self._submodule_cache[node_name]
-        submodule = self._create_submodule(node_name, device)
+        submodule = self._create_submodule(node_name, device, autocast_dtype=autocast_dtype)
         self._submodule_cache[node_name] = submodule
         if submodule is not None:
             logger.info("Loaded V-JEPA 2 submodule for %s", node_name)
         return submodule
 
-    def _create_submodule(self, node_name: str, device: str) -> NodeSubmodule | None:
+    def _create_submodule(
+        self, node_name: str, device: str,
+        autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule | None:
         if node_name == "video_encoder":
-            self._init_encoder(device)
+            self._init_encoder(device, autocast_dtype=autocast_dtype)
             return VJepa2EncoderSubmodule(self.encoder, self.config)
         if node_name == "predictor":
-            self._init_predictor(device)
+            self._init_predictor(device, autocast_dtype=autocast_dtype)
             if self.config.predictor_kind == "ac":
                 return VJepa2ACPredictorSubmodule(self.predictor, self.config)
             return VJepa2PredictorSubmodule(self.predictor, self.config)
         if node_name == "rollout_predictor":
-            self._init_predictor(device)
+            self._init_predictor(device, autocast_dtype=autocast_dtype)
             if self.config.predictor_kind == "ac":
                 # Sliding-window AC autoregressive rollout.  Shares the
                 # predictor nn.Module with the single-shot ``predictor``
@@ -972,7 +978,7 @@ class VJepa2Model(Model):
                 raise NotImplementedError(
                     "ac_predictor_mpc is only available with predictor_kind='ac'."
                 )
-            self._init_predictor(device)
+            self._init_predictor(device, autocast_dtype=autocast_dtype)
             return VJepa2MPCPredictorSubmodule(self.predictor, self.config)
         if node_name == "mpc_scorer":
             if self.config.predictor_kind != "ac":
@@ -982,12 +988,16 @@ class VJepa2Model(Model):
             return VJepa2MPCScorerSubmodule(self.config)
         return None
 
-    def _init_encoder(self, device: str) -> None:
+    def _init_encoder(self, device: str, autocast_dtype: torch.dtype | None = None) -> None:
         if self.encoder is not None:
             return
         meta = torch.device("meta" if not self.skip_weight_loading else "cpu")
         with meta:
             self.encoder = VJEPA2Encoder(self.config)
+        # Cast on meta (no allocation) so to_empty allocates directly in the
+        # target dtype instead of fp32-then-downcast.
+        if autocast_dtype is not None:
+            self.encoder = self.encoder.to(autocast_dtype)
         if self.skip_weight_loading:
             self.encoder = self.encoder.to_empty(device=device)
             return
@@ -1017,7 +1027,7 @@ class VJepa2Model(Model):
             device=device,
         )
 
-    def _init_predictor(self, device: str) -> None:
+    def _init_predictor(self, device: str, autocast_dtype: torch.dtype | None = None) -> None:
         if self.predictor is not None:
             return
         meta = torch.device("meta" if not self.skip_weight_loading else "cpu")
@@ -1026,6 +1036,10 @@ class VJepa2Model(Model):
             with meta:
                 predictor = VisionTransformerPredictorAC(self.config.ac_predictor)
             self.predictor = predictor
+            # Cast on meta (no allocation) so to_empty allocates directly in
+            # the target dtype instead of fp32-then-downcast.
+            if autocast_dtype is not None:
+                self.predictor = self.predictor.to(autocast_dtype)
             if self.skip_weight_loading:
                 self.predictor = self.predictor.to_empty(device=device)
                 return
@@ -1041,6 +1055,10 @@ class VJepa2Model(Model):
 
         with meta:
             self.predictor = VJEPA2Predictor(self.config)
+        # Cast on meta (no allocation) so to_empty allocates directly in the
+        # target dtype instead of fp32-then-downcast.
+        if autocast_dtype is not None:
+            self.predictor = self.predictor.to(autocast_dtype)
         if self.skip_weight_loading:
             self.predictor = self.predictor.to_empty(device=device)
             return

--- a/mstar/worker/engine_manager.py
+++ b/mstar/worker/engine_manager.py
@@ -88,13 +88,24 @@ class EngineManager:
         if "autocast_dtype" in model_config:
             autocast_dtype = model_config["autocast_dtype"]
 
-        # Pre-resolve submodules: needed to ask each STATELESS node's
-        # submodule for its flavor before we know which engine to build.
+        # Allocation dtype hint for get_submodule: a node's params should be
+        # allocated directly in ``autocast_dtype`` (cast meta -> dtype before
+        # ``to_empty``) instead of allocating fp32 then down-casting after
+        # return — the latter doubles the load-time VRAM peak. This is the
+        # SAME resolved dtype applied by the post-return cast at the
+        # ``engine.has_autocast()`` branch below, so allocation and runtime
+        # dtype stay consistent. ``None`` (no model/config autocast) means
+        # leave fp32. Build paths that must stay fp32 regardless (e.g. the
+        # audio-codec vocoders, whose stateless engine locks autocast off)
+        # don't use the meta+to_empty path and simply ignore this hint.
         node_submodules: dict[str, torch.nn.Module | None] = {}
         if model is not None:
             for name in node_names:
                 node_tp_group = tp_groups.get_tp_config_for_node(name)
-                node_submodules[name] = model.get_submodule(name, device, tp_group=node_tp_group)
+                node_submodules[name] = model.get_submodule(
+                    name, device, tp_group=node_tp_group,
+                    autocast_dtype=autocast_dtype,
+                )
 
         # Group nodes by the factory key. STATELESS nodes split further by
         # the flavor declared on the submodule; other engine types group

--- a/test/modular/test_submodule_alloc_dtype.py
+++ b/test/modular/test_submodule_alloc_dtype.py
@@ -1,0 +1,55 @@
+"""Regression tests for the weight-load allocation-dtype fix.
+
+`get_submodule` implementations build modules on the meta device and call
+`to_empty(device)` to materialise storage. `to_empty` allocates each param
+in its *current* dtype, so the dtype cast must happen on the meta module
+(metadata-only, no allocation) BEFORE `to_empty` — otherwise params are first
+materialised in the meta default (float32, 2x bf16) and only then down-cast,
+doubling the load-time VRAM peak (the TP=4 OOM that motivated this change).
+
+These tests pin the contract with a tiny module so they run CPU-only:
+  - cast-before-to_empty allocates directly in the target dtype,
+  - the engine-manager's None hint leaves params at the default (float32),
+  - the inverted order still ends at the right dtype but is the pattern we
+    explicitly avoid (documented here so the intent is greppable).
+"""
+import torch
+import torch.nn as nn
+
+
+def _build_meta_module() -> nn.Module:
+    with torch.device("meta"):
+        return nn.Sequential(
+            nn.Linear(8, 16),
+            nn.GELU(),
+            nn.Linear(16, 8),
+        )
+
+
+def test_meta_cast_before_to_empty_allocates_in_dtype():
+    m = _build_meta_module()
+    # The fix's pattern: cast on meta (no allocation), then materialise.
+    m.to(torch.bfloat16)
+    m.to_empty(device="cpu")
+    for name, p in m.named_parameters():
+        assert p.dtype == torch.bfloat16, f"{name} is {p.dtype}, expected bf16"
+    assert not any(p.is_meta for p in m.parameters())
+
+
+def test_none_dtype_leaves_default_float32():
+    m = _build_meta_module()
+    # autocast_dtype=None path: skip the cast, params stay at the meta default.
+    m.to_empty(device="cpu")
+    for name, p in m.named_parameters():
+        assert p.dtype == torch.float32, f"{name} is {p.dtype}, expected fp32"
+
+
+def test_to_on_meta_is_in_place_and_zero_alloc():
+    # `.to(dtype)` on a meta module mutates in place (returns self) and
+    # allocates nothing — the property the fix relies on to cast safely
+    # before to_empty.
+    m = _build_meta_module()
+    ret = m.to(torch.bfloat16)
+    assert ret is m
+    assert all(p.is_meta for p in m.parameters())
+    assert all(p.dtype == torch.bfloat16 for p in m.parameters())

--- a/test/modular/test_submodule_alloc_dtype.py
+++ b/test/modular/test_submodule_alloc_dtype.py
@@ -14,7 +14,7 @@ These tests pin the contract with a tiny module so they run CPU-only:
     explicitly avoid (documented here so the intent is greppable).
 """
 import torch
-import torch.nn as nn
+from torch import nn
 
 
 def _build_meta_module() -> nn.Module:


### PR DESCRIPTION
## Changes

- `mstar/model/base.py` — `get_submodule` signature gains
  `autocast_dtype: torch.dtype | None = None` + contract docstring.
- `mstar/worker/engine_manager.py` — passes the resolved `autocast_dtype` into
  `get_submodule` (same value as the existing post-return cast).
- Meta-cast-before-`to_empty` applied to all five model impls:
  `bagel`, `orpheus`, `qwen3_omni`, `pi05`, `vjepa2`.
  (`ming_flash_omni` inherits the generic path on its port branch.)
- `test/modular/test_submodule_alloc_dtype.py` — CPU-only unit test pinning the
  contract (cast-before-`to_empty` → in-dtype alloc; `None` → fp32; `.to()` on
  meta is in-place + zero-alloc).

Weight loaders use `param.data.copy_` / indexed assignment, which respect the
param dtype, so casting before load is value-preserving.

## Test plan

- [x] `test/modular/test_submodule_alloc_dtype.py` (3 pass, CPU-only)
- [x] No regressions vs clean `main` — the failing `pi05`/`orpheus` tests
      (sincos signature, image preprocessing, `kv.num_layers`) fail identically
      on `main` and are unrelated to this change.
- [x] **End-to-end GPU verification** on the model that originally OOM'd:
      Ming-flash-omni-2.0 TP=4 (4×H100), driven through the generic path
      (engine_manager → `get_submodule(autocast_dtype=…)`):
  - all 4 ranks loaded (`Loaded 507 unique target params … rank 0/4 … 3/4`)
  - all 4 ranks captured CUDA graphs (`warmup_and_capture done`)
  - **57–62 GB/rank** steady-state (vs the 78.58 GB fp32 peak that OOM'd before)
  - server reached `Application startup complete` + healthy `/health`

## Sequencing

Land this before the Ming-flash-omni port PR. Once merged, rebase the port
branch onto it and drop Ming's local dtype fix — it becomes the generic path
(verified above via cherry-pick onto the port branch).