### PR TITLE
Performance improvements for cosmos3

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -35,3 +35,6 @@ HOST=0.0.0.0
 # --- VBench benchmark cache (downloads datasets here) ---
 # Must be a directory YOU have write access to
 VBENCH_CACHE_DIR=/mnt/storage/yourname/vbench
+
+# For temporary files, e.g., for use in nsys profiling
+TMPDIR=...

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ LLM serving stacks assume inference is a single autoregressive loop. Composite m
 - Paged attention (FlashInfer) and continuous batching for autoregressive backbones
 - CUDA-graph capture for encoders and decode
 - Classifier-free-guidance parallelism for diffusion / flow
+- Tensor parallelism and Ulysses sequence parallelism, composable as a TP × SP mesh per component
 - Sliding-window chunk streaming for audio codecs
 - Component-level disaggregation with pluggable tensor transport (shared memory, TCP, RDMA)
 

--- a/configs/cosmos3_nano.yaml
+++ b/configs/cosmos3_nano.yaml
@@ -10,6 +10,12 @@ max_seq_len: 8192
 # ~19 GB for activations.
 kv_cache:
   max_num_pages: 1024
+# Denoise CUDA-graph capture knobs (serving). cuda_graph=false serves eager;
+# graph_max_latent_area caps which resolutions are captured (latent H*W). The
+# COSMOS3_DISABLE_CUDA_GRAPH / COSMOS3_GRAPH_MAX_LATENT_AREA env vars override.
+model_kwargs:
+  cuda_graph: true
+  graph_max_latent_area: 2000
 node_groups:
   - node_names: ["dit"]
     ranks: [0]

--- a/configs/cosmos3_nano_sp2.yaml
+++ b/configs/cosmos3_nano_sp2.yaml
@@ -11,8 +11,10 @@ kv_cache:
 # so each rank attends the full sequence over half the heads. Weights are
 # replicated (no tensor parallelism here). The VAE decoder is small and runs
 # un-sharded on rank 0; the DiT all-gathers its final latents, so the decoder
-# reads them directly. Serve eager (DISABLE_GRAPH=1) — the denoise CUDA-graph
-# does not yet capture the all-to-all.
+# reads them directly. The denoise CUDA-graph captures the image step under SP:
+# during capture the Ulysses exchange switches to all-gather (the all-to-all is
+# point-to-point send/recv, which a CUDA graph cannot replay), so serving
+# graph-on graphs t2i. Video runs eager (dense, uncaptured) on the all-to-all.
 node_groups:
   - node_names: ["dit"]
     ranks: [0, 1]

--- a/configs/cosmos3_nano_sp2.yaml
+++ b/configs/cosmos3_nano_sp2.yaml
@@ -1,0 +1,21 @@
+model: "cosmos3"
+# Sequence-length hint for the scheduler (see cosmos3_nano.yaml).
+max_seq_len: 8192
+# Per-rank KV pool. Sequence parallelism shards the generation sequence and the
+# attention heads (each rank holds num_kv_heads / sp_size heads), so the cache is
+# lighter than the single-GPU run; 1024 pages leave ample headroom.
+kv_cache:
+  max_num_pages: 1024
+# The DiT runs Ulysses sequence-parallel across two ranks: the generation token
+# sequence is sharded and an all-to-all around attention swaps sequence for heads
+# so each rank attends the full sequence over half the heads. Weights are
+# replicated (no tensor parallelism here). The VAE decoder is small and runs
+# un-sharded on rank 0; the DiT all-gathers its final latents, so the decoder
+# reads them directly. Serve eager (DISABLE_GRAPH=1) — the denoise CUDA-graph
+# does not yet capture the all-to-all.
+node_groups:
+  - node_names: ["dit"]
+    ranks: [0, 1]
+    sp_size: 2
+  - node_names: ["vae_decoder"]
+    ranks: [0]

--- a/configs/cosmos3_nano_sp4.yaml
+++ b/configs/cosmos3_nano_sp4.yaml
@@ -1,0 +1,20 @@
+model: "cosmos3"
+# Sequence-length hint for the scheduler (see cosmos3_nano.yaml).
+max_seq_len: 8192
+# Per-rank KV pool. Sequence parallelism shards the generation sequence and the
+# attention heads (each rank holds num_kv_heads / sp_size heads), so the cache is
+# lighter than the single-GPU run; 1024 pages leave ample headroom.
+kv_cache:
+  max_num_pages: 1024
+# The DiT runs Ulysses sequence-parallel across four ranks: the generation token
+# sequence is sharded and an all-to-all around attention swaps sequence for heads
+# so each rank attends the full sequence over a quarter of the heads (sp_size 4
+# divides the 8 KV heads -> 2 heads/rank). Weights are replicated (no tensor
+# parallelism). Serve eager (DISABLE_GRAPH=1) — the denoise CUDA-graph does not
+# yet capture the all-to-all.
+node_groups:
+  - node_names: ["dit"]
+    ranks: [0, 1, 2, 3]
+    sp_size: 4
+  - node_names: ["vae_decoder"]
+    ranks: [0]

--- a/configs/cosmos3_nano_sp4.yaml
+++ b/configs/cosmos3_nano_sp4.yaml
@@ -10,8 +10,9 @@ kv_cache:
 # sequence is sharded and an all-to-all around attention swaps sequence for heads
 # so each rank attends the full sequence over a quarter of the heads (sp_size 4
 # divides the 8 KV heads -> 2 heads/rank). Weights are replicated (no tensor
-# parallelism). Serve eager (DISABLE_GRAPH=1) — the denoise CUDA-graph does not
-# yet capture the all-to-all.
+# parallelism). A 4-GPU correctness cross-check. The denoise CUDA-graph captures
+# the image step via the all-gather Ulysses exchange (the all-to-all is
+# point-to-point send/recv, which a CUDA graph cannot replay).
 node_groups:
   - node_names: ["dit"]
     ranks: [0, 1, 2, 3]

--- a/configs/cosmos3_nano_tp2_sp2.yaml
+++ b/configs/cosmos3_nano_tp2_sp2.yaml
@@ -1,0 +1,22 @@
+model: "cosmos3"
+# Sequence-length hint for the scheduler (see cosmos3_nano.yaml).
+max_seq_len: 8192
+# Per-rank KV pool. With 2D tensor + sequence parallelism each rank holds
+# num_kv_heads / (tp_size * sp_size) heads, so the cache is light; 1024 pages
+# leave ample headroom.
+kv_cache:
+  max_num_pages: 1024
+# 2D parallel mesh over 4 ranks: tensor-parallel (heads/weights shard, the
+# row-parallel projections all-reduce) composed with Ulysses sequence-parallel
+# (the generation sequence shards, an all-to-all swaps sequence for heads around
+# attention). The 4 ranks form a [sp_size, tp_size] grid: TP groups {0,1},{2,3};
+# SP groups {0,2},{1,3}. Used to validate TP x SP composition on Nano (the small
+# model fits on one GPU, so this is a correctness cross-check, not a perf config).
+# Serve eager (DISABLE_GRAPH=1).
+node_groups:
+  - node_names: ["dit"]
+    ranks: [0, 1, 2, 3]
+    tp_size: 2
+    sp_size: 2
+  - node_names: ["vae_decoder"]
+    ranks: [0]

--- a/configs/cosmos3_nano_tp2_sp2.yaml
+++ b/configs/cosmos3_nano_tp2_sp2.yaml
@@ -12,7 +12,9 @@ kv_cache:
 # attention). The 4 ranks form a [sp_size, tp_size] grid: TP groups {0,1},{2,3};
 # SP groups {0,2},{1,3}. Used to validate TP x SP composition on Nano (the small
 # model fits on one GPU, so this is a correctness cross-check, not a perf config).
-# Serve eager (DISABLE_GRAPH=1).
+# The denoise CUDA-graph captures the image step: the SP Ulysses exchange uses
+# all-gather under capture (the all-to-all is point-to-point send/recv, which a
+# CUDA graph cannot replay); the TP row-parallel projections all-reduce as usual.
 node_groups:
   - node_names: ["dit"]
     ranks: [0, 1, 2, 3]

--- a/configs/cosmos3_nano_tp4.yaml
+++ b/configs/cosmos3_nano_tp4.yaml
@@ -1,0 +1,18 @@
+model: "cosmos3"
+# Sequence-length hint for the scheduler (see cosmos3_nano.yaml).
+max_seq_len: 8192
+# Per-rank KV pool. Tensor parallelism shards the attention heads (each rank
+# holds num_kv_heads / tp_size heads -> 2 of 8), so the cache is light; 1024
+# pages leave ample headroom.
+kv_cache:
+  max_num_pages: 1024
+# The DiT runs tensor-parallel across four ranks: the attention heads and the
+# row-parallel projections shard, and the projections all-reduce. A pure-TP
+# cross-check at degree 4 (the small model fits on one GPU, so this is a
+# correctness check, not a perf config). Serve eager (DISABLE_GRAPH=1).
+node_groups:
+  - node_names: ["dit"]
+    ranks: [0, 1, 2, 3]
+    tp_size: 4
+  - node_names: ["vae_decoder"]
+    ranks: [0]

--- a/configs/cosmos3_super_tp2.yaml
+++ b/configs/cosmos3_super_tp2.yaml
@@ -1,0 +1,21 @@
+model: "cosmos3_super"
+# Sequence-length hint for the scheduler (see cosmos3_nano.yaml).
+max_seq_len: 8192
+# Per-rank KV pool. Super is 64 layers and ~64 GB of weights/rank already sit on
+# each 80 GB card at TP=2, so the KV pool must stay small or init OOMs (1024
+# pages = 16 GB/rank here, which OOMs). 384 pages (~6 GB/rank) covers t2i plus
+# 256p/480p video (480p needs ~300 pages) and leaves room for activations; 720p
+# video (~692 pages + large replicated activations) does not fit at TP=2 and is
+# deferred to sequence-parallelism.
+kv_cache:
+  max_num_pages: 384
+# Super (64B, ~128 GB bf16) is unviable on one 80 GB GPU, so the DiT runs
+# tensor-parallel across 2 ranks (~64 GB weights/rank). The VAE decoder is small
+# and runs un-sharded on rank 0 (the DiT's final latents are replicated, so it
+# reads them directly).
+node_groups:
+  - node_names: ["dit"]
+    ranks: [0, 1]
+    tp_size: 2
+  - node_names: ["vae_decoder"]
+    ranks: [0]

--- a/configs/cosmos3_super_tp2_sp2.yaml
+++ b/configs/cosmos3_super_tp2_sp2.yaml
@@ -1,0 +1,22 @@
+model: "cosmos3_super"
+# Sequence-length hint for the scheduler (see cosmos3_nano.yaml).
+max_seq_len: 8192
+# Per-rank KV pool. With 2D tp*sp = 4 each rank holds num_kv_heads / 4 heads, so
+# the cache is half the per-page memory of the TP=2 config; 384 pages cover t2i
+# plus 256p/480p video with headroom for activations.
+kv_cache:
+  max_num_pages: 384
+# Super (64B, ~128 GB bf16) needs tensor parallelism just to fit its weights
+# (~64 GB/rank at tp_size=2). Ulysses sequence parallelism is layered on top to
+# shard the replicated diffusion activations that TP alone leaves full — the
+# lever for the 480p-video cells (free memory so the denoise can graph) and for
+# 720p-video denoise. The 4 ranks form a [sp_size, tp_size] grid: TP groups
+# {0,1},{2,3}; SP groups {0,2},{1,3}. The VAE decoder runs un-sharded on rank 0.
+# Serve eager (DISABLE_GRAPH=1) for v1.
+node_groups:
+  - node_names: ["dit"]
+    ranks: [0, 1, 2, 3]
+    tp_size: 2
+    sp_size: 2
+  - node_names: ["vae_decoder"]
+    ranks: [0]

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -268,7 +268,11 @@ class Conductor:
                         f"but its sharding group has tp_size {group.tp_size}. "
                         f"node_groups and sharding_config disagree."
                     )
-                    for ranks in wg._tp_ranks:
+                    # tp_rank here is the worker's index within the lockstep
+                    # instance (0..tp*sp-1), used by the replicated-signal fanout
+                    # (so exactly one rank — index 0 — forwards a replicated
+                    # tensor to a downstream node).
+                    for ranks in wg._instance_ranks:
                         for i, r in enumerate(ranks):
                             self.worker_tp_group_to_tp_rank.setdefault(r, {})[group_key] = i
 
@@ -426,11 +430,15 @@ class Conductor:
         group_id_to_replica_idx: dict[int, int] = {}
         result = {}
         for wg_id, wg in self.worker_graphs.items():
-            if wg._tp_ranks:
+            if wg._instance_ranks:
+                # Route to a whole instance (the lockstep unit): every rank of a
+                # tp*sp instance runs the request together, so its TP all-reduce
+                # and SP all-to-all collectives stay in sync. Picking a single TP
+                # row here would desync the SP all-to-all across rows.
                 replica_idx = group_id_to_replica_idx.setdefault(
-                    wg._group_id, np.random.randint(len(wg._tp_ranks)),
+                    wg._group_id, np.random.randint(len(wg._instance_ranks)),
                 )
-                ranks = wg._tp_ranks[replica_idx]
+                ranks = wg._instance_ranks[replica_idx]
                 result[wg_id] = [f"worker_{r}" for r in ranks]
             else:
                 replica_idx = group_id_to_replica_idx.setdefault(

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -22,7 +22,7 @@ from mstar.conductor.request_info import (
     StreamingConnectionState,
 )
 from mstar.distributed.base import ShardingConfig
-from mstar.distributed.communication import GlobalTPConfig, WorkerTPGroups
+from mstar.distributed.communication import GlobalParallelConfig, WorkerParallelGroups
 from mstar.engine.base import EngineType
 from mstar.engine.kv_store import KVCacheConfig
 from mstar.graph.base import GraphEdge, NodeAndGraphWalk, TensorPointerInfo
@@ -85,7 +85,7 @@ def _worker_process_target(
     all_worker_graph_ids_to_nodes: dict[str, set[str]],
     all_worker_graph_ids_to_dyn_loops: dict[str, set[str]],
     sharding_config: ShardingConfig,
-    tp_groups: WorkerTPGroups,
+    parallel_groups: WorkerParallelGroups,
     hostname: str,
     socket_path_prefix: str,
     dist_init_method: str,
@@ -120,7 +120,7 @@ def _worker_process_target(
             all_worker_graph_ids_to_nodes=all_worker_graph_ids_to_nodes,
             all_worker_graph_ids_to_dyn_loops=all_worker_graph_ids_to_dyn_loops,
             sharding_config=sharding_config,
-            tp_groups=tp_groups,
+            parallel_groups=parallel_groups,
             hostname=hostname,
             socket_path_prefix=socket_path_prefix,
             dist_init_method=dist_init_method,
@@ -218,8 +218,8 @@ class Conductor:
         self.streaming_consumers = set()
         self.node_walk_to_wg: dict[tuple[str, str], WorkerGraph] = {}
 
-        # (worker idx) -> {tp_group_str: tp_rank}
-        self.worker_tp_group_to_tp_rank: dict[int, dict[str, int]] = {}
+        # (worker idx) -> {sharding group key: rank within the lockstep instance}
+        self.worker_group_to_instance_rank: dict[int, dict[str, int]] = {}
 
         graph_walks = set()
         for wg in self.worker_graphs.values():
@@ -268,13 +268,13 @@ class Conductor:
                         f"but its sharding group has tp_size {group.tp_size}. "
                         f"node_groups and sharding_config disagree."
                     )
-                    # tp_rank here is the worker's index within the lockstep
-                    # instance (0..tp*sp-1), used by the replicated-signal fanout
-                    # (so exactly one rank — index 0 — forwards a replicated
-                    # tensor to a downstream node).
+                    # The instance rank is the worker's index within the
+                    # lockstep instance (0..tp*sp-1), used by the
+                    # replicated-signal fanout (so exactly one rank — index 0
+                    # — forwards a replicated tensor to a downstream node).
                     for ranks in wg._instance_ranks:
                         for i, r in enumerate(ranks):
-                            self.worker_tp_group_to_tp_rank.setdefault(r, {})[group_key] = i
+                            self.worker_group_to_instance_rank.setdefault(r, {})[group_key] = i
 
         # Pick a free TCP port for the NCCL init store. Done once on the
         # conductor and shared with every spawned worker via
@@ -355,17 +355,17 @@ class Conductor:
             for worker_graph_id, worker_graph in self.worker_graphs.items()
         }
 
-        # set the _tp_rank properly for each worker
+        # set each group's _tp_rank (the worker's instance rank) per worker
         self.per_worker_sharding_config: dict[str, ShardingConfig] = {}
         for i, worker_id in enumerate(self.worker_ids):
             sharding_cfg = self.default_sharding_config.clone_empty()
             for group in sharding_cfg.groups:
                 group_key = group.key_str()
-                if group_key in self.worker_tp_group_to_tp_rank.get(i, {}):
-                    group._tp_rank = self.worker_tp_group_to_tp_rank[i][group_key]
+                if group_key in self.worker_group_to_instance_rank.get(i, {}):
+                    group._tp_rank = self.worker_group_to_instance_rank[i][group_key]
             self.per_worker_sharding_config[worker_id] = sharding_cfg
 
-        self.tp_config = GlobalTPConfig(
+        self.parallel_config = GlobalParallelConfig(
             worker_graphs=self.worker_graphs,
             worker_ids=self.worker_ids,
         )
@@ -386,7 +386,7 @@ class Conductor:
                     "all_worker_graph_ids_to_nodes": self._all_worker_graph_ids_to_nodes,
                     "all_worker_graph_ids_to_dyn_loops": self._all_worker_graph_ids_to_dyn_loops,
                     "sharding_config": self.per_worker_sharding_config[worker_id],
-                    "tp_groups": self.tp_config.per_worker_config[worker_id],
+                    "parallel_groups": self.parallel_config.per_worker_config[worker_id],
                     "hostname": self.hostname,
                     "socket_path_prefix": self.socket_path_prefix,
                     "dist_init_method": self._dist_init_method,

--- a/mstar/distributed/base.py
+++ b/mstar/distributed/base.py
@@ -57,9 +57,12 @@ class ShardingConfig:
     groups: list[ShardingGroup]
     tp_enabled_nodes: set[str]
     shard_dim: dict[str, int | None]  # signal name to shard dim (None/absent for replicated)
-    # Nodes whose attention supports Ulysses sequence parallelism. SP is
-    # in-module (an all-to-all around attention), so unlike TP it produces no
-    # ShardingGroup / shard_dim entries; this set only gates config validation.
+    # Nodes whose attention supports Ulysses sequence parallelism. SP shards
+    # activations in-module (an all-to-all around attention) rather than
+    # weights, so it adds no shard_dim entries — signals stay replicated
+    # across the instance — but it does widen the node's ShardingGroup: the
+    # group is the lockstep unit, spanning the whole tp*sp instance. This
+    # set itself only gates config validation.
     sp_enabled_nodes: set[str] = field(default_factory=set)
 
     def clone_empty(self):

--- a/mstar/distributed/base.py
+++ b/mstar/distributed/base.py
@@ -1,6 +1,6 @@
 import math
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from mstar.graph.base import GraphEdge, NodeAndGraphWalk
 
@@ -57,12 +57,17 @@ class ShardingConfig:
     groups: list[ShardingGroup]
     tp_enabled_nodes: set[str]
     shard_dim: dict[str, int | None]  # signal name to shard dim (None/absent for replicated)
+    # Nodes whose attention supports Ulysses sequence parallelism. SP is
+    # in-module (an all-to-all around attention), so unlike TP it produces no
+    # ShardingGroup / shard_dim entries; this set only gates config validation.
+    sp_enabled_nodes: set[str] = field(default_factory=set)
 
     def clone_empty(self):
         return ShardingConfig(
             groups=[group.clone_empty() for group in self.groups],
             tp_enabled_nodes=self.tp_enabled_nodes,
-            shard_dim=self.shard_dim
+            shard_dim=self.shard_dim,
+            sp_enabled_nodes=self.sp_enabled_nodes,
         )
 
     def get_sharding_group(
@@ -74,6 +79,7 @@ class ShardingConfig:
         self.group_mapping: dict[NodeAndGraphWalk, ShardingGroup] = {}
         self.node_to_worker: dict[NodeAndGraphWalk, list[str]] = {}
         self.tp_enabled_nodes = set(self.tp_enabled_nodes)
+        self.sp_enabled_nodes = set(self.sp_enabled_nodes)
         self._setup_done = False
 
     def assert_stream_consumer_compatibility(self, streaming_consumers: set[str]):

--- a/mstar/distributed/communication.py
+++ b/mstar/distributed/communication.py
@@ -101,22 +101,80 @@ class TPCommGroup:
         dist.broadcast(tensor, self.group_members[src], self.device_group)
         return tensor
 
+    def all_to_all(
+        self,
+        input_: torch.Tensor,
+        scatter_dim: int,
+        gather_dim: int,
+        scatter_sizes: list[int] | None = None,
+        gather_sizes: list[int] | None = None,
+    ) -> torch.Tensor:
+        """Redistribute ``input_`` across the group: split it into
+        ``world_size`` pieces along ``scatter_dim`` (piece i goes to rank i)
+        and concatenate the pieces received from every rank along
+        ``gather_dim``.
+
+        This is the primitive behind Ulysses sequence parallelism: with
+        ``scatter_dim`` = heads and ``gather_dim`` = sequence it converts a
+        sequence-sharded ``[seq/P, heads, dim]`` tensor into a head-sharded
+        ``[seq, heads/P, dim]`` one (and the reverse with the dims swapped).
+
+        ``scatter_sizes`` / ``gather_sizes`` give per-rank extents for an
+        uneven split / gather (e.g. a sequence length not divisible by the
+        group size); when ``None`` the respective dimension is split evenly
+        (and ``scatter_dim`` must then be divisible by ``world_size``).
+        """
+        if self.world_size == 1:
+            return input_
+        world_size = self.world_size
+        if scatter_sizes is None:
+            assert input_.size(scatter_dim) % world_size == 0, (
+                f"all_to_all: scatter_dim {scatter_dim} size "
+                f"{input_.size(scatter_dim)} not divisible by world_size "
+                f"{world_size}; pass scatter_sizes for an uneven split"
+            )
+            chunk = input_.size(scatter_dim) // world_size
+            scatter_sizes = [chunk] * world_size
+        send = [
+            t.contiguous()
+            for t in torch.split(input_, scatter_sizes, dim=scatter_dim)
+        ]
+        if gather_sizes is None:
+            gather_sizes = [send[self.rank].size(gather_dim)] * world_size
+        base_shape = list(send[self.rank].shape)
+        recv = []
+        for r in range(world_size):
+            shape = list(base_shape)
+            shape[gather_dim] = gather_sizes[r]
+            recv.append(
+                torch.empty(shape, dtype=input_.dtype, device=input_.device)
+            )
+        dist.all_to_all(recv, send, group=self.device_group)
+        return torch.cat(recv, dim=gather_dim).contiguous()
+
 
 @dataclass
 class WorkerTPGroups:
     num_workers: int
     global_rank: int
-    # True iff any worker in the run uses TP. Set by GlobalTPConfig from
+    # True iff any worker in the run uses TP / SP. Set by GlobalTPConfig from
     # the global worker-graph view so all ranks agree.
     any_tp: bool = False
-    # Every distinct TP rank tuple in the run, sorted for stable iteration
-    # order across workers. Set by GlobalTPConfig. ``init_dist`` calls
-    # ``dist.new_group`` once per entry on every rank — including ranks
+    any_sp: bool = False
+    # Every distinct TP (and SP) rank tuple in the run, sorted for stable
+    # iteration order across workers. Set by GlobalTPConfig. ``init_dist``
+    # calls ``dist.new_group`` once per entry on every rank — including ranks
     # that aren't members of the group — because PyTorch assigns an
     # auto-incrementing tag inside ``new_group`` that all ranks must agree
     # on; asymmetric call counts deadlock the participating ranks.
     world_tp_groups: list[tuple[int, ...]] = field(default_factory=list)
+    world_sp_groups: list[tuple[int, ...]] = field(default_factory=list)
+    # Per-node comm groups. Tensor parallelism and sequence parallelism are
+    # orthogonal axes of the same device mesh, so a node may carry one of
+    # each (the SP group all-to-alls around attention; the TP group
+    # all-reduces the row-parallel projections).
     node_to_group: dict[str, TPCommGroup] = field(default_factory=dict)
+    node_to_sp_group: dict[str, TPCommGroup] = field(default_factory=dict)
 
     def add(self, node: str, comm_group: TPCommGroup):
         # disallow colocation of multiple comm groups on the same node
@@ -126,6 +184,15 @@ class WorkerTPGroups:
             )
         if node not in self.node_to_group:
             self.node_to_group[node] = comm_group
+
+    def add_sp(self, node: str, comm_group: TPCommGroup):
+        # SP analogue of ``add`` — the sequence-parallel comm group for a node.
+        if node in self.node_to_sp_group and self.node_to_sp_group[node].group_members != comm_group.group_members:
+            raise RuntimeError(
+                f"Node {node} already has an SP comm group assigned for worker {self.global_rank}"
+            )
+        if node not in self.node_to_sp_group:
+            self.node_to_sp_group[node] = comm_group
 
     def init_dist(
         self, init_method="tcp://127.0.0.1:29500",
@@ -146,7 +213,7 @@ class WorkerTPGroups:
         discard it.
         """
         torch.cuda.set_device(self.global_rank)
-        if not self.any_tp:
+        if not (self.any_tp or self.any_sp):
             return
 
         dist.init_process_group(
@@ -156,12 +223,18 @@ class WorkerTPGroups:
             rank=self.global_rank,
         )
 
+        # One subgroup per distinct rank tuple across BOTH meshes. The union is
+        # sorted so every rank iterates it identically — ``new_group`` is
+        # collective and tag-ordered (see the class docstring). A tuple shared
+        # by a TP and an SP group (degenerate meshes) maps to one subgroup.
         rank_tuple_to_pg: dict[tuple[int, ...], "dist.ProcessGroup"] = {}
-        for rank_tuple in self.world_tp_groups:
+        for rank_tuple in sorted(set(self.world_tp_groups) | set(self.world_sp_groups)):
             rank_tuple_to_pg[rank_tuple] = dist.new_group(ranks=list(rank_tuple))
 
         seen: set[int] = set()
-        for comm_group in self.node_to_group.values():
+        for comm_group in (
+            list(self.node_to_group.values()) + list(self.node_to_sp_group.values())
+        ):
             if id(comm_group) in seen:
                 continue
             seen.add(id(comm_group))
@@ -175,6 +248,11 @@ class WorkerTPGroups:
         if node not in self.node_to_group:
             self.node_to_group[node] = TPCommGroup.trivial()
         return self.node_to_group[node]
+
+    def get_sp_config_for_node(self, node: str) -> TPCommGroup:
+        if node not in self.node_to_sp_group:
+            self.node_to_sp_group[node] = TPCommGroup.trivial()
+        return self.node_to_sp_group[node]
 
     def barrier_all(self) -> None:
         """Global barrier across every worker process in the run.
@@ -200,22 +278,31 @@ class GlobalTPConfig:
     ):
         self.num_workers = len(worker_ids)
         any_tp = any(wg.tp_size > 1 for wg in worker_graphs.values())
+        any_sp = any(getattr(wg, "sp_size", 1) > 1 for wg in worker_graphs.values())
         world_tp_groups: list[tuple[int, ...]] = sorted({
             tuple(rank_group)
             for wg in worker_graphs.values()
             for rank_group in wg._tp_ranks
             if len(rank_group) > 1
         })
+        world_sp_groups: list[tuple[int, ...]] = sorted({
+            tuple(rank_group)
+            for wg in worker_graphs.values()
+            for rank_group in getattr(wg, "_sp_ranks", [])
+            if len(rank_group) > 1
+        })
         self.per_worker_config: dict[str, WorkerTPGroups] = {
             wid: WorkerTPGroups(
                 global_rank=i, num_workers=self.num_workers,
-                any_tp=any_tp,
+                any_tp=any_tp, any_sp=any_sp,
                 world_tp_groups=world_tp_groups,
+                world_sp_groups=world_sp_groups,
             ) for i, wid in enumerate(worker_ids)
         }
 
-        # (global rank, (group ranks...)) -> comm group
+        # (global rank, (group ranks...)) -> comm group, for each mesh axis.
         self.comm_groups: dict[tuple[int, tuple], TPCommGroup] = {}
+        self.sp_comm_groups: dict[tuple[int, tuple], TPCommGroup] = {}
         for wg in worker_graphs.values():
             for rank_group in wg._tp_ranks:
                 rank_group_tuple = tuple(rank_group)
@@ -230,5 +317,19 @@ class GlobalTPConfig:
                     for node in wg.section.get_nodes().keys():
                         self.per_worker_config[worker_ids[rank]].add(
                             node,  self.comm_groups[key]
+                        )
+            for rank_group in getattr(wg, "_sp_ranks", []):
+                rank_group_tuple = tuple(rank_group)
+                for i, rank in enumerate(rank_group):
+                    key = (rank, rank_group_tuple)
+                    if key not in self.sp_comm_groups:
+                        self.sp_comm_groups[key] = TPCommGroup(
+                            my_global_rank=rank,
+                            my_group_rank=i,
+                            group_members=rank_group
+                        )
+                    for node in wg.section.get_nodes().keys():
+                        self.per_worker_config[worker_ids[rank]].add_sp(
+                            node, self.sp_comm_groups[key]
                         )
 

--- a/mstar/distributed/communication.py
+++ b/mstar/distributed/communication.py
@@ -5,7 +5,16 @@ import torch
 import torch.distributed as dist
 
 
-class TPCommGroup:
+class CommGroup:
+    """A communication group over one axis of the worker device mesh.
+
+    Serves both parallelism axes: tensor parallelism (all-reduce /
+    all-gather of row-parallel projections) and Ulysses sequence
+    parallelism (all-to-all around attention). ``rank`` / ``world_size``
+    are relative to this group; ``global_rank`` is the worker's rank in
+    the world.
+    """
+
     def __init__(
         self,
         my_global_rank: int,
@@ -20,10 +29,10 @@ class TPCommGroup:
         self.initialized = False
 
     @classmethod
-    def trivial(cls) -> "TPCommGroup":
+    def trivial(cls) -> "CommGroup":
         """A degenerate single-rank group. All collectives are no-ops;
         ``init_process_group`` does nothing. Useful as the default for
-        non-TP runs so the same code path works everywhere."""
+        non-parallel runs so the same code path works everywhere."""
         return cls(my_global_rank=0, my_group_rank=0, group_members=[0])
 
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
@@ -154,38 +163,46 @@ class TPCommGroup:
 
 
 @dataclass
-class WorkerTPGroups:
+class WorkerParallelGroups:
+    """Per-worker view of the parallelism comm groups in the run.
+
+    Tensor parallelism and sequence parallelism are orthogonal axes of the
+    same device mesh, so a node may carry one comm group of each. The
+    combined TP x SP block is the node's lockstep *instance* — the unit the
+    conductor routes a request to — exposed via
+    ``get_instance_rank_for_node`` / ``get_instance_world_size_for_node``.
+    """
+
     num_workers: int
     global_rank: int
-    # True iff any worker in the run uses TP / SP. Set by GlobalTPConfig from
-    # the global worker-graph view so all ranks agree.
-    any_tp: bool = False
-    any_sp: bool = False
-    # Every distinct TP (and SP) rank tuple in the run, sorted for stable
-    # iteration order across workers. Set by GlobalTPConfig. ``init_dist``
-    # calls ``dist.new_group`` once per entry on every rank — including ranks
-    # that aren't members of the group — because PyTorch assigns an
-    # auto-incrementing tag inside ``new_group`` that all ranks must agree
-    # on; asymmetric call counts deadlock the participating ranks.
-    world_tp_groups: list[tuple[int, ...]] = field(default_factory=list)
-    world_sp_groups: list[tuple[int, ...]] = field(default_factory=list)
-    # Per-node comm groups. Tensor parallelism and sequence parallelism are
-    # orthogonal axes of the same device mesh, so a node may carry one of
-    # each (the SP group all-to-alls around attention; the TP group
-    # all-reduces the row-parallel projections).
-    node_to_group: dict[str, TPCommGroup] = field(default_factory=dict)
-    node_to_sp_group: dict[str, TPCommGroup] = field(default_factory=dict)
+    # True iff any worker in the run uses TP or SP. Set by
+    # GlobalParallelConfig from the global worker-graph view so all ranks
+    # agree.
+    any_parallelism: bool = False
+    # Every distinct TP / SP rank tuple in the run — the union of both mesh
+    # axes, sorted for stable iteration order across workers. Set by
+    # GlobalParallelConfig. ``init_dist`` calls ``dist.new_group`` once per
+    # entry on every rank — including ranks that aren't members of the
+    # group — because PyTorch assigns an auto-incrementing tag inside
+    # ``new_group`` that all ranks must agree on; asymmetric call counts
+    # deadlock the participating ranks.
+    world_parallel_groups: list[tuple[int, ...]] = field(default_factory=list)
+    # Per-node comm groups, one per mesh axis (the SP group all-to-alls
+    # around attention; the TP group all-reduces the row-parallel
+    # projections).
+    node_to_tp_group: dict[str, CommGroup] = field(default_factory=dict)
+    node_to_sp_group: dict[str, CommGroup] = field(default_factory=dict)
 
-    def add(self, node: str, comm_group: TPCommGroup):
+    def add(self, node: str, comm_group: CommGroup):
         # disallow colocation of multiple comm groups on the same node
-        if node in self.node_to_group and self.node_to_group[node].group_members != comm_group.group_members:
+        if node in self.node_to_tp_group and self.node_to_tp_group[node].group_members != comm_group.group_members:
             raise RuntimeError(
                 f"Node {node} already has a comm group assigned for worker {self.global_rank}"
             )
-        if node not in self.node_to_group:
-            self.node_to_group[node] = comm_group
+        if node not in self.node_to_tp_group:
+            self.node_to_tp_group[node] = comm_group
 
-    def add_sp(self, node: str, comm_group: TPCommGroup):
+    def add_sp(self, node: str, comm_group: CommGroup):
         # SP analogue of ``add`` — the sequence-parallel comm group for a node.
         if node in self.node_to_sp_group and self.node_to_sp_group[node].group_members != comm_group.group_members:
             raise RuntimeError(
@@ -197,23 +214,23 @@ class WorkerTPGroups:
     def init_dist(
         self, init_method="tcp://127.0.0.1:29500",
     ):
-        """Initialize the NCCL world group and per-node TP subgroups.
+        """Initialize the NCCL world group and per-node parallel subgroups.
 
         Every worker calls ``dist.init_process_group`` when *any* worker
-        in the run participates in TP (``self.any_tp``) — otherwise ranks
-        with no local TP would skip the call and the TP-participating
-        ranks would hang waiting for them.
+        in the run participates in TP or SP (``self.any_parallelism``) —
+        otherwise ranks with no local parallelism would skip the call and
+        the participating ranks would hang waiting for them.
 
         Subgroup creation: PyTorch's ``dist.new_group`` is collective on
         the global world. It assigns an auto-incrementing tag inside the
         call that every rank must agree on; if non-member ranks skip the
         call, the tag counter drifts and member ranks deadlock. We
-        therefore call ``new_group`` once per distinct TP rank tuple on
+        therefore call ``new_group`` once per distinct rank tuple on
         every rank — members keep the returned handle, non-members
         discard it.
         """
         torch.cuda.set_device(self.global_rank)
-        if not (self.any_tp or self.any_sp):
+        if not self.any_parallelism:
             return
 
         dist.init_process_group(
@@ -223,17 +240,18 @@ class WorkerTPGroups:
             rank=self.global_rank,
         )
 
-        # One subgroup per distinct rank tuple across BOTH meshes. The union is
-        # sorted so every rank iterates it identically — ``new_group`` is
-        # collective and tag-ordered (see the class docstring). A tuple shared
-        # by a TP and an SP group (degenerate meshes) maps to one subgroup.
+        # One subgroup per distinct rank tuple across BOTH mesh axes —
+        # ``world_parallel_groups`` is the sorted union, so every rank
+        # iterates it identically; ``new_group`` is collective and
+        # tag-ordered (see the field comment). A tuple shared by a TP and
+        # an SP group (degenerate meshes) maps to one subgroup.
         rank_tuple_to_pg: dict[tuple[int, ...], "dist.ProcessGroup"] = {}
-        for rank_tuple in sorted(set(self.world_tp_groups) | set(self.world_sp_groups)):
+        for rank_tuple in self.world_parallel_groups:
             rank_tuple_to_pg[rank_tuple] = dist.new_group(ranks=list(rank_tuple))
 
         seen: set[int] = set()
         for comm_group in (
-            list(self.node_to_group.values()) + list(self.node_to_sp_group.values())
+            list(self.node_to_tp_group.values()) + list(self.node_to_sp_group.values())
         ):
             if id(comm_group) in seen:
                 continue
@@ -244,41 +262,59 @@ class WorkerTPGroups:
             comm_group.device_group = rank_tuple_to_pg[tuple(comm_group.group_members)]
             comm_group.initialized = True
 
-    def get_tp_config_for_node(self, node: str) -> TPCommGroup:
-        if node not in self.node_to_group:
-            self.node_to_group[node] = TPCommGroup.trivial()
-        return self.node_to_group[node]
+    def get_tp_config_for_node(self, node: str) -> CommGroup:
+        if node not in self.node_to_tp_group:
+            self.node_to_tp_group[node] = CommGroup.trivial()
+        return self.node_to_tp_group[node]
 
-    def get_sp_config_for_node(self, node: str) -> TPCommGroup:
+    def get_sp_config_for_node(self, node: str) -> CommGroup:
         if node not in self.node_to_sp_group:
-            self.node_to_sp_group[node] = TPCommGroup.trivial()
+            self.node_to_sp_group[node] = CommGroup.trivial()
         return self.node_to_sp_group[node]
+
+    def get_instance_rank_for_node(self, node: str) -> int:
+        """This worker's rank within ``node``'s lockstep instance — the
+        TP x SP block, row-major [sp][tp] to match
+        ``WorkerGraph._instance_ranks``. 0 iff this worker leads the
+        instance (it is rank 0 in both its TP and SP comm groups)."""
+        tp = self.get_tp_config_for_node(node)
+        sp = self.get_sp_config_for_node(node)
+        return sp.rank * tp.world_size + tp.rank
+
+    def get_instance_world_size_for_node(self, node: str) -> int:
+        """Total ranks in ``node``'s lockstep instance (tp_size * sp_size)."""
+        return (
+            self.get_tp_config_for_node(node).world_size
+            * self.get_sp_config_for_node(node).world_size
+        )
 
     def barrier_all(self) -> None:
         """Global barrier across every worker process in the run.
 
-        No-op when ``any_tp`` is False (no NCCL world was initialized in
-        ``init_dist``). Otherwise calls ``dist.barrier()`` on the default
-        global process group, syncing both TP-participating and non-TP
-        workers. Used at phase boundaries that require all ranks to be
-        ready — e.g. between CUDA-graph warmup and the worker's main
-        loop, so a TP leader can't send a ``ScheduleTPNode`` to a
-        follower that's still inside ``engine.warmup``.
+        No-op when ``any_parallelism`` is False (no NCCL world was
+        initialized in ``init_dist``). Otherwise calls ``dist.barrier()``
+        on the default global process group, syncing participating and
+        non-participating workers alike. Used where every rank must be
+        ready before proceeding — e.g. between CUDA-graph warmup and the
+        worker's main loop, so an instance leader can't send a
+        ``ScheduleTPNode`` to a follower that's still inside
+        ``engine.warmup``.
         """
-        if not self.any_tp:
+        if not self.any_parallelism:
             return
         dist.barrier()
 
 
-class GlobalTPConfig:
+class GlobalParallelConfig:
     def __init__(
         # leaving type annotation as Any due to circular import
         self, worker_graphs: dict[str, Any],
         worker_ids: list[str]
     ):
         self.num_workers = len(worker_ids)
-        any_tp = any(wg.tp_size > 1 for wg in worker_graphs.values())
-        any_sp = any(getattr(wg, "sp_size", 1) > 1 for wg in worker_graphs.values())
+        any_parallelism = any(
+            wg.tp_size > 1 or wg.sp_size > 1 for wg in worker_graphs.values()
+        )
         world_tp_groups: list[tuple[int, ...]] = sorted({
             tuple(rank_group)
             for wg in worker_graphs.values()
@@ -288,28 +324,32 @@ class GlobalTPConfig:
         world_sp_groups: list[tuple[int, ...]] = sorted({
             tuple(rank_group)
             for wg in worker_graphs.values()
-            for rank_group in getattr(wg, "_sp_ranks", [])
+            for rank_group in wg._sp_ranks
             if len(rank_group) > 1
         })
-        self.per_worker_config: dict[str, WorkerTPGroups] = {
-            wid: WorkerTPGroups(
+        # The union of both axes, sorted — the per-rank ``new_group``
+        # schedule (see the ``world_parallel_groups`` field comment).
+        world_parallel_groups: list[tuple[int, ...]] = sorted(
+            set(world_tp_groups) | set(world_sp_groups)
+        )
+        self.per_worker_config: dict[str, WorkerParallelGroups] = {
+            wid: WorkerParallelGroups(
                 global_rank=i, num_workers=self.num_workers,
-                any_tp=any_tp, any_sp=any_sp,
-                world_tp_groups=world_tp_groups,
-                world_sp_groups=world_sp_groups,
+                any_parallelism=any_parallelism,
+                world_parallel_groups=world_parallel_groups,
             ) for i, wid in enumerate(worker_ids)
         }
 
         # (global rank, (group ranks...)) -> comm group, for each mesh axis.
-        self.comm_groups: dict[tuple[int, tuple], TPCommGroup] = {}
-        self.sp_comm_groups: dict[tuple[int, tuple], TPCommGroup] = {}
+        self.comm_groups: dict[tuple[int, tuple], CommGroup] = {}
+        self.sp_comm_groups: dict[tuple[int, tuple], CommGroup] = {}
         for wg in worker_graphs.values():
             for rank_group in wg._tp_ranks:
                 rank_group_tuple = tuple(rank_group)
                 for i, rank in enumerate(rank_group):
                     key = (rank, rank_group_tuple)
                     if key not in self.comm_groups:
-                        self.comm_groups[key] = TPCommGroup(
+                        self.comm_groups[key] = CommGroup(
                             my_global_rank=rank,
                             my_group_rank=i,
                             group_members=rank_group
@@ -318,12 +358,12 @@ class GlobalTPConfig:
                         self.per_worker_config[worker_ids[rank]].add(
                             node,  self.comm_groups[key]
                         )
-            for rank_group in getattr(wg, "_sp_ranks", []):
+            for rank_group in wg._sp_ranks:
                 rank_group_tuple = tuple(rank_group)
                 for i, rank in enumerate(rank_group):
                     key = (rank, rank_group_tuple)
                     if key not in self.sp_comm_groups:
-                        self.sp_comm_groups[key] = TPCommGroup(
+                        self.sp_comm_groups[key] = CommGroup(
                             my_global_rank=rank,
                             my_group_rank=i,
                             group_members=rank_group

--- a/mstar/engine/base.py
+++ b/mstar/engine/base.py
@@ -7,7 +7,7 @@ import torch
 
 from mstar.communication.tensors import NameToTensorList
 from mstar.conductor.request_info import CurrentForwardPassInfo
-from mstar.distributed.communication import WorkerTPGroups
+from mstar.distributed.communication import WorkerParallelGroups
 from mstar.engine.kv_store import KVCacheConfig, StoreWritePolicy
 
 
@@ -143,7 +143,7 @@ class BaseEngine(ABC):
     def load_model(
         self,
         submodules: dict[str, torch.nn.Module],
-        tp_groups: WorkerTPGroups,
+        parallel_groups: WorkerParallelGroups,
         kv_cache_config: list[KVCacheConfig],
         device: torch.device,
         **kwargs

--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -71,6 +71,11 @@ class WorkspaceBufferManager:
         return self.buffers[label]
 
 
+@dataclass
+class BatchedCfgInfo:
+    per_label_seq_len: dict[str, list[int]]
+
+
 class BatchedCacheManager:
     """Manages batched FlashInfer attention for multiple requests simultaneously.
 
@@ -149,6 +154,8 @@ class BatchedCacheManager:
         # pre-plan was applied.
         self._plan_done_event: "torch.cuda.Event | None" = None
 
+        self._batched_cfg_info: BatchedCfgInfo | None = None
+
     @torch.compiler.disable
     def _get_state(self, request_id: str, label: str | None = None) -> KVRequestState:
         label = label or self.active_labels.get(request_id, "main")
@@ -208,6 +215,7 @@ class BatchedCacheManager:
             label: cache label to plan for. If None, uses the current active label.
         """
         from mstar.utils.profiler import range_pop, range_push
+        self._batched_cfg_info = None
 
         if self.enable_nvtx:
             range_push("cache.plan_attention", synchronize=False)
@@ -386,45 +394,6 @@ class BatchedCacheManager:
             ps = _PlanState(wrapper=wrapper)
             self._plan_states[effective_label] = ps
 
-        # TODO(perf): overlap wrapper.plan(step N+1) with the previous step's
-        # replay+sample to hide its ~750 µs critical-path cost.
-        #
-        # plan() only depends on the next KV state (seq_lens + page indices),
-        # not on the token sampled by the previous step, so it can be issued
-        # as soon as advance_seq_lens(N) runs — well before sample(N) returns.
-        # At bs=8 on H200, sample_and_remap is ~0.9 ms vs plan ~0.75 ms, so
-        # the whole plan could in principle be hidden.
-        #
-        # Design sketch (double-buffered wrappers):
-        #   * Keep two FlashInferDecodeWrappers, wrapper[0] and wrapper[1],
-        #     each with its own persistent workspace + static plan buffers.
-        #   * Step N's run() uses wrapper[N % 2]; a background worker thread
-        #     calls plan(N+1) on wrapper[(N+1) % 2] concurrently.
-        #   * Main thread join()s the plan future just before replay(N+1).
-        #
-        # Why a worker *thread* and not just a side CUDA stream:
-        #   plan()'s wall-clock is dominated by CPU-side work — Python
-        #   bookkeeping, a dozen cudaMemcpyAsync API calls (~13 µs host-side
-        #   each), and two internal D→H reads (CUB scan result) that block
-        #   the calling thread. A side stream only hides plan's ~50 µs of
-        #   actual GPU kernel time; the thread still stalls on the D→H waits.
-        #   PyTorch releases the GIL inside CUDA ops, so a Python thread can
-        #   issue plan() while the main thread submits sample(N).
-        #
-        # Risks / prerequisites:
-        #   * PagedAllocationManager mutation (.alloc, .reset_label, etc.)
-        #     is now guarded by a per-manager RLock; the underlying
-        #     PageAllocator's queue compound-ops are guarded by their own
-        #     Lock so qsize-then-get cannot race with concurrent free.
-        #   * advance_seq_lens() inside a captured CUDA graph updates state
-        #     via .copy_(); the worker must wait on a real cudaEvent, not a
-        #     torch stream sync, before reading page indices.
-        #   * wrapper[(N+1) % 2]'s static buffers are read by the main
-        #     thread's next replay — need a handshake (Event/Condition) so
-        #     replay doesn't start before the worker finishes plan().
-        #   * If sample(N) ever runs shorter than plan(N+1) (short prefill,
-        #     very small batch), the main thread waits. Still no worse than
-        #     today.
         if self.enable_nvtx:
             range_push("cache.plan_attention.wrapper_plan", synchronize=False)
         try:
@@ -559,7 +528,7 @@ class BatchedCacheManager:
     def plan_attention_batched_cfg(
         self,
         labels: list[str],
-        seq_lens: list[int],
+        seq_lens: list[int] | dict[str, list[int]],
         is_causal: bool = False,
         write_store: bool = False,
         dtype=torch.bfloat16,
@@ -579,6 +548,14 @@ class BatchedCacheManager:
             combined_label: key for the combined _PlanState.
         """
         assert self.kv_cache is not None
+        if isinstance(seq_lens, list):
+            seq_lens = {
+                key: seq_lens for key in labels
+            }
+
+        self._batched_cfg_info = BatchedCfgInfo(
+            per_label_seq_len=seq_lens
+        )
 
         if (_dense_gen_attn_enabled() and not is_causal
                 and not self._cuda_graph_mode):
@@ -610,7 +587,7 @@ class BatchedCacheManager:
         for label in labels:
             for i, rid in enumerate(self.request_ids):
                 state = self._get_state(rid, label)
-                sl = seq_lens[i]
+                sl = seq_lens[label][i]
                 total_len = state.seq_len + sl
 
                 self.alloc_manager.alloc(rid, label=label, seq_len=total_len)
@@ -691,7 +668,7 @@ class BatchedCacheManager:
     def plan_rope_batched_cfg(
         self,
         labels: list[str],
-        seq_lens: list[int],
+        seq_lens: list[int] | dict[str, list[int]],
         per_label_pos_ids: dict[str, list[torch.Tensor]] | None = None,
         combined_label: str = "_cfg_batched",
     ):
@@ -705,6 +682,11 @@ class BatchedCacheManager:
             combined_label: key for the combined _PlanState (must already exist
                 from plan_attention_batched_cfg).
         """
+        if isinstance(seq_lens, list):
+            seq_lens = {
+                key: seq_lens for key in labels
+            }
+
         # Build one tensor *per label* in `labels` order, then concat. Order
         # matters: downstream attention indexes these positions by
         # (label_i * per_label_len + within_label_offset), so reordering the
@@ -717,7 +699,7 @@ class BatchedCacheManager:
                 parts.append(torch.cat(per_label_pos_ids[label]))
             else:
                 pos_ids_list: list[int] = []
-                for rid, sl in zip(self.request_ids, seq_lens, strict=True):
+                for rid, sl in zip(self.request_ids, seq_lens[label], strict=True):
                     start = self._get_state(rid, label).position_id_start
                     pos_ids_list.extend(range(start, start + sl))
                 parts.append(torch.tensor(
@@ -781,7 +763,10 @@ class BatchedCacheManager:
 
         return ps.wrapper.run(q, self.kv_cache[layer_idx]).to(orig_dtype)
 
-    def _build_dense_gen_plan(self, labels: list[str], seq_lens: list[int]) -> dict:
+    def _build_dense_gen_plan(
+        self, labels: list[str],
+        seq_lens: list[int] | dict[str, list[int]]
+    ) -> dict:
         """Pre-compute the per-segment gather + varlen layout for the dense
         generation-attention path, in the same (label, request) batch order the
         generation tokens are packed in. Each segment attends its fresh
@@ -790,6 +775,12 @@ class BatchedCacheManager:
         (the same across all layers) and the cumulative-sequence-length tensors a
         single varlen kernel needs. Built once per denoise step, reused by every
         layer's run_attention."""
+
+        if isinstance(seq_lens, list):
+            seq_lens = {
+                key: seq_lens for key in labels
+            }
+
         cfg = self.kv_cache_config
         page_size = cfg.page_size
         segs = []  # (prefix_page_indices, prefix_len, gen_len)
@@ -801,7 +792,7 @@ class BatchedCacheManager:
             for i, rid in enumerate(self.request_ids):
                 state = self._get_state(rid, label)
                 prefix_len = state.seq_len
-                gen_len = seq_lens[i]
+                gen_len = seq_lens[label][i]
                 n_pages = (prefix_len + page_size - 1) // page_size
                 idx = torch.tensor(
                     state.page_indices[:n_pages], dtype=torch.long, device=self.device
@@ -986,20 +977,35 @@ class BatchedCacheManager:
         side-channel is auto-cleared after use so it doesn't leak across
         calls.
         """
-        for i, rid in enumerate(self.request_ids):
-            ps = self._plan_states[self.active_labels[rid]]
-            n = ps.seq_lens[i]
-            state = self._get_state(rid)
-            state.seq_len += n
-            if pos_id_ns is None:
-                if ps.custom_pos_advance is not None:
-                    state.position_id_start += ps.custom_pos_advance[i]
+
+        if self._batched_cfg_info:
+            for label, seq_lens in self._batched_cfg_info.per_label_seq_len.items():
+                for i, rid in enumerate(self.request_ids):
+                    n = seq_lens[i]
+                    state = self._get_state(rid, label=label)
+                    state.seq_len += n
+                    if pos_id_ns is None:
+                        state.position_id_start += n
+                    elif isinstance(pos_id_ns, int):
+                        state.position_id_start += pos_id_ns
+                    else:
+                        state.position_id_start += pos_id_ns[i]
+        else:
+            for i, rid in enumerate(self.request_ids):
+                label = self.active_labels[rid]
+                ps = self._plan_states[label]
+                n = ps.seq_lens[i]
+                state = self._get_state(rid, label=label)
+                state.seq_len += n
+                if pos_id_ns is None:
+                    if ps.custom_pos_advance is not None:
+                        state.position_id_start += ps.custom_pos_advance[i]
+                    else:
+                        state.position_id_start += n
+                elif isinstance(pos_id_ns, int):
+                    state.position_id_start += pos_id_ns
                 else:
-                    state.position_id_start += n
-            elif isinstance(pos_id_ns, int):
-                state.position_id_start += pos_id_ns
-            else:
-                state.position_id_start += pos_id_ns[i]
+                    state.position_id_start += pos_id_ns[i]
         # Clear the side-channel on every consumer so a stale value can't
         # bleed into a subsequent walk.
         for ps in self._plan_states.values():

--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -13,10 +13,16 @@ from mstar.utils.flashinfer_utils import FlashInferDecodeWrapper, FlashInferPref
 # pure overhead here; a dense pass gathers the small prefix, concatenates it with
 # the freshly projected K/V, and runs one varlen kernel — which is also the
 # faster attention kernel at these shapes. Eager-only (the captured image path
-# keeps the paged wrapper). Off unless COSMOS3_DENSE_FA3 is set; read per plan
-# (once per denoise step) so it can be toggled for A/B parity checks.
-def _dense_gen_attn_enabled() -> bool:
-    return bool(os.environ.get("COSMOS3_DENSE_FA3"))
+# keeps the paged wrapper) and single-request only (the launch-overhead it
+# removes is what matters at bs=1; bs>1 amortizes the plan and grows the
+# per-request prefix gather, so it stays on the paged path). Defaults to the
+# model's KVCacheConfig.dense_gen_attn; COSMOS3_DENSE_FA3 overrides per plan for
+# A/B parity ("0"/"false"/"off" forces paged, any other value forces dense).
+def _dense_gen_attn_enabled(config_default: bool) -> bool:
+    env = os.environ.get("COSMOS3_DENSE_FA3")
+    if env:
+        return env.lower() not in ("0", "false", "no", "off")
+    return config_default
 
 
 @dataclass
@@ -241,8 +247,9 @@ class BatchedCacheManager:
                     range_push("cache.plan_attention.skipped_pre_planned", synchronize=False)
                     range_pop(synchronize=False)
                 return
-            if (_dense_gen_attn_enabled() and not is_causal
-                    and not self._cuda_graph_mode):
+            if (_dense_gen_attn_enabled(self.kv_cache_config.dense_gen_attn)
+                    and not is_causal and not self._cuda_graph_mode
+                    and len(self.request_ids) == 1):
                 # Lean dense generation-attention path: the gen K/V is never
                 # written to pages and attention is one varlen FA3 over the
                 # frozen prefix + fresh gen, so the whole paged-FlashInfer plan
@@ -423,7 +430,9 @@ class BatchedCacheManager:
         # reader — dropped along with their per-rid GPU construction above.
         ps.seq_lens = seq_lens
         ps.write_store = write_store
-        if _dense_gen_attn_enabled() and not is_causal and not self._cuda_graph_mode:
+        if (_dense_gen_attn_enabled(self.kv_cache_config.dense_gen_attn)
+                and not is_causal and not self._cuda_graph_mode
+                and len(self.request_ids) == 1):
             ps.dense_gen = self._build_dense_gen_plan([effective_label], seq_lens)
         else:
             ps.dense_gen = None
@@ -557,8 +566,9 @@ class BatchedCacheManager:
             per_label_seq_len=seq_lens
         )
 
-        if (_dense_gen_attn_enabled() and not is_causal
-                and not self._cuda_graph_mode):
+        if (_dense_gen_attn_enabled(self.kv_cache_config.dense_gen_attn)
+                and not is_causal and not self._cuda_graph_mode
+                and len(self.request_ids) == 1):
             # Lean dense generation-attention path (see plan_attention): skip the
             # paged-FlashInfer plan (per-label page alloc, index tensors, and
             # wrapper.plan()'s radix-sort/fills) — _run_dense_gen reads none of
@@ -659,7 +669,9 @@ class BatchedCacheManager:
         )
         ps.seq_lens = combined_seq_lens
         ps.write_store = write_store
-        if _dense_gen_attn_enabled() and not is_causal and not self._cuda_graph_mode:
+        if (_dense_gen_attn_enabled(self.kv_cache_config.dense_gen_attn)
+                and not is_causal and not self._cuda_graph_mode
+                and len(self.request_ids) == 1):
             ps.dense_gen = self._build_dense_gen_plan(labels, seq_lens)
         else:
             ps.dense_gen = None

--- a/mstar/engine/cuda_graph_config.py
+++ b/mstar/engine/cuda_graph_config.py
@@ -115,6 +115,7 @@ class FlashInferPackedCudaGraphConfig(CudaGraphConfig):
         batched_cfg: bool = False,
         capture_batch_sizes: list[int] | None = None,
         zero_padding_input: ARNodeInputs | None = None,
+        caps_eager_batch_size: bool = True
     ):
         super().__init__(
             capture_graph_walk=capture_graph_walk,
@@ -127,6 +128,8 @@ class FlashInferPackedCudaGraphConfig(CudaGraphConfig):
         self.num_token_to_inputs = packed_seq_len_to_inputs
         self.causal_attention = causal_attention
         self.zero_padding_input = zero_padding_input
+        self.batched_cfg = batched_cfg
+        self.caps_eager_batch_size = caps_eager_batch_size
 
     def get_config_type(self) -> CudaGraphConfigType:
         return CudaGraphConfigType.FLASH_INFER_PACKED

--- a/mstar/engine/cuda_graph_config.py
+++ b/mstar/engine/cuda_graph_config.py
@@ -112,6 +112,7 @@ class FlashInferPackedCudaGraphConfig(CudaGraphConfig):
         labels: list[str]  = None,
         compile: bool = True,
         causal_attention: bool = True,
+        batched_cfg: bool = False,
         capture_batch_sizes: list[int] | None = None,
         zero_padding_input: ARNodeInputs | None = None,
     ):

--- a/mstar/engine/cuda_graph_runner.py
+++ b/mstar/engine/cuda_graph_runner.py
@@ -81,6 +81,7 @@ class PiecewiseGraphData:
 class CudaGraphData:
     config: CudaGraphConfig
     bs: int
+    index: int
     # One CudaGraphSlot per double-buffer slot. Always length NUM_SLOTS.
     # Each slot has its own captured graph + persistent FlashInfer wrappers
     # so plan(N+1) on slot[(s+1)%2] runs concurrent with replay(N) on slot[s].
@@ -197,6 +198,12 @@ class CudaGraphRunner:
         # the canonical pattern; the cuda_graph memory_pool + largest-first
         # capture order keep the slice views' addresses stable across replays.
         self.shared_static_buffers: dict[tuple[int, str], torch.Tensor] = {}
+        # (config_idx, tensor_key) → the dim that carries the (bucket-varying)
+        # seq length in that tensor's ORIGINAL layout. _intern_static_buffer
+        # brings this dim to the front for storage (so smaller buckets reslice
+        # along dim 0) and inverts the move on return; the replay copy reads it
+        # back to slice the right dim. 0 for the common seq-leading case.
+        self._static_buffer_seq_dims: dict[tuple[int, str], int] = {}
         # Sum of bytes that WOULD have been allocated by per-capture clones
         # (one full tensor per call) — incremented on every _intern_static_buffer
         # call. Compared against the actual shared-buffer footprint at the end
@@ -377,10 +384,23 @@ class CudaGraphRunner:
             for label in config.labels:
                 self.alloc_manager.reset_label(rid, label, free=True)
 
+    @staticmethod
+    def _seq_dim(value: torch.Tensor, seq_len: int) -> int:
+        """Index of the first dim whose size matches ``seq_len``, else 0.
+
+        Used to bring the (bucket-varying) seq dim to the front for shared-buffer
+        interning: most inputs are seq-leading (returns 0), but mrope-style ids
+        carry seq in a later dim (e.g. ``[3, seq]`` → 1)."""
+        for dim, size in enumerate(value.shape):
+            if size == seq_len:
+                return dim
+        return 0
+
     def _intern_static_buffer(
         self, config_idx: int, key: str, value: torch.Tensor,
+        seq_len: int | None = None,
     ) -> torch.Tensor:
-        """Return a leading-dim slice view into the shared buffer for (config_idx, key).
+        """Return a slice view into the shared buffer for (config_idx, key).
 
         Allocates the shared buffer at ``value``'s shape on first encounter
         — relies on ``warmup_and_capture``'s largest-first iteration
@@ -391,28 +411,33 @@ class CudaGraphRunner:
         buckets cost one max-shape allocation per tensor instead of one full
         clone per bucket.
 
-        Trailing dims (everything past dim 0) must match between the shared
-        buffer and ``value`` — the bucket varies the leading dim only. A
-        mismatch is a design-level surprise (a tensor whose shape depends on
-        bs in a non-leading way), so we hard-fail with a precise message.
+        When ``seq_len`` is given and the bucket-varying dim is not already dim 0
+        (e.g. mrope ids ``[3, seq]``), that dim is moved to the front for storage
+        and the returned view is moved back so the captured forward still sees the
+        original layout. The seq dim is recorded so the replay copy slices it too.
+        Trailing dims of the stored (seq-leading) tensor must match the shared
+        buffer — a mismatch is a design-level surprise, so we hard-fail.
         """
         buf_key = (config_idx, key)
+        seq_dim = self._seq_dim(value, seq_len) if seq_len is not None else 0
+        self._static_buffer_seq_dims[buf_key] = seq_dim
+        stored = value.movedim(seq_dim, 0) if seq_dim != 0 else value
         shared = self.shared_static_buffers.get(buf_key)
         if shared is None:
-            shared = torch.empty(value.shape, dtype=value.dtype, device=value.device)
+            shared = torch.empty(stored.shape, dtype=stored.dtype, device=stored.device)
             self.shared_static_buffers[buf_key] = shared
-        self._capture_clone_bytes_naive += value.numel() * value.element_size()
-        leading = value.shape[0]
-        if leading > shared.shape[0] or value.shape[1:] != shared.shape[1:]:
+        self._capture_clone_bytes_naive += stored.numel() * stored.element_size()
+        leading = stored.shape[0]
+        if leading > shared.shape[0] or stored.shape[1:] != shared.shape[1:]:
             raise RuntimeError(
                 f"_intern_static_buffer: capture for key={key!r} (config_idx={config_idx}) "
-                f"requires shape {tuple(value.shape)} but shared buffer is "
+                f"requires (seq-leading) shape {tuple(stored.shape)} but shared buffer is "
                 f"{tuple(shared.shape)} — captures should be ordered largest-first "
                 "by leading dim with matching trailing dims"
             )
         sliced = shared[:leading]
-        sliced.copy_(value)
-        return sliced
+        sliced.copy_(stored)
+        return sliced.movedim(0, seq_dim) if seq_dim != 0 else sliced
 
     def _create_cache_mgr_and_dummy_engine_inputs(
         self, dummy_rids, plan_states,
@@ -464,6 +489,18 @@ class CudaGraphRunner:
         seq_lens[0] += total_tokens % bs
         return seq_lens
 
+    def _split_seq_lens_across_labels(
+        self, bs: int, total_tokens: int, labels: list[str],
+    ) -> dict[str, list[int]]:
+        """Distribute total_tokens across every (label, request) entry so the
+        combined per-label seq_lens sum to total_tokens — the layout a batched-CFG
+        capture needs (one packed sequence covering all labels)."""
+        n = len(labels) * bs
+        per = total_tokens // n
+        seq_lens = {label: [per] * bs for label in labels}
+        seq_lens[labels[0]][0] += total_tokens - per * n
+        return seq_lens
+
     def _build_slot_from_capture(
         self, output, graph, static_inputs, cache_manager,
     ) -> CudaGraphSlot:
@@ -491,6 +528,7 @@ class CudaGraphRunner:
         key: CudaGraphKey,
         config: CudaGraphConfig,
         bs: int,
+        index: int,
         slots: list[CudaGraphSlot],
         applied_penalty_in_graph: bool=False
     ) -> None:
@@ -515,6 +553,7 @@ class CudaGraphRunner:
             self.graphs[lookup_key] = CudaGraphData(
                 config=config,
                 bs=bs,
+                index=index,
                 slots=slots,
                 next_slot=0,
                 applied_penalty_in_graph=applied_penalty_in_graph
@@ -525,6 +564,7 @@ class CudaGraphRunner:
         key: CudaGraphKey,
         config: CudaGraphConfig,
         submodule: ARNodeSubmodule,
+        index: int,
         prepare_slot: Callable[[int], _SlotCaptureSpec],
     ) -> None:
         """Drive the per-slot warmup + capture loop for one (config, bs) bucket.
@@ -604,7 +644,8 @@ class CudaGraphRunner:
 
             self._register_graph_data(
                 key=key, config=config, bs=key.bs, slots=captured_slots,
-                applied_penalty_in_graph=applied_penalty_in_graph
+                applied_penalty_in_graph=applied_penalty_in_graph,
+                index=index
             )
         finally:
             for rids in dummy_rids_to_free:
@@ -625,12 +666,19 @@ class CudaGraphRunner:
         template_dict = config.num_token_to_inputs[key.num_tokens]
         config_idx = self.capture_configs.index(config)
         seq_lens = self._make_dummy_seq_lens(bs, key.num_tokens)
+        # Batched CFG packs all labels into one combined sequence, so the bucket's
+        # num_tokens is the combined (cond+uncond) length — split it back across
+        # (label, request) so the dummy plan's per-label seq_lens sum to it.
+        cfg_seq_lens = (
+            self._split_seq_lens_across_labels(bs, key.num_tokens, config.labels)
+            if config.batched_cfg else None
+        )
 
         def prepare_slot(slot_idx: int) -> _SlotCaptureSpec:
             dummy_rids = self._make_dummy_rids(config, bs, slot_idx)
 
             templates = {
-                k: (self._intern_static_buffer(config_idx, k, v)
+                k: (self._intern_static_buffer(config_idx, k, v, seq_len=key.num_tokens)
                     if isinstance(v, torch.Tensor) else v)
                 for k, v in template_dict.items()
             }
@@ -644,6 +692,22 @@ class CudaGraphRunner:
             cache_manager = engine_inputs.cache_manager
 
             def plan_attention() -> None:
+                if config.batched_cfg:
+                    # One combined plan over all labels (the _cfg_batched plan
+                    # state + wrapper the batched-CFG forward looks up). Mirrors
+                    # the submodule's eager preprocess so capture and replay plan
+                    # the same wrapper.
+                    cache_manager.plan_attention_batched_cfg(
+                        labels=config.labels,
+                        seq_lens=cfg_seq_lens,
+                        is_causal=config.causal_attention,
+                        write_store=False,
+                    )
+                    cache_manager.plan_rope_batched_cfg(
+                        labels=config.labels,
+                        seq_lens=cfg_seq_lens,
+                    )
+                    return
                 for label in config.labels:
                     cache_manager.plan_attention(
                         seq_lens=seq_lens,
@@ -675,6 +739,7 @@ class CudaGraphRunner:
 
         self._capture_slots(
             key=key, config=config, submodule=submodule, prepare_slot=prepare_slot,
+            index=config_idx,
         )
 
 
@@ -758,6 +823,7 @@ class CudaGraphRunner:
 
         self._capture_slots(
             key=key, config=config, submodule=submodule, prepare_slot=prepare_slot,
+            index=config_idx
         )
 
     def can_run(
@@ -1577,12 +1643,17 @@ class CudaGraphRunner:
             # --- Step 3: Copy real packed tensors into static buffers ---
             if self.enable_nvtx:
                 range_push("cg.copy_inputs", synchronize=False)
+            config_idx = self.capture_configs.index(graph_data.config)
             for k in static_input_keys:
                 real_val = real_packed.get(k)
                 if real_val is None or not isinstance(real_val, torch.Tensor):
                     continue
                 static_buf = templates[k]
-                static_buf[:real_val.shape[0]].copy_(real_val)
+                # Slice the same (possibly non-leading) seq dim _intern_static_buffer
+                # recorded for this key, so mrope-style [.., seq, ..] inputs land in
+                # the right axis of the original-layout view.
+                seq_dim = self._static_buffer_seq_dims.get((config_idx, k), 0)
+                static_buf.narrow(seq_dim, 0, real_val.shape[seq_dim]).copy_(real_val)
             if self.enable_nvtx:
                 range_pop(synchronize=False)
                 range_pop(synchronize=False)
@@ -1619,9 +1690,15 @@ class CudaGraphRunner:
             # same tail pages every step, so they opt out of the advance (it would
             # grow the prefix across steps and corrupt attention).
             if graph_data.config.advance_seq_lens:
-                for label in config_labels:
-                    static_cm.set_active_label(label)
+                if graph_data.config.batched_cfg:
+                    # _batched_cfg_info (set by the preprocess plan above) makes a
+                    # single advance_seq_lens walk every label's state; looping
+                    # per label would advance each one once per label.
                     static_cm.advance_seq_lens()
+                else:
+                    for label in config_labels:
+                        static_cm.set_active_label(label)
+                        static_cm.advance_seq_lens()
             if self.enable_nvtx:
                 range_pop(synchronize=False)
 

--- a/mstar/engine/cuda_graph_runner.py
+++ b/mstar/engine/cuda_graph_runner.py
@@ -165,11 +165,11 @@ class CudaGraphRunner:
         default_sampling_config: SamplingConfig,
         tp_group=None,
     ):
-        from mstar.distributed.communication import TPCommGroup
+        from mstar.distributed.communication import CommGroup
 
         self.submodule_name = submodule_name
         self.submodule = submodule
-        self.tp_group: TPCommGroup = tp_group or TPCommGroup.trivial()
+        self.tp_group: CommGroup = tp_group or CommGroup.trivial()
         self.capture_configs: list[CudaGraphConfig] = submodule.get_cuda_graph_configs(
             device, self.tp_group.world_size
         )
@@ -2373,7 +2373,7 @@ class PiecewiseCudaGraphRunner:
         cache_labels: list[str] | None = None,
         tp_group=None,
     ):
-        from mstar.distributed.communication import TPCommGroup
+        from mstar.distributed.communication import CommGroup
 
         self.fn_factory = fn_factory
         self.embed_dim = embed_dim
@@ -2393,7 +2393,7 @@ class PiecewiseCudaGraphRunner:
         # parallel layers — ``warmup_and_capture`` barriers before each
         # per-bs capture to keep ranks in lockstep (the same race the
         # standard ``CudaGraphRunner`` guards against).
-        self.tp_group: TPCommGroup = tp_group or TPCommGroup.trivial()
+        self.tp_group: CommGroup = tp_group or CommGroup.trivial()
 
         self.graphs: dict[int, PiecewiseGraphData] = {}
         self.memory_pool = None

--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -118,13 +118,26 @@ class KVCacheEngine(BaseEngine):
             tp_ranks = set([
                 tp_groups.get_tp_config_for_node(node).rank for node in nodes
             ])
-            if len(world_sizes) > 1 or len(tp_ranks) > 1:
+            sp_sizes = set([
+                tp_groups.get_sp_config_for_node(node).world_size for node in nodes
+            ])
+            sp_ranks = set([
+                tp_groups.get_sp_config_for_node(node).rank for node in nodes
+            ])
+            if (
+                len(world_sizes) > 1 or len(tp_ranks) > 1
+                or len(sp_sizes) > 1 or len(sp_ranks) > 1
+            ):
                 raise RuntimeError(
                     "It is disallowed to share a KV cache among colocated nodes "
-                    f"from different TP groups: {nodes}."
+                    f"from different TP/SP groups: {nodes}."
                 )
             tp_size = world_sizes.pop()
-            cfg.shard(tp_size)
+            sp_size = sp_sizes.pop()
+            # Ulysses sequence parallelism makes attention run at effective
+            # head-degree tp*sp (the all-to-all redistributes heads across the
+            # SP group), so each rank's cache holds num_kv_heads / (tp*sp).
+            cfg.shard(tp_size * sp_size)
             num_kv_heads = cfg.num_kv_heads
 
             kv_cache = torch.zeros(

--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -838,6 +838,10 @@ class KVCacheEngine(BaseEngine):
         node_inputs = planned.node_inputs
         submod_mgmt = planned.prepared.metadata["submod_mgmt"]
         sampler = submod_mgmt.sampler
+
+        if not batch.request_ids:
+            return NodeOutput(per_request_output_tensors={})
+
         submod_mgmt.tp_group.barrier()
 
         if self._can_use_cuda_graph(batch, node_inputs):

--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -5,7 +5,7 @@ from dataclasses import asdict, dataclass, field
 import torch
 
 from mstar.conductor.request_info import CurrentForwardPassInfo
-from mstar.distributed.communication import TPCommGroup, WorkerTPGroups
+from mstar.distributed.communication import CommGroup, WorkerParallelGroups
 from mstar.engine.base import (
     BaseEngine,
     EngineCapabilities,
@@ -46,7 +46,7 @@ class KVManagement:
 class SubmoduleManagement:
     submodule: ARNodeSubmodule
     kv_management: KVManagement
-    tp_group: TPCommGroup
+    tp_group: CommGroup
     default_sampling_config: SamplingConfig
     sampler: Sampler = field(default_factory=Sampler)
     cuda_graph_runner: CudaGraphRunner | None = None
@@ -91,7 +91,7 @@ class KVCacheEngine(BaseEngine):
     def load_model(
         self,
         submodules: dict[str, torch.nn.Module],
-        tp_groups: WorkerTPGroups,
+        parallel_groups: WorkerParallelGroups,
         kv_cache_config: list[KVCacheConfig],
         device: torch.device,
         transfer_engine_info: TransferEngineInfo,
@@ -113,16 +113,16 @@ class KVCacheEngine(BaseEngine):
             if not nodes:
                 continue  # skip KV cache configs that don't apply to any loaded submodule
             world_sizes = set([
-                tp_groups.get_tp_config_for_node(node).world_size for node in nodes
+                parallel_groups.get_tp_config_for_node(node).world_size for node in nodes
             ])
             tp_ranks = set([
-                tp_groups.get_tp_config_for_node(node).rank for node in nodes
+                parallel_groups.get_tp_config_for_node(node).rank for node in nodes
             ])
             sp_sizes = set([
-                tp_groups.get_sp_config_for_node(node).world_size for node in nodes
+                parallel_groups.get_sp_config_for_node(node).world_size for node in nodes
             ])
             sp_ranks = set([
-                tp_groups.get_sp_config_for_node(node).rank for node in nodes
+                parallel_groups.get_sp_config_for_node(node).rank for node in nodes
             ])
             if (
                 len(world_sizes) > 1 or len(tp_ranks) > 1
@@ -132,12 +132,14 @@ class KVCacheEngine(BaseEngine):
                     "It is disallowed to share a KV cache among colocated nodes "
                     f"from different TP/SP groups: {nodes}."
                 )
-            tp_size = world_sizes.pop()
-            sp_size = sp_sizes.pop()
             # Ulysses sequence parallelism makes attention run at effective
             # head-degree tp*sp (the all-to-all redistributes heads across the
-            # SP group), so each rank's cache holds num_kv_heads / (tp*sp).
-            cfg.shard(tp_size * sp_size)
+            # SP group), so each rank's cache holds num_kv_heads / (tp*sp) —
+            # the instance world size (all nodes share one instance, validated
+            # above).
+            cfg.shard(
+                parallel_groups.get_instance_world_size_for_node(next(iter(nodes)))
+            )
             num_kv_heads = cfg.num_kv_heads
 
             kv_cache = torch.zeros(
@@ -178,7 +180,7 @@ class KVCacheEngine(BaseEngine):
                 node_to_kv_mgmt[node_name] = kv_mgmt
 
         for node_name, submodule in submodules.items():
-            tp_group = tp_groups.get_tp_config_for_node(node_name)
+            tp_group = parallel_groups.get_tp_config_for_node(node_name)
             self.submodule_management[node_name] = SubmoduleManagement(
                 submodule=submodule,
                 kv_management=node_to_kv_mgmt[node_name],

--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -787,6 +787,7 @@ class KVCacheEngine(BaseEngine):
             range_pop(synchronize=False)
 
         node_inputs: list[ARNodeInputs] = []
+        skipped_rids: set[str] = set()
         if self.enable_nvtx:
             range_push("kv_cache.prepare_inputs")
         for rid in batch.request_ids:
@@ -796,15 +797,26 @@ class KVCacheEngine(BaseEngine):
                     rid, label
                 ).get_pos_info() for label in labels
             }
-            node_inputs.append(
-                submodule.prepare_inputs(
-                    graph_walk=batch.graph_walk,
-                    fwd_info=batch.per_request_info[rid],
-                    inputs=batch.per_request_input_tensors[rid],
-                    pos_info=pos_info,
-                    seen_token_mask=submod_mgmt.sampler.get_token_mask(rid)
-                )
+            req_inputs = submodule.prepare_inputs(
+                graph_walk=batch.graph_walk,
+                fwd_info=batch.per_request_info[rid],
+                inputs=batch.per_request_input_tensors[rid],
+                pos_info=pos_info,
+                seen_token_mask=submod_mgmt.sampler.get_token_mask(rid)
             )
+            if req_inputs is None:
+                skipped_rids.add(rid)
+            else:
+                node_inputs.append(req_inputs)
+        
+        if skipped_rids:
+            batch.request_ids = [rid for rid in batch.request_ids if rid not in skipped_rids]
+            batch.per_request_info = {
+                rid: info
+                for rid, info in batch.per_request_info.items()
+                if rid not in skipped_rids
+            }
+
         if self.enable_nvtx:
             range_pop(synchronize=False)
 

--- a/mstar/engine/kv_store.py
+++ b/mstar/engine/kv_store.py
@@ -97,12 +97,12 @@ class KVCacheConfig:
             return "ALL_NODES"
         return "///".join(self.nodes)
 
-    def shard(self, tp_size: int):
-        if tp_size >= self.original_num_kv_heads:
+    def shard(self, num_shards: int):
+        if num_shards >= self.original_num_kv_heads:
             self.num_kv_heads = 1
         else:
-            self.num_kv_heads = divide(self.original_num_kv_heads, tp_size)
-        self.num_qo_heads = divide(self.original_num_qo_heads, tp_size)
+            self.num_kv_heads = divide(self.original_num_kv_heads, num_shards)
+        self.num_qo_heads = divide(self.original_num_qo_heads, num_shards)
         self._sharded = True
 
 

--- a/mstar/engine/kv_store.py
+++ b/mstar/engine/kv_store.py
@@ -78,6 +78,11 @@ class KVCacheConfig:
     num_qo_heads: int | None = None  # Optional, defaults to num_kv_heads
     cpu_offload_pages: int = 0  # >0 enables CPU offloading with this many CPU pages
     nodes: list[str] = None # defaults to all AR nodes
+    # When True, run the non-causal generation attention through the dense FA3
+    # path (gather frozen prefix + fresh gen, one varlen kernel) instead of the
+    # paged FlashInfer prefill. Only the diffusion generator sets this; the
+    # cache manager additionally restricts it to eager, single-request batches.
+    dense_gen_attn: bool = False
 
     def __post_init__(self):
         if self.num_qo_heads is None:

--- a/mstar/engine/stateless_engine.py
+++ b/mstar/engine/stateless_engine.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 
 import torch
 
-from mstar.distributed.communication import WorkerTPGroups
+from mstar.distributed.communication import WorkerParallelGroups
 from mstar.engine.base import (
     BaseEngine,
     EngineType,
@@ -164,7 +164,7 @@ class StatelessEngine(BaseEngine):
     def load_model(
         self,
         submodules: dict[str, torch.nn.Module],
-        tp_groups: WorkerTPGroups,
+        parallel_groups: WorkerParallelGroups,
         device: torch.device,
         **kwargs,
     ) -> None:
@@ -174,7 +174,7 @@ class StatelessEngine(BaseEngine):
         else:
             self.submodules = dict(submodules)
         self.device = device
-        self.tp_groups = tp_groups
+        self.parallel_groups = parallel_groups
 
     def add_request(self, request_id: str, **kwargs) -> None:
         pass  # stateless
@@ -218,7 +218,7 @@ class StatelessEngine(BaseEngine):
                 f"engine.{self.config.name}.{batch.node_name}."
                 f"{batch.graph_walk}.bs{len(batch.request_ids)}"
             )
-        self.tp_groups.get_tp_config_for_node(batch.node_name).barrier()
+        self.parallel_groups.get_tp_config_for_node(batch.node_name).barrier()
         submodule = self.submodules.get(batch.node_name)
         per_submodule_dtype = submodule.get_autocast_dtype() if submodule is not None else None
         try:
@@ -554,7 +554,7 @@ class StatelessEngine(BaseEngine):
                 submodule_name=node_name,
                 submodule=submodule,
                 device=self.device,
-                tp_group=self.tp_groups.get_tp_config_for_node(node_name)
+                tp_group=self.parallel_groups.get_tp_config_for_node(node_name)
             )
             runner.enable_nvtx = self.enable_nvtx
             runner.warmup_and_capture()
@@ -600,7 +600,7 @@ class StatelessEngine(BaseEngine):
                 kv_cache_config=None,
                 alloc_manager=None,
                 buffer_manager=None,
-                tp_group=self.tp_groups.get_tp_config_for_node(node_name),
+                tp_group=self.parallel_groups.get_tp_config_for_node(node_name),
             )
             pcgr.warmup_and_capture()
             if pcgr.graphs:

--- a/mstar/model/base.py
+++ b/mstar/model/base.py
@@ -44,23 +44,53 @@ class WorkerGraph:
 
     ranks: list[int] = field(default_factory=list)
     tp_size: int = 1
+    sp_size: int = 1
 
-    # each element of the outer list is a tensor-parallel group; populated
-    # in __post_init__ from ``ranks`` chunked by ``tp_size``.
+    # ``ranks`` form a 2D [sp_size, tp_size] mesh per instance (instances tile
+    # for data parallelism). ``_tp_ranks`` are the mesh rows (tensor-parallel
+    # comm groups: sharded heads/weights, all-reduce); ``_sp_ranks`` are the
+    # columns (sequence-parallel comm groups: Ulysses all-to-all);
+    # ``_instance_ranks`` are the whole instances (the conductor's lockstep
+    # routing unit — every rank of an instance runs a request together). With
+    # sp_size==1 this reduces to the old ``ranks`` chunked by ``tp_size``
+    # (trivial SP groups; instance == TP row). ``tp_size`` is rewritten in
+    # __post_init__ to the instance size (tp*sp) so the conductor — which models
+    # a parallel group as its lockstep unit — routes to the whole instance; the
+    # original per-axis degrees live in ``_tp_comm_size`` and ``sp_size``.
     _tp_ranks: list[list[int]] = field(default_factory=list)
+    _sp_ranks: list[list[int]] = field(default_factory=list)
+    _instance_ranks: list[list[int]] = field(default_factory=list)
+    _tp_comm_size: int = 1
     _group_id: int = field(default=-1)  # original index into config's node_groups
     worker_graph_id: str = field(default_factory=lambda: str(uuid4()))
 
     def __post_init__(self):
-        if self.tp_size > 1 and not self._tp_ranks:
-            assert len(self.ranks) % self.tp_size == 0, (
+        if (self.tp_size > 1 or self.sp_size > 1) and not self._tp_ranks:
+            tp = self.tp_size  # tensor-parallel (row / all-reduce) degree
+            sp = self.sp_size  # sequence-parallel (all-to-all) degree
+            inst = tp * sp
+            assert len(self.ranks) % inst == 0, (
                 f"WorkerGraph {self.worker_graph_id} has {len(self.ranks)} ranks; "
-                f"not divisible by tp_size {self.tp_size}."
+                f"not divisible by tp_size*sp_size ({tp}*{sp}={inst})."
             )
-            self._tp_ranks = [
-                self.ranks[i:i + self.tp_size]
-                for i in range(0, len(self.ranks), self.tp_size)
-            ]
+            tp_ranks: list[list[int]] = []
+            sp_ranks: list[list[int]] = []
+            instance_ranks: list[list[int]] = []
+            for base in range(0, len(self.ranks), inst):
+                block = self.ranks[base:base + inst]
+                instance_ranks.append(block)
+                # row-major [sp][tp] grid over this instance's ranks
+                grid = [block[s * tp:(s + 1) * tp] for s in range(sp)]
+                tp_ranks += grid  # rows: vary tp within fixed sp
+                sp_ranks += [
+                    [grid[s][t] for s in range(sp)] for t in range(tp)
+                ]  # columns: vary sp within fixed tp
+            self._tp_ranks = tp_ranks
+            self._sp_ranks = sp_ranks
+            self._instance_ranks = instance_ranks
+            self._tp_comm_size = tp
+            # Conductor routes to the lockstep unit (the whole instance).
+            self.tp_size = inst
 
 
 def _combine_sections_sequential_or_parallel(
@@ -103,6 +133,7 @@ def _divide_into_worker_graphs(
                 _group_id=group_idx,
                 ranks=ng["ranks"],
                 tp_size=ng.get("tp_size", 1),
+                sp_size=ng.get("sp_size", 1),
             )
         ]
 
@@ -273,24 +304,42 @@ class Model(ABC):
         # the separate "sharding_config" section just holds shard_dim.
         groups: list[ShardingGroup] = []
         for ng in config.get("node_groups", []):
-            if ng.get("tp_size", 1) <= 1:
+            tp = ng.get("tp_size", 1)
+            sp = ng.get("sp_size", 1)
+            instance_size = tp * sp
+            if instance_size <= 1:
                 continue
-            if any(
+            if tp > 1 and any(
                 node not in sharding_config.tp_enabled_nodes
                 for node in ng["node_names"]
             ):
                 raise ValueError(
-                    f"Node group with tp_size {ng['tp_size']} contains "
+                    f"Node group with tp_size {tp} contains "
                     f"nodes not in tp_enabled_nodes {sharding_config.tp_enabled_nodes}: "
                     f"{ng['node_names']}"
                 )
+            if sp > 1 and any(
+                node not in sharding_config.sp_enabled_nodes
+                for node in ng["node_names"]
+            ):
+                raise ValueError(
+                    f"Node group with sp_size {sp} contains "
+                    f"nodes not in sp_enabled_nodes {sharding_config.sp_enabled_nodes}: "
+                    f"{ng['node_names']}"
+                )
+            # The sharding group is the lockstep unit — tp*sp workers routed
+            # together. TP shards weights via shard_dim-driven fanout; SP is
+            # in-module (replicated signals, no shard_dim) but its ranks must
+            # still run each request together, so the group spans the whole
+            # instance.
             groups.append(ShardingGroup(
                 nodes=set(ng["node_names"]),
-                tp_size=ng["tp_size"],
+                tp_size=instance_size,
                 graph_walks=set(ng["graph_walks"]) if "graph_walks" in ng else None,
             ))
 
         sharding_config.groups = groups
+
         sharding_config_yaml = config.get("sharding_config")
         if sharding_config_yaml is not None and "shard_dim" in sharding_config_yaml:
             sharding_config.shard_dim.update(sharding_config_yaml["shard_dim"])
@@ -417,7 +466,7 @@ class Model(ABC):
     @abstractmethod
     def get_submodule(
         self, node_name: str, device="cpu", tp_group=None,
-        autocast_dtype: torch.dtype | None = None,
+        autocast_dtype: torch.dtype | None = None, sp_group=None,
     ) -> torch.nn.Module | None:
         """Return the nn.Module for this node, or None for dummy mode.
 
@@ -426,6 +475,12 @@ class Model(ABC):
         Models that support tensor parallelism should forward it to
         parallel-linear constructors so weight shapes are partitioned at
         init time and the weight loaders shard correctly.
+
+        ``sp_group`` is the node's sequence-parallel comm group, orthogonal
+        to ``tp_group``. The engine manager only passes it when the node
+        participates in a non-trivial SP group, so models without SP support
+        never receive it. Models that support SP forward it to their
+        attention so it can all-to-all the sequence around the kernel.
 
         ``autocast_dtype`` is the dtype this node's params should be
         allocated in. Models that build on the meta device must cast the

--- a/mstar/model/base.py
+++ b/mstar/model/base.py
@@ -470,7 +470,7 @@ class Model(ABC):
     ) -> torch.nn.Module | None:
         """Return the nn.Module for this node, or None for dummy mode.
 
-        ``tp_group`` is the :class:`TPCommGroup` for this node on the
+        ``tp_group`` is the :class:`CommGroup` for this node on the
         calling worker (``None`` when TP is not active for this node).
         Models that support tensor parallelism should forward it to
         parallel-linear constructors so weight shapes are partitioned at

--- a/mstar/model/components/distributed/attention.py
+++ b/mstar/model/components/distributed/attention.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.engine.cache_manager import BatchedCacheManager
 from mstar.model.components.distributed.linear import (
     QKVParallelLinear,
@@ -36,7 +36,7 @@ class ParallelAttention(nn.Module):
     def __init__(
         self,
         *,
-        comm_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
         hidden_size: int,
         num_heads: int,
         num_kv_heads: int,
@@ -54,7 +54,7 @@ class ParallelAttention(nn.Module):
     ):
         super().__init__()
         if comm_group is None:
-            comm_group = TPCommGroup.trivial()
+            comm_group = CommGroup.trivial()
         self.comm_group = comm_group
         self.hidden_size = hidden_size
         self.input_hidden_size = input_hidden_size or hidden_size

--- a/mstar/model/components/distributed/embedding.py
+++ b/mstar/model/components/distributed/embedding.py
@@ -20,7 +20,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.distributed.utils import divide
 
 
@@ -37,13 +37,13 @@ class VocabParallelEmbedding(nn.Module):
         self,
         num_embeddings: int,
         embedding_dim: int,
-        comm_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
         padding_idx: int | None = None,
         dtype: torch.dtype | None = None,
     ):
         super().__init__()
         if comm_group is None:
-            comm_group = TPCommGroup.trivial()
+            comm_group = CommGroup.trivial()
         self.comm_group = comm_group
         self.tp_rank = comm_group.rank
         self.tp_size = comm_group.world_size

--- a/mstar/model/components/distributed/linear.py
+++ b/mstar/model/components/distributed/linear.py
@@ -1,7 +1,7 @@
 import torch
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.distributed.utils import divide, split_tensor_along_last_dim
 
 
@@ -14,7 +14,7 @@ class ColumnParallelLinear(nn.Module):
 
     def __init__(
         self,
-        comm_group: TPCommGroup,
+        comm_group: CommGroup,
         input_size: int,
         output_size: int,
         bias: bool = False,
@@ -119,7 +119,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
     def __init__(
         self,
-        comm_group: TPCommGroup,
+        comm_group: CommGroup,
         input_size: int,
         output_sizes: list[int],
         bias: bool = True,
@@ -191,7 +191,7 @@ class QKVParallelLinear(ColumnParallelLinear):
 
     def __init__(
         self,
-        comm_group: TPCommGroup,
+        comm_group: CommGroup,
         hidden_size: int,
         head_size: int,
         total_num_heads: int,
@@ -306,7 +306,7 @@ class RowParallelLinear(nn.Module):
 
     def __init__(
         self,
-        comm_group: TPCommGroup,
+        comm_group: CommGroup,
         input_size: int,
         output_size: int,
         bias: bool = True,

--- a/mstar/model/components/distributed/mlp.py
+++ b/mstar/model/components/distributed/mlp.py
@@ -17,7 +17,7 @@ from typing import Callable
 import torch
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.model.components.distributed.linear import (
     MergedColumnParallelLinear,
     RowParallelLinear,
@@ -44,13 +44,13 @@ class ParallelGatedMLP(nn.Module):
         self,
         hidden_size: int,
         intermediate_size: int,
-        comm_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
         activation: str | Callable = "silu",
         bias: bool = False,
     ):
         super().__init__()
         if comm_group is None:
-            comm_group = TPCommGroup.trivial()
+            comm_group = CommGroup.trivial()
         self.hidden_size = hidden_size
         self.intermediate_size = intermediate_size
         self.act = _resolve_activation(activation)

--- a/mstar/model/components/distributed/sequence_parallel.py
+++ b/mstar/model/components/distributed/sequence_parallel.py
@@ -1,0 +1,130 @@
+"""Ulysses sequence parallelism — model-agnostic primitives.
+
+Sequence parallelism (SP) shards the token sequence across an ``sp_group`` and
+replicates the weights, the mirror image of tensor parallelism (which shards the
+weights and replicates the sequence). Attention is the only operator that needs
+the whole sequence, so Ulysses brackets it with two all-to-alls: the first turns
+a sequence-sharded ``[seq/P, heads, dim]`` tensor into a head-sharded
+``[seq, heads/P, dim]`` one (full sequence, this rank's slice of heads), the
+attention runs locally, and the second converts back. Net effect: attention runs
+exactly as if at tensor-parallel degree ``tp*sp`` — the kernel (``run_attention``)
+is unchanged — while every pointwise op (norms, MLP, residuals) runs on the
+``seq/P`` shard for free.
+
+These helpers take an ``sp_group`` (a :class:`TPCommGroup` over the SP axis of the
+mesh; trivial when ``sp_size == 1``) and are model-independent: any attention that
+projects to ``[tokens, heads, head_dim]`` and calls a ``run_attention(q, k, v)``
+can use :func:`ulysses_attention`. ``seq_sizes`` is the per-rank token count along
+the sequence (need not be equal — sequences indivisible by ``sp`` are handled
+without padding); the scatter/gather of the residual stream at the model boundary
+uses the same split.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+import torch
+
+from mstar.distributed.communication import TPCommGroup
+
+
+def sp_seq_split(total: int, world_size: int) -> list[int]:
+    """Even per-rank token counts summing to ``total`` (earlier ranks get the
+    remainder). The sequence need not be divisible by ``world_size``."""
+    base, rem = divmod(total, world_size)
+    return [base + (1 if r < rem else 0) for r in range(world_size)]
+
+
+def scatter_sequence(
+    sp_group: TPCommGroup,
+    x_full: torch.Tensor,
+    seq_sizes: list[int],
+    dim: int = 0,
+) -> torch.Tensor:
+    """Return this rank's contiguous slice of a sequence-replicated tensor. No
+    communication — every SP rank holds the identical ``x_full`` (the denoise
+    latent is replicated), so each simply narrows to its ``seq_sizes`` window."""
+    if sp_group.world_size == 1:
+        return x_full
+    start = sum(seq_sizes[: sp_group.rank])
+    return x_full.narrow(dim, start, seq_sizes[sp_group.rank]).contiguous()
+
+
+def gather_sequence(
+    sp_group: TPCommGroup,
+    x_shard: torch.Tensor,
+    seq_sizes: list[int],
+    dim: int = 0,
+) -> torch.Tensor:
+    """All-gather the sequence shards back into the full tensor (rank order).
+
+    Pads each shard to the max per-rank length so the underlying collective is a
+    native equal-size all-gather, then trims — robust to sequences not divisible
+    by the group size. For the common even split it is a plain all-gather."""
+    world_size = sp_group.world_size
+    if world_size == 1:
+        return x_shard
+    max_sz = max(seq_sizes)
+    local = x_shard
+    if local.size(dim) < max_sz:
+        pad_shape = list(local.shape)
+        pad_shape[dim] = max_sz - local.size(dim)
+        pad = torch.zeros(pad_shape, dtype=local.dtype, device=local.device)
+        local = torch.cat([local, pad], dim=dim)
+    gathered = sp_group.all_gather(local.contiguous(), dim=dim)
+    if all(s == max_sz for s in seq_sizes):
+        return gathered
+    chunks = list(torch.split(gathered, max_sz, dim=dim))
+    return torch.cat(
+        [chunks[r].narrow(dim, 0, seq_sizes[r]) for r in range(world_size)],
+        dim=dim,
+    ).contiguous()
+
+
+def ulysses_attention(
+    sp_group: TPCommGroup,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    run_attention: Callable[..., torch.Tensor],
+    seq_sizes: list[int],
+) -> torch.Tensor:
+    """Run attention under Ulysses SP.
+
+    ``q``: ``[seq/P, Hq, D]``; ``k``/``v``: ``[seq/P, Hkv, D]`` (this rank's
+    tokens, TP-local heads). Returns ``[seq/P, Hq, D]``. The head counts must be
+    divisible by ``sp`` (Ulysses shards heads). When the group is trivial this is
+    a passthrough — byte-identical to the non-SP path."""
+    if sp_group.world_size == 1:
+        return run_attention(q=q, k=k, v=v)
+    # scatter heads, gather sequence: [seq/P, H, D] -> [seq, H/P, D]
+    q = sp_group.all_to_all(q, scatter_dim=1, gather_dim=0, gather_sizes=seq_sizes)
+    k = sp_group.all_to_all(k, scatter_dim=1, gather_dim=0, gather_sizes=seq_sizes)
+    v = sp_group.all_to_all(v, scatter_dim=1, gather_dim=0, gather_sizes=seq_sizes)
+    out = run_attention(q=q, k=k, v=v)  # [seq, Hq/P, D] (attends [UND-prefix | GEN])
+    # scatter sequence, gather heads: [seq, H/P, D] -> [seq/P, H, D]
+    out = sp_group.all_to_all(out, scatter_dim=0, gather_dim=1, scatter_sizes=seq_sizes)
+    return out
+
+
+def sp_head_slice(sp_group: TPCommGroup, x: torch.Tensor) -> torch.Tensor:
+    """Keep this SP rank's contiguous head-group: ``[T, H, D] -> [T, H/P, D]``.
+
+    The selected heads ``[rank*H/P : (rank+1)*H/P]`` are exactly those that
+    :func:`ulysses_attention`'s all-to-all routes to this rank, so a tensor sliced
+    here (e.g. the replicated UND prefix K/V) lands on the same head partition as
+    the sequence-parallel GEN attention."""
+    world_size = sp_group.world_size
+    if world_size == 1:
+        return x
+    b = x.size(1) // world_size
+    return x[:, sp_group.rank * b:(sp_group.rank + 1) * b, :].contiguous()
+
+
+def sp_head_gather(sp_group: TPCommGroup, x: torch.Tensor) -> torch.Tensor:
+    """Reassemble full TP-local heads from per-rank head-groups (the inverse of
+    :func:`sp_head_slice`): ``[T, H/P, D] -> [T, H, D]`` via an all-gather over
+    heads, restoring the layout the row-parallel output projection expects."""
+    if sp_group.world_size == 1:
+        return x
+    return sp_group.all_gather(x, dim=1)

--- a/mstar/model/components/distributed/sequence_parallel.py
+++ b/mstar/model/components/distributed/sequence_parallel.py
@@ -11,7 +11,7 @@ exactly as if at tensor-parallel degree ``tp*sp`` — the kernel (``run_attentio
 is unchanged — while every pointwise op (norms, MLP, residuals) runs on the
 ``seq/P`` shard for free.
 
-These helpers take an ``sp_group`` (a :class:`TPCommGroup` over the SP axis of the
+These helpers take an ``sp_group`` (a :class:`CommGroup` over the SP axis of the
 mesh; trivial when ``sp_size == 1``) and are model-independent: any attention that
 projects to ``[tokens, heads, head_dim]`` and calls a ``run_attention(q, k, v)``
 can use :func:`ulysses_attention`. ``seq_sizes`` is the per-rank token count along
@@ -25,7 +25,7 @@ from typing import Callable
 
 import torch
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 
 
 def sp_seq_split(total: int, world_size: int) -> list[int]:
@@ -36,7 +36,7 @@ def sp_seq_split(total: int, world_size: int) -> list[int]:
 
 
 def scatter_sequence(
-    sp_group: TPCommGroup,
+    sp_group: CommGroup,
     x_full: torch.Tensor,
     seq_sizes: list[int],
     dim: int = 0,
@@ -51,7 +51,7 @@ def scatter_sequence(
 
 
 def gather_sequence(
-    sp_group: TPCommGroup,
+    sp_group: CommGroup,
     x_shard: torch.Tensor,
     seq_sizes: list[int],
     dim: int = 0,
@@ -82,7 +82,7 @@ def gather_sequence(
 
 
 def ulysses_attention(
-    sp_group: TPCommGroup,
+    sp_group: CommGroup,
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -122,7 +122,7 @@ def ulysses_attention(
 
 
 def _ulysses_attention_via_all_gather(
-    sp_group: TPCommGroup,
+    sp_group: CommGroup,
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -153,7 +153,7 @@ def _ulysses_attention_via_all_gather(
     return out[rank * sl:(rank + 1) * sl, :, :].contiguous()
 
 
-def sp_head_slice(sp_group: TPCommGroup, x: torch.Tensor) -> torch.Tensor:
+def sp_head_slice(sp_group: CommGroup, x: torch.Tensor) -> torch.Tensor:
     """Keep this SP rank's contiguous head-group: ``[T, H, D] -> [T, H/P, D]``.
 
     The selected heads ``[rank*H/P : (rank+1)*H/P]`` are exactly those that
@@ -167,7 +167,7 @@ def sp_head_slice(sp_group: TPCommGroup, x: torch.Tensor) -> torch.Tensor:
     return x[:, sp_group.rank * b:(sp_group.rank + 1) * b, :].contiguous()
 
 
-def sp_head_gather(sp_group: TPCommGroup, x: torch.Tensor) -> torch.Tensor:
+def sp_head_gather(sp_group: CommGroup, x: torch.Tensor) -> torch.Tensor:
     """Reassemble full TP-local heads from per-rank head-groups (the inverse of
     :func:`sp_head_slice`): ``[T, H/P, D] -> [T, H, D]`` via an all-gather over
     heads, restoring the layout the row-parallel output projection expects."""

--- a/mstar/model/components/distributed/sequence_parallel.py
+++ b/mstar/model/components/distributed/sequence_parallel.py
@@ -88,15 +88,29 @@ def ulysses_attention(
     v: torch.Tensor,
     run_attention: Callable[..., torch.Tensor],
     seq_sizes: list[int],
+    prefer_all_gather: bool = False,
 ) -> torch.Tensor:
     """Run attention under Ulysses SP.
 
     ``q``: ``[seq/P, Hq, D]``; ``k``/``v``: ``[seq/P, Hkv, D]`` (this rank's
     tokens, TP-local heads). Returns ``[seq/P, Hq, D]``. The head counts must be
     divisible by ``sp`` (Ulysses shards heads). When the group is trivial this is
-    a passthrough — byte-identical to the non-SP path."""
+    a passthrough — byte-identical to the non-SP path.
+
+    ``prefer_all_gather`` selects the all-gather collective instead of the
+    all-to-all (see :func:`_ulysses_attention_via_all_gather`). The caller sets
+    it on the denoise forward that the CUDA graph captures: the all-to-all is
+    grouped point-to-point send/recv and does not replay from a captured graph,
+    whereas all-gather (a true collective, like the TP all-reduce) does. It must
+    be set consistently across warmup, capture and replay so the all-gather
+    kernels are compiled and autotuned during eager warmup, not mid-capture
+    (autotuning synchronizes, which is illegal while a graph is recording).
+    Eager paths (video, uncaptured resolutions) leave it off for the lighter
+    all-to-all. Both produce identical results."""
     if sp_group.world_size == 1:
         return run_attention(q=q, k=k, v=v)
+    if prefer_all_gather:
+        return _ulysses_attention_via_all_gather(sp_group, q, k, v, run_attention)
     # scatter heads, gather sequence: [seq/P, H, D] -> [seq, H/P, D]
     q = sp_group.all_to_all(q, scatter_dim=1, gather_dim=0, gather_sizes=seq_sizes)
     k = sp_group.all_to_all(k, scatter_dim=1, gather_dim=0, gather_sizes=seq_sizes)
@@ -105,6 +119,38 @@ def ulysses_attention(
     # scatter sequence, gather heads: [seq, H/P, D] -> [seq/P, H, D]
     out = sp_group.all_to_all(out, scatter_dim=0, gather_dim=1, scatter_sizes=seq_sizes)
     return out
+
+
+def _ulysses_attention_via_all_gather(
+    sp_group: TPCommGroup,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    run_attention: Callable[..., torch.Tensor],
+) -> torch.Tensor:
+    """CUDA-graph-capturable Ulysses attention built from all-gather.
+
+    Same result as :func:`ulysses_attention`'s all-to-all, different collective:
+    each rank all-gathers the full sequence and attends over its own head-group,
+    then all-gathers the full heads back and keeps its own sequence shard. The
+    all-to-all would move fewer bytes, but it is grouped send/recv and does not
+    replay from a CUDA graph; all-gather is a true collective and does. Assumes
+    an even sequence split across the group (the captured resolutions guarantee
+    it). Head counts are divisible by the group size (the Ulysses constraint)."""
+    world_size, rank = sp_group.world_size, sp_group.rank
+    # [seq/P, H, D] -> all-gather sequence -> [seq, H, D] -> keep head-group rank
+    q_full = sp_group.all_gather(q, dim=0)
+    k_full = sp_group.all_gather(k, dim=0)
+    v_full = sp_group.all_gather(v, dim=0)
+    hq, hkv = q_full.size(1) // world_size, k_full.size(1) // world_size
+    q = q_full[:, rank * hq:(rank + 1) * hq, :].contiguous()
+    k = k_full[:, rank * hkv:(rank + 1) * hkv, :].contiguous()
+    v = v_full[:, rank * hkv:(rank + 1) * hkv, :].contiguous()
+    out = run_attention(q=q, k=k, v=v)  # [seq, Hq/P, D]
+    # [seq, Hq/P, D] -> all-gather heads -> [seq, Hq, D] -> keep sequence shard rank
+    out = sp_group.all_gather(out, dim=1)
+    sl = out.size(0) // world_size
+    return out[rank * sl:(rank + 1) * sl, :, :].contiguous()
 
 
 def sp_head_slice(sp_group: TPCommGroup, x: torch.Tensor) -> torch.Tensor:

--- a/mstar/model/components/moe.py
+++ b/mstar/model/components/moe.py
@@ -29,7 +29,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.distributed.utils import divide
 
 logger = logging.getLogger(__name__)
@@ -332,11 +332,11 @@ class ParallelSparseMoeBlock(nn.Module):
         num_experts_per_tok: int,
         moe_intermediate_size: int,
         norm_topk_prob: bool = True,
-        comm_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
     ) -> None:
         super().__init__()
         if comm_group is None:
-            comm_group = TPCommGroup.trivial()
+            comm_group = CommGroup.trivial()
         self.comm_group = comm_group
         tp_size = comm_group.world_size
         tp_rank = comm_group.rank
@@ -429,11 +429,11 @@ class ParallelSparseMoeBlockWithSharedExpert(nn.Module):
         moe_intermediate_size: int,
         shared_expert: nn.Module,
         norm_topk_prob: bool = False,
-        comm_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
     ) -> None:
         super().__init__()
         if comm_group is None:
-            comm_group = TPCommGroup.trivial()
+            comm_group = CommGroup.trivial()
         self.comm_group = comm_group
         tp_size = comm_group.world_size
         tp_rank = comm_group.rank

--- a/mstar/model/cosmos3/components/transformer.py
+++ b/mstar/model/cosmos3/components/transformer.py
@@ -99,9 +99,13 @@ class Cosmos3RotaryEmbedding(nn.Module):
         )
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)  # [3,B,N]
-        inv_freq_expanded = inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(device)
-        position_ids_expanded = position_ids[:, :, None, :].float()  # [3,B,1,N]
-        freqs = (inv_freq_expanded @ position_ids_expanded).transpose(2, 3)  # [3,B,N,head_dim//2]
+        # Outer product position ⊗ inv_freq via broadcast multiply. The original
+        # form built stride-0 broadcast views and ran a batched matmul whose
+        # output the CUDA-graph memory pool can mis-capture at some sequence
+        # lengths (the rotary table comes out wrong on replay, scrambling the
+        # image). A plain broadcast multiply produces a fresh contiguous tensor
+        # and is capture-faithful — bit-identical eagerly.
+        freqs = position_ids[:, :, :, None].float() * inv_freq.view(1, 1, 1, -1)  # [3,B,N,head_dim//2]
         freqs = self.apply_interleaved_mrope(freqs)  # [B,N,head_dim//2]
         emb = torch.cat((freqs, freqs), dim=-1)  # [B,N,head_dim]
         return emb.cos().to(dtype=dtype), emb.sin().to(dtype=dtype)

--- a/mstar/model/cosmos3/components/transformer.py
+++ b/mstar/model/cosmos3/components/transformer.py
@@ -443,6 +443,9 @@ class Cosmos3OmniTransformer(nn.Module):
         if sp_group is None:
             sp_group = TPCommGroup.trivial()
         self.sp_group = sp_group
+        if comm_group is None:
+            comm_group = TPCommGroup.trivial()
+        self.comm_group = comm_group
 
         self.embed_tokens = nn.Embedding(config.vocab_size, h)
         self.layers = nn.ModuleList(

--- a/mstar/model/cosmos3/components/transformer.py
+++ b/mstar/model/cosmos3/components/transformer.py
@@ -31,6 +31,14 @@ from diffusers.models.embeddings import Timesteps
 from torch import nn
 
 from mstar.distributed.communication import TPCommGroup
+from mstar.model.components.distributed.sequence_parallel import (
+    gather_sequence,
+    scatter_sequence,
+    sp_head_gather,
+    sp_head_slice,
+    sp_seq_split,
+    ulysses_attention,
+)
 from mstar.model.components.distributed.linear import (
     ColumnParallelLinear,
     RowParallelLinear,
@@ -173,20 +181,30 @@ class Cosmos3PackedMoTAttention(nn.Module):
         attention_bias: bool,
         rms_norm_eps: float,
         comm_group: TPCommGroup | None = None,
+        sp_group: TPCommGroup | None = None,
     ):
         super().__init__()
         if comm_group is None:
             comm_group = TPCommGroup.trivial()
+        if sp_group is None:
+            sp_group = TPCommGroup.trivial()
+        self.sp_group = sp_group
         tp_size = comm_group.world_size
-        if num_attention_heads % tp_size or num_key_value_heads % tp_size:
+        sp_size = sp_group.world_size
+        # Ulysses sequence parallelism redistributes heads across the SP group
+        # via an all-to-all around attention, so the attention runs at effective
+        # head-degree tp*sp — both head counts must divide that product.
+        eff_size = tp_size * sp_size
+        if num_attention_heads % eff_size or num_key_value_heads % eff_size:
             raise ValueError(
-                f"TP size {tp_size} must divide both num_attention_heads "
-                f"({num_attention_heads}) and num_key_value_heads "
-                f"({num_key_value_heads})"
+                f"tp_size*sp_size ({tp_size}*{sp_size}={eff_size}) must divide "
+                f"both num_attention_heads ({num_attention_heads}) and "
+                f"num_key_value_heads ({num_key_value_heads})"
             )
         self.head_dim = head_dim
-        # Per-rank head counts: TP shards the head dimension, so the q/k/v
-        # reshapes below operate on this rank's slice of heads.
+        # TP-local (post-projection) head counts: the column-parallel q/k/v
+        # projections shard heads by tp_size, and the SP all-to-all further
+        # splits these to tp*sp heads around the attention kernel.
         self.num_attention_heads = num_attention_heads // tp_size
         self.num_key_value_heads = num_key_value_heads // tp_size
 
@@ -274,17 +292,37 @@ class Cosmos3PackedMoTAttention(nn.Module):
         v = self.to_v(und_seq).view(-1, Hkv, D)
         q = self._apply_rope(q, cos, sin)
         k = self._apply_rope(k, cos, sin)
-        out = cache_handle.run_attention(q=q, k=k, v=v).reshape(-1, H * D)
+        if self.sp_group.world_size > 1:
+            # The UND prefix is replicated across the SP group (small text). Keep
+            # this rank's head-group so the cached prefix K/V lands on the same
+            # head partition the GEN all-to-all produces, then gather heads back
+            # for the row-parallel output projection.
+            q = sp_head_slice(self.sp_group, q)
+            k = sp_head_slice(self.sp_group, k)
+            v = sp_head_slice(self.sp_group, v)
+            out = cache_handle.run_attention(q=q, k=k, v=v)
+            out = sp_head_gather(self.sp_group, out).reshape(-1, H * D)
+        else:
+            out = cache_handle.run_attention(q=q, k=k, v=v).reshape(-1, H * D)
         return self.to_out(out)
 
-    def forward_gen(self, gen_seq: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, cache_handle) -> torch.Tensor:
+    def forward_gen(
+        self, gen_seq: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor,
+        cache_handle, seq_sizes: list[int] | None = None,
+    ) -> torch.Tensor:
         H, Hkv, D = self.num_attention_heads, self.num_key_value_heads, self.head_dim
         q = self.norm_added_q(self.add_q_proj(gen_seq).view(-1, H, D))
         k = self.norm_added_k(self.add_k_proj(gen_seq).view(-1, Hkv, D))
         v = self.add_v_proj(gen_seq).view(-1, Hkv, D)
         q = self._apply_rope(q, cos, sin)
         k = self._apply_rope(k, cos, sin)
-        out = cache_handle.run_attention(q=q, k=k, v=v).reshape(-1, H * D)
+        # Ulysses all-to-all wraps run_attention: gen_seq is sequence-sharded
+        # across the SP group, so attention runs over the full sequence at
+        # tp*sp head-degree, then the result is re-sharded back. Trivial SP
+        # group -> passthrough (byte-identical to the non-SP path).
+        out = ulysses_attention(
+            self.sp_group, q, k, v, cache_handle.run_attention, seq_sizes,
+        ).reshape(-1, H * D)
         return self.to_add_out(out)
 
 
@@ -301,6 +339,7 @@ class Cosmos3MoTDecoderLayer(nn.Module):
         attention_bias: bool,
         rms_norm_eps: float,
         comm_group: TPCommGroup | None = None,
+        sp_group: TPCommGroup | None = None,
     ):
         super().__init__()
         self.self_attn = Cosmos3PackedMoTAttention(
@@ -311,6 +350,7 @@ class Cosmos3MoTDecoderLayer(nn.Module):
             attention_bias=attention_bias,
             rms_norm_eps=rms_norm_eps,
             comm_group=comm_group,
+            sp_group=sp_group,
         )
         self.mlp = Cosmos3MLP(hidden_size, intermediate_size, comm_group=comm_group)
         self.mlp_moe_gen = Cosmos3MLP(hidden_size, intermediate_size, comm_group=comm_group)
@@ -344,9 +384,12 @@ class Cosmos3MoTDecoderLayer(nn.Module):
         residual = und_seq + attn_out
         return residual + self.mlp(self.post_attention_layernorm(residual))
 
-    def forward_gen(self, gen_seq: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, cache_handle) -> torch.Tensor:
+    def forward_gen(
+        self, gen_seq: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor,
+        cache_handle, seq_sizes: list[int] | None = None,
+    ) -> torch.Tensor:
         gen_norm = self.input_layernorm_moe_gen(gen_seq)
-        attn_out = self.self_attn.forward_gen(gen_norm, cos, sin, cache_handle)
+        attn_out = self.self_attn.forward_gen(gen_norm, cos, sin, cache_handle, seq_sizes)
         residual = gen_seq + attn_out
         return residual + self.mlp_moe_gen(self.post_attention_layernorm_moe_gen(residual))
 
@@ -386,10 +429,13 @@ class Cosmos3OmniTransformer(nn.Module):
     predicts flow velocity through ``proj_out`` and never decodes text logits.
     """
 
-    def __init__(self, config, comm_group: TPCommGroup | None = None):
+    def __init__(self, config, comm_group: TPCommGroup | None = None, sp_group: TPCommGroup | None = None):
         super().__init__()
         self.config = config
         h = config.hidden_size
+        if sp_group is None:
+            sp_group = TPCommGroup.trivial()
+        self.sp_group = sp_group
 
         self.embed_tokens = nn.Embedding(config.vocab_size, h)
         self.layers = nn.ModuleList(
@@ -402,6 +448,7 @@ class Cosmos3OmniTransformer(nn.Module):
                 attention_bias=config.attention_bias,
                 rms_norm_eps=config.rms_norm_eps,
                 comm_group=comm_group,
+                sp_group=sp_group,
             )
             for _ in range(config.num_hidden_layers)
         )
@@ -744,6 +791,34 @@ class Cosmos3OmniTransformer(nn.Module):
             und_seq = layer.forward_und(und_seq, cos, sin, cache_handle)
         cache_handle.advance_seq_lens()
 
+    def _sp_run_gen_layers(self, gen_seq, cos, sin, cache_handle):
+        """Run the generation layer stack, sequence-parallel-sharded across the
+        SP group when active. ``gen_seq``/``cos``/``sin`` are the FULL sequence
+        (identical on every SP rank); returns the FULL post-layer sequence.
+
+        This is the only sequence-parallel bracket in the denoise path: the
+        prologue (patchify, proj_in, timestep scatter-add, action concat, rotary)
+        and epilogue (final norm, proj_out, unpatchify) all use absolute token
+        indices and must run on the full sequence, so SP shards only the layer
+        stack — where essentially all the compute is. The Ulysses all-to-all
+        inside each layer is a redistribute-and-reconstruct, so a contiguous
+        scatter + rank-order gather preserves the exact token order (including a
+        packed ``[cond | uncond]`` CFG batch)."""
+        sp = self.sp_group
+        if sp.world_size == 1:
+            for i, layer in enumerate(self.layers):
+                cache_handle.set_layer_idx(i)
+                gen_seq = layer.forward_gen(gen_seq, cos, sin, cache_handle)
+            return gen_seq
+        seq_sizes = sp_seq_split(gen_seq.shape[0], sp.world_size)
+        gen_seq = scatter_sequence(sp, gen_seq, seq_sizes)
+        cos = scatter_sequence(sp, cos, seq_sizes)
+        sin = scatter_sequence(sp, sin, seq_sizes)
+        for i, layer in enumerate(self.layers):
+            cache_handle.set_layer_idx(i)
+            gen_seq = layer.forward_gen(gen_seq, cos, sin, cache_handle, seq_sizes)
+        return gather_sequence(sp, gen_seq, seq_sizes)
+
     def denoise_step(
         self,
         latents: torch.Tensor,
@@ -791,9 +866,7 @@ class Cosmos3OmniTransformer(nn.Module):
             gen_seq = torch.cat([gen_seq, action_seq], dim=0)
 
         cos, sin = self._rotary(position_ids, gen_seq.device, gen_seq.dtype)
-        for i, layer in enumerate(self.layers):
-            cache_handle.set_layer_idx(i)
-            gen_seq = layer.forward_gen(gen_seq, cos, sin, cache_handle)
+        gen_seq = self._sp_run_gen_layers(gen_seq, cos, sin, cache_handle)
         gen_out = self.norm_moe_gen(gen_seq)
         preds_packed = self.proj_out(gen_out[vision_mse_loss_indexes])
         preds = self._unpatchify_and_unpack_latents(
@@ -866,9 +939,7 @@ class Cosmos3OmniTransformer(nn.Module):
         cos = torch.cat([cos_c, cos_u], dim=0)
         sin = torch.cat([sin_c, sin_u], dim=0)
 
-        for i, layer in enumerate(self.layers):
-            cache_handle.set_layer_idx(i)
-            gen_seq = layer.forward_gen(gen_seq, cos, sin, cache_handle)
+        gen_seq = self._sp_run_gen_layers(gen_seq, cos, sin, cache_handle)
         gen_out = self.norm_moe_gen(gen_seq)
 
         def _decode(out):
@@ -904,6 +975,10 @@ class Cosmos3OmniTransformer(nn.Module):
         Each ``requests`` entry is a dict with: ``latents``, ``vision_timesteps``,
         ``position_ids_cond``, ``position_ids_uncond``, ``vision_token_shapes``,
         ``vision_noisy_frame_indexes``, ``vision_mse_loss_indexes``."""
+        assert self.sp_group.world_size == 1, (
+            "Sequence parallelism is not supported with multi-request batched "
+            "denoising yet (v1 targets bs=1)."
+        )
         gen_seqs, shapes, cos_cond, sin_cond, cos_uncond, sin_uncond = [], [], [], [], [], []
         for req in requests:
             packed, original_latent_shapes = self._patchify_and_pack_latents([req["latents"]])
@@ -984,6 +1059,10 @@ class Cosmos3OmniTransformer(nn.Module):
         ``vision_noisy_frame_indexes``, ``vision_mse_loss_indexes``,
         ``action_token_shapes``, ``action_noisy_frame_indexes``,
         ``action_mse_gen_indexes``, ``action_domain_id``."""
+        assert self.sp_group.world_size == 1, (
+            "Sequence parallelism is not supported with multi-request batched "
+            "action denoising yet (v1 targets bs=1)."
+        )
         gen_seqs, shapes, cos_cond, sin_cond, cos_uncond, sin_uncond = [], [], [], [], [], []
         for req in requests:
             packed, original_latent_shapes = self._patchify_and_pack_latents([req["latents"]])

--- a/mstar/model/cosmos3/components/transformer.py
+++ b/mstar/model/cosmos3/components/transformer.py
@@ -990,10 +990,6 @@ class Cosmos3OmniTransformer(nn.Module):
         Each ``requests`` entry is a dict with: ``latents``, ``vision_timesteps``,
         ``position_ids_cond``, ``position_ids_uncond``, ``vision_token_shapes``,
         ``vision_noisy_frame_indexes``, ``vision_mse_loss_indexes``."""
-        assert self.sp_group.world_size == 1, (
-            "Sequence parallelism is not supported with multi-request batched "
-            "denoising yet (v1 targets bs=1)."
-        )
         gen_seqs, shapes, cos_cond, sin_cond, cos_uncond, sin_uncond = [], [], [], [], [], []
         for req in requests:
             packed, original_latent_shapes = self._patchify_and_pack_latents([req["latents"]])
@@ -1020,9 +1016,7 @@ class Cosmos3OmniTransformer(nn.Module):
         all_gen = torch.cat(gen_seqs + gen_seqs, dim=0)
         cos = torch.cat(cos_cond + cos_uncond, dim=0)
         sin = torch.cat(sin_cond + sin_uncond, dim=0)
-        for i, layer in enumerate(self.layers):
-            cache_handle.set_layer_idx(i)
-            all_gen = layer.forward_gen(all_gen, cos, sin, cache_handle)
+        all_gen = self._sp_run_gen_layers(all_gen, cos, sin, cache_handle)
         gen_out = self.norm_moe_gen(all_gen)
 
         sizes = [g.shape[0] for g in gen_seqs]
@@ -1074,10 +1068,6 @@ class Cosmos3OmniTransformer(nn.Module):
         ``vision_noisy_frame_indexes``, ``vision_mse_loss_indexes``,
         ``action_token_shapes``, ``action_noisy_frame_indexes``,
         ``action_mse_gen_indexes``, ``action_domain_id``."""
-        assert self.sp_group.world_size == 1, (
-            "Sequence parallelism is not supported with multi-request batched "
-            "action denoising yet (v1 targets bs=1)."
-        )
         gen_seqs, shapes, cos_cond, sin_cond, cos_uncond, sin_uncond = [], [], [], [], [], []
         for req in requests:
             packed, original_latent_shapes = self._patchify_and_pack_latents([req["latents"]])
@@ -1116,9 +1106,7 @@ class Cosmos3OmniTransformer(nn.Module):
             cos = torch.cat(cos_cond, dim=0)
             sin = torch.cat(sin_cond, dim=0)
 
-        for i, layer in enumerate(self.layers):
-            cache_handle.set_layer_idx(i)
-            all_gen = layer.forward_gen(all_gen, cos, sin, cache_handle)
+        all_gen = self._sp_run_gen_layers(all_gen, cos, sin, cache_handle)
         gen_out = self.norm_moe_gen(all_gen)
 
         sizes = [g.shape[0] for g in gen_seqs]

--- a/mstar/model/cosmos3/components/transformer.py
+++ b/mstar/model/cosmos3/components/transformer.py
@@ -309,6 +309,7 @@ class Cosmos3PackedMoTAttention(nn.Module):
     def forward_gen(
         self, gen_seq: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor,
         cache_handle, seq_sizes: list[int] | None = None,
+        prefer_all_gather: bool = False,
     ) -> torch.Tensor:
         H, Hkv, D = self.num_attention_heads, self.num_key_value_heads, self.head_dim
         q = self.norm_added_q(self.add_q_proj(gen_seq).view(-1, H, D))
@@ -319,9 +320,12 @@ class Cosmos3PackedMoTAttention(nn.Module):
         # Ulysses all-to-all wraps run_attention: gen_seq is sequence-sharded
         # across the SP group, so attention runs over the full sequence at
         # tp*sp head-degree, then the result is re-sharded back. Trivial SP
-        # group -> passthrough (byte-identical to the non-SP path).
+        # group -> passthrough (byte-identical to the non-SP path). The captured
+        # denoise forward sets prefer_all_gather (the all-to-all does not replay
+        # from a CUDA graph; all-gather does).
         out = ulysses_attention(
             self.sp_group, q, k, v, cache_handle.run_attention, seq_sizes,
+            prefer_all_gather=prefer_all_gather,
         ).reshape(-1, H * D)
         return self.to_add_out(out)
 
@@ -387,9 +391,12 @@ class Cosmos3MoTDecoderLayer(nn.Module):
     def forward_gen(
         self, gen_seq: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor,
         cache_handle, seq_sizes: list[int] | None = None,
+        prefer_all_gather: bool = False,
     ) -> torch.Tensor:
         gen_norm = self.input_layernorm_moe_gen(gen_seq)
-        attn_out = self.self_attn.forward_gen(gen_norm, cos, sin, cache_handle, seq_sizes)
+        attn_out = self.self_attn.forward_gen(
+            gen_norm, cos, sin, cache_handle, seq_sizes, prefer_all_gather
+        )
         residual = gen_seq + attn_out
         return residual + self.mlp_moe_gen(self.post_attention_layernorm_moe_gen(residual))
 
@@ -791,7 +798,7 @@ class Cosmos3OmniTransformer(nn.Module):
             und_seq = layer.forward_und(und_seq, cos, sin, cache_handle)
         cache_handle.advance_seq_lens()
 
-    def _sp_run_gen_layers(self, gen_seq, cos, sin, cache_handle):
+    def _sp_run_gen_layers(self, gen_seq, cos, sin, cache_handle, prefer_all_gather=False):
         """Run the generation layer stack, sequence-parallel-sharded across the
         SP group when active. ``gen_seq``/``cos``/``sin`` are the FULL sequence
         (identical on every SP rank); returns the FULL post-layer sequence.
@@ -816,7 +823,9 @@ class Cosmos3OmniTransformer(nn.Module):
         sin = scatter_sequence(sp, sin, seq_sizes)
         for i, layer in enumerate(self.layers):
             cache_handle.set_layer_idx(i)
-            gen_seq = layer.forward_gen(gen_seq, cos, sin, cache_handle, seq_sizes)
+            gen_seq = layer.forward_gen(
+                gen_seq, cos, sin, cache_handle, seq_sizes, prefer_all_gather
+            )
         return gather_sequence(sp, gen_seq, seq_sizes)
 
     def denoise_step(
@@ -899,6 +908,7 @@ class Cosmos3OmniTransformer(nn.Module):
         action_mse_gen_indexes: torch.Tensor | None = None,
         action_timesteps: torch.Tensor | None = None,
         action_domain_id: torch.Tensor | None = None,
+        prefer_all_gather: bool = False,
     ):
         """Conditional and unconditional generation in one batched pass.
 
@@ -939,7 +949,9 @@ class Cosmos3OmniTransformer(nn.Module):
         cos = torch.cat([cos_c, cos_u], dim=0)
         sin = torch.cat([sin_c, sin_u], dim=0)
 
-        gen_seq = self._sp_run_gen_layers(gen_seq, cos, sin, cache_handle)
+        gen_seq = self._sp_run_gen_layers(
+            gen_seq, cos, sin, cache_handle, prefer_all_gather=prefer_all_gather
+        )
         gen_out = self.norm_moe_gen(gen_seq)
 
         def _decode(out):

--- a/mstar/model/cosmos3/components/transformer.py
+++ b/mstar/model/cosmos3/components/transformer.py
@@ -30,7 +30,7 @@ import torch.nn.functional as F
 from diffusers.models.embeddings import Timesteps
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.model.components.distributed.sequence_parallel import (
     gather_sequence,
     scatter_sequence,
@@ -148,11 +148,11 @@ class Cosmos3MLP(nn.Module):
         self,
         hidden_size: int,
         intermediate_size: int,
-        comm_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
     ):
         super().__init__()
         if comm_group is None:
-            comm_group = TPCommGroup.trivial()
+            comm_group = CommGroup.trivial()
         self.gate_proj = ColumnParallelLinear(comm_group, hidden_size, intermediate_size, bias=False)
         self.up_proj = ColumnParallelLinear(comm_group, hidden_size, intermediate_size, bias=False)
         self.down_proj = RowParallelLinear(comm_group, intermediate_size, hidden_size, bias=False)
@@ -180,14 +180,14 @@ class Cosmos3PackedMoTAttention(nn.Module):
         num_key_value_heads: int,
         attention_bias: bool,
         rms_norm_eps: float,
-        comm_group: TPCommGroup | None = None,
-        sp_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
+        sp_group: CommGroup | None = None,
     ):
         super().__init__()
         if comm_group is None:
-            comm_group = TPCommGroup.trivial()
+            comm_group = CommGroup.trivial()
         if sp_group is None:
-            sp_group = TPCommGroup.trivial()
+            sp_group = CommGroup.trivial()
         self.sp_group = sp_group
         tp_size = comm_group.world_size
         sp_size = sp_group.world_size
@@ -342,8 +342,8 @@ class Cosmos3MoTDecoderLayer(nn.Module):
         intermediate_size: int,
         attention_bias: bool,
         rms_norm_eps: float,
-        comm_group: TPCommGroup | None = None,
-        sp_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
+        sp_group: CommGroup | None = None,
     ):
         super().__init__()
         self.self_attn = Cosmos3PackedMoTAttention(
@@ -436,15 +436,15 @@ class Cosmos3OmniTransformer(nn.Module):
     predicts flow velocity through ``proj_out`` and never decodes text logits.
     """
 
-    def __init__(self, config, comm_group: TPCommGroup | None = None, sp_group: TPCommGroup | None = None):
+    def __init__(self, config, comm_group: CommGroup | None = None, sp_group: CommGroup | None = None):
         super().__init__()
         self.config = config
         h = config.hidden_size
         if sp_group is None:
-            sp_group = TPCommGroup.trivial()
+            sp_group = CommGroup.trivial()
         self.sp_group = sp_group
         if comm_group is None:
-            comm_group = TPCommGroup.trivial()
+            comm_group = CommGroup.trivial()
         self.comm_group = comm_group
 
         self.embed_tokens = nn.Embedding(config.vocab_size, h)

--- a/mstar/model/cosmos3/config.py
+++ b/mstar/model/cosmos3/config.py
@@ -146,6 +146,16 @@ class Cosmos3Config:
     # (the Wan VAE downsamples time by 4, so latent frames = 1 + (n - 1) // 4).
     num_frames_video: int = 17
 
+    # ----- denoise CUDA-graph capture (serving knobs) -----
+    # Capture the fixed-shape denoise step as a CUDA graph (the launch-bound-tier
+    # accelerator). Set False to serve the denoise loop eagerly. The env var
+    # COSMOS3_DISABLE_CUDA_GRAPH, when set, overrides this.
+    cuda_graph: bool = True
+    # Only capture resolutions whose latent H*W is at or below this; larger tiers
+    # (720p+, video) run eager+dense where the graph is net-slower. The env var
+    # COSMOS3_GRAPH_MAX_LATENT_AREA overrides this.
+    graph_max_latent_area: int = 2000
+
     # ----- sub-configs -----
     vae: Cosmos3VAEConfig = field(default_factory=Cosmos3VAEConfig)
     scheduler: Cosmos3SchedulerConfig = field(default_factory=Cosmos3SchedulerConfig)

--- a/mstar/model/cosmos3/cosmos3_model.py
+++ b/mstar/model/cosmos3/cosmos3_model.py
@@ -434,49 +434,67 @@ class Cosmos3Model(Model):
             return buf.getvalue()
         if modality == "video":
             import os
-            import tempfile
-
-            from torchvision.io import write_video
+            import time as _time
 
             # The decoder emits 8-bit frames [B, C, T, H, W]; encode all of them as
             # an H.264 mp4. The frames already reflect the request fps (it modulates
             # the temporal positions during generation); the container plays back
             # at the model's default fps.
+            #
+            # CRF 18 keeps the H.264 output near-visually-lossless; libx264
+            # otherwise defaults to 23, which is visibly lossier. The "ultrafast"
+            # preset and multithreading (threads=0) target the same CRF/quality
+            # but encode several times faster than libx264's default "medium"
+            # preset, which otherwise dominates the serving latency for a
+            # many-frame clip. Both are overridable via COSMOS3_X264_PRESET.
             x = output[0] if output.ndim == 5 else output  # [C, T, H, W] uint8
             _prof = os.environ.get("COSMOS3_PROFILE")
-            import time as _time
+            fps = self.config.fps
+            preset = os.environ.get("COSMOS3_X264_PRESET", "ultrafast")
             _vt0 = _time.perf_counter()
-            frames = x.permute(1, 2, 3, 0).cpu()  # [T, H, W, C] uint8
-            _vt1 = _time.perf_counter()
-            fd, path = tempfile.mkstemp(suffix=".mp4")
-            os.close(fd)
             try:
-                # CRF 18 keeps the H.264 output near-visually-lossless; libx264
-                # otherwise defaults to 23, which is visibly lossier. The "ultrafast"
-                # preset and multithreading (threads=0) target the same CRF/quality
-                # but encode several times faster than libx264's default "medium"
-                # preset, which otherwise dominates the serving latency for a
-                # many-frame clip. Both are overridable via COSMOS3_X264_PRESET.
-                write_video(
-                    path,
-                    frames,
-                    fps=self.config.fps,
-                    video_codec="libx264",
-                    options={
-                        "crf": "18",
-                        "preset": os.environ.get("COSMOS3_X264_PRESET", "ultrafast"),
-                        "threads": "0",
-                    },
+                # Preferred: torchcodec (torchvision >= 0.27 removed write_video).
+                from torchcodec.encoders import VideoEncoder
+
+                frames = x.permute(1, 0, 2, 3).contiguous().cpu()  # [T, C, H, W] uint8
+                _vt1 = _time.perf_counter()
+                encoded = VideoEncoder(frames, frame_rate=fps).to_tensor(
+                    "mp4",
+                    codec="libx264",
+                    crf=18,
+                    preset=preset,
+                    extra_options={"threads": "0"},
                 )
-                with open(path, "rb") as f:
-                    data = f.read()
-                if _prof:
-                    print(f"COSMOS3_PROFILE mp4 d2h={1000 * (_vt1 - _vt0):.1f}ms "
-                          f"encode={1000 * (_time.perf_counter() - _vt1):.1f}ms frames={frames.shape[0]} "
-                          f"bytes={len(data)}", flush=True)
-                return data
-            finally:
-                os.remove(path)
+                data = encoded.numpy().tobytes()
+            except ImportError:
+                # Fallback for environments without torchcodec (or with the
+                # older decode-only torchcodec that lacks VideoEncoder), where
+                # torchvision still ships write_video.
+                import tempfile
+
+                from torchvision.io import write_video
+
+                frames = x.permute(1, 2, 3, 0).cpu()  # [T, H, W, C] uint8
+                _vt1 = _time.perf_counter()
+                fd, path = tempfile.mkstemp(suffix=".mp4")
+                os.close(fd)
+                try:
+                    write_video(
+                        path,
+                        frames,
+                        fps=fps,
+                        video_codec="libx264",
+                        options={"crf": "18", "preset": preset, "threads": "0"},
+                    )
+                    with open(path, "rb") as f:
+                        data = f.read()
+                finally:
+                    os.remove(path)
+            if _prof:
+                print(f"COSMOS3_PROFILE mp4 d2h={1000 * (_vt1 - _vt0):.1f}ms "
+                      f"encode={1000 * (_time.perf_counter() - _vt1):.1f}ms frames={frames.shape[0]} "
+                      f"bytes={len(data)}", flush=True)
+            return data
         if modality == "action":
             # The predicted action latents [1, chunk, action_dim] -> [chunk,
             # action_dim] float32 bytes. Columns beyond the request's

--- a/mstar/model/cosmos3/cosmos3_model.py
+++ b/mstar/model/cosmos3/cosmos3_model.py
@@ -185,7 +185,8 @@ class Cosmos3Model(Model):
         # between nodes stay replicated (empty shard_dim) — the sharding is
         # in-module, Megatron-style. The VAE decoder runs un-sharded on one rank.
         return ShardingConfig(
-            groups=[], tp_enabled_nodes={DIT_NODE}, shard_dim={}
+            groups=[], tp_enabled_nodes={DIT_NODE}, shard_dim={},
+            sp_enabled_nodes={DIT_NODE},
         )
 
     def get_graph_walk_graphs(self) -> dict[str, GraphSection]:
@@ -709,24 +710,26 @@ class Cosmos3Model(Model):
 
     def get_submodule(
         self, node_name: str, device: str = "cpu", tp_group=None,
-        autocast_dtype: torch.dtype | None = None,
+        autocast_dtype: torch.dtype | None = None, sp_group=None,
     ) -> torch.nn.Module | None:
         # autocast_dtype is accepted for interface parity (the engine manager
         # passes it to every model). Cosmos3 already casts the meta module to
         # bf16 before to_empty in _build_transformer, so params are allocated
         # directly in the checkpoint dtype and the hint is redundant here.
+        # sp_group is the DiT's sequence-parallel comm group (trivial unless the
+        # config sets sp_size > 1); it is orthogonal to the tp_group.
         if node_name in self._submodule_cache:
             return self._submodule_cache[node_name]
-        submodule = self._create_submodule(node_name, device, tp_group)
+        submodule = self._create_submodule(node_name, device, tp_group, sp_group)
         self._submodule_cache[node_name] = submodule
         if submodule is not None:
             logger.info("Loaded Cosmos3 submodule for %s", node_name)
         return submodule
 
-    def _create_submodule(self, node_name: str, device: str, tp_group=None):
+    def _create_submodule(self, node_name: str, device: str, tp_group=None, sp_group=None):
         if node_name == DIT_NODE:
             return Cosmos3DiTSubmodule(
-                transformer=self._build_transformer(device, tp_group=tp_group),
+                transformer=self._build_transformer(device, tp_group=tp_group, sp_group=sp_group),
                 config=self.config,
                 scheduler=self._build_scheduler(),
                 vae=self._build_vae(device),
@@ -744,7 +747,7 @@ class Cosmos3Model(Model):
 
         return UniPCMultistepScheduler.from_pretrained(str(self._ensure_repo() / "scheduler"))
 
-    def _build_transformer(self, device: str, tp_group=None):
+    def _build_transformer(self, device: str, tp_group=None, sp_group=None):
         from mstar.model.cosmos3.components.transformer import Cosmos3OmniTransformer
         from mstar.model.cosmos3.loader import load_transformer_weights
 
@@ -756,7 +759,7 @@ class Cosmos3Model(Model):
         # meta default; the engine additionally runs the forward under a bf16
         # autocast (a no-op here).
         with torch.device("meta" if not self.skip_weight_loading else "cpu"):
-            model = Cosmos3OmniTransformer(self.config, comm_group=tp_group)
+            model = Cosmos3OmniTransformer(self.config, comm_group=tp_group, sp_group=sp_group)
         model = model.to(torch.bfloat16)
         if self.skip_weight_loading:
             return model.to_empty(device=device)

--- a/mstar/model/cosmos3/cosmos3_model.py
+++ b/mstar/model/cosmos3/cosmos3_model.py
@@ -567,7 +567,7 @@ class Cosmos3Model(Model):
             "guidance_scale": float(mk.get("guidance_scale", 6.0)),
             "num_inference_steps": steps,
             "has_image_condition": "image" in (input_modalities or []),
-            "use_karras_sigma": mk.get("use_karras_sigmas", False),
+            "use_karras_sigma": mk.get("use_karras_sigmas"),
         }
         # Text-to-image (single frame, no visual conditioning) follows the
         # reference Cosmos3 t2i recipe: classifier-free guidance only on the

--- a/mstar/model/cosmos3/cosmos3_model.py
+++ b/mstar/model/cosmos3/cosmos3_model.py
@@ -243,7 +243,7 @@ class Cosmos3Model(Model):
                                 GraphEdge(next_node=DIT_NODE, name="latents"),
                                 GraphEdge(next_node=DIT_NODE, name="time_index"),
                             ],
-                            enable_async_scheduling=False,
+                            enable_async_scheduling=True,
                         ),
                         max_iters=self.config.max_inference_steps,
                         outputs=[
@@ -282,7 +282,7 @@ class Cosmos3Model(Model):
                             GraphEdge(next_node=DIT_NODE, name="action_latents"),
                             GraphEdge(next_node=DIT_NODE, name="time_index"),
                         ],
-                        enable_async_scheduling=False,
+                        enable_async_scheduling=True,
                     ),
                     max_iters=self.config.max_inference_steps,
                     # The loop's terminal output is matched into the section by
@@ -318,7 +318,7 @@ class Cosmos3Model(Model):
                             GraphEdge(next_node=DIT_NODE, name="action_latents"),
                             GraphEdge(next_node=DIT_NODE, name="time_index"),
                         ],
-                        enable_async_scheduling=False,
+                        enable_async_scheduling=True,
                     ),
                     max_iters=self.config.max_inference_steps,
                     outputs=[

--- a/mstar/model/cosmos3/cosmos3_model.py
+++ b/mstar/model/cosmos3/cosmos3_model.py
@@ -168,6 +168,7 @@ class Cosmos3Model(Model):
                 head_dim=self.config.head_dim,
                 max_seq_len=self.config.max_position_embeddings,
                 num_qo_heads=self.config.num_attention_heads,
+                dense_gen_attn=True,
             )
         ]
 

--- a/mstar/model/cosmos3/cosmos3_model.py
+++ b/mstar/model/cosmos3/cosmos3_model.py
@@ -522,6 +522,7 @@ class Cosmos3Model(Model):
                 width, height = int(sw), int(sh)
             except ValueError:
                 pass
+        
         # A video request without an explicit frame count gets the video default
         # (>1); image requests stay single-frame.
         default_frames = (
@@ -546,6 +547,7 @@ class Cosmos3Model(Model):
             "guidance_scale": float(mk.get("guidance_scale", 6.0)),
             "num_inference_steps": steps,
             "has_image_condition": "image" in (input_modalities or []),
+            "use_karras_sigma": mk.get("use_karras_sigmas", False),
         }
         # Text-to-image (single frame, no visual conditioning) follows the
         # reference Cosmos3 t2i recipe: classifier-free guidance only on the

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1113,22 +1113,22 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         configs = []
         for height, width in resolutions:
             latent_shape = self._latent_shape(height, width, num_frames=1)
-            # CUDA-graph capture of the denoise step corrupts the output at some
-            # resolutions: the served image is globally degraded while the eager
-            # path stays clean. Empirically the capture is faithful only when
-            # both latent dims are divisible by 4 (256p latent 12x20 is clean;
-            # 480p 30x52 and 720p 45x80 corrupt). The underlying capture cause is
-            # still open (ruled out: latent padding, attention backend,
-            # torch.compile, cuBLAS workspace, and the baked token layout); until
-            # it is fixed, capture only divisible-by-4 dims and run the rest
-            # eagerly, which is clean and only marginally slower at these
-            # compute-bound tiers.
-            if any(d % 4 for d in latent_shape[3:5]):
+            # The denoise CUDA-graph capture is bit-faithful at every resolution
+            # (the rotary outer product is a broadcast multiply, not a batched
+            # matmul over stride-0 views — see Cosmos3RotaryEmbedding; the matmul
+            # form was mis-captured by the graph memory pool at some sequence
+            # lengths). The graph only HELPS the launch-bound tiers, though: its
+            # per-step input copies scale with resolution, so at large latents
+            # (720p+) the graph is net-slower than the eager dense path. So
+            # capture only below COSMOS3_GRAPH_MAX_LATENT_AREA (latent H*W): 256p
+            # (240) and 480p (1560) graph; 720p (3600) and video run eager+dense.
+            latent_area = latent_shape[3] * latent_shape[4]
+            max_area = int(os.environ.get("COSMOS3_GRAPH_MAX_LATENT_AREA", "2000"))
+            if latent_area > max_area:
                 logger.info(
-                    "Cosmos3: skipping CUDA-graph capture for %dx%d "
-                    "(latent dim %s not divisible by 4 -> known graph-capture "
-                    "corruption -> eager fallback)",
-                    height, width, tuple(latent_shape[3:]),
+                    "Cosmos3: skipping CUDA-graph capture for %dx%d (latent H*W "
+                    "%d > %d -> graph net-slower than eager dense here -> eager)",
+                    height, width, latent_area, max_area,
                 )
                 continue
             static = self._build_static(
@@ -1370,7 +1370,7 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
         # — fine for the few fixed generation tiers (the first request at each
         # shape pays the trace). Off by default; set COSMOS3_COMPILE_VAE=1 to
         # enable (A/B against the eager decode, which is identical bar fp
-        # rounding). The compile wraps the same fp32, autocast-off decode below.
+        # rounding). The compile wraps the same bf16, autocast-off decode below.
         self._decode = vae.decode if vae is not None else None
         if vae is not None and os.environ.get("COSMOS3_COMPILE_VAE"):
             self._decode = torch.compile(vae.decode, fullgraph=False, dynamic=False)

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -221,10 +221,16 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         static["mse_gen_indexes"] = static["vision_mse_loss_indexes"] - static["und_len"]
         return static
 
-    def _new_scheduler(self, num_inference_steps: int, device, use_karras_sigma=False, flow_shift=None):
+    def _new_scheduler(self, num_inference_steps: int, device, use_karras_sigma=None, flow_shift=None):
         from diffusers import UniPCMultistepScheduler
 
-        overrides = {"use_karras_sigmas": use_karras_sigma}
+        # The checkpoint scheduler config carries the trained sigma schedule
+        # (karras sigmas); keep it unless the request explicitly overrides a
+        # field. Forcing karras off uses the wrong schedule and corrupts the
+        # larger model's high-resolution text-to-video.
+        overrides = {}
+        if use_karras_sigma is not None:
+            overrides["use_karras_sigmas"] = use_karras_sigma
         if flow_shift is not None:
             overrides["flow_shift"] = flow_shift
 
@@ -295,7 +301,7 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             "guidance_interval": md.get("guidance_interval"),
             "scheduler": self._new_scheduler(
                 steps, device, flow_shift=md.get("flow_shift"),
-                use_karras_sigma=md.get("use_karras_sigma", False)
+                use_karras_sigma=md.get("use_karras_sigma")
             ),
             "num_noisy": cond["num_noisy_vision_tokens"],
             "num_vision": cond["num_vision_tokens"],
@@ -434,7 +440,7 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             "gs": gs,
             "scheduler": self._new_scheduler(
                 steps, device, flow_shift=md.get("flow_shift"),
-                use_karras_sigma=md.get("use_karras_sigma", False)
+                use_karras_sigma=md.get("use_karras_sigma")
             ),
             "num_noisy": cond["num_noisy_vision_tokens"],
             "num_noisy_action": cond["num_noisy_action_tokens"],
@@ -1109,6 +1115,11 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         else:
             capture_batch_sizes = list(self.gen_capture_batch_sizes)
         dtype = self.transformer.proj_in.weight.dtype
+        # The 2D (TP x SP) captured denoise graph hits a CUDA illegal access at
+        # 480p+ in the combined Ulysses all-gather + TP all-reduce path (pure-TP and
+        # pure-SP capture cleanly; only the combination at this scale). For 2D,
+        # capture only the smallest tier; 480p+ runs eager (correct, just no graph).
+        two_d = self.transformer.sp_group.world_size > 1 and self.transformer.comm_group.world_size > 1
         self._capture_layout: dict[tuple, dict] = {}
         configs = []
         for height, width in resolutions:
@@ -1124,6 +1135,8 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             # (240) and 480p (1560) graph; 720p (3600) and video run eager+dense.
             latent_area = latent_shape[3] * latent_shape[4]
             max_area = int(os.environ.get("COSMOS3_GRAPH_MAX_LATENT_AREA", "2000"))
+            if two_d:
+                max_area = min(max_area, 1000)  # 256p latent 240 captures; 480p 1560 does not
             if latent_area > max_area:
                 logger.info(
                     "Cosmos3: skipping CUDA-graph capture for %dx%d (latent H*W "

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1308,8 +1308,17 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             latents = inp.tensor_inputs["latents"]
             time_index = inp.tensor_inputs["time_index"]
             step_index = int(time_index.reshape(-1)[0].item())
-            if step_index >= len(st["scheduler"].timesteps):
-                # Discarded extra step past this request's denoise count.
+            sched = st["scheduler"]
+            sched_idx = sched.step_index
+            if step_index >= len(sched.timesteps) or (
+                sched_idx is not None and sched_idx >= len(sched.timesteps)
+            ):
+                # Discarded extra step past this request's denoise count. Guard on
+                # BOTH the engine step counter and the scheduler's own step_index:
+                # with concurrent (bs>1) requests the batched loop dispatches one
+                # extra step whose engine time_index can lag the scheduler, and
+                # stepping an already-exhausted UniPC scheduler trips
+                # `assert self.this_order > 0`.
                 outputs[rid] = {"latents": [latents], "time_index": [time_index]}
                 continue
             t = st["scheduler"].timesteps[step_index]

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1100,7 +1100,9 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         ``COSMOS3_GEN_CAPTURE_BS`` (e.g. ``"1,4,8"``) to also capture batched
         denoise steps so concurrent requests replay a padded graph instead of
         falling back to the eager path."""
-        if self.transformer is None or os.environ.get("COSMOS3_DISABLE_CUDA_GRAPH"):
+        disable_env = os.environ.get("COSMOS3_DISABLE_CUDA_GRAPH")
+        disabled = bool(disable_env) if disable_env is not None else not self.config.cuda_graph
+        if self.transformer is None or disabled:
             return []
         res_env = os.environ.get("COSMOS3_GEN_CAPTURE_RES")
         if res_env:
@@ -1134,7 +1136,8 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             # capture only below COSMOS3_GRAPH_MAX_LATENT_AREA (latent H*W): 256p
             # (240) and 480p (1560) graph; 720p (3600) and video run eager+dense.
             latent_area = latent_shape[3] * latent_shape[4]
-            max_area = int(os.environ.get("COSMOS3_GRAPH_MAX_LATENT_AREA", "2000"))
+            max_area = int(os.environ.get(
+                "COSMOS3_GRAPH_MAX_LATENT_AREA", self.config.graph_max_latent_area))
             if two_d:
                 max_area = min(max_area, 1000)  # 256p latent 240 captures; 480p 1560 does not
             if latent_area > max_area:

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -469,7 +469,7 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         else:
             latents = inputs["latents"][0]
             time_index = inputs["time_index"][0]
-        
+
         scheduler = st["scheduler"]
         step_index = int(time_index.reshape(-1)[0].item())
         if step_index >= len(scheduler.timesteps):
@@ -521,7 +521,7 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             latents = inputs["latents"][0]
             action_latents = inputs["action_latents"][0]
             time_index = inputs["time_index"][0]
-        
+
         scheduler = st["scheduler"]
         step_index = int(time_index.reshape(-1)[0].item())
         if step_index >= len(scheduler.timesteps):
@@ -1223,23 +1223,19 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
 
     def forward(self, graph_walk, engine_inputs: ModelInputsFromEngine, latents, **kwargs):
         vae = self.vae
-        # The Wan VAE's 3D convolutions run several times faster in fp32 (TF32
-        # tensor cores) than in bf16 on this cuDNN, and the reference pipeline
-        # decodes in fp32. The engine casts this submodule to bf16, so restore the
-        # vae to fp32 once and decode outside autocast to keep the fast path.
-        if next(vae.parameters()).dtype != torch.float32:
-            vae.float()
-        mean = torch.tensor(vae.config.latents_mean, dtype=torch.float32, device=latents.device).view(1, -1, 1, 1, 1)
-        inv_std = (1.0 / torch.tensor(vae.config.latents_std, dtype=torch.float32, device=latents.device)).view(
+        vae_dtype = torch.bfloat16
+        if next(vae.parameters()).dtype != vae_dtype:
+            vae = vae.to(vae_dtype)
+        mean = torch.tensor(vae.config.latents_mean, dtype=vae_dtype, device=latents.device).view(1, -1, 1, 1, 1)
+        inv_std = (1.0 / torch.tensor(vae.config.latents_std, dtype=vae_dtype, device=latents.device)).view(
             1, -1, 1, 1, 1
         )
-        z = latents.float() / inv_std + mean
+        z = latents.to(vae_dtype) / inv_std + mean
         _prof = os.environ.get("COSMOS3_PROFILE")
         if _prof:
             _e0 = torch.cuda.Event(enable_timing=True); _e1 = torch.cuda.Event(enable_timing=True)
             _e0.record()
-        with torch.autocast(device_type=z.device.type, enabled=False):
-            decoded = self._decode(z).sample  # [1, 3, T, H, W] in [-1, 1]
+        decoded = self._decode(z).sample  # [1, 3, T, H, W] in [-1, 1]
         if _prof:
             _e1.record(); torch.cuda.synchronize()
             logger.info("COSMOS3_PROFILE vae_decode %.1f ms out=%s", _e0.elapsed_time(_e1), tuple(decoded.shape))

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -209,13 +209,14 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         static["mse_gen_indexes"] = static["vision_mse_loss_indexes"] - static["und_len"]
         return static
 
-    def _new_scheduler(self, num_inference_steps: int, device, flow_shift=None):
+    def _new_scheduler(self, num_inference_steps: int, device, use_karras_sigma=False, flow_shift=None):
         from diffusers import UniPCMultistepScheduler
 
+        overrides = {"use_karras_sigmas": use_karras_sigma}
         if flow_shift is not None:
-            scheduler = UniPCMultistepScheduler.from_config(self._scheduler_template.config, flow_shift=flow_shift)
-        else:
-            scheduler = UniPCMultistepScheduler.from_config(self._scheduler_template.config)
+            overrides["flow_shift"] = flow_shift
+
+        scheduler = UniPCMultistepScheduler.from_config(self._scheduler_template.config, **overrides)
         scheduler.set_timesteps(num_inference_steps, device=device)
         return scheduler
 
@@ -280,7 +281,10 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             "uncond": uncond,
             "gs": gs,
             "guidance_interval": md.get("guidance_interval"),
-            "scheduler": self._new_scheduler(steps, device, flow_shift=md.get("flow_shift")),
+            "scheduler": self._new_scheduler(
+                steps, device, flow_shift=md.get("flow_shift"),
+                use_karras_sigma=md.get("use_karras_sigma", False)
+            ),
             "num_noisy": cond["num_noisy_vision_tokens"],
             "num_vision": cond["num_vision_tokens"],
             "latent_shape": self._latent_shape(height, width, num_frames),
@@ -398,7 +402,10 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             "cond": cond,
             "uncond": uncond,
             "gs": gs,
-            "scheduler": self._new_scheduler(steps, device, flow_shift=md.get("flow_shift")),
+            "scheduler": self._new_scheduler(
+                steps, device, flow_shift=md.get("flow_shift"),
+                use_karras_sigma=md.get("use_karras_sigma", False)
+            ),
             "num_noisy": cond["num_noisy_vision_tokens"],
             "num_noisy_action": cond["num_noisy_action_tokens"],
             "num_vision": cond["num_vision_tokens"],

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1368,11 +1368,15 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
         # causal-conv feature cache, and dynamic=False gives the best per-shape
         # kernels at the cost of a one-time trace per new (frames, height, width)
         # — fine for the few fixed generation tiers (the first request at each
-        # shape pays the trace). Off by default; set COSMOS3_COMPILE_VAE=1 to
-        # enable (A/B against the eager decode, which is identical bar fp
-        # rounding). The compile wraps the same bf16, autocast-off decode below.
+        # shape pays the trace). On by default — it cuts the 189-frame video VAE
+        # decode ~30% (a large share of video latency) and is neutral for the
+        # tiny single-frame image decode; set COSMOS3_COMPILE_VAE=0 to disable
+        # (A/B against the eager decode, which is identical bar fp rounding). The
+        # compile wraps the same bf16, autocast-off decode below.
         self._decode = vae.decode if vae is not None else None
-        if vae is not None and os.environ.get("COSMOS3_COMPILE_VAE"):
+        if vae is not None and os.environ.get("COSMOS3_COMPILE_VAE", "1").lower() not in (
+            "0", "false", "no", "off",
+        ):
             self._decode = torch.compile(vae.decode, fullgraph=False, dynamic=False)
             logger.info("Cosmos3 VAE decode torch.compile enabled")
 

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1113,15 +1113,21 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         configs = []
         for height, width in resolutions:
             latent_shape = self._latent_shape(height, width, num_frames=1)
-            # patchify-2 pads an odd latent height/width (e.g. 720p: 720 // 16 =
-            # 45 -> pad to 46), and the captured/replayed padded layout produces
-            # degraded output (clean on the left, scrambled on the right). Skip
-            # capture for such resolutions; they fall back to the eager path,
-            # which is clean and ~as fast at these compute-bound tiers.
-            if latent_shape[3] % 2 or latent_shape[4] % 2:
+            # CUDA-graph capture of the denoise step corrupts the output at some
+            # resolutions: the served image is globally degraded while the eager
+            # path stays clean. Empirically the capture is faithful only when
+            # both latent dims are divisible by 4 (256p latent 12x20 is clean;
+            # 480p 30x52 and 720p 45x80 corrupt). The underlying capture cause is
+            # still open (ruled out: latent padding, attention backend,
+            # torch.compile, cuBLAS workspace, and the baked token layout); until
+            # it is fixed, capture only divisible-by-4 dims and run the rest
+            # eagerly, which is clean and only marginally slower at these
+            # compute-bound tiers.
+            if any(d % 4 for d in latent_shape[3:5]):
                 logger.info(
                     "Cosmos3: skipping CUDA-graph capture for %dx%d "
-                    "(odd latent dim %s -> patchify pad -> eager fallback)",
+                    "(latent dim %s not divisible by 4 -> known graph-capture "
+                    "corruption -> eager fallback)",
                     height, width, tuple(latent_shape[3:]),
                 )
                 continue

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -298,7 +298,41 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                 self._req[fwd_info.request_id]["cond_latents"] = self._encode_conditioning(
                     image[0], height, width, num_frames, device, anchor_only=True
                 )
-        return ARNodeInputs(input_seq_len=cond["und_len"])
+
+        return self._get_prefill_node_inputs(cond, uncond)
+
+    def _get_prefill_node_inputs(self, cond, uncond):
+        if uncond is None:
+            return ARNodeInputs(
+                input_ids=cond["input_ids"],
+                input_seq_len=cond["und_len"],
+                tensor_inputs={
+                    "text_mrope_ids": cond["text_mrope_ids"]
+                },
+                kwargs=dict(
+                    cfg=False,
+                    seq_lens={
+                        COND_LABEL: cond["und_len"]
+                    }
+                )
+            )
+        return ARNodeInputs(
+            input_seq_len=cond["und_len"] + uncond["und_len"],
+            input_ids=torch.concat((cond["input_ids"], uncond["input_ids"])),
+            tensor_inputs={
+                "text_mrope_ids": torch.concat(
+                    (cond["text_mrope_ids"], uncond["text_mrope_ids"]),
+                    dim=1
+                )
+            },
+            kwargs=dict(
+                cfg=True,
+                seq_lens={
+                    COND_LABEL: cond["und_len"],
+                    UNCOND_LABEL: uncond["und_len"],
+                }
+            )
+        )
 
     def _encode_conditioning(self, image, height, width, num_frames, device, anchor_only=False):
         """VAE-encode a conditioning frame into clean anchor latents.
@@ -423,7 +457,7 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             "cond_video_latents": cond_latents,
             "clean_action": clean_action,
         }
-        return ARNodeInputs(input_seq_len=cond["und_len"])
+        return self._get_prefill_node_inputs(cond, uncond)
 
     def _encode_conditioning_video(self, video, height, width, num_frames, device):
         """VAE-encode a conditioning video clip into clean anchor latents.
@@ -583,7 +617,10 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             "position_ids_uncond": torch.stack([inp.tensor_inputs["position_ids_uncond"] for inp in inputs]),
         }
 
-    def preprocess(self, graph_walk, engine_inputs: ModelInputsFromEngine, inputs) -> dict:
+    def preprocess(
+        self, graph_walk, engine_inputs: ModelInputsFromEngine,
+        inputs: list[ARNodeInputs]
+    ) -> dict:
         cm = engine_inputs.cache_manager
 
         if graph_walk == IMAGE_GEN_WALK and getattr(cm, "_cuda_graph_mode", False):
@@ -592,12 +629,29 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         st = self._req[engine_inputs.request_ids[0]]
 
         if graph_walk in PREFILL_WALKS:
-            cm.plan_attention(seq_lens=[st["cond"]["und_len"]], is_causal=True, label=COND_LABEL, write_store=False)
-            if st["uncond"] is not None:
-                cm.plan_attention(
-                    seq_lens=[st["uncond"]["und_len"]], is_causal=True, label=UNCOND_LABEL, write_store=False
+            has_cfg = inputs[0].kwargs.get("cfg")
+            if has_cfg:
+                labels = [COND_LABEL, UNCOND_LABEL]
+                cm.plan_attention_batched_cfg(
+                    labels=labels,
+                    seq_lens={
+                        key: [inp.kwargs["seq_lens"][key] for inp in inputs] \
+                            for key in labels
+                    }, is_causal=True, write_store=False
                 )
-            return {}
+            else:
+                cm.plan_attention(
+                    seq_lens=[inp.input_seq_len for inp in inputs],
+                    is_causal=True, label=COND_LABEL,
+                    write_store=False
+                )
+            return {
+                "cfg": has_cfg,
+                "input_ids": torch.concat([inp.input_ids for inp in inputs]),
+                "text_mrope_ids": torch.concat([
+                    inp.tensor_inputs["text_mrope_ids"] for inp in inputs
+                ], dim=1)
+            }
 
         if graph_walk in GEN_WALKS:
             rids = engine_inputs.request_ids
@@ -671,25 +725,31 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         cm = engine_inputs.cache_manager
         rid = engine_inputs.request_ids[0]
         if graph_walk in PREFILL_WALKS:
-            return self._forward_prefill(cm, self._req[rid])
+            return self._forward_prefill(cm, **kwargs)
         if graph_walk in GEN_WALKS:
             return self._forward_image_gen(cm, self._req[rid], **kwargs)
         if graph_walk in ACTION_WALKS:
             return self._forward_action_gen(cm, self._req[rid], **kwargs)
         raise ValueError(f"Unknown Cosmos3 DiT graph walk: {graph_walk!r}")
 
-    def _forward_prefill(self, cm, st) -> dict:
+    def _forward_prefill(
+        self, cm,
+        input_ids: torch.Tensor,
+        text_mrope_ids: torch.Tensor,
+        cfg=False,
+        **kwargs
+    ) -> dict:
         _prof = os.environ.get("COSMOS3_PROFILE")
         if _prof:
             _e0 = torch.cuda.Event(enable_timing=True); _e1 = torch.cuda.Event(enable_timing=True)
             _e0.record()
-        cond = st["cond"]
-        cm.set_active_label(COND_LABEL)
-        self.transformer.prefill_und(cond["input_ids"], cond["text_mrope_ids"], cm)
-        if st["uncond"] is not None:
-            uncond = st["uncond"]
-            cm.set_active_label(UNCOND_LABEL)
-            self.transformer.prefill_und(uncond["input_ids"], uncond["text_mrope_ids"], cm)
+
+        if cfg:
+            cm.set_active_label(CFG_BATCHED_LABEL)
+        else:
+            cm.set_active_label(COND_LABEL)
+
+        self.transformer.prefill_und(input_ids, text_mrope_ids, cm)
         if _prof:
             _e1.record(); torch.cuda.synchronize()
             logger.info("COSMOS3_PROFILE prefill %.1f ms", _e0.elapsed_time(_e1))
@@ -868,7 +928,7 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         sts = [self._req.get(rid) for rid in batch.request_ids]
         if any(st is None for st in sts):
             return False
-        if batch.graph_walk in GEN_WALKS:
+        if batch.graph_walk in GEN_WALKS or batch.graph_walk in PREFILL_WALKS:
             # Image/video batch only in the two-branch guidance regime, so one
             # batched-CFG plan covers them.
             return all(st["uncond"] is not None for st in sts)
@@ -891,13 +951,30 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
     @torch.autocast(device_type="cuda", enabled=False)
     def forward_batched(
         self, graph_walk, engine_inputs: ModelInputsFromEngine,
-        latents, time_index, action_latents=None, **kwargs,
+        latents=None, time_index=None, action_latents=None,
+        input_ids=None, text_mrope_ids=None, **kwargs,
     ):
+        cm = engine_inputs.cache_manager
+        if graph_walk in PREFILL_WALKS:
+            _prof = os.environ.get("COSMOS3_PROFILE")
+            if _prof:
+                _e0 = torch.cuda.Event(enable_timing=True); _e1 = torch.cuda.Event(enable_timing=True)
+                _e0.record()
+
+            if kwargs.get("cfg"):
+                cm.set_active_label(CFG_BATCHED_LABEL)
+            else:
+                cm.set_active_label(COND_LABEL)
+
+            self.transformer.prefill_und(input_ids, text_mrope_ids, cm)
+            if _prof:
+                _e1.record(); torch.cuda.synchronize()
+                logger.info("COSMOS3_PROFILE prefill %.1f ms", _e0.elapsed_time(_e1))
+            return {}
         if graph_walk in ACTION_WALKS:
             return self._forward_batched_action(engine_inputs, latents, action_latents, time_index)
         if graph_walk not in GEN_WALKS:
             raise ValueError(f"Cosmos3 batched forward only supports generation walks, got {graph_walk!r}")
-        cm = engine_inputs.cache_manager
         cm.set_active_label(CFG_BATCHED_LABEL)
         reqs, meta = [], []
         for rid in engine_inputs.request_ids:

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1376,6 +1376,7 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
         super().__init__()
         self.vae = vae
         self.config = config
+        self._decode_dtype_cached = None
         # The Wan VAE decode is 3D-conv bound and is not captured into a CUDA
         # graph (it runs once per request at request-specific frame/resolution
         # shapes). torch.compile fuses the pointwise epilogues around those convs;
@@ -1384,10 +1385,10 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
         # kernels at the cost of a one-time trace per new (frames, height, width)
         # — fine for the few fixed generation tiers (the first request at each
         # shape pays the trace). On by default — it cuts the 189-frame video VAE
-        # decode ~30% (a large share of video latency) and is neutral for the
+        # decode ~20-30% (a large share of video latency) and is neutral for the
         # tiny single-frame image decode; set COSMOS3_COMPILE_VAE=0 to disable
         # (A/B against the eager decode, which is identical bar fp rounding). The
-        # compile wraps the same bf16, autocast-off decode below.
+        # compile wraps the autocast-off decode below.
         self._decode = vae.decode if vae is not None else None
         if vae is not None and os.environ.get("COSMOS3_COMPILE_VAE", "1").lower() not in (
             "0", "false", "no", "off",
@@ -1398,9 +1399,61 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
     def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs) -> NodeInputs:
         return NodeInputs(tensor_inputs={"latents": inputs["latents"][0]})
 
+    def _decode_dtype(self):
+        # Which dtype the Wan-VAE 3D-conv decode runs fastest in is a property of
+        # the cuDNN build, not of a version string: cuDNN 9.10 (the cu12.8 wheel)
+        # has no fast bf16/fp16 conv3d for these shapes and falls to a slow path
+        # (a 256p-video decode is ~10s in bf16 vs ~1s in fp32/TF32), while cuDNN
+        # 9.19 (cu13) decodes bf16 fast. cuDNN versions don't track the CUDA
+        # toolkit version 1:1, so probe the actual machine once and cache the
+        # faster dtype rather than guessing. COSMOS3_VAE_DECODE_FP32 forces it.
+        if self._decode_dtype_cached is not None:
+            return self._decode_dtype_cached
+        override = os.environ.get("COSMOS3_VAE_DECODE_FP32")
+        if override is not None:
+            on = override.lower() not in ("0", "false", "no", "off")
+            self._decode_dtype_cached = torch.float32 if on else torch.bfloat16
+        else:
+            self._decode_dtype_cached = self._probe_decode_dtype()
+        logger.info("Cosmos3 VAE decode dtype = %s", self._decode_dtype_cached)
+        return self._decode_dtype_cached
+
+    def _probe_decode_dtype(self):
+        # Time one small decode per dtype the way the served decode runs (eager,
+        # autocast off) and keep the faster. fp32 here uses TF32 tensor cores
+        # (allow_tf32 default on) — the fast conv path on cuDNN 9.10; true fp32 is
+        # as slow as bf16, so this measures the path that actually ships.
+        vae = self.vae
+        if vae is None:
+            return torch.bfloat16
+        device = next(vae.parameters()).device
+        c = int(getattr(vae.config, "z_dim", 48))
+        # Small: the dtype gap is decided by conv-kernel availability, not size
+        # (it shows ~16x even at one frame), and a slow-path bf16 probe must stay
+        # cheap since it runs once at the first decode.
+        probe = torch.randn(1, c, 3, 16, 16, device=device)
+        best, best_ms = torch.bfloat16, float("inf")
+        for dt in (torch.float32, torch.bfloat16):
+            try:
+                vae.to(dt)
+                z = probe.to(dt)
+                e0 = torch.cuda.Event(enable_timing=True); e1 = torch.cuda.Event(enable_timing=True)
+                with torch.no_grad(), torch.autocast(device_type="cuda", enabled=False):
+                    vae.decode(z)
+                    torch.cuda.synchronize(); e0.record()
+                    vae.decode(z); vae.decode(z)
+                    e1.record(); torch.cuda.synchronize()
+                ms = e0.elapsed_time(e1) / 2
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Cosmos3 VAE decode probe failed for %s: %s", dt, e)
+                ms = float("inf")
+            if ms < best_ms:
+                best_ms, best = ms, dt
+        return best
+
     def forward(self, graph_walk, engine_inputs: ModelInputsFromEngine, latents, **kwargs):
         vae = self.vae
-        vae_dtype = torch.bfloat16
+        vae_dtype = self._decode_dtype()
         if next(vae.parameters()).dtype != vae_dtype:
             vae = vae.to(vae_dtype)
         mean = torch.tensor(vae.config.latents_mean, dtype=vae_dtype, device=latents.device).view(1, -1, 1, 1, 1)
@@ -1412,7 +1465,8 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
         if _prof:
             _e0 = torch.cuda.Event(enable_timing=True); _e1 = torch.cuda.Event(enable_timing=True)
             _e0.record()
-        decoded = self._decode(z).sample  # [1, 3, T, H, W] in [-1, 1]
+        with torch.autocast(device_type="cuda", enabled=False):
+            decoded = self._decode(z).sample  # [1, 3, T, H, W] in [-1, 1]
         if _prof:
             _e1.record(); torch.cuda.synchronize()
             logger.info("COSMOS3_PROFILE vae_decode %.1f ms out=%s", _e0.elapsed_time(_e1), tuple(decoded.shape))

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1265,10 +1265,16 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         layout = self._capture_layout[tuple(latents.shape[1:])]
         rids = engine_inputs.request_ids
         if latents.shape[0] == 1:
+            # This forward is captured into the denoise CUDA graph. Under SP the
+            # Ulysses exchange must use all-gather, not all-to-all: the latter is
+            # grouped point-to-point send/recv and does not replay from a graph.
+            # The flag holds across warmup, capture and replay (all routed here),
+            # so the all-gather kernels are compiled during eager warmup rather
+            # than mid-capture. No-op without SP.
             cond_v, uncond_v = self.transformer.denoise_step_batched_cfg(
                 latents[0], vision_timesteps[0], position_ids_cond[0], position_ids_uncond[0],
                 layout["vision_token_shapes"], layout["vision_noisy_frame_indexes"],
-                layout["mse_gen_indexes"], cm,
+                layout["mse_gen_indexes"], cm, prefer_all_gather=True,
             )
             return {rids[0]: {"cond_v": [cond_v], "uncond_v": [uncond_v]}}
         reqs = [

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1395,18 +1395,21 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
         ):
             self._decode = torch.compile(vae.decode, fullgraph=False, dynamic=False)
             logger.info("Cosmos3 VAE decode torch.compile enabled")
+        # Resolve + log the decode dtype now (a cheap cuDNN-version read) so the
+        # choice is fixed at startup, not on the first request.
+        self._decode_dtype()
 
     def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs) -> NodeInputs:
         return NodeInputs(tensor_inputs={"latents": inputs["latents"][0]})
 
     def _decode_dtype(self):
-        # Which dtype the Wan-VAE 3D-conv decode runs fastest in is a property of
-        # the cuDNN build, not of a version string: cuDNN 9.10 (the cu12.8 wheel)
-        # has no fast bf16/fp16 conv3d for these shapes and falls to a slow path
-        # (a 256p-video decode is ~10s in bf16 vs ~1s in fp32/TF32), while cuDNN
-        # 9.19 (cu13) decodes bf16 fast. cuDNN versions don't track the CUDA
-        # toolkit version 1:1, so probe the actual machine once and cache the
-        # faster dtype rather than guessing. COSMOS3_VAE_DECODE_FP32 forces it.
+        # cuDNN ships the fast Hopper bf16 conv3d kernels for the Wan-VAE decode
+        # only from 9.16 on; before that (e.g. the 9.10 cu12.8 wheel) bf16/fp16
+        # fall back and a 256p-video decode is ~10s vs ~1s in fp32/TF32, so use
+        # fp32 there. Measured single-variable (same torch/GPU, swapping only the
+        # cuDNN libs): bf16 vid256 decode 10.3s at 9.13 -> 0.85s at 9.16; fp32/TF32
+        # ~1.1s throughout. Gate on the live cuDNN version (a cuDNN upgrade flips
+        # it automatically); COSMOS3_VAE_DECODE_FP32 overrides.
         if self._decode_dtype_cached is not None:
             return self._decode_dtype_cached
         override = os.environ.get("COSMOS3_VAE_DECODE_FP32")
@@ -1414,42 +1417,11 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
             on = override.lower() not in ("0", "false", "no", "off")
             self._decode_dtype_cached = torch.float32 if on else torch.bfloat16
         else:
-            self._decode_dtype_cached = self._probe_decode_dtype()
-        logger.info("Cosmos3 VAE decode dtype = %s", self._decode_dtype_cached)
+            ver = torch.backends.cudnn.version() or 0
+            self._decode_dtype_cached = torch.bfloat16 if ver >= 91600 else torch.float32
+        logger.info("Cosmos3 VAE decode dtype = %s (cuDNN %s)",
+                    self._decode_dtype_cached, torch.backends.cudnn.version())
         return self._decode_dtype_cached
-
-    def _probe_decode_dtype(self):
-        # Time one small decode per dtype the way the served decode runs (eager,
-        # autocast off) and keep the faster. fp32 here uses TF32 tensor cores
-        # (allow_tf32 default on) — the fast conv path on cuDNN 9.10; true fp32 is
-        # as slow as bf16, so this measures the path that actually ships.
-        vae = self.vae
-        if vae is None:
-            return torch.bfloat16
-        device = next(vae.parameters()).device
-        c = int(getattr(vae.config, "z_dim", 48))
-        # Small: the dtype gap is decided by conv-kernel availability, not size
-        # (it shows ~16x even at one frame), and a slow-path bf16 probe must stay
-        # cheap since it runs once at the first decode.
-        probe = torch.randn(1, c, 3, 16, 16, device=device)
-        best, best_ms = torch.bfloat16, float("inf")
-        for dt in (torch.float32, torch.bfloat16):
-            try:
-                vae.to(dt)
-                z = probe.to(dt)
-                e0 = torch.cuda.Event(enable_timing=True); e1 = torch.cuda.Event(enable_timing=True)
-                with torch.no_grad(), torch.autocast(device_type="cuda", enabled=False):
-                    vae.decode(z)
-                    torch.cuda.synchronize(); e0.record()
-                    vae.decode(z); vae.decode(z)
-                    e1.record(); torch.cuda.synchronize()
-                ms = e0.elapsed_time(e1) / 2
-            except Exception as e:  # noqa: BLE001
-                logger.warning("Cosmos3 VAE decode probe failed for %s: %s", dt, e)
-                ms = float("inf")
-            if ms < best_ms:
-                best_ms, best = ms, dt
-        return best
 
     def forward(self, graph_walk, engine_inputs: ModelInputsFromEngine, latents, **kwargs):
         vae = self.vae

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -28,7 +28,10 @@ import os
 import torch
 
 from mstar.conductor.request_info import CurrentForwardPassInfo
-from mstar.engine.cuda_graph_config import BasicBatchedCudaGraphConfig
+from mstar.engine.cuda_graph_config import (
+    BasicBatchedCudaGraphConfig,
+    FlashInferPackedCudaGraphConfig,
+)
 from mstar.model.cosmos3.packing import (
     action_start_frame_offset,
     build_action_static_inputs,
@@ -128,6 +131,15 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
     )
     # Batch sizes to capture per resolution.
     gen_capture_batch_sizes: tuple[int, ...] = (1,)
+
+    # Understanding-tower (text prefill) CUDA-graph capture. The text length is
+    # prompt-dependent, so capture a few combined (cond+uncond) token buckets and
+    # round up at replay; prompts past the largest bucket fall back to eager.
+    # Targets the small-prompt, non-compute-bound regime where the launch
+    # overhead the graph removes actually matters. Override with
+    # COSMOS3_PREFILL_CAPTURE_TOKENS / COSMOS3_PREFILL_CAPTURE_BS.
+    prefill_capture_token_buckets: tuple[int, ...] = (16, 32, 64, 128, 256)
+    prefill_capture_batch_sizes: tuple[int, ...] = (1,)
 
     def __init__(self, transformer, config, scheduler=None, vae=None):
         super().__init__()
@@ -302,36 +314,20 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         return self._get_prefill_node_inputs(cond, uncond)
 
     def _get_prefill_node_inputs(self, cond, uncond):
-        if uncond is None:
-            return ARNodeInputs(
-                input_ids=cond["input_ids"],
-                input_seq_len=cond["und_len"],
-                tensor_inputs={
-                    "text_mrope_ids": cond["text_mrope_ids"]
-                },
-                kwargs=dict(
-                    cfg=False,
-                    seq_lens={
-                        COND_LABEL: cond["und_len"]
-                    }
-                )
-            )
+        statics = {COND_LABEL: cond}
+        if uncond is not None:
+            statics[UNCOND_LABEL] = uncond
+        tensor_inputs = {}
+        for label, s in statics.items():
+            tensor_inputs[f"input_ids_{label}"] = s["input_ids"]
+            tensor_inputs[f"text_mrope_ids_{label}"] = s["text_mrope_ids"]
         return ARNodeInputs(
-            input_seq_len=cond["und_len"] + uncond["und_len"],
-            input_ids=torch.concat((cond["input_ids"], uncond["input_ids"])),
-            tensor_inputs={
-                "text_mrope_ids": torch.concat(
-                    (cond["text_mrope_ids"], uncond["text_mrope_ids"]),
-                    dim=1
-                )
-            },
+            input_seq_len=sum(s["und_len"] for s in statics.values()),
+            tensor_inputs=tensor_inputs,
             kwargs=dict(
-                cfg=True,
-                seq_lens={
-                    COND_LABEL: cond["und_len"],
-                    UNCOND_LABEL: uncond["und_len"],
-                }
-            )
+                cfg=uncond is not None,
+                seq_lens={label: s["und_len"] for label, s in statics.items()},
+            ),
         )
 
     def _encode_conditioning(self, image, height, width, num_frames, device, anchor_only=False):
@@ -626,12 +622,10 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         if graph_walk == IMAGE_GEN_WALK and getattr(cm, "_cuda_graph_mode", False):
             return self._preprocess_image_gen_captured(cm, inputs)
 
-        st = self._req[engine_inputs.request_ids[0]]
-
         if graph_walk in PREFILL_WALKS:
             has_cfg = inputs[0].kwargs.get("cfg")
+            labels = [COND_LABEL, UNCOND_LABEL] if has_cfg else [COND_LABEL]
             if has_cfg:
-                labels = [COND_LABEL, UNCOND_LABEL]
                 cm.plan_attention_batched_cfg(
                     labels=labels,
                     seq_lens={
@@ -645,13 +639,21 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                     is_causal=True, label=COND_LABEL,
                     write_store=False
                 )
+            # Pack label-major (all cond segments, then all uncond) to match the
+            # (label, request) batch order of the plan above.
             return {
                 "cfg": has_cfg,
-                "input_ids": torch.concat([inp.input_ids for inp in inputs]),
+                "input_ids": torch.concat([
+                    inp.tensor_inputs[f"input_ids_{label}"]
+                    for label in labels for inp in inputs
+                ]),
                 "text_mrope_ids": torch.concat([
-                    inp.tensor_inputs["text_mrope_ids"] for inp in inputs
-                ], dim=1)
+                    inp.tensor_inputs[f"text_mrope_ids_{label}"]
+                    for label in labels for inp in inputs
+                ], dim=1),
             }
+        
+        st = self._req[engine_inputs.request_ids[0]]
 
         if graph_walk in GEN_WALKS:
             rids = engine_inputs.request_ids
@@ -956,7 +958,9 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
     ):
         cm = engine_inputs.cache_manager
         if graph_walk in PREFILL_WALKS:
-            _prof = os.environ.get("COSMOS3_PROFILE")
+            # The synchronize() in the profiling block is illegal while a CUDA
+            # graph is capturing this forward, so skip timing during capture.
+            _prof = os.environ.get("COSMOS3_PROFILE") and not torch.cuda.is_current_stream_capturing()
             if _prof:
                 _e0 = torch.cuda.Event(enable_timing=True); _e1 = torch.cuda.Event(enable_timing=True)
                 _e0.record()
@@ -1158,9 +1162,66 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                 # max_batch_size to the captured sizes.
                 caps_eager_batch_size=False,
             ))
+
+        # Understanding-tower text prefill: cond+uncond packed into one combined
+        # sequence (batched CFG). The dummy zeros are placeholders — the real
+        # input_ids / mrope ids are copied into the static buffers at replay.
+        if not os.environ.get("COSMOS3_DISABLE_PREFILL_CUDA_GRAPH"):
+            tok_env = os.environ.get("COSMOS3_PREFILL_CAPTURE_TOKENS")
+            prefill_tokens = (
+                [int(x) for x in tok_env.split(",")] if tok_env
+                else list(self.prefill_capture_token_buckets)
+            )
+            bs_env = os.environ.get("COSMOS3_PREFILL_CAPTURE_BS")
+            prefill_bs = (
+                [int(x) for x in bs_env.split(",")] if bs_env
+                else list(self.prefill_capture_batch_sizes)
+            )
+            mrope_dtype = torch.float32 if self.config.enable_fps_modulation else torch.long
+
+            def _prefill_template(n):
+                return {
+                    "input_ids": torch.zeros(n, dtype=torch.long, device=device),
+                    "text_mrope_ids": torch.zeros((3, n), dtype=mrope_dtype, device=device),
+                    "cfg": True,
+                }
+
+            configs.append(FlashInferPackedCudaGraphConfig(
+                capture_graph_walk=PREFILL_WALK,
+                replay_graph_walks=list(PREFILL_WALKS),
+                packed_seq_len_to_inputs={n: _prefill_template(n) for n in prefill_tokens},
+                requires_cfg=False,
+                labels=[COND_LABEL, UNCOND_LABEL],
+                batched_cfg=True,
+                causal_attention=True,
+                compile=False,
+                capture_batch_sizes=prefill_bs,
+                caps_eager_batch_size=False,
+                zero_padding_input=ARNodeInputs(
+                    input_seq_len=0,
+                    tensor_inputs={
+                        "input_ids_" + COND_LABEL: torch.zeros(0, dtype=torch.long, device=device),
+                        "input_ids_" + UNCOND_LABEL: torch.zeros(0, dtype=torch.long, device=device),
+                        "text_mrope_ids_" + COND_LABEL: torch.zeros((3, 0), dtype=mrope_dtype, device=device),
+                        "text_mrope_ids_" + UNCOND_LABEL: torch.zeros((3, 0), dtype=mrope_dtype, device=device),
+                    },
+                    kwargs=dict(
+                        cfg=True,
+                        seq_lens={COND_LABEL: 0, UNCOND_LABEL: 0},
+                    ),
+                ),
+            ))
         return configs
 
     def can_use_cuda_graphs(self, batch, model_inputs) -> bool:
+        # Text prefill is captured only with two-branch guidance (the combined
+        # cond+uncond packed sequence); the runner's can_run picks the token
+        # bucket, so a prompt past the largest bucket falls back to eager here.
+        if batch.graph_walk in PREFILL_WALKS:
+            return all(
+                (st := self._req.get(rid)) is not None and st["uncond"] is not None
+                for rid in batch.request_ids
+            )
         # Only the image denoise step is captured, only with two-branch guidance,
         # and only at a resolution we captured a graph for. A batched capture is a
         # single fixed resolution, so a concurrent batch must be uniform-resolution
@@ -1222,10 +1283,17 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             for rid, (cond_v, uncond_v) in zip(rids, results, strict=True)
         }
 
-    def postprocess_captured(self, request_ids, inputs, per_request_info, outputs) -> dict:
+    def postprocess_captured(
+        self, request_ids: list[str],
+        inputs: list,
+        per_request_info: dict[str, CurrentForwardPassInfo],
+        outputs: dict
+    ) -> dict:
         """Eager tail run after graph replay: the classifier-free-guidance combine
         and the (Python, multistep) scheduler step the graph can't hold. Mirrors
         the tail of ``_forward_image_gen``."""
+        if per_request_info[request_ids[0]].graph_walk not in GEN_WALKS:
+            return outputs
         for rid, inp in zip(request_ids, inputs, strict=True):
             st = self._req[rid]
             cond_v = outputs[rid]["cond_v"][0]

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -469,6 +469,11 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         else:
             latents = inputs["latents"][0]
             time_index = inputs["time_index"][0]
+        
+        scheduler = st["scheduler"]
+        step_index = int(time_index.reshape(-1)[0].item())
+        if step_index >= len(scheduler.timesteps):
+            return None
         tensors = {"latents": latents, "time_index": time_index}
         # The CUDA-graph capture reads the timestep and rotary positions as static
         # buffers (it can't reach the per-request scheduler at replay), so
@@ -516,6 +521,11 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             latents = inputs["latents"][0]
             action_latents = inputs["action_latents"][0]
             time_index = inputs["time_index"][0]
+        
+        scheduler = st["scheduler"]
+        step_index = int(time_index.reshape(-1)[0].item())
+        if step_index >= len(scheduler.timesteps):
+            return None
         return ARNodeInputs(
             input_seq_len=st["num_vision"] + st["num_action"],
             tensor_inputs={"latents": latents, "action_latents": action_latents, "time_index": time_index},
@@ -710,11 +720,6 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
     def _forward_image_gen(self, cm, st, latents, time_index, **kwargs) -> dict:
         scheduler = st["scheduler"]
         step_index = int(time_index.reshape(-1)[0].item())
-        if step_index >= len(scheduler.timesteps):
-            # One extra step past this request's denoise count: the loop has
-            # already been told to stop and this output is discarded. Pass the
-            # finished latents through without touching the (stateful) scheduler.
-            return {"latents": [latents], "time_index": [time_index]}
         t = scheduler.timesteps[step_index]
         vision_timesteps = torch.full((st["num_noisy"],), t.item(), device=latents.device)
 
@@ -795,13 +800,6 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
     def _forward_action_gen(self, cm, st, latents, action_latents, time_index, **kwargs) -> dict:
         scheduler = st["scheduler"]
         step_index = int(time_index.reshape(-1)[0].item())
-        if step_index >= len(scheduler.timesteps):
-            # One extra step past this request's denoise count (discarded output).
-            return {
-                "latents": [latents],
-                "action_latents": [action_latents],
-                "time_index": [time_index],
-            }
         t = scheduler.timesteps[step_index]
         device = latents.device
         vts = torch.full((st["num_noisy"],), t.item(), device=device)
@@ -904,7 +902,6 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             # step) while others in the batch are still running; clamp its
             # timestep so the shared forward can't index past the schedule, and
             # skip its scheduler step below.
-            past_end = step_index >= n_steps
             t = st["scheduler"].timesteps[min(step_index, n_steps - 1)]
             reqs.append({
                 "latents": lat,
@@ -915,15 +912,12 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                 "vision_noisy_frame_indexes": st["cond"]["vision_noisy_frame_indexes"],
                 "vision_mse_loss_indexes": st["cond"]["mse_gen_indexes"],
             })
-            meta.append((rid, st, lat, ti, t, past_end))
+            meta.append((rid, st, lat, ti, t))
 
         results = self.transformer.denoise_step_batched(reqs, cm)
 
         out = {}
-        for (rid, st, lat, ti, t, past_end), (cond_v, uncond_v) in zip(meta, results, strict=True):
-            if past_end:
-                out[rid] = {"latents": [lat], "time_index": [ti]}
-                continue
+        for (rid, st, lat, ti, t), (cond_v, uncond_v) in zip(meta, results, strict=True):
             velocity = uncond_v + st["gs"] * (cond_v - uncond_v)
             new_latents = st["scheduler"].step(
                 velocity.unsqueeze(0), t, lat.unsqueeze(0), return_dict=False
@@ -951,7 +945,6 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             # others in the batch are still running; clamp its timestep so the
             # shared forward can't index past the schedule, and skip its scheduler
             # step below.
-            past_end = step_index >= n_steps
             t = st["scheduler"].timesteps[min(step_index, n_steps - 1)]
             cond = st["cond"]
             und = cond["und_len"]
@@ -973,15 +966,12 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                 unc = st["uncond"]
                 req["position_ids_uncond"] = unc["position_ids"][:, unc["und_len"]:]
             reqs.append(req)
-            meta.append((rid, st, lat, act, ti, t, past_end))
+            meta.append((rid, st, lat, act, ti, t))
 
         results = self.transformer.denoise_step_action_batched(reqs, cm, with_cfg)
 
         out = {}
-        for (rid, st, lat, act, ti, t, past_end), branches in zip(meta, results, strict=True):
-            if past_end:
-                out[rid] = {"latents": [lat], "action_latents": [act], "time_index": [ti]}
-                continue
+        for (rid, st, lat, act, ti, t), branches in zip(meta, results, strict=True):
             if with_cfg:
                 (cond_video, cond_action), (uncond_video, uncond_action) = branches
                 video_v = uncond_video + st["gs"] * (cond_video - uncond_video)

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1445,7 +1445,13 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
         inv_std = (1.0 / torch.tensor(vae.config.latents_std, dtype=vae_dtype, device=latents.device)).view(
             1, -1, 1, 1, 1
         )
-        z = latents.to(vae_dtype) / inv_std + mean
+        # Force z to the VAE dtype. An outer autocast(enabled=True) context is
+        # active during this forward and promotes the `1.0 / std` division to
+        # fp32, which would silently make z fp32 even though latents/mean/vae_dtype
+        # are all bf16 -> the bf16 VAE conv3d below (run under autocast-off) would
+        # then hit "Input type (float) and bias type (BFloat16)". The explicit cast
+        # is a no-op for the fp32 path (S1) and unblocks bf16 decode (cuDNN >= 9.16).
+        z = (latents.to(vae_dtype) / inv_std + mean).to(vae_dtype)
         _prof = os.environ.get("COSMOS3_PROFILE")
         if _prof:
             _e0 = torch.cuda.Event(enable_timing=True); _e1 = torch.cuda.Event(enable_timing=True)

--- a/mstar/model/cosmos3/tests/test_action.py
+++ b/mstar/model/cosmos3/tests/test_action.py
@@ -236,7 +236,10 @@ def test_action_denoise_step_matches_fused() -> None:
         und_len = s["und_len"]
         cache.set_active_label("main")
         cache.plan(is_causal=True)
-        model.prefill_und(s["input_ids"], s["text_mrope_ids"], cache)
+        _cos, _sin = model._rotary(
+            s["text_mrope_ids"], s["input_ids"].device, model.embed_tokens.weight.dtype
+        )
+        model.prefill_und(s["input_ids"], _cos, _sin, cache)
         cache.plan(is_causal=False)
         with torch.no_grad():
             dv, da = model.denoise_step(
@@ -272,7 +275,10 @@ def test_action_batched_one_matches_single() -> None:
         cache = _SdpaCache()
         cache.set_active_label("main")
         cache.plan(is_causal=True)
-        model.prefill_und(s["input_ids"], s["text_mrope_ids"], cache)
+        _cos, _sin = model._rotary(
+            s["text_mrope_ids"], s["input_ids"].device, model.embed_tokens.weight.dtype
+        )
+        model.prefill_und(s["input_ids"], _cos, _sin, cache)
         cache.plan(is_causal=False)
         with torch.no_grad():
             dv, da = model.denoise_step(
@@ -288,7 +294,10 @@ def test_action_batched_one_matches_single() -> None:
         cache2 = _SdpaCache()
         cache2.set_active_label("main")
         cache2.plan(is_causal=True)
-        model.prefill_und(s["input_ids"], s["text_mrope_ids"], cache2)
+        _cos, _sin = model._rotary(
+            s["text_mrope_ids"], s["input_ids"].device, model.embed_tokens.weight.dtype
+        )
+        model.prefill_und(s["input_ids"], _cos, _sin, cache2)
         cache2.plan_attention_batched_cfg(
             labels=["main"],
             seq_lens=[s["num_vision_tokens"] + s["num_action_tokens"]],

--- a/mstar/model/cosmos3/tests/test_engine_cache.py
+++ b/mstar/model/cosmos3/tests/test_engine_cache.py
@@ -596,7 +596,7 @@ def _run_cuda_graph_denoise(ctx):
     CudaGraphRunner (one captured forward per step covering both guidance
     branches), returning the final latents."""
     from mstar.conductor.request_info import CurrentForwardPassInfo
-    from mstar.distributed.communication import TPCommGroup
+    from mstar.distributed.communication import CommGroup
     from mstar.engine.cuda_graph_runner import CudaGraphRunner
     from mstar.model.submodule_base import ModelInputsFromEngine
     from mstar.utils.sampling import Sampler, SamplingConfig
@@ -623,9 +623,9 @@ def _run_cuda_graph_denoise(ctx):
 
     runner = CudaGraphRunner(
         submodule_name="dit", submodule=dit, kv_cache_config=shared["cfg"],
-        alloc_manager=shared["alloc"], sampler=Sampler(device=dev, tp_group=TPCommGroup.trivial()),
+        alloc_manager=shared["alloc"], sampler=Sampler(device=dev, tp_group=CommGroup.trivial()),
         buffer_manager=shared["buf"], device=dev, autocast_dtype=dtype,
-        default_sampling_config=SamplingConfig(), tp_group=TPCommGroup.trivial(),
+        default_sampling_config=SamplingConfig(), tp_group=CommGroup.trivial(),
     )
     runner.warmup_and_capture()
     assert runner.graphs, "no CUDA graph captured for cosmos3 image_gen"

--- a/mstar/model/cosmos3/tests/test_engine_cache.py
+++ b/mstar/model/cosmos3/tests/test_engine_cache.py
@@ -350,8 +350,9 @@ def _check_dense_fa3(num_frames, tag):
     if ctx is None:
         print(f"  (skipped {tag} dense-FA3 parity: needs COSMOS3_NANO_DIR + CUDA)")
         return
-    had = os.environ.pop("COSMOS3_DENSE_FA3", None)
+    had = os.environ.get("COSMOS3_DENSE_FA3")
     try:
+        os.environ["COSMOS3_DENSE_FA3"] = "0"  # paged baseline (cosmos3 config defaults dense on)
         cm = _flashinfer_cache(ctx["model"], "r0", ctx["device"], ctx["dtype"])
         lat_paged = _run_cache_once(
             ctx["model"], ctx["dit"], cm, ctx["init"], ctx["cond"], ctx["uncond"],

--- a/mstar/model/orpheus/components/language_model.py
+++ b/mstar/model/orpheus/components/language_model.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.engine.kv_cache_engine import BatchedCacheManager
 from mstar.model.components import DecoderLayer, RMSNorm
 from mstar.model.components.distributed import (
@@ -27,7 +27,7 @@ from mstar.model.components.distributed import (
 from mstar.model.orpheus.config import OrpheusModelConfig
 
 
-def _build_decoder_layer(config: OrpheusModelConfig, comm_group: TPCommGroup | None = None) -> DecoderLayer:
+def _build_decoder_layer(config: OrpheusModelConfig, comm_group: CommGroup | None = None) -> DecoderLayer:
     return DecoderLayer(
         self_attn=ParallelAttention(
             comm_group=comm_group,
@@ -53,7 +53,7 @@ def _build_decoder_layer(config: OrpheusModelConfig, comm_group: TPCommGroup | N
 
 
 class OrpheusLanguageModel(nn.Module):
-    def __init__(self, config: OrpheusModelConfig, comm_group: TPCommGroup | None = None):
+    def __init__(self, config: OrpheusModelConfig, comm_group: CommGroup | None = None):
         super().__init__()
         # Vocab-parallel embedding: ``[V, H]`` is row-sharded so each rank
         # holds ``V/tp`` rows. Forward masks + ``all_reduce`` produces a
@@ -84,7 +84,7 @@ class OrpheusLanguageModel(nn.Module):
 
 
 class OrpheusForCausalLM(nn.Module):
-    def __init__(self, config: OrpheusModelConfig, comm_group: TPCommGroup | None = None):
+    def __init__(self, config: OrpheusModelConfig, comm_group: CommGroup | None = None):
         super().__init__()
         self.model = OrpheusLanguageModel(config, comm_group=comm_group)
         # LM head is column-parallel over vocab: each rank computes

--- a/mstar/model/qwen3_omni/components/attention.py
+++ b/mstar/model/qwen3_omni/components/attention.py
@@ -18,7 +18,7 @@ from typing import Optional, Tuple
 
 import torch
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.engine.cache_manager import BatchedCacheManager
 from mstar.model.components.distributed import ParallelAttention
 
@@ -41,7 +41,7 @@ class Qwen3OmniAttention(ParallelAttention):
         rope_theta: float = 1_000_000.0,
         rms_norm_eps: float = 1e-6,
         use_mrope: bool = False,
-        comm_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
     ):
         super().__init__(
             comm_group=comm_group,

--- a/mstar/model/qwen3_omni/components/talker.py
+++ b/mstar/model/qwen3_omni/components/talker.py
@@ -20,7 +20,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.engine.kv_cache_engine import BatchedCacheManager
 from mstar.model.components import ParallelSparseMoeBlockWithSharedExpert, RMSNorm
 from mstar.model.components.distributed import ParallelGatedMLP
@@ -65,7 +65,7 @@ class Qwen3OmniTalkerLayer(nn.Module):
 
     def __init__(
         self, config: TalkerTextConfig, layer_idx: int,
-        comm_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
     ):
         super().__init__()
         hidden_size = config.hidden_size
@@ -133,7 +133,7 @@ class Qwen3OmniTalkerLanguageModel(nn.Module):
     This corresponds to the ``talker.model.*`` weight namespace.
     """
 
-    def __init__(self, config: TalkerTextConfig, comm_group: TPCommGroup | None = None):
+    def __init__(self, config: TalkerTextConfig, comm_group: CommGroup | None = None):
         super().__init__()
         # NOTE: No embed_tokens here -- the HF Talker text model does not
         # have a text embedding table.  The Talker receives pre-computed
@@ -193,7 +193,7 @@ class Qwen3OmniTalkerModel(nn.Module):
 
     def __init__(
         self, config: Qwen3OmniModelConfig,
-        comm_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
     ):
         super().__init__()
         talker_text = config.talker_text

--- a/mstar/model/qwen3_omni/components/thinker.py
+++ b/mstar/model/qwen3_omni/components/thinker.py
@@ -26,7 +26,7 @@ from typing import Optional, Tuple
 import torch
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.engine.cache_manager import BatchedCacheManager
 from mstar.model.components import ParallelSparseMoeBlock, RMSNorm
 from mstar.model.components.distributed import ParallelGatedMLP
@@ -48,7 +48,7 @@ class Qwen3OmniThinkerLayer(nn.Module):
 
     def __init__(
         self, config: Qwen3OmniModelConfig, layer_idx: int,
-        comm_group: TPCommGroup | None = None,
+        comm_group: CommGroup | None = None,
     ):
         super().__init__()
         tc = config.thinker_text
@@ -138,7 +138,7 @@ class Qwen3OmniThinkerLayer(nn.Module):
 class Qwen3OmniThinkerTextModel(nn.Module):
     """Inner text model (maps to ``thinker.model.*`` in HF weights)."""
 
-    def __init__(self, config: Qwen3OmniModelConfig, comm_group: TPCommGroup | None = None):
+    def __init__(self, config: Qwen3OmniModelConfig, comm_group: CommGroup | None = None):
         super().__init__()
         tc = config.thinker_text
         self.embed_tokens = nn.Embedding(tc.vocab_size, tc.hidden_size)
@@ -165,7 +165,7 @@ class Qwen3OmniThinkerModel(nn.Module):
     - Layer-N hidden states (``accept_hidden_layer``) for Talker conditioning
     """
 
-    def __init__(self, config: Qwen3OmniModelConfig, comm_group: TPCommGroup | None = None):
+    def __init__(self, config: Qwen3OmniModelConfig, comm_group: CommGroup | None = None):
         super().__init__()
         tc = config.thinker_text
 

--- a/mstar/utils/sampling.py
+++ b/mstar/utils/sampling.py
@@ -303,7 +303,7 @@ class Sampler(BaseSampler):
     # (seeded) sampling draws a fresh number each step — otherwise identical
     # (seed, offset=0) draws repeat forever and stable logits never reach EOS.
     _step_offset: dict[str, int] = field(default_factory=dict)
-    tp_group: "TPCommGroup | None" = None  # noqa: F821
+    tp_group: "CommGroup | None" = None  # noqa: F821
 
     def add_request(self, request_id: str):
         self._sampling_config[request_id] = SamplingConfig()
@@ -593,7 +593,7 @@ class CudaGraphableSampler(BaseSampler):
     # that don't opt into seen-token tracking (then ``apply_penalty`` is a no-op).
     rep_penalty_buf: torch.Tensor | None = None
     seen_tokens_buf: torch.Tensor | None = None  # [bs, V] bool
-    tp_group: "TPCommGroup | None" = None  # noqa: F821
+    tp_group: "CommGroup | None" = None  # noqa: F821
 
     # Set during graph capture, and used by the cuda graph runner to determine
     # whether requests' seen token buffers should be synced post-replay
@@ -780,7 +780,7 @@ class SamplerBuffers:
     # and TP ranks would drift apart on the first tied-logit sample —
     # garbled audio for Talker, premature EOS for Thinker. Defaults to
     # ``None`` for non-TP submodules (trivial broadcast is a cheap no-op).
-    tp_group: "TPCommGroup | None" = None  # noqa: F821
+    tp_group: "CommGroup | None" = None  # noqa: F821
     # Per-request seen-token mask buffer for the repetition penalty. Present
     # only for submodules that opt in by declaring a vocab size (e.g. the
     # Qwen3-Omni Talker). ``None`` => the CUDA-graph path applies no penalty.
@@ -812,7 +812,7 @@ class SamplerBuffers:
         cls,
         max_batch_size: int,
         device: torch.device,
-        tp_group: "TPCommGroup | None" = None,  # noqa: F821
+        tp_group: "CommGroup | None" = None,  # noqa: F821
         vocab_size: int | None = None,
     ) -> "SamplerBuffers":
         """Allocate sampling buffers for ``max_batch_size``.

--- a/mstar/worker/engine_manager.py
+++ b/mstar/worker/engine_manager.py
@@ -102,9 +102,16 @@ class EngineManager:
         if model is not None:
             for name in node_names:
                 node_tp_group = tp_groups.get_tp_config_for_node(name)
+                # Sequence parallelism is opt-in per node; only forward the SP
+                # group when this node actually participates in one, so models
+                # that don't support SP keep their existing get_submodule call.
+                extra = {}
+                node_sp_group = tp_groups.get_sp_config_for_node(name)
+                if node_sp_group.world_size > 1:
+                    extra["sp_group"] = node_sp_group
                 node_submodules[name] = model.get_submodule(
                     name, device, tp_group=node_tp_group,
-                    autocast_dtype=autocast_dtype,
+                    autocast_dtype=autocast_dtype, **extra,
                 )
 
         # Group nodes by the factory key. STATELESS nodes split further by

--- a/mstar/worker/engine_manager.py
+++ b/mstar/worker/engine_manager.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 import torch
 
-from mstar.distributed.communication import WorkerTPGroups
+from mstar.distributed.communication import WorkerParallelGroups
 from mstar.engine.base import BaseEngine, EngineType
 from mstar.engine.kv_cache_engine import KVCacheEngine
 from mstar.engine.kv_store import KVCacheConfig, TransferEngineInfo
@@ -65,7 +65,7 @@ class EngineManager:
         device: torch.device,
         kv_config: list[KVCacheConfig],
         model_config: dict,
-        tp_groups: WorkerTPGroups,
+        parallel_groups: WorkerParallelGroups,
         transfer_engine_info: TransferEngineInfo,
         model: Model,
         enable_nvtx: bool = False,
@@ -101,12 +101,12 @@ class EngineManager:
         node_submodules: dict[str, torch.nn.Module | None] = {}
         if model is not None:
             for name in node_names:
-                node_tp_group = tp_groups.get_tp_config_for_node(name)
+                node_tp_group = parallel_groups.get_tp_config_for_node(name)
                 # Sequence parallelism is opt-in per node; only forward the SP
                 # group when this node actually participates in one, so models
                 # that don't support SP keep their existing get_submodule call.
                 extra = {}
-                node_sp_group = tp_groups.get_sp_config_for_node(name)
+                node_sp_group = parallel_groups.get_sp_config_for_node(name)
                 if node_sp_group.world_size > 1:
                     extra["sp_group"] = node_sp_group
                 node_submodules[name] = model.get_submodule(
@@ -150,7 +150,7 @@ class EngineManager:
 
             engine.load_model(
                 submodules,
-                tp_groups=tp_groups,
+                parallel_groups=parallel_groups,
                 kv_cache_config=kv_config,
                 device=device,
                 transfer_engine_info=transfer_engine_info,

--- a/mstar/worker/micro_scheduler.py
+++ b/mstar/worker/micro_scheduler.py
@@ -55,15 +55,15 @@ class MicroScheduler:
     def __init__(
         self, engine_manager: EngineManager,
         sched_type=SchedulingType.ROUND_ROBIN,
-        tp_rank_zero_nodes: set[str] | None = None,
+        parallel_leader_nodes: set[str] | None = None,
         max_consec_tp_follower_batches: int = 1,
     ):
         self.engine_manager = engine_manager
         self.batch_number = 0
         self.sched_type = sched_type
 
-        # tensor parallel
-        self.tp_rank_zero_nodes = tp_rank_zero_nodes
+        # lockstep-parallel (TP / SP instance) scheduling
+        self.parallel_leader_nodes = parallel_leader_nodes
         self.tp_batches_pending_schedule = deque()
         self.num_consec_tp_follower_batches = 0
         self.max_consec_tp_follower_batches = max_consec_tp_follower_batches
@@ -230,7 +230,7 @@ class MicroScheduler:
                 if request_id in self.held_until:
                     continue
                 for sname in node_names:
-                    if sname not in self.tp_rank_zero_nodes:
+                    if sname not in self.parallel_leader_nodes:
                         continue # only rank 0 can initiate scheduling!
                     if target_node_name is not None and sname != target_node_name:
                         continue

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -1598,6 +1598,15 @@ class Worker:
         # pending stops are only needed for one iteration, so can be cleared now
         self._pending_loop_stops.clear()
 
+        # An engine can drop rids that were skipped during execution (a
+        # submodule's prepare_inputs returned None) from node_batch.request_ids,
+        # but it cannot reach the worker-side ScheduledBatch. Reconcile it here so
+        # the routing/output loops below only touch rids that produced outputs.
+        for rid in list(batch_N.batch.request_to_worker_graph):
+            if rid not in valid_rids:
+                batch_N.batch.request_to_worker_graph.pop(rid, None)
+                batch_N.batch.node_objects.pop(rid, None)
+
         per_req_nested_idxs = {
             rid: self.worker_graphs_manager.get_nested_loop_idxs_for_node(
                 rid, batch_N.partition, batch_N.node_name

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -217,13 +217,28 @@ class Worker:
             worker_id=self.worker_id
         )
 
+        # The lockstep unit for a node is its whole instance: the tensor-parallel
+        # row composed with the sequence-parallel column. Exactly one rank per
+        # instance — the one that is rank 0 in BOTH its TP and SP comm groups —
+        # leads scheduling and broadcasts ScheduleTPNode to the rest; every other
+        # instance rank follows. Keying the leader off the TP rank alone would
+        # elect one leader per TP row (e.g. ranks 0 and 2 of a tp2*sp2 instance),
+        # racing the followers and desyncing the per-step graph walk.
         self.tp_rank_zero_nodes = set([
-            node for node in node_names if self.tp_groups.get_tp_config_for_node(node).rank == 0
+            node for node in node_names
+            if self.tp_groups.get_tp_config_for_node(node).rank == 0
+            and self.tp_groups.get_sp_config_for_node(node).rank == 0
         ])
 
-        # v1: disallow multiple TP nodes in the same worker
+        # v1: disallow multiple lockstep-scheduled nodes in the same worker.
+        # A node is lockstep-scheduled when its instance spans more than one rank,
+        # i.e. tp_size * sp_size > 1. Pure sequence-parallel nodes (tp_size 1,
+        # sp_size > 1) need this too: their attention all-to-all requires the
+        # whole instance to step together. Without SP this is just tp_size > 1.
         self.tp_nodes = set([
-            node for node in node_names if self.tp_groups.get_tp_config_for_node(node).world_size > 1
+            node for node in node_names
+            if self.tp_groups.get_tp_config_for_node(node).world_size
+            * self.tp_groups.get_sp_config_for_node(node).world_size > 1
         ])
         if len(self.tp_nodes) > 1:
             raise NotImplementedError(

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -17,7 +17,7 @@ from mstar.communication.event import EventWakeup
 from mstar.communication.tensors import NameToTensorList, create_tensor_communication_manager
 from mstar.conductor.request_info import CurrentForwardPassInfo
 from mstar.distributed.base import ShardingConfig
-from mstar.distributed.communication import WorkerTPGroups
+from mstar.distributed.communication import WorkerParallelGroups
 from mstar.engine.base import EngineType, NodeBatch, NodeOutput
 from mstar.engine.kv_store import KVCacheConfig, StoreWritePolicy, TransferEngineInfo
 from mstar.graph.base import GraphEdge, GraphNode
@@ -122,7 +122,7 @@ class Worker:
         all_worker_graph_ids_to_nodes: dict[str, set[str]],
         all_worker_graph_ids_to_dyn_loops: dict[str, set[str]],
         sharding_config: ShardingConfig,
-        tp_groups: WorkerTPGroups,
+        parallel_groups: WorkerParallelGroups,
         hostname: str = "localhost",
         socket_path_prefix: str = "/tmp/mstar",
         tensor_comm_protocol: CommProtocol = CommProtocol.RDMA,
@@ -146,8 +146,8 @@ class Worker:
         if dist_init_method is None:
             dist_init_method = f"tcp://{hostname}:29500"
 
-        self.tp_groups = tp_groups
-        self.tp_groups.init_dist(init_method=dist_init_method)
+        self.parallel_groups = parallel_groups
+        self.parallel_groups.init_dist(init_method=dist_init_method)
 
         # Build node_to_partition mapping from model's partitions and graph walks
         node_to_partition: dict[str, str] = {}
@@ -187,7 +187,7 @@ class Worker:
             device=device,
             kv_config=kv_config,
             model_config=model_config,
-            tp_groups=self.tp_groups,
+            parallel_groups=self.parallel_groups,
             transfer_engine_info=TransferEngineInfo(
                 my_entity_id=worker_id,
                 my_session_id=self.tensor_manager.my_session_id,
@@ -219,15 +219,15 @@ class Worker:
 
         # The lockstep unit for a node is its whole instance: the tensor-parallel
         # row composed with the sequence-parallel column. Exactly one rank per
-        # instance — the one that is rank 0 in BOTH its TP and SP comm groups —
-        # leads scheduling and broadcasts ScheduleTPNode to the rest; every other
-        # instance rank follows. Keying the leader off the TP rank alone would
-        # elect one leader per TP row (e.g. ranks 0 and 2 of a tp2*sp2 instance),
-        # racing the followers and desyncing the per-step graph walk.
-        self.tp_rank_zero_nodes = set([
+        # instance — instance rank 0, i.e. rank 0 in BOTH its TP and SP comm
+        # groups — leads scheduling and broadcasts ScheduleTPNode to the rest;
+        # every other instance rank follows. Keying the leader off the TP rank
+        # alone would elect one leader per TP row (e.g. ranks 0 and 2 of a
+        # tp2*sp2 instance), racing the followers and desyncing the per-step
+        # graph walk.
+        self.parallel_leader_nodes = set([
             node for node in node_names
-            if self.tp_groups.get_tp_config_for_node(node).rank == 0
-            and self.tp_groups.get_sp_config_for_node(node).rank == 0
+            if self.parallel_groups.get_instance_rank_for_node(node) == 0
         ])
 
         # v1: disallow multiple lockstep-scheduled nodes in the same worker.
@@ -235,19 +235,19 @@ class Worker:
         # i.e. tp_size * sp_size > 1. Pure sequence-parallel nodes (tp_size 1,
         # sp_size > 1) need this too: their attention all-to-all requires the
         # whole instance to step together. Without SP this is just tp_size > 1.
-        self.tp_nodes = set([
+        self.parallel_nodes = set([
             node for node in node_names
-            if self.tp_groups.get_tp_config_for_node(node).world_size
-            * self.tp_groups.get_sp_config_for_node(node).world_size > 1
+            if self.parallel_groups.get_instance_world_size_for_node(node) > 1
         ])
-        if len(self.tp_nodes) > 1:
+        if len(self.parallel_nodes) > 1:
             raise NotImplementedError(
-                f"Multiple TP nodes {self.tp_nodes} found in worker {worker_id}; "
-                "current implementation requires at most one TP node per worker."
+                f"Multiple parallel nodes {self.parallel_nodes} found in worker "
+                f"{worker_id}; current implementation requires at most one "
+                "lockstep-parallel node per worker."
             )
         self.scheduler = MicroScheduler(
             self.engine_manager,
-            tp_rank_zero_nodes=self.tp_rank_zero_nodes
+            parallel_leader_nodes=self.parallel_leader_nodes
         )
 
         # Determine store write policy based on worker graph topology
@@ -851,8 +851,8 @@ class Worker:
     def maybe_send_zmq_to_tp_followers(
         self, node_batch: NodeBatch
     ):
-        if node_batch.node_name not in self.tp_nodes or \
-                node_batch.node_name not in self.tp_rank_zero_nodes:
+        if node_batch.node_name not in self.parallel_nodes or \
+                node_batch.node_name not in self.parallel_leader_nodes:
             return
         # this worker is only a part of one TP group for this node,
         # so, we can just look at the sharding_config for the first
@@ -1265,8 +1265,8 @@ class Worker:
     def _can_speculate(self, batch: ScheduledBatch) -> bool:
         if any(
             not node.enable_async_scheduling for node in batch.node_objects.values()
-        ) or batch.node_name in self.tp_nodes:
-            # disable speculation for TP nodes for now
+        ) or batch.node_name in self.parallel_nodes:
+            # disable speculation for lockstep-parallel nodes for now
             return False
         return True
 
@@ -1329,8 +1329,9 @@ class Worker:
 
         # Filter out destinations that aren't speculation candidates.
         #
-        # * ``info.node_name in self.tp_nodes`` — TP nodes don't support
-        #   speculation in v1 (rank-0 schedules; followers can't initiate).
+        # * ``info.node_name in self.parallel_nodes`` — lockstep-parallel nodes
+        #   don't support speculation in v1 (the instance leader schedules;
+        #   followers can't initiate).
         # * ``not wgio.nodes[info.node_name].enable_async_scheduling`` — the
         #   destination node opts out of async scheduling. Mirrors the
         #   source-side check in ``_can_speculate``; without this, a
@@ -1339,7 +1340,7 @@ class Worker:
         #   then dropped per-rid further down.
         ready_for_spec = [
             info for info in ready_for_spec
-            if info.node_name not in self.tp_nodes
+            if info.node_name not in self.parallel_nodes
             and wgio.nodes[info.node_name].enable_async_scheduling
         ]
 
@@ -1938,7 +1939,7 @@ class Worker:
         # large multi-tower models. Syncing here means every worker
         # reaches warmup at the same wall-clock instant, so subgroup
         # bootstrap completes within the retry budget.
-        self.tp_groups.barrier_all()
+        self.parallel_groups.barrier_all()
 
         # CUDA graph capture before entering the main loop
         self.engine_manager.warmup_all()
@@ -1952,7 +1953,7 @@ class Worker:
         # ``ScheduleTPNode`` to a follower that's still inside another
         # engine's ``warmup``. The follower can't service the message
         # yet, but the leader will sit on the first NCCL collective.
-        self.tp_groups.barrier_all()
+        self.parallel_groups.barrier_all()
 
         # Setup (weight load + warmup + CUDA-graph capture) is complete. Tell
         # the conductor this worker is ready. The conductor blocks its main

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -1570,14 +1570,15 @@ class Worker:
                         or pending_stop.rid not in batch_N.node_batch.request_ids:
                     continue
                 stopped_rid = pending_stop.rid
-                if stopped_rid not in batch_N.batch.node_objects:
-                    continue
                 output.per_request_output_tensors.pop(stopped_rid, None)
                 valid_rids.discard(stopped_rid)
                 batch_N.batch.node_objects.pop(stopped_rid)
                 batch_N.batch.request_to_worker_graph.pop(stopped_rid)
                 batch_N.node_batch.per_request_info.pop(stopped_rid)
         batch_N.node_batch.request_ids = list(valid_rids)
+        if not valid_rids:
+            range_pop(synchronize=False)
+            return
 
         # pending stops are only needed for one iteration, so can be cleared now
         self._pending_loop_stops.clear()

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -1572,9 +1572,9 @@ class Worker:
                 stopped_rid = pending_stop.rid
                 output.per_request_output_tensors.pop(stopped_rid, None)
                 valid_rids.discard(stopped_rid)
-                batch_N.batch.node_objects.pop(stopped_rid)
-                batch_N.batch.request_to_worker_graph.pop(stopped_rid)
-                batch_N.node_batch.per_request_info.pop(stopped_rid)
+                batch_N.batch.node_objects.pop(stopped_rid, None)
+                batch_N.batch.request_to_worker_graph.pop(stopped_rid, None)
+                batch_N.node_batch.per_request_info.pop(stopped_rid, None)
         batch_N.node_batch.request_ids = list(valid_rids)
         if not valid_rids:
             range_pop(synchronize=False)

--- a/test/cosmos3/bench_t2i.py
+++ b/test/cosmos3/bench_t2i.py
@@ -1,0 +1,69 @@
+"""Apples-to-apples t2i latency client — hits the OpenAI /v1/images/generations
+endpoint that BOTH our mstar server and vLLM-Omni (`vllm serve --omni`) expose, with
+an identical payload, and reports client-side wall latency (warmup + median of N).
+
+Same scope on both engines (client-side end-to-end incl. HTTP + b64 PNG), same config
+(tiers, steps, guidance, seed, prompt). Run once per server (different --port/--model).
+
+  python bench_t2i_oai.py --port 8000 --model nvidia/Cosmos3-Nano --tag vllm
+  python bench_t2i_oai.py --port 8100 --model cosmos3_nano --tag ours
+"""
+import argparse
+import base64
+import json
+import statistics
+import time
+import urllib.request
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--port", type=int, required=True)
+ap.add_argument("--model", default="nvidia/Cosmos3-Nano")
+ap.add_argument("--sizes", default="320x192,832x480,1280x720")  # 256p/480p/720p tiers
+ap.add_argument("--steps", type=int, default=50)
+ap.add_argument("--gs", type=float, default=6.0)
+ap.add_argument("--seed", type=int, default=0)
+ap.add_argument("--rounds", type=int, default=5)
+ap.add_argument("--warmup", type=int, default=2)
+ap.add_argument("--tag", default="run")
+ap.add_argument("--save", default="")  # optional PNG path prefix
+args = ap.parse_args()
+
+PROMPT = "A red cube resting on a polished wooden table, soft daylight."
+NEG = "blurry, distorted, low quality"
+URL = f"http://localhost:{args.port}/v1/images/generations"
+
+
+def one(size):
+    body = json.dumps({
+        "model": args.model, "prompt": PROMPT, "negative_prompt": NEG,
+        "size": size, "n": 1, "response_format": "b64_json",
+        "num_inference_steps": args.steps, "guidance_scale": args.gs, "seed": args.seed,
+    }).encode()
+    req = urllib.request.Request(URL, data=body, headers={"Content-Type": "application/json"})
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=1200) as r:
+        payload = json.load(r)
+    dt = time.perf_counter() - t0
+    b64 = payload["data"][0]["b64_json"]
+    return dt, b64
+
+
+print(f"=== {args.tag}  port={args.port} model={args.model}  steps={args.steps} gs={args.gs} seed={args.seed} ===", flush=True)
+for size in args.sizes.split(","):
+    try:
+        for _ in range(args.warmup):
+            one(size)
+        ts = []
+        last_b64 = None
+        for _ in range(args.rounds):
+            dt, last_b64 = one(size)
+            ts.append(dt)
+        ts.sort()
+        med = statistics.median(ts)
+        print(f"  {size:9s}  median {med:.3f}s  min {ts[0]:.3f}  max {ts[-1]:.3f}  (n={args.rounds})", flush=True)
+        if args.save and last_b64:
+            with open(f"{args.save}_{size}.png", "wb") as f:
+                f.write(base64.b64decode(last_b64))
+    except Exception as e:  # noqa: BLE001
+        print(f"  {size:9s}  ERROR {type(e).__name__}: {str(e)[:120]}", flush=True)
+print("DONE", flush=True)

--- a/test/cosmos3/launch_nsys.sh
+++ b/test/cosmos3/launch_nsys.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -f "./.env" ]; then
+    source ".env"
+else
+    echo "Error: No .env file found. Run:  \"cp .sample.env .env\" and configure it. Make sure the .env file is in your current working directory."
+    exit 1
+fi
+
+CUDA_VISIBLE_DEVICES=$DEVICES nsys profile --trace=cuda,nvtx --output=cosmos_profile --force-overwrite=true \
+    python mstar/api_server/entrypoint.py \
+    --config configs/cosmos3_nano.yaml --enable-nvtx \
+    --socket-path-prefix /tmp/mstar_$WHO/ \
+    --upload-dir /tmp/mstar_uploads_$WHO/ \
+    --port $PORT \
+    --tensor-comm-protocol $TENSOR_PROTOCOL \
+    --tcp-transfer-device ${TCP_DEVICE:-0.0.0.0.0}
+    # --log-level DEBUG

--- a/test/cosmos3/launch_server.sh
+++ b/test/cosmos3/launch_server.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -f "./.env" ]; then
+    source ".env"
+else
+    echo "Error: No .env file found. Run:  \"cp .sample.env .env\" and configure it. Make sure the .env file is in your current working directory."
+    exit 1
+fi
+
+
+CUDA_VISIBLE_DEVICES=$DEVICES python mstar/api_server/entrypoint.py \
+    --config configs/cosmos3_nano.yaml \
+    --socket-path-prefix /tmp/mstar_$WHO/ \
+    --upload-dir /tmp/mstar_uploads_$WHO/ \
+    --port $PORT \
+    --tensor-comm-protocol $TENSOR_PROTOCOL \
+    --tcp-transfer-device ${TCP_DEVICE:-0.0.0.0.0}
+    # --log-level DEBUG

--- a/test/cosmos3/launch_server.sh
+++ b/test/cosmos3/launch_server.sh
@@ -8,7 +8,7 @@ else
 fi
 
 
-CUDA_VISIBLE_DEVICES=$DEVICES python mstar/api_server/entrypoint.py \
+CUDA_VISIBLE_DEVICES=$DEVICES COSMOS3_PROFILE=1 COSMOS3_DENSE_FA3=1 python mstar/api_server/entrypoint.py \
     --config configs/cosmos3_nano.yaml \
     --socket-path-prefix /tmp/mstar_$WHO/ \
     --upload-dir /tmp/mstar_uploads_$WHO/ \


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

- Change `use_karras_sigma` to have parity with vllm-omi (default False, with ability to pass True through the model_kwargs)
- Use bfloat16 for vae decoder
- Enable async scheduling for image/video/action gen

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

## How was it tested?

Partially tested (t2i benchmark)

```
=== run  port=8001 model=nvidia/Cosmos3-Nano  steps=50 gs=6.0 seed=0 ===
  320x192    median 0.561s  min 0.560  max 0.566  (n=5)
  832x480    median 1.183s  min 1.176  max 1.199  (n=5)
  1280x720   median 2.454s  min 2.381  max 2.466  (n=5)
```

<!-- Commands you ran, or why tests aren't applicable. -->

## Checklist
- [ ] `ruff check .` passes
- [ ] Added or updated tests / docs where relevant
