### PR TITLE
[BugFix] Fix Qwen3-Omni Talker TTS embedding dtype mismatch

### DIFF
--- a/mstar/model/qwen3_omni/submodules.py
+++ b/mstar/model/qwen3_omni/submodules.py
@@ -1265,16 +1265,19 @@ class TalkerSubmodule(ARNodeSubmodule):
         constant tensors during model init.
         """
         device = next(self.model.parameters()).device
+        # The Thinker embedding table may be fp32 while the Talker runs in
+        # autocast dtype; match text_projection's weight dtype before projecting.
+        proj_dtype = self.model.text_projection.linear_fc1.weight.dtype
         with torch.no_grad():
             pad_raw = thinker_embed_tokens(
                 torch.tensor([self.config.tts_pad_token_id], device=device)
-            )
+            ).to(proj_dtype)
             bos_raw = thinker_embed_tokens(
                 torch.tensor([self.config.tts_bos_token_id], device=device)
-            )
+            ).to(proj_dtype)
             eos_raw = thinker_embed_tokens(
                 torch.tensor([self.config.tts_eos_token_id], device=device)
-            )
+            ).to(proj_dtype)
             self._tts_pad_embed_cached = self.model.text_projection(pad_raw).squeeze(0)
             self._tts_bos_embed_cached = self.model.text_projection(bos_raw).squeeze(0)
             self._tts_eos_embed_cached = self.model.text_projection(eos_raw).squeeze(0)


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

`TalkerSubmodule.init_tts_embeds` projects the Thinker embedding table (fp32) through the Talker `text_projection` (bf16 under autocast), raising `RuntimeError: mat1 and mat2 must have the same dtype` and crashing the Talker worker at setup. Affects every config that builds the Talker (2gpu, colocated, thinker_tp2). Regression from #120 (submodule params now allocated in autocast dtype).

Cast the embedding output to `text_projection.linear_fc1.weight.dtype` before projecting - the same idiom the decode path already uses. Covers both the disaggregated (local fp32 embed) and colocated call sites; no-op when params are fp32.

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->

- `qwen3omni_thinker_tp2.yaml` and `qwen3omni_2gpu.yaml` both reach "Uvicorn running" (Talker builds, graphs captured, no dtype crash).
- All 6 modalities verified: text/audio/image/video-->text correct; text-->speech and image-->speech produce valid 24 kHz audio.
- Seed-TTS regression vs. paper Figs 5 & 6 (closed-loop): RTF + throughput within ~7% at every batch size on both configs and found no perf regression.
- `ruff` clean.

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
