### PR TITLE
Abort in-flight requests when the client disconnects

### DIFF
--- a/mstar/api_server/data_worker.py
+++ b/mstar/api_server/data_worker.py
@@ -86,6 +86,7 @@ class PreprocessWorker:
 
     def abort_request(self, request_id: str):
         self.abort_request_queue.put(request_id)
+        self.cleanup_request(request_id)
 
     def new_result_tensors(self, input: ResultTensors):
         name = input.graph_edge.name

--- a/mstar/api_server/data_worker.py
+++ b/mstar/api_server/data_worker.py
@@ -20,6 +20,7 @@ from mstar.communication.communicator import CommProtocol, ZMQCommunicator
 from mstar.communication.tensors import NameToTensorList, create_tensor_communication_manager
 from mstar.model.base import Model
 from mstar.utils.ipc_format import (
+    AbortRequest,
     ConductorMessage,
     ConductorMessageType,
     NewRequestConductor,
@@ -51,6 +52,7 @@ class PreprocessWorker:
         self.request_input_queue = queue.Queue()
         self.result_tensor_input_queue = queue.Queue()
         self.cleanup_request_queue = queue.Queue()
+        self.abort_request_queue = queue.Queue()
         self.output_queue = queue.Queue()
         self.stop_event = threading.Event()
 
@@ -64,6 +66,7 @@ class PreprocessWorker:
                 result_tensor_queue=self.result_tensor_input_queue,
                 out_queue=self.output_queue,
                 cleanup_request_queue=self.cleanup_request_queue,
+                abort_request_queue=self.abort_request_queue,
                 stop_event=self.stop_event,
                 hostname=hostname,
                 socket_path_prefix=socket_path_prefix,
@@ -78,6 +81,9 @@ class PreprocessWorker:
         self.output_loop_idxs[input.request_id] = {}
         self.per_request_reading_tensors[input.request_id] = 0
         self.request_input_queue.put(input)
+
+    def abort_request(self, request_id: str):
+        self.abort_request_queue.put(request_id)
 
     def new_result_tensors(self, input: ResultTensors):
         name = input.graph_edge.name
@@ -123,8 +129,8 @@ class PreprocessWorker:
 
     def cleanup_request(self, request_id: str):
         self.cleanup_request_queue.put(request_id)
-        del self.output_loop_idxs[request_id]
-        del self.per_request_reading_tensors[request_id]
+        self.output_loop_idxs.pop(request_id, None)
+        self.per_request_reading_tensors.pop(request_id, None)
 
     def shutdown(self):
         self.stop_event.set()
@@ -139,6 +145,7 @@ class PreprocessWorkerThread:
         result_tensor_queue: queue.Queue, # for output streaming
         out_queue: queue.Queue,
         cleanup_request_queue: queue.Queue,
+        abort_request_queue: queue.Queue,
         stop_event: threading.Event,
         hostname: str = "localhost",
         socket_path_prefix: str = "/tmp/mstar",
@@ -150,6 +157,7 @@ class PreprocessWorkerThread:
         self.in_queue = in_queue
         self.result_tensor_queue = result_tensor_queue
         self.cleanup_request_queue = cleanup_request_queue
+        self.abort_request_queue = abort_request_queue
         self.out_queue = out_queue
 
         self.stop_event = stop_event
@@ -348,6 +356,15 @@ class PreprocessWorkerThread:
                 if not self.result_tensor_queue.empty():
                     did_work = True
                     self._read_result_tensor(self.result_tensor_queue.get())
+                if not self.abort_request_queue.empty():
+                    did_work = True
+                    self.communicator.send(
+                        "conductor",
+                        ConductorMessage(
+                            message_type=ConductorMessageType.ABORT_REQUEST,
+                            body=AbortRequest(request_id=self.abort_request_queue.get()),
+                        ),
+                    )
                 if not self.cleanup_request_queue.empty():
                     did_work = True
                     req_id = self.cleanup_request_queue.get()

--- a/mstar/api_server/data_worker.py
+++ b/mstar/api_server/data_worker.py
@@ -53,6 +53,7 @@ class PreprocessWorker:
         self.result_tensor_input_queue = queue.Queue()
         self.cleanup_request_queue = queue.Queue()
         self.abort_request_queue = queue.Queue()
+        self.discard_tensor_queue = queue.Queue()
         self.output_queue = queue.Queue()
         self.stop_event = threading.Event()
 
@@ -67,6 +68,7 @@ class PreprocessWorker:
                 out_queue=self.output_queue,
                 cleanup_request_queue=self.cleanup_request_queue,
                 abort_request_queue=self.abort_request_queue,
+                discard_tensor_queue=self.discard_tensor_queue,
                 stop_event=self.stop_event,
                 hostname=hostname,
                 socket_path_prefix=socket_path_prefix,
@@ -88,7 +90,10 @@ class PreprocessWorker:
     def new_result_tensors(self, input: ResultTensors):
         name = input.graph_edge.name
         if input.request_id not in self.output_loop_idxs:
-            logger.debug("Late result_tensors for cleaned-up request %s, ignoring", input.request_id)
+            # Request was removed while this output was still in flight; ack the
+            # tensors so the producing worker can reclaim them rather than leak.
+            logger.debug("Late result_tensors for cleaned-up request %s, acking and dropping", input.request_id)
+            self.discard_result_tensors(input)
             return
 
         self.output_loop_idxs[input.request_id][name] = input.loop_indices.max(
@@ -101,6 +106,14 @@ class PreprocessWorker:
             input.request_id,  self.per_request_reading_tensors[input.request_id]
         )
         self.result_tensor_input_queue.put(input)
+
+    def discard_result_tensors(self, input: ResultTensors):
+        """Ack and drop result tensors for an already-removed request.
+
+        Routed to the worker thread (which owns the communicator) so the
+        producing worker gets its TENSOR_RECEIVED ack and frees the buffers.
+        """
+        self.discard_tensor_queue.put(input)
 
     def has_pending_tensors(self, request_id: str):
         return self.per_request_reading_tensors.get(request_id, 0) > 0
@@ -146,6 +159,7 @@ class PreprocessWorkerThread:
         out_queue: queue.Queue,
         cleanup_request_queue: queue.Queue,
         abort_request_queue: queue.Queue,
+        discard_tensor_queue: queue.Queue,
         stop_event: threading.Event,
         hostname: str = "localhost",
         socket_path_prefix: str = "/tmp/mstar",
@@ -158,6 +172,7 @@ class PreprocessWorkerThread:
         self.result_tensor_queue = result_tensor_queue
         self.cleanup_request_queue = cleanup_request_queue
         self.abort_request_queue = abort_request_queue
+        self.discard_tensor_queue = discard_tensor_queue
         self.out_queue = out_queue
 
         self.stop_event = stop_event
@@ -283,6 +298,16 @@ class PreprocessWorkerThread:
             self.tensor_uuid_to_metadata_per_request[result.request_id][
                 tensor_info.uuid] = result.metadata
 
+    def _discard_result_tensor(
+        self, result: ResultTensors
+    ):
+        # The request is gone, so don't start a read — just ack the tensors back
+        # to the producing worker so it can free the source buffers.
+        self.tensor_manager.ack_unread_tensors(
+            request_id=result.request_id,
+            graph_edges=[result.graph_edge],
+        )
+
     def _process_read_tensors(self):
         did_work = False
         for request_id, graph_edges in self.tensor_manager.get_ready_tensors().items():
@@ -365,6 +390,9 @@ class PreprocessWorkerThread:
                             body=AbortRequest(request_id=self.abort_request_queue.get()),
                         ),
                     )
+                if not self.discard_tensor_queue.empty():
+                    did_work = True
+                    self._discard_result_tensor(self.discard_tensor_queue.get())
                 if not self.cleanup_request_queue.empty():
                     did_work = True
                     req_id = self.cleanup_request_queue.get()

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -459,7 +459,6 @@ class APIServer:
             return
         logger.info("Client cancelled request %s; releasing resources", request_id)
         self.preprocess_worker.abort_request(request_id)
-        self.preprocess_worker.cleanup_request(request_id)
 
     # ----------------------------------------------------------
     # Cleanup

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -325,10 +325,14 @@ class APIServer:
                                     message.body.final_outputs
                         elif rid in self.recently_completed:
                             logger.debug("Late message for completed %s: %s", rid, message.message_type)
+                            if message.message_type == "result_tensors":
+                                self.preprocess_worker.discard_result_tensors(message.body)
                         else:
                             logger.warning(
                                 "Message for unknown request %s: %s", rid, message.message_type
                             )
+                            if message.message_type == "result_tensors":
+                                self.preprocess_worker.discard_result_tensors(message.body)
                 for result_chunk in self.preprocess_worker.get_result_chunks():
                     logger.debug(
                         "Got result chunk of %s modality for request %s",

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Optional
 
 import uvicorn
-from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.concurrency import run_in_threadpool
@@ -360,42 +360,46 @@ class APIServer:
         pre-serialized line).
         """
         start = time.time()
-        while True:
-            if time.time() - start > self.timeout_seconds:
-                with self.request_lock:
-                    self.pending_requests.pop(request_id, None)
-                raise HTTPException(status_code=500, detail="Request timed out")
+        finished = False
+        try:
+            while True:
+                if time.time() - start > self.timeout_seconds:
+                    raise HTTPException(status_code=500, detail="Request timed out")
 
-            new_chunks: list[ResultChunk] = []
-            done = False
-            with self.request_lock:
-                req = self.pending_requests.get(request_id)
-                if req:
-                    avail = len(req["chunks"])
-                    consumed = req["consumed_chunks"]
-                    new_chunks = req["chunks"][consumed:avail]
-                    req["consumed_chunks"] = avail
-                    done = req["event"].is_set()
-                else:
-                    done = True
-
-            for chunk in new_chunks:
-                yield chunk
-
-            if done:
-                logger.info("Async stream results received finish for %s", request_id)
-                # flush remaining
-                remaining: list[ResultChunk] = []
+                new_chunks: list[ResultChunk] = []
+                done = False
                 with self.request_lock:
                     req = self.pending_requests.get(request_id)
                     if req:
-                        remaining = req["chunks"][req["consumed_chunks"]:]
-                        self.pending_requests.pop(request_id, None)
-                for chunk in remaining:
-                    yield chunk
-                break
+                        avail = len(req["chunks"])
+                        consumed = req["consumed_chunks"]
+                        new_chunks = req["chunks"][consumed:avail]
+                        req["consumed_chunks"] = avail
+                        done = req["event"].is_set()
+                    else:
+                        done = True
 
-            await asyncio.sleep(0.001)
+                for chunk in new_chunks:
+                    yield chunk
+
+                if done:
+                    logger.info("Async stream results received finish for %s", request_id)
+                    # flush remaining
+                    remaining: list[ResultChunk] = []
+                    with self.request_lock:
+                        req = self.pending_requests.get(request_id)
+                        if req:
+                            remaining = req["chunks"][req["consumed_chunks"]:]
+                            self.pending_requests.pop(request_id, None)
+                    for chunk in remaining:
+                        yield chunk
+                    finished = True
+                    break
+
+                await asyncio.sleep(0.001)
+        finally:
+            if not finished:
+                self.abort_request(request_id)
 
     async def async_stream_results(self, request_id: str):
         """Yield NDJSON lines as result chunks arrive (``/generate`` format)."""
@@ -411,28 +415,47 @@ class APIServer:
         }) + "\n"
 
     # ----------------------------------------------------------
-    # Blocking helper (non-streaming)
+    # Non-streaming helper
     # ----------------------------------------------------------
 
-    def collect_results(self, request_id: str) -> list[ResultChunk]:
-        """Block until the request completes, then return all chunks."""
-        with self.request_lock:
-            req = self.pending_requests.get(request_id)
-            if not req:
-                raise HTTPException(
-                    status_code=404, detail=f"Request {request_id} not found"
-                )
-            event = req["event"]
-
-        if not event.wait(timeout=self.timeout_seconds):
+    async def collect_results(
+        self, request_id: str, raw_request: Request | None = None
+    ) -> list[ResultChunk]:
+        """Wait for the request to finish (or the client to disconnect), then
+        return its chunks. Disconnecting or timing out releases engine state."""
+        start = time.time()
+        while True:
             with self.request_lock:
-                self.pending_requests.pop(request_id, None)
-            raise HTTPException(status_code=500, detail="Request timed out")
+                req = self.pending_requests.get(request_id)
+                done = req["event"].is_set() if req else True
+            if done:
+                break
+            if time.time() - start > self.timeout_seconds:
+                self.abort_request(request_id)
+                raise HTTPException(status_code=500, detail="Request timed out")
+            if raw_request is not None and await raw_request.is_disconnected():
+                self.abort_request(request_id)
+                return []
+            await asyncio.sleep(0.005)
 
         with self.request_lock:
-            chunks = self.pending_requests[request_id]["chunks"][:]
+            req = self.pending_requests.pop(request_id, None)
+            return list(req["chunks"]) if req else []
+
+    def abort_request(self, request_id: str) -> None:
+        """Stop GPU work for a request the client abandoned and drop its state."""
+        with self.request_lock:
+            active = (
+                request_id in self.pending_requests
+                or request_id in self.recently_completed
+            )
             self.pending_requests.pop(request_id, None)
-        return chunks
+            self.recently_completed.pop(request_id, None)
+        if not active:
+            return
+        logger.info("Client cancelled request %s; releasing resources", request_id)
+        self.preprocess_worker.abort_request(request_id)
+        self.preprocess_worker.cleanup_request(request_id)
 
     # ----------------------------------------------------------
     # Cleanup
@@ -472,6 +495,7 @@ app.include_router(openai_router)
 
 @app.post("/generate")
 async def generate(
+    request: Request,
     text: Optional[str] = Form(None),
     files: Optional[list[UploadFile]] = File(None),
     input_modalities: Optional[str] = Form(None),
@@ -547,9 +571,7 @@ async def generate(
                 headers={"Cache-Control": "no-cache"},
             )
 
-        chunks = await run_in_threadpool(
-            api_server.collect_results, request_id
-        )
+        chunks = await api_server.collect_results(request_id, request)
         outputs: dict[str, list[dict]] = {}
         for chunk in chunks:
             outputs.setdefault(chunk.modality, []).append({

--- a/mstar/api_server/openai/router.py
+++ b/mstar/api_server/openai/router.py
@@ -75,12 +75,12 @@ async def list_models():
 
 
 @router.post("/v1/chat/completions")
-async def chat_completions(request: ChatCompletionRequest):
+async def chat_completions(request: ChatCompletionRequest, raw_request: Request):
     api, model_name, adapter, err = _resolve("supports_chat")
     if err is not None:
         return err
     try:
-        result = await serving_chat.create_chat_completion(api, model_name, adapter, request)
+        result = await serving_chat.create_chat_completion(api, model_name, adapter, request, raw_request)
     except Exception as e:  # noqa: BLE001 — surface as an OpenAI error envelope
         return _error(getattr(e, "status_code", 500), str(getattr(e, "detail", e)), "server_error")
     if request.stream:
@@ -91,23 +91,23 @@ async def chat_completions(request: ChatCompletionRequest):
 
 
 @router.post("/v1/audio/speech")
-async def audio_speech(request: SpeechRequest):
+async def audio_speech(request: SpeechRequest, raw_request: Request):
     api, model_name, adapter, err = _resolve("supports_speech")
     if err is not None:
         return err
     try:
-        return await serving_speech.create_speech(api, model_name, adapter, request)
+        return await serving_speech.create_speech(api, model_name, adapter, request, raw_request)
     except Exception as e:  # noqa: BLE001
         return _error(getattr(e, "status_code", 500), str(getattr(e, "detail", e)), "server_error")
 
 
 @router.post("/v1/images/generations")
-async def images_generations(request: ImageGenerationRequest):
+async def images_generations(request: ImageGenerationRequest, raw_request: Request):
     api, model_name, adapter, err = _resolve("supports_images")
     if err is not None:
         return err
     try:
-        result = await serving_images.create_images(api, model_name, adapter, request)
+        result = await serving_images.create_images(api, model_name, adapter, request, raw_request)
     except Exception as e:  # noqa: BLE001
         return _error(getattr(e, "status_code", 500), str(getattr(e, "detail", e)), "server_error")
     return JSONResponse(result)
@@ -144,6 +144,7 @@ async def images_edits(request: Request):
             image_bytes=image_bytes,
             image_filename=getattr(image, "filename", None),
             model_kwargs=extra,
+            raw_request=request,
         )
     except Exception as e:  # noqa: BLE001
         return _error(getattr(e, "status_code", 500), str(getattr(e, "detail", e)), "server_error")

--- a/mstar/api_server/openai/serving_chat.py
+++ b/mstar/api_server/openai/serving_chat.py
@@ -10,13 +10,11 @@ from __future__ import annotations
 
 import base64
 
-from starlette.concurrency import run_in_threadpool
-
 from mstar.api_server import media_io
 from mstar.api_server.openai._util import SSE_DONE, now, rid, sse
 
 
-async def create_chat_completion(api, model_name, adapter, req):
+async def create_chat_completion(api, model_name, adapter, req, raw_request=None):
     args = adapter.chat_to_request(req, api.upload_dir)
     request_id = rid("chatcmpl")
     sample_rate = api.model.get_output_sample_rate("audio") if api.model is not None else 24000
@@ -33,7 +31,7 @@ async def create_chat_completion(api, model_name, adapter, req):
 
     if req.stream:
         return _stream(api, model_name, request_id, sample_rate)
-    chunks = await run_in_threadpool(api.collect_results, request_id)
+    chunks = await api.collect_results(request_id, raw_request)
     return _build_response(model_name, request_id, chunks, sample_rate)
 
 

--- a/mstar/api_server/openai/serving_images.py
+++ b/mstar/api_server/openai/serving_images.py
@@ -7,12 +7,10 @@ import os
 from pathlib import Path
 from uuid import uuid4
 
-from starlette.concurrency import run_in_threadpool
-
 from mstar.api_server.openai._util import now, rid
 
 
-async def create_images(api, model_name, adapter, req):  # noqa: ARG001
+async def create_images(api, model_name, adapter, req, raw_request=None):  # noqa: ARG001
     args = adapter.image_to_request(req, api.upload_dir)
     request_id = rid("img")
 
@@ -26,7 +24,7 @@ async def create_images(api, model_name, adapter, req):  # noqa: ARG001
         request_id=request_id,
     )
 
-    chunks = await run_in_threadpool(api.collect_results, request_id)
+    chunks = await api.collect_results(request_id, raw_request)
     data = [
         {"b64_json": base64.b64encode(c.data).decode("ascii"), "url": None}
         for c in chunks
@@ -35,7 +33,9 @@ async def create_images(api, model_name, adapter, req):  # noqa: ARG001
     return {"created": now(), "data": data}
 
 
-async def create_image_edit(api, model_name, adapter, *, prompt, image_bytes, image_filename, model_kwargs):  # noqa: ARG001
+async def create_image_edit(
+    api, model_name, adapter, *, prompt, image_bytes, image_filename, model_kwargs, raw_request=None,  # noqa: ARG001
+):
     # Persist the uploaded image so the model's loader can read it by path
     # (same contract as multipart uploads), then run the image-to-image edit.
     upload_dir = Path(api.upload_dir)
@@ -57,7 +57,7 @@ async def create_image_edit(api, model_name, adapter, *, prompt, image_bytes, im
         request_id=request_id,
     )
 
-    chunks = await run_in_threadpool(api.collect_results, request_id)
+    chunks = await api.collect_results(request_id, raw_request)
     data = [
         {"b64_json": base64.b64encode(c.data).decode("ascii"), "url": None}
         for c in chunks

--- a/mstar/api_server/openai/serving_speech.py
+++ b/mstar/api_server/openai/serving_speech.py
@@ -8,13 +8,12 @@ the audio is produced.
 from __future__ import annotations
 
 from fastapi.responses import Response, StreamingResponse
-from starlette.concurrency import run_in_threadpool
 
 from mstar.api_server import media_io
 from mstar.api_server.openai._util import rid
 
 
-async def create_speech(api, model_name, adapter, req):  # noqa: ARG001
+async def create_speech(api, model_name, adapter, req, raw_request=None):  # noqa: ARG001
     args = adapter.speech_to_request(req, api.upload_dir)
     request_id = rid("speech")
     sample_rate = api.model.get_output_sample_rate("audio") if api.model is not None else 24000
@@ -37,7 +36,7 @@ async def create_speech(api, model_name, adapter, req):  # noqa: ARG001
             headers={"Cache-Control": "no-cache"},
         )
 
-    chunks = await run_in_threadpool(api.collect_results, request_id)
+    chunks = await api.collect_results(request_id, raw_request)
     pcm = b"".join(c.data for c in chunks if c.modality == "audio")
     audio_bytes, mime = media_io.pcm16_to_container(pcm, sample_rate, fmt)
     return Response(content=audio_bytes, media_type=mime)

--- a/mstar/communication/tensors.py
+++ b/mstar/communication/tensors.py
@@ -589,6 +589,16 @@ class TensorCommunicationManager(ABC):
                 ),
             )
 
+    def ack_unread_tensors(
+        self, request_id: str, graph_edges: list[GraphEdge],
+    ):
+        """Ack result tensors for an already-removed request without reading them.
+
+        The producer holds these output buffers until it gets the
+        TENSOR_RECEIVED ack; emit it here so it can reclaim them.
+        """
+        self._collect_and_send_acks(request_id, graph_edges)
+
     def get_ready_tensors(self, graph_walk: str | None=None) -> dict[str, list[GraphEdge]]:
         ready: dict[str, list[GraphEdge]] = {}
         still_pending = []

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -739,6 +739,35 @@ class Conductor:
             if graph_walk in self.worker_graphs[wg_id].graph_walks
         }
 
+    def _abort_request(self, request_id: str):
+        """Tear down a request the client abandoned, freeing its worker GPU state."""
+        for i, body in enumerate(self.waiting_queue):
+            if body.request_id == request_id:
+                self.waiting_queue.pop(i)
+                logger.info("Aborted request %s before admission", request_id)
+                return
+
+        request_data = self.requests.get(request_id)
+        if request_data is None:
+            return
+
+        workers = {
+            worker_id
+            for worker_ids in request_data.worker_graph_to_workers.values()
+            for worker_id in worker_ids
+        }
+        for worker_id in workers:
+            self.communicator.send(
+                worker_id,
+                WorkerMessage(
+                    message_type=WorkerMessageType.REMOVE_REQUEST,
+                    body=RemoveRequest(request_id),
+                ),
+            )
+        del self.requests[request_id]
+        logger.info("Aborted request %s; freed worker resources", request_id)
+        self._try_admit_waiting()
+
     def _process_request_done(
         self, request_id: str
     ):
@@ -1033,6 +1062,8 @@ class Conductor:
                 for message in startup_backlog + self.communicator.get_all_new_messages():
                     if message.message_type == ConductorMessageType.NEW_REQUEST:
                         self._ingest_request(message.body)
+                    elif message.message_type == ConductorMessageType.ABORT_REQUEST:
+                        self._abort_request(message.body.request_id)
                     elif message.message_type == ConductorMessageType.WORKER_GRAPHS_DONE:
                         rid = message.body.request_id
                         if rid not in self.requests:

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -749,6 +749,7 @@ class Conductor:
 
         request_data = self.requests.get(request_id)
         if request_data is None:
+            logger.info("Abort for request %s ignored; already finished or unknown", request_id)
             return
 
         workers = {

--- a/mstar/utils/ipc_format.py
+++ b/mstar/utils/ipc_format.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass, field
-from enum import Enum
+from enum import Enum, IntEnum
 
 from mstar.conductor.request_info import CurrentForwardPassInfo, PerLabelSeqInfo
 from mstar.graph.base import GraphEdge, TensorPointerInfo
@@ -45,9 +45,15 @@ class NewRequest(MessageBody):
     request_info: CurrentForwardPassInfo
 
 
+class MessageSource(IntEnum):
+    CONDUCTOR = 0
+    TP_RANK_0 = 1
+    SELF = 2
+
 @dataclass
 class RemoveRequest(MessageBody):
     request_id: str
+    source: int = MessageSource.CONDUCTOR
 
 
 @dataclass

--- a/mstar/utils/ipc_format.py
+++ b/mstar/utils/ipc_format.py
@@ -99,6 +99,7 @@ class ConductorMessageType(Enum):
     NEW_REQUEST = "new_request"
     WORKER_GRAPHS_DONE = "worker_graphs_done"
     SETUP_DONE = "setup_done"
+    ABORT_REQUEST = "abort_request"
 
 
 @dataclass
@@ -129,6 +130,12 @@ class WorkerGraphsDone(MessageBody):
 @dataclass
 class SetupDone(MessageBody):
     worker_id: str
+
+
+@dataclass
+class AbortRequest(MessageBody):
+    request_id: str
+
 
 @dataclass
 class ConductorMessage:

--- a/mstar/worker/micro_scheduler.py
+++ b/mstar/worker/micro_scheduler.py
@@ -71,6 +71,9 @@ class MicroScheduler:
         self.node_and_walk_to_last_batch_num = {}
         # request_id -> monotonic time until which the request is held
         self.held_until: dict[str, float] = {}
+        # Rids with a deferred remove; stop initiating new work for them.
+        # Shared by reference with Worker._pending_removes.
+        self.pending_removes: set[str] = set()
 
     def _select_node_priority(
         self, node_name_to_requests: dict[str, list[ReadyNodeEntry]]
@@ -226,6 +229,8 @@ class MicroScheduler:
             for request_id, node_names in ready_map.items():
                 if request_id not in worker_graphs_manager.per_request_info:
                     continue  # request was removed between scheduling cycles
+                if request_id in self.pending_removes:
+                    continue  # remove deferred for in-flight safety; don't start new work
                 # Skip requests in OOM backoff
                 if request_id in self.held_until:
                     continue

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -29,6 +29,7 @@ from mstar.utils.ipc_format import (
     ConductorMessage,
     ConductorMessageType,
     InputSignals,
+    MessageSource,
     NewRequest,
     RemoveRequest,
     ScheduleTPNode,
@@ -230,6 +231,9 @@ class Worker:
                 f"Multiple TP nodes {self.tp_nodes} found in worker {worker_id}; "
                 "current implementation requires at most one TP node per worker."
             )
+
+        self.is_tp_follower = len(self.tp_nodes - self.tp_rank_zero_nodes) > 0
+
         self.scheduler = MicroScheduler(
             self.engine_manager,
             tp_rank_zero_nodes=self.tp_rank_zero_nodes
@@ -266,6 +270,9 @@ class Worker:
         self._in_flight_rids: set[str] = set()
         self._pending_removes: set[str] = set()
         self._pending_loop_stops: set[PendingLoopStop] = set()
+        # Let the scheduler see deferred removes so it stops initiating new work
+        # for those rids (shared by reference — mutations are visible to both).
+        self.scheduler.pending_removes = self._pending_removes
 
         # Side stream for D→H copies in postprocess (check_stop pre-materialize).
         # The default stream has GPU(N+1) queued behind GPU(N)'s outputs after
@@ -434,6 +441,9 @@ class Worker:
 
 
     def _remove_request(self, body: RemoveRequest) -> None:
+        if self.is_tp_follower and body.source not in (MessageSource.TP_RANK_0, MessageSource.SELF):
+            return # wait for removal message from TP rank 0 to avoid race conditions
+
         # Async-scheduling deferral: if this rid is currently held by an
         # in-flight GPU step (or its speculation), tearing down engine /
         # tensor state now would race the GPU thread reading those tensors
@@ -443,6 +453,30 @@ class Worker:
         if body.request_id in getattr(self, "_in_flight_rids", set()):
             self._pending_removes.add(body.request_id)
             return
+
+        # If we are the TP leader for this request, signal the followers to
+        # remove it too. Followers defer removal until they get this message
+        # (see the guard at the top of this method) so they can't tear down
+        # state we're still reading from an in-flight step/speculation.
+        cfg = self.worker_graphs_manager.per_request_info.get(body.request_id)
+        if cfg is not None:
+            followers: set[str] = set()
+            for group in cfg.sharding_config.groups:
+                # _workers is rank-ordered; index 0 is this worker when we are
+                # rank 0. Only real TP groups (tp_size > 1) have followers.
+                if group.tp_size > 1 and group._tp_rank == 0:
+                    followers.update(group._workers[1:])
+            for worker in followers:
+                self.communicator.send(
+                    worker, msg=WorkerMessage(
+                        message_type=WorkerMessageType.REMOVE_REQUEST,
+                        body=RemoveRequest(
+                            request_id=body.request_id,
+                            source=MessageSource.TP_RANK_0,
+                        )
+                    )
+                )
+
         self.engine_manager.remove_request(body.request_id)
         self.worker_graphs_manager.remove_request(body.request_id)
         self.tensor_manager.cleanup_request(body.request_id)
@@ -1883,7 +1917,7 @@ class Worker:
         to_apply = [r for r in self._pending_removes if r not in in_flight_rids]
         for rid in to_apply:
             self._pending_removes.discard(rid)
-            self._remove_request(RemoveRequest(request_id=rid))
+            self._remove_request(RemoveRequest(request_id=rid, source=MessageSource.SELF))
 
     def run(self) -> None:
         switch_interval = os.environ.get("MSTAR_PY_SWITCH_INTERVAL_SEC", "")

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -596,7 +596,10 @@ class Worker:
             WorkerMessageType.INPUT_SIGNALS,
             WorkerMessageType.STOP_LOOPS
         ]
-        for message in messages:
+        # Snapshot: a REMOVE handled mid-iteration can re-buffer trailing
+        # signals onto this same list, and mutating it while iterating it would
+        # never terminate.
+        for message in list(messages):
             if (
                 message.message_type in msg_types_needing_active_request and \
                 message.body.request_id not in self.worker_graphs_manager.per_request_info

--- a/test/modular/test_openai_router.py
+++ b/test/modular/test_openai_router.py
@@ -49,7 +49,7 @@ class _StubAPI:
         self._chunks[kw["request_id"]] = list(self.next_chunks)
         return kw["request_id"]
 
-    def collect_results(self, request_id):
+    async def collect_results(self, request_id, raw_request=None):
         return self._chunks.get(request_id, [])
 
     async def iter_result_chunks(self, request_id):

--- a/test/modular/test_shm_tensor_comm.py
+++ b/test/modular/test_shm_tensor_comm.py
@@ -16,6 +16,7 @@ from mstar.communication.tensors import (
 )
 from mstar.distributed.base import ShardingConfig
 from mstar.graph.base import GraphEdge, TensorPointerInfo
+from mstar.utils.ipc_format import WorkerMessageType
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -231,6 +232,66 @@ def test_ack_sent_on_remote_read():
         assert len(comm.sent) == 1
         entity_id, msg = comm.sent[0]
         assert entity_id == "worker_0"
+
+
+def _produce_registered_output(mgr, request_id, name="audio_output"):
+    """Producer stores an output edge bound for the api server and registers it
+    for send, leaving it held by the +1 awaiting-ack ref (returns the uuid)."""
+    edges = [GraphEdge(next_node="api_server", name=name)]
+    mgr.store_and_populate_graph_edges(request_id, {name: [torch.randn(8, 16)]}, edges)
+    uuid = edges[0].tensor_info[0].uuid
+    mgr.register_for_send(request_id, [uuid])
+    return edges, uuid
+
+
+def test_unacked_result_tensors_leak_producer_buffer():
+    """Without an ack, the producer never reclaims the output buffer.
+
+    A result dropped for an already-removed request leaves the producer holding
+    the buffer (ref never released), so even its own cleanup defers it.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        producer = _make_manager(tmpdir, entity_id="worker_0", request_id="req1")
+        _, uuid = _produce_registered_output(producer, "req1")
+
+        shm_path = os.path.join(tmpdir, f"mstar_worker_0_{uuid}")
+        assert os.path.isfile(shm_path)
+        assert not producer.tensor_store.can_gc("req1", uuid)  # held by send ref
+
+        # No ack arrives; the producer's own cleanup must defer the buffer.
+        producer.cleanup_request("req1")
+        assert os.path.isfile(shm_path)  # leaked: still on disk, awaiting an ack
+
+
+def test_ack_unread_tensors_lets_producer_reclaim_buffer():
+    """ack_unread_tensors emits the TENSOR_RECEIVED that frees the producer.
+
+    Acking a result for a removed request (without reading) lets the producing
+    worker reclaim the buffer it holds.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        producer = _make_manager(tmpdir, entity_id="worker_0", request_id="req1")
+        edges, uuid = _produce_registered_output(producer, "req1")
+        shm_path = os.path.join(tmpdir, f"mstar_worker_0_{uuid}")
+        assert os.path.isfile(shm_path)
+
+        # api server never registered "req1" (unknown/removed request) yet still
+        # acks the abandoned tensors back to the producer.
+        api_server = _make_manager(tmpdir, entity_id="api_server_preprocess_worker")
+        api_server.ack_unread_tensors("req1", edges)
+
+        sent = api_server.communicator.sent
+        assert len(sent) == 1
+        entity_id, msg = sent[0]
+        assert entity_id == "worker_0"
+        assert msg.message_type == WorkerMessageType.TENSOR_RECEIVED
+        assert msg.body.successful_tensors == {uuid: 1}
+
+        # Producer applies the ack (mirrors worker._handle_tensor_received) and
+        # reclaims the buffer.
+        for u, n in msg.body.successful_tensors.items():
+            producer.dereference("req1", u, n=n)
+        assert not os.path.isfile(shm_path)  # reclaimed -> no leak
 
 
 # ---------------------------------------------------------------------------

--- a/test/modular/test_worker_message_handling.py
+++ b/test/modular/test_worker_message_handling.py
@@ -1,0 +1,100 @@
+"""Regression tests for Worker._process_message_list out-of-order handling.
+
+A REMOVE handled while replaying a request's buffered messages must not let its
+trailing signals re-buffer onto the list being iterated (which would loop).
+"""
+import threading
+import types
+
+from mstar.utils.ipc_format import (
+    InputSignals,
+    MessageSource,
+    RemoveRequest,
+    WorkerMessage,
+    WorkerMessageType,
+)
+from mstar.worker.worker import Worker
+
+
+def _stub_worker(active_rids):
+    """Minimal stub exposing only what _process_message_list touches."""
+    stub = types.SimpleNamespace()
+    stub.worker_graphs_manager = types.SimpleNamespace(
+        per_request_info={rid: object() for rid in active_rids}
+    )
+    stub._unprocessed_messages = {}
+
+    # REMOVE drops the rid from per_request_info (mirrors _remove_request's
+    # teardown); the other handlers are no-ops we don't exercise here.
+    def _remove(body):
+        stub.worker_graphs_manager.per_request_info.pop(body.request_id, None)
+
+    stub._remove_request = _remove
+    stub._add_new_request = lambda body: None
+    stub._process_new_inputs = lambda body: None
+    stub._handle_tensor_received = lambda body: None
+    stub._unpersist_tensors = lambda body: None
+    stub._stop_loops = lambda body: None
+    stub.scheduler = types.SimpleNamespace(register_tp_follow=lambda body: None)
+    return stub
+
+
+def _run_with_timeout(fn, timeout=5.0):
+    done = threading.Event()
+    err = []
+
+    def target():
+        try:
+            fn()
+        except Exception as e:  # noqa: BLE001 - surfaced via assertion below
+            err.append(e)
+        finally:
+            done.set()
+
+    threading.Thread(target=target, daemon=True).start()
+    return done.wait(timeout), (err[0] if err else None)
+
+
+def test_replay_buffered_remove_then_signal_terminates():
+    """A buffered REMOVE that drops the request mid-replay, followed by trailing
+    signals, must not spin _process_message_list forever (the signals would
+    otherwise re-buffer onto the list being iterated)."""
+    stub = _stub_worker(active_rids=["X"])
+    buffered = [
+        WorkerMessage(
+            message_type=WorkerMessageType.REMOVE_REQUEST,
+            body=RemoveRequest(request_id="X", source=MessageSource.TP_RANK_0),
+        ),
+        WorkerMessage(
+            message_type=WorkerMessageType.INPUT_SIGNALS,
+            body=InputSignals(request_id="X", inputs=[], request_info=None),
+        ),
+        WorkerMessage(
+            message_type=WorkerMessageType.INPUT_SIGNALS,
+            body=InputSignals(request_id="X", inputs=[], request_info=None),
+        ),
+    ]
+    stub._unprocessed_messages["X"] = buffered
+
+    finished, err = _run_with_timeout(
+        lambda: Worker._process_message_list(stub, stub._unprocessed_messages["X"]),
+        timeout=5.0,
+    )
+    assert err is None, f"unexpected error: {err!r}"
+    assert finished, "_process_message_list did not terminate (re-append loop)"
+    # The request was removed and not resurrected.
+    assert "X" not in stub.worker_graphs_manager.per_request_info
+
+
+def test_out_of_order_messages_buffer_for_unknown_request():
+    """Signals for a not-yet-added request are buffered, not dropped or looped."""
+    stub = _stub_worker(active_rids=[])
+    msg = WorkerMessage(
+        message_type=WorkerMessageType.INPUT_SIGNALS,
+        body=InputSignals(request_id="Y", inputs=[], request_info=None),
+    )
+    finished, err = _run_with_timeout(
+        lambda: Worker._process_message_list(stub, [msg]), timeout=5.0
+    )
+    assert err is None and finished
+    assert stub._unprocessed_messages.get("Y") == [msg]


### PR DESCRIPTION
Propagate client cancellation from the API server to the conductor, which removes the request from its workers and frees KV-cache pages and the concurrency slot instead of running cancelled requests to completion.

<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

Closes Issue #135.

When a client cancels a request, M* now aborts it instead of running it to EOS/`max_tokens`. The API server detects the disconnect - streaming via the response generator's teardown, non-streaming via `Request.is_disconnected()` - and signals  the conductor, which removes the request from its workers and admits the next queued request. The worker-side teardown is unchanged; this adds the missing trigger.

## How was it tested?

  - `ruff check .` and `test/modular/test_openai_router.py` pass.
  - Live Orpheus server with `max_concurrent_requests=1`: a cancelled request previously held the only slot until natural EOS (~7s); now the slot frees within ~2ms of disconnect and the next request starts immediately - verified for streaming, non-streaming, and timeout paths.
  - Normal outputs unchanged across Orpheus (audio), BAGEL (text + image), Pi0.5 (actions), and V-JEPA 2 (rollout).

<!-- Commands you ran, or why tests aren't applicable. -->

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
