### PR TITLE
[Feature] Profiling Support for M*

### DIFF
--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -56,6 +56,14 @@ mstar serve
    * - ``--log-level``
      - ``INFO``
      - ``DEBUG`` / ``INFO`` / ``WARNING`` / ``ERROR``.
+   * - ``--log-stats``
+     - off
+     - Print a per-request profile when each request finishes (see
+       :ref:`request-profiling`).
+   * - ``--log-stats-file``
+     - stdout
+     - Append the per-request profiles to this file instead of stdout
+       (implies ``--log-stats``).
 
 Each model maps to a default config (override with ``--config``):
 
@@ -132,6 +140,14 @@ mstar-serve
    * - ``--enable-nvtx``
      - off
      - Emit NVTX markers for profiling.
+   * - ``--log-stats``
+     - off
+     - Print a per-request profile when each request finishes (see
+       :ref:`request-profiling`).
+   * - ``--log-stats-file``
+     - stdout
+     - Append the per-request profiles to this file instead of stdout
+       (implies ``--log-stats``).
    * - ``--log-level``
      - ``INFO``
      - ``DEBUG`` / ``INFO`` / ``WARNING`` / ``ERROR``.
@@ -227,6 +243,8 @@ Pi0.5 DROID variant fixes the action horizon:
 Per-request knobs (``temperature``, ``voice``, ``max_output_tokens``, …) are sent by the
 client instead — see :doc:`clients`.
 
+.. _tensor-transport:
+
 Tensor transport
 ----------------
 
@@ -237,3 +255,97 @@ Workers route tensors directly to one another using one of three transports, sel
 - ``TCP`` — works anywhere; used for some multi-node setups.
 - ``RDMA`` — lowest latency for multi-GPU / multi-node, via the Mooncake transfer engine
   (requires RDMA-capable networking).
+
+.. _request-profiling:
+
+Request profiling
+-----------------
+
+Pass ``--log-stats`` (to either ``mstar serve`` or ``mstar-serve``) to print a per-request
+profile when each request finishes. Add ``--log-stats-file <path>`` to append the profiles
+to a file instead of stdout (it implies ``--log-stats``):
+
+.. code-block:: bash
+
+   mstar serve bagel --log-stats
+   mstar-serve --config configs/orpheus_colocated.yaml --log-stats-file stats.txt
+
+The report has four sections (any that has no data is omitted):
+
+.. code-block:: text
+
+   ============================================================
+    Request profile: 3f9c1e2a-…
+   ============================================================
+    Inputs:
+      text         x1           72 B
+      image        x1        1.1 MiB
+    Outputs:
+      image        x1        1.1 MiB
+   ------------------------------------------------------------
+    Timeline:
+      recv → preprocess done                       62.6 ms
+      preprocess done → conductor ingest            2.3 ms
+      conductor ingest → first chunk              133.7 ms
+      first chunk → last chunk                    683.3 ms
+      last chunk → conductor done                   1.5 ms
+      conductor done → finish                       3.1 ms
+      total                                       886.5 ms
+   ------------------------------------------------------------
+    Graph timings (CPU, ms) — total over request (avg per exec):
+                                    all                 fwd                 pre               post*
+      LLM
+        decode     n=588      3277.9 (   5.57)    2858.0 (   4.86)     243.0 (   0.41)     176.9 (   0.30)
+        prefill    n=1          8.78 (   8.78)      4.24 (   4.24)      3.47 (   3.47)      1.06 (   1.06)
+      * post overlaps the next step / another in-flight batch under
+        speculative scheduling, so it is not necessarily additive.
+   ------------------------------------------------------------
+    Tensor transfer   size / transport-time / count:
+      rx (received over the wire), by source → dest:
+        worker_0 → worker_1
+          hidden                  106.7 MiB      78.7 ms  (x49)
+      tx (registered/written for send), by source:
+        worker_0
+          hidden                  106.7 MiB       0.90 ms  (x49)
+   ============================================================
+
+**Inputs / Outputs** — per-modality count and byte size. Inputs are the *raw*
+client-supplied bytes (uploaded file sizes on disk, UTF-8 length of the prompt), not the
+much larger decoded tensors, so they line up with what was sent over the wire.
+
+**Timeline** — wall-clock stage boundaries for the request as it flows
+``api server → conductor → workers → api server``. Stages are ordered by their actual
+timestamp, so a stage is never negative even when two checkpoints race (e.g. the API
+server's ``last chunk`` and the conductor's ``done`` can arrive in either order). All
+timestamps are ``time.perf_counter()``; they are comparable across the api-server,
+conductor, and worker processes because those run on the **same host** (``perf_counter`` is
+``CLOCK_MONOTONIC``, which is boot-relative and shared). The numbers are not meaningful if
+processes ever run on different hosts.
+
+**Graph timings** — CPU time per ``(node, graph_walk)``, accumulated over the request.
+Each cell shows the **total over the request** and, in parentheses, the **average per
+execution** (``n`` is the execution count, so e.g. one entry covers all ``588`` decode
+steps). The columns:
+
+- ``all`` — the full node execution (= ``pre`` + ``fwd`` + ``post``).
+- ``fwd`` — the GPU forward region. Because execution is asynchronous and *not* synced
+  (a sync would serialize the pipeline), this measures the CPU launch/enqueue span of the
+  whole batch, not per-request GPU time.
+- ``pre`` — input preparation / preprocessing before the launch.
+- ``post`` — CPU postprocess after the forward. Marked ``post*`` because under
+  speculative scheduling it can overlap the next step's forward or another in-flight
+  batch, so it is **not necessarily additive**.
+
+**Tensor transfer** — bytes moved between entities via the tensor transport
+(:ref:`above <tensor-transport>`). ``rx`` (received) is grouped by ``source → dest``; ``tx``
+(sent) is grouped by source only — the sender registers/writes data without knowing a
+priori which worker will read it (and may register data that is never sent), so there is no
+per-destination breakdown. ``size`` is total bytes, the time is transport cost (the
+RDMA-read or SHM file-read time on ``rx``; the registration / serialize-and-write time on
+``tx``), and ``count`` is the number of tensors.
+
+.. note::
+
+   Profiling is gated end-to-end on ``--log-stats``: when it is off, the workers,
+   conductor, and data worker skip the timing/transfer bookkeeping entirely, so there is no
+   steady-state overhead.

--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -347,5 +347,4 @@ RDMA-read or SHM file-read time on ``rx``; the registration / serialize-and-writ
 .. note::
 
    Profiling is gated end-to-end on ``--log-stats``: when it is off, the workers,
-   conductor, and data worker skip the timing/transfer bookkeeping entirely, so there is no
-   steady-state overhead.
+   conductor, and data worker skip the timing/transfer bookkeeping entirely.

--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -319,8 +319,8 @@ timestamp, so a stage is never negative even when two checkpoints race (e.g. the
 server's ``last chunk`` and the conductor's ``done`` can arrive in either order). All
 timestamps are ``time.perf_counter()``; they are comparable across the api-server,
 conductor, and worker processes because those run on the **same host** (``perf_counter`` is
-``CLOCK_MONOTONIC``, which is boot-relative and shared). The numbers are not meaningful if
-processes ever run on different hosts.
+``CLOCK_MONOTONIC``, which is boot-relative and shared).
+This implementation will be updated when multi-node support is added.
 
 **Graph timings** — CPU time per ``(node, graph_walk)``, accumulated over the request.
 Each cell shows the **total over the request** and, in parentheses, the **average per

--- a/mstar/api_server/data_worker.py
+++ b/mstar/api_server/data_worker.py
@@ -15,7 +15,13 @@ try:
 except (ImportError, RuntimeError, OSError):
     VideoDecoder = None
 
-from mstar.api_server.request_types import PreprocessInput, ResultChunk, ResultTensors
+from mstar.api_server.request_types import (
+    PreprocessInput,
+    PreprocessProfile,
+    ResultChunk,
+    ResultTensors,
+)
+from mstar.profile.format import InputInfo
 from mstar.communication.communicator import CommProtocol, ZMQCommunicator
 from mstar.communication.tensors import NameToTensorList, create_tensor_communication_manager
 from mstar.model.base import Model
@@ -55,6 +61,7 @@ class PreprocessWorker:
         self.abort_request_queue = queue.Queue()
         self.discard_tensor_queue = queue.Queue()
         self.output_queue = queue.Queue()
+        self.profile_queue = queue.Queue()
         self.stop_event = threading.Event()
 
         self.per_request_reading_tensors = {}
@@ -66,6 +73,7 @@ class PreprocessWorker:
                 in_queue=self.request_input_queue,
                 result_tensor_queue=self.result_tensor_input_queue,
                 out_queue=self.output_queue,
+                profile_queue=self.profile_queue,
                 cleanup_request_queue=self.cleanup_request_queue,
                 abort_request_queue=self.abort_request_queue,
                 discard_tensor_queue=self.discard_tensor_queue,
@@ -141,6 +149,13 @@ class PreprocessWorker:
             results.append(result)
         return results
 
+    def get_profile_updates(self) -> list[PreprocessProfile]:
+        """Drain preprocess-side profiling updates emitted by the worker thread."""
+        updates = []
+        while not self.profile_queue.empty():
+            updates.append(self.profile_queue.get())
+        return updates
+
     def cleanup_request(self, request_id: str):
         self.cleanup_request_queue.put(request_id)
         self.output_loop_idxs.pop(request_id, None)
@@ -158,6 +173,7 @@ class PreprocessWorkerThread:
         in_queue: queue.Queue, # for preprocessing
         result_tensor_queue: queue.Queue, # for output streaming
         out_queue: queue.Queue,
+        profile_queue: queue.Queue,
         cleanup_request_queue: queue.Queue,
         abort_request_queue: queue.Queue,
         discard_tensor_queue: queue.Queue,
@@ -175,6 +191,7 @@ class PreprocessWorkerThread:
         self.abort_request_queue = abort_request_queue
         self.discard_tensor_queue = discard_tensor_queue
         self.out_queue = out_queue
+        self.profile_queue = profile_queue
 
         self.stop_event = stop_event
         self.device = device
@@ -284,6 +301,38 @@ class PreprocessWorkerThread:
             ),
         )
         self.communicator.send("conductor", msg)
+
+        # Record preprocess-side profiling: the moment the fully preprocessed
+        # request was handed off to the conductor, and the per-modality sizes of
+        # the input tensors we produced. ``perf_counter`` is consistent here
+        # because the worker runs as a thread inside the API server process.
+        self.profile_queue.put(PreprocessProfile(
+            request_id=input.request_id,
+            preprocess_finish_time=time.perf_counter(),
+            inputs=self._summarize_inputs(tensors),
+        ))
+
+    @staticmethod
+    def _summarize_inputs(tensors: NameToTensorList) -> list[InputInfo]:
+        """Aggregate the preprocessed input tensors into per-modality sizes.
+
+        Keys are the tensor-bundle names (e.g. ``image_inputs``); the trailing
+        ``_inputs`` is stripped to recover the modality label.
+        """
+        infos = []
+        for name, tensor_list in tensors.items():
+            modality = name[: -len("_inputs")] if name.endswith("_inputs") else name
+            total_bytes = sum(
+                t.numel() * t.element_size()
+                for t in tensor_list
+                if t is not None
+            )
+            infos.append(InputInfo(
+                modality=modality,
+                count=len(tensor_list),
+                total_bytes=total_bytes,
+            ))
+        return infos
 
     def _read_result_tensor(
         self, result: ResultTensors

--- a/mstar/api_server/data_worker.py
+++ b/mstar/api_server/data_worker.py
@@ -1,6 +1,7 @@
 
 
 import logging
+import os
 import queue
 import threading
 import time
@@ -16,15 +17,15 @@ except (ImportError, RuntimeError, OSError):
     VideoDecoder = None
 
 from mstar.api_server.request_types import (
+    DataWorkerProfile,
     PreprocessInput,
-    PreprocessProfile,
     ResultChunk,
     ResultTensors,
 )
-from mstar.profile.format import InputInfo
 from mstar.communication.communicator import CommProtocol, ZMQCommunicator
 from mstar.communication.tensors import NameToTensorList, create_tensor_communication_manager
 from mstar.model.base import Model
+from mstar.profile.format import InputInfo, RxInfo, TxInfo
 from mstar.utils.ipc_format import (
     AbortRequest,
     ConductorMessage,
@@ -54,6 +55,7 @@ class PreprocessWorker:
         socket_path_prefix: str = "/tmp/mstar",
         tensor_comm_protocol: CommProtocol = CommProtocol.RDMA,
         tcp_transfer_device="",
+        enable_prof: bool=False
     ):
         self.request_input_queue = queue.Queue()
         self.result_tensor_input_queue = queue.Queue()
@@ -67,6 +69,26 @@ class PreprocessWorker:
         self.per_request_reading_tensors = {}
         self.output_loop_idxs: dict[str, NameToLoopIndices] = {}
 
+        # Build the communicator + tensor manager here (main thread) and hand
+        # them to the worker thread, rather than constructing them inside it.
+        # The socket is only *used* from the worker thread, but owning the
+        # tensor manager here lets the main thread read its tx/rx profiling
+        # directly once a request is done (no cross-thread queue / race).
+        self.communicator = ZMQCommunicator(
+            my_id="api_server_preprocess_worker",
+            push_ids=["conductor"],
+            ipc_socket_path_prefix=socket_path_prefix,
+        )  # only used to send (from the worker thread)
+        self.tensor_manager = create_tensor_communication_manager(
+            protocol=tensor_comm_protocol,
+            my_entity_id="api_server_preprocess_worker",
+            hostname=hostname,
+            device="cpu",
+            communicator=self.communicator,
+            tcp_transfer_device=tcp_transfer_device,
+            enable_prof=enable_prof,
+        )
+
         self.thread = threading.Thread(
             target=_preprocess_loop,
             kwargs=dict(
@@ -78,11 +100,10 @@ class PreprocessWorker:
                 abort_request_queue=self.abort_request_queue,
                 discard_tensor_queue=self.discard_tensor_queue,
                 stop_event=self.stop_event,
-                hostname=hostname,
-                socket_path_prefix=socket_path_prefix,
-                tensor_comm_protocol=tensor_comm_protocol,
+                communicator=self.communicator,
+                tensor_manager=self.tensor_manager,
                 model=model,
-                tcp_transfer_device=tcp_transfer_device
+                enable_prof=enable_prof
             )
         )
         self.thread.start()
@@ -149,12 +170,29 @@ class PreprocessWorker:
             results.append(result)
         return results
 
-    def get_profile_updates(self) -> list[PreprocessProfile]:
+    def get_profile_updates(self) -> list[DataWorkerProfile]:
         """Drain preprocess-side profiling updates emitted by the worker thread."""
         updates = []
         while not self.profile_queue.empty():
             updates.append(self.profile_queue.get())
         return updates
+
+    def get_tx_info(self, request_id: str) -> list[TxInfo]:
+        """Snapshot the data worker's send (tx) profiling for a request.
+
+        Safe to call from the main thread once the request is done: by then the
+        worker thread is no longer mutating this request's tx state, and the
+        caller must read it before ``cleanup_request`` drops it.
+        """
+        return self.tensor_manager.get_tx_info(request_id)
+
+    def get_rx_info(self, request_id: str) -> list[RxInfo]:
+        """Snapshot the data worker's receive (rx) profiling for a request.
+
+        Same safety contract as :meth:`get_tx_info` — read once the request's
+        final chunks have all arrived, before ``cleanup_request``.
+        """
+        return self.tensor_manager.get_rx_info(request_id)
 
     def cleanup_request(self, request_id: str):
         self.cleanup_request_queue.put(request_id)
@@ -178,12 +216,11 @@ class PreprocessWorkerThread:
         abort_request_queue: queue.Queue,
         discard_tensor_queue: queue.Queue,
         stop_event: threading.Event,
-        hostname: str = "localhost",
-        socket_path_prefix: str = "/tmp/mstar",
-        tensor_comm_protocol: CommProtocol = CommProtocol.RDMA,
+        communicator: ZMQCommunicator,
+        tensor_manager,
         device: str = "cpu",
         model: Model | None = None,
-        tcp_transfer_device="",
+        enable_prof: bool=False
     ):
         self.in_queue = in_queue
         self.result_tensor_queue = result_tensor_queue
@@ -196,23 +233,13 @@ class PreprocessWorkerThread:
         self.stop_event = stop_event
         self.device = device
         self.model = model
+        self.enable_prof = enable_prof
 
         self.tensor_uuid_to_metadata_per_request = {}
 
-        self.communicator = ZMQCommunicator(
-            my_id="api_server_preprocess_worker",
-            push_ids=["conductor"],
-            ipc_socket_path_prefix=socket_path_prefix,
-        ) # only used to send
-
-        self.tensor_manager = create_tensor_communication_manager(
-            protocol=tensor_comm_protocol,
-            my_entity_id="api_server_preprocess_worker",
-            hostname=hostname,
-            device=self.device,
-            communicator=self.communicator,
-            tcp_transfer_device=tcp_transfer_device,
-        )
+        # Owned by PreprocessWorker (main thread); used only from this thread.
+        self.communicator = communicator
+        self.tensor_manager = tensor_manager
 
     def _process_input(
         self, input: PreprocessInput
@@ -303,33 +330,43 @@ class PreprocessWorkerThread:
         self.communicator.send("conductor", msg)
 
         # Record preprocess-side profiling: the moment the fully preprocessed
-        # request was handed off to the conductor, and the per-modality sizes of
-        # the input tensors we produced. ``perf_counter`` is consistent here
-        # because the worker runs as a thread inside the API server process.
-        self.profile_queue.put(PreprocessProfile(
-            request_id=input.request_id,
-            preprocess_finish_time=time.perf_counter(),
-            inputs=self._summarize_inputs(tensors),
-        ))
+        # request was handed off to the conductor, plus the per-modality sizes of
+        # the *raw* inputs. ``perf_counter`` is consistent here because the worker
+        # runs as a thread inside the API server process. (tx/rx are snapshotted
+        # directly by the main thread at request completion — see APIServer.)
+        if self.enable_prof:
+            self.profile_queue.put(DataWorkerProfile(
+                request_id=input.request_id,
+                preprocess_finish_time=time.perf_counter(),
+                inputs=self._summarize_inputs(input),
+            ))
 
     @staticmethod
-    def _summarize_inputs(tensors: NameToTensorList) -> list[InputInfo]:
-        """Aggregate the preprocessed input tensors into per-modality sizes.
+    def _summarize_inputs(input: PreprocessInput) -> list[InputInfo]:
+        """Aggregate the *raw* (pre-decoding) inputs into per-modality sizes.
 
-        Keys are the tensor-bundle names (e.g. ``image_inputs``); the trailing
-        ``_inputs`` is stripped to recover the modality label.
+        Reports the bytes the client actually sent — uploaded file sizes on
+        disk and the UTF-8 length of the prompt — rather than the much larger
+        decoded tensors (e.g. a compressed JPEG vs. its raw RGB tensor), so the
+        numbers line up with what a user thinks of as "input size".
         """
         infos = []
-        for name, tensor_list in tensors.items():
-            modality = name[: -len("_inputs")] if name.endswith("_inputs") else name
-            total_bytes = sum(
-                t.numel() * t.element_size()
-                for t in tensor_list
-                if t is not None
-            )
+        if input.text:
+            infos.append(InputInfo(
+                modality="text",
+                count=1,
+                total_bytes=len(input.text.encode("utf-8")),
+            ))
+        for modality, paths in (input.file_paths or {}).items():
+            total_bytes = 0
+            for path in paths:
+                try:
+                    total_bytes += os.path.getsize(path)
+                except OSError:
+                    pass  # file already cleaned up / unreadable — count as 0
             infos.append(InputInfo(
                 modality=modality,
-                count=len(tensor_list),
+                count=len(paths),
                 total_bytes=total_bytes,
             ))
         return infos

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -3,7 +3,6 @@
 import asyncio
 import base64
 import collections
-from dataclasses import dataclass, field
 import json
 import logging
 import multiprocessing as mp
@@ -12,6 +11,7 @@ import signal
 import threading
 import time
 import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
@@ -191,7 +191,8 @@ class APIServer:
             hostname=hostname,
             socket_path_prefix=socket_path_prefix,
             tensor_comm_protocol=tensor_comm_protocol,
-            tcp_transfer_device=tcp_transfer_device
+            tcp_transfer_device=tcp_transfer_device,
+            enable_prof=self.log_stats
         )
 
         # Concurrent request tracking
@@ -316,6 +317,16 @@ class APIServer:
         for rid in stale:
             # only set the event when there are no more pending chunks
             self.pending_requests[rid].event.set()
+            # Snapshot the data worker's tx/rx now: the request is done (all
+            # final chunks received), so the worker thread is no longer mutating
+            # this rid's transport state, and we must read it before
+            # cleanup_request drops it. Extends so it combines with the
+            # conductor's worker-side transfers (set in the request_complete
+            # handler).
+            if self.log_stats:
+                profile = self.pending_requests[rid].profile
+                profile.tx_info.extend(self.preprocess_worker.get_tx_info(rid))
+                profile.rx_info.extend(self.preprocess_worker.get_rx_info(rid))
             self.preprocess_worker.cleanup_request(rid)
             self.recently_completed.pop(rid, None)
 
@@ -354,6 +365,11 @@ class APIServer:
                                 req.profile.timing.conductor_finish_time = \
                                     message.body.conductor_finish_time
                                 req.profile.graph_timings = list(message.body.graph_timings.values())
+                                # Conductor-merged worker-side transfers; extend
+                                # so they combine with the data worker's own
+                                # tx/rx (applied from the profile-update queue).
+                                req.profile.rx_info.extend(message.body.rx_info)
+                                req.profile.tx_info.extend(message.body.tx_info)
                         elif rid in self.recently_completed:
                             logger.debug("Late message for completed %s: %s", rid, message.message_type)
                             if message.message_type == "result_tensors":
@@ -364,8 +380,9 @@ class APIServer:
                             )
                             if message.message_type == "result_tensors":
                                 self.preprocess_worker.discard_result_tensors(message.body)
-                # Apply preprocess-side profiling (preprocess finish time +
-                # input sizes) reported by the data worker for each request.
+                # Apply data-worker profiling: preprocess-finish timestamp + raw
+                # input sizes. (The data worker's own tx/rx are snapshotted
+                # directly in _prune_recently_completed once the request is done.)
                 for update in self.preprocess_worker.get_profile_updates():
                     with self.request_lock:
                         req = self.pending_requests.get(update.request_id)

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import collections
+from dataclasses import dataclass, field
 import json
 import logging
 import multiprocessing as mp
@@ -24,6 +25,8 @@ from mstar.api_server.data_worker import PreprocessWorker
 from mstar.api_server.request_types import APIServerMessage, PreprocessInput, ResultChunk
 from mstar.communication.communicator import CommProtocol, ZMQCommunicator
 from mstar.model.registry import HF_MODELS
+from mstar.profile.display import pretty_print_profile
+from mstar.profile.format import OutputInfo, RequestProfile, RequestTiming
 from mstar.utils.logging_config import quiet_noisy_loggers
 
 logger = logging.getLogger(__name__)
@@ -54,6 +57,7 @@ def _conductor_process_target(
     config_path: str,
     socket_path_prefix: str,
     enable_nvtx: bool = False,
+    enable_prof: bool = False,
     log_level: str = "INFO",
     cache_dir: str | None = None,
     tensor_comm_protocol=CommProtocol.RDMA,
@@ -98,6 +102,7 @@ def _conductor_process_target(
         model_config_file=config_path,
         socket_path_prefix=socket_path_prefix,
         enable_nvtx=enable_nvtx,
+        enable_prof=enable_prof,
         log_level=log_level,
         tensor_comm_protocol=tensor_comm_protocol,
         tcp_transfer_device=tcp_transfer_device
@@ -135,6 +140,19 @@ def _shutdown_conductor_process(
 # APIServer
 # ------------------------------------------------------------------
 
+
+@dataclass
+class PendingRequest:
+    streaming: bool
+    input_modalities: list[str]
+    output_modalities: list[str]
+    profile: RequestProfile
+    event: threading.Event = field(default_factory=threading.Event)
+    chunks: list[ResultChunk] = field(default_factory=list)
+    final_outputs: dict = field(default_factory=dict)
+    consumed_chunks: int = 0
+
+
 class APIServer:
     """Accept multimodal requests, forward to conductor, collect results."""
 
@@ -148,10 +166,18 @@ class APIServer:
         tcp_transfer_device="",
         model=None,
         model_name: str = "dummy",
+        log_stats: bool = False,
+        log_stats_file: str | None = None,
     ):
         self.upload_dir = Path(upload_dir)
         self.upload_dir.mkdir(parents=True, exist_ok=True)
         self.timeout_seconds = timeout_seconds
+
+        # Per-request profiling: when enabled, a RequestProfile is collected for
+        # each request and pretty-printed when the request finishes. ``log_stats_file``
+        # (optional) appends the report to a file instead of only stdout.
+        self.log_stats = log_stats
+        self.log_stats_file = log_stats_file
 
         # Kept so the OpenAI-compatible layer can look up the per-model adapter
         # (``model_name``) and query model-level metadata such as the audio
@@ -169,7 +195,7 @@ class APIServer:
         )
 
         # Concurrent request tracking
-        self.pending_requests: dict[str, dict] = {}
+        self.pending_requests: dict[str, PendingRequest] = {}
         self.recently_completed: collections.OrderedDict[str, float] = (
             collections.OrderedDict()
         )
@@ -246,15 +272,15 @@ class APIServer:
 
         # Register pending request
         with self.request_lock:
-            self.pending_requests[request_id] = {
-                "chunks": [],           # list[ResultChunk]
-                "event": threading.Event(),
-                "streaming": streaming,
-                "consumed_chunks": 0,
-                "input_modalities": input_modalities,
-                "output_modalities": output_modalities,
-                "final_outputs": {},
-            }
+            self.pending_requests[request_id] = PendingRequest(
+                streaming=streaming,
+                input_modalities=input_modalities,
+                output_modalities=output_modalities,
+                profile=RequestProfile(
+                    rid=request_id,
+                    timing=RequestTiming(recv_time=time.perf_counter()),
+                ),
+            )
 
         self.preprocess_worker.new_request(PreprocessInput(
             request_id=request_id,
@@ -283,13 +309,13 @@ class APIServer:
             if (
                 (not self.preprocess_worker.has_pending_tensors(rid)) \
                     and self.preprocess_worker.received_final_chunks(
-                        rid, self.pending_requests[rid]["final_outputs"]
+                        rid, self.pending_requests[rid].final_outputs
                     )
             ) or (now - ts) >= self._recently_completed_ttl
         ]
         for rid in stale:
             # only set the event when there are no more pending chunks
-            self.pending_requests[rid]["event"].set()
+            self.pending_requests[rid].event.set()
             self.preprocess_worker.cleanup_request(rid)
             self.recently_completed.pop(rid, None)
 
@@ -321,8 +347,13 @@ class APIServer:
                             elif message.message_type == "request_complete":
                                 logger.info("API server received %s done", rid)
                                 self.recently_completed[rid] = time.time()
-                                self.pending_requests[rid]["final_outputs"] = \
-                                    message.body.final_outputs
+                                req = self.pending_requests[rid]
+                                req.final_outputs = message.body.final_outputs
+                                req.profile.timing.conductor_ingest_time = \
+                                    message.body.conductor_ingest_time
+                                req.profile.timing.conductor_finish_time = \
+                                    message.body.conductor_finish_time
+                                req.profile.graph_timings = list(message.body.graph_timings.values())
                         elif rid in self.recently_completed:
                             logger.debug("Late message for completed %s: %s", rid, message.message_type)
                             if message.message_type == "result_tensors":
@@ -333,6 +364,16 @@ class APIServer:
                             )
                             if message.message_type == "result_tensors":
                                 self.preprocess_worker.discard_result_tensors(message.body)
+                # Apply preprocess-side profiling (preprocess finish time +
+                # input sizes) reported by the data worker for each request.
+                for update in self.preprocess_worker.get_profile_updates():
+                    with self.request_lock:
+                        req = self.pending_requests.get(update.request_id)
+                        if req is not None:
+                            req.profile.timing.preprocess_finish_time = \
+                                update.preprocess_finish_time
+                            req.profile.inputs = update.inputs
+
                 for result_chunk in self.preprocess_worker.get_result_chunks():
                     logger.debug(
                         "Got result chunk of %s modality for request %s",
@@ -340,9 +381,12 @@ class APIServer:
                     )
                     rid = result_chunk.request_id
                     with self.request_lock:
-                        self.pending_requests[rid]["chunks"].append(
-                            result_chunk
-                        )
+                        req = self.pending_requests[rid]
+                        now = time.perf_counter()
+                        if req.profile.timing.first_chunk_time is None:
+                            req.profile.timing.first_chunk_time = now
+                        req.profile.timing.last_chunk_time = now
+                        req.chunks.append(result_chunk)
             except Exception:
                 if self.running:
                     logger.exception("Error in message processing loop")
@@ -375,11 +419,11 @@ class APIServer:
                 with self.request_lock:
                     req = self.pending_requests.get(request_id)
                     if req:
-                        avail = len(req["chunks"])
-                        consumed = req["consumed_chunks"]
-                        new_chunks = req["chunks"][consumed:avail]
-                        req["consumed_chunks"] = avail
-                        done = req["event"].is_set()
+                        avail = len(req.chunks)
+                        consumed = req.consumed_chunks
+                        new_chunks = req.chunks[consumed:avail]
+                        req.consumed_chunks = avail
+                        done = req.event.is_set()
                     else:
                         done = True
 
@@ -390,11 +434,16 @@ class APIServer:
                     logger.info("Async stream results received finish for %s", request_id)
                     # flush remaining
                     remaining: list[ResultChunk] = []
+                    finished_req: PendingRequest | None = None
                     with self.request_lock:
                         req = self.pending_requests.get(request_id)
                         if req:
-                            remaining = req["chunks"][req["consumed_chunks"]:]
-                            self.pending_requests.pop(request_id, None)
+                            remaining = req.chunks[req.consumed_chunks:]
+                            finished_req = self.pending_requests.pop(request_id, None)
+                    # Profiling (incl. the optional file write) runs outside the
+                    # lock; the popped request is no longer shared with other threads.
+                    if finished_req is not None:
+                        self._finalize_profile(finished_req)
                     for chunk in remaining:
                         yield chunk
                     finished = True
@@ -431,7 +480,7 @@ class APIServer:
         while True:
             with self.request_lock:
                 req = self.pending_requests.get(request_id)
-                done = req["event"].is_set() if req else True
+                done = req.event.is_set() if req else True
             if done:
                 break
             if time.time() - start > self.timeout_seconds:
@@ -444,7 +493,41 @@ class APIServer:
 
         with self.request_lock:
             req = self.pending_requests.pop(request_id, None)
-            return list(req["chunks"]) if req else []
+        if req is None:
+            return []
+        # Profiling (incl. the optional file write) runs outside the lock; the
+        # popped request is no longer shared with other threads.
+        self._finalize_profile(req)
+        return list(req.chunks)
+
+    def _finalize_profile(self, req: PendingRequest) -> None:
+        """Stamp the finish time, aggregate output sizes, and emit the report.
+
+        Called once per request from whichever completion path pops it
+        (streaming or non-streaming), after the request has been removed from
+        ``pending_requests`` so it is no longer shared — callers must NOT hold
+        ``request_lock``. No-op unless ``--log-stats`` is set.
+        """
+        if not self.log_stats:
+            return
+
+        req.profile.timing.finish_time = time.perf_counter()
+
+        # Aggregate the collected chunks into per-modality output info.
+        by_modality: dict[str, OutputInfo] = {}
+        for chunk in req.chunks:
+            info = by_modality.get(chunk.modality)
+            if info is None:
+                info = OutputInfo(modality=chunk.modality, count=0, total_bytes=0)
+                by_modality[chunk.modality] = info
+            info.count += 1
+            info.total_bytes += len(chunk.data)
+        req.profile.outputs = list(by_modality.values())
+
+        try:
+            pretty_print_profile(req.profile, self.log_stats_file)
+        except Exception:
+            logger.exception("Failed to emit request profile for %s", req.profile.rid)
 
     def abort_request(self, request_id: str) -> None:
         """Stop GPU work for a request the client abandoned and drop its state."""
@@ -667,6 +750,15 @@ def main(argv: list[str] | None = None):
         "--log-level", type=str, default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
     )
+    parser.add_argument(
+        "--log-stats",
+        action="store_true",
+        help="Print per-request profiling stats when each request finishes",
+    )
+    parser.add_argument(
+        "--log-stats-file", type=str, default=None,
+        help="Append per-request profiling stats to this file (implies --log-stats)",
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(
@@ -694,6 +786,7 @@ def main(argv: list[str] | None = None):
     )
 
     global api_server
+    log_stats = args.log_stats or args.log_stats_file is not None
     api_server = APIServer(
         socket_path_prefix=args.socket_path_prefix,
         upload_dir=args.upload_dir,
@@ -701,7 +794,9 @@ def main(argv: list[str] | None = None):
         tensor_comm_protocol=CommProtocol(args.tensor_comm_protocol),
         model=model,
         model_name=model_name,
-        tcp_transfer_device=args.tcp_transfer_device
+        tcp_transfer_device=args.tcp_transfer_device,
+        log_stats=log_stats,
+        log_stats_file=args.log_stats_file,
     )
 
     # Spawn conductor in a separate process
@@ -713,6 +808,7 @@ def main(argv: list[str] | None = None):
             args.config,
             args.socket_path_prefix,
             args.enable_nvtx,
+            log_stats,
             args.log_level,
             args.cache_dir,
             CommProtocol(args.tensor_comm_protocol),

--- a/mstar/api_server/request_types.py
+++ b/mstar/api_server/request_types.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 
 from mstar.graph.base import GraphEdge
 from mstar.graph.loop_indices import NestedLoopIndices
+from mstar.profile.format import InputInfo
+from mstar.profile.worker import GraphTimings
 
 
 @dataclass
@@ -30,6 +32,9 @@ class RequestComplete:
     # The API server waits until all entries are received before
     # completing the request.
     final_outputs: dict[str, NestedLoopIndices]
+    conductor_ingest_time: float
+    conductor_finish_time: float
+    graph_timings: GraphTimings = field(default_factory=dict)
 
 
 @dataclass
@@ -37,6 +42,16 @@ class APIServerMessage:
     """Envelope for messages received by the API server."""
     message_type: str  # "result_tensors" | "request_complete" | "setup_done"
     body: ResultTensors | RequestComplete | None = None  # None for setup_done message
+
+
+@dataclass
+class PreprocessProfile:
+    """Preprocess-side profiling reported by the data worker back to the API
+    server. Carries the timestamp at which preprocessing finished (and the
+    request was handed to the conductor) plus the per-modality input sizes."""
+    request_id: str
+    preprocess_finish_time: float  # time.perf_counter
+    inputs: list[InputInfo] = field(default_factory=list)
 
 
 @dataclass

--- a/mstar/api_server/request_types.py
+++ b/mstar/api_server/request_types.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 
 from mstar.graph.base import GraphEdge
 from mstar.graph.loop_indices import NestedLoopIndices
-from mstar.profile.format import InputInfo
+from mstar.profile.format import InputInfo, RxInfo, TxInfo
 from mstar.profile.worker import GraphTimings
 
 
@@ -35,6 +35,8 @@ class RequestComplete:
     conductor_ingest_time: float
     conductor_finish_time: float
     graph_timings: GraphTimings = field(default_factory=dict)
+    rx_info: list[RxInfo] = field(default_factory=list)
+    tx_info: list[TxInfo] = field(default_factory=list)
 
 
 @dataclass
@@ -45,12 +47,13 @@ class APIServerMessage:
 
 
 @dataclass
-class PreprocessProfile:
-    """Preprocess-side profiling reported by the data worker back to the API
-    server. Carries the timestamp at which preprocessing finished (and the
-    request was handed to the conductor) plus the per-modality input sizes."""
+class DataWorkerProfile:
+    """Profiling reported by the API-server data worker at preprocess finish:
+    the timestamp at which the request was handed to the conductor and the
+    per-modality sizes of the raw inputs. (The data worker's tx/rx are read
+    directly from its tensor manager at request completion, not via this.)"""
     request_id: str
-    preprocess_finish_time: float  # time.perf_counter
+    preprocess_finish_time: float | None = None  # time.perf_counter
     inputs: list[InputInfo] = field(default_factory=list)
 
 

--- a/mstar/cli/main.py
+++ b/mstar/cli/main.py
@@ -123,6 +123,10 @@ def _serve(args: argparse.Namespace) -> None:
     ]
     if args.cache_dir:
         argv += ["--cache-dir", args.cache_dir]
+    if args.log_stats:
+        argv += ["--log-stats"]
+    if args.log_stats_file:
+        argv += ["--log-stats-file", args.log_stats_file]
 
     print(_next_steps(args.model, args.host, args.port), file=sys.stderr)
 
@@ -150,6 +154,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     serve.add_argument(
         "--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    serve.add_argument(
+        "--log-stats", action="store_true",
+        help="print per-request profiling stats when each request finishes",
+    )
+    serve.add_argument(
+        "--log-stats-file", default=None,
+        help="append per-request profiling stats to this file (implies --log-stats)",
     )
     serve.set_defaults(func=_serve)
     return parser

--- a/mstar/communication/tensors.py
+++ b/mstar/communication/tensors.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import platform
+import time
 from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import nullcontext as _nullcontext
@@ -9,6 +10,7 @@ from uuid import uuid4
 
 from mstar.distributed.base import ShardingConfig
 from mstar.graph.special_destinations import EMPTY_DESTINATION
+from mstar.profile.format import RxInfo, TxInfo
 
 try:
     from mooncake.engine import TransferEngine
@@ -31,6 +33,7 @@ class FutureAndPointers:
     future: Future | None
     graph_edges: list[GraphEdge]
     request_id: str = ""
+    rx_time: float | None = None # seconds
 
 
 @dataclass
@@ -149,6 +152,7 @@ class TransferReadInfo:
     local_ptr: int
     remote_ptr: int
     nbytes: int
+    fp: FutureAndPointers | None = None
 
 
 class AsyncMooncakeReader:
@@ -160,8 +164,14 @@ class AsyncMooncakeReader:
     The default stream is never blocked by store writes.
     """
 
-    def __init__(self, engine, device, max_workers: int = 3, max_batch_size=500):
+    def __init__(
+        self, engine, device,
+        max_workers: int = 3,
+        max_batch_size=500,
+        enable_prof: bool=False
+    ):
         self._engine = engine
+        self.enable_prof = enable_prof
         self.max_batch_size = max_batch_size
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self._pending: list[Future] = []
@@ -190,6 +200,8 @@ class AsyncMooncakeReader:
         self._copy_stream.wait_event(event)
         self._copy_stream.synchronize()
 
+        start_time = time.perf_counter()
+
         # group read_info by session id for batch read
         grouped_read = {}
         for info in read_info:
@@ -207,6 +219,11 @@ class AsyncMooncakeReader:
                 )
                 if status < 0:
                     raise RuntimeError(f"Mooncake read failed. Status: {status}")
+        end_time = time.perf_counter()
+        if self.enable_prof:
+            for info in read_info:
+                if info.fp is not None:
+                    info.fp.rx_time = (end_time - start_time)
 
     def wait_all(self):
         """Block until all pending writes complete. Re-raises exceptions."""
@@ -320,6 +337,10 @@ class BufferedShards:
         ]
 
 
+EdgeNameToTxInfo = dict[str, TxInfo]
+SourceAndEdgeToRxInfo = dict[tuple[str, str], RxInfo]
+
+
 class TensorCommunicationManager(ABC):
     """Base class for inter-worker tensor transport.
 
@@ -335,15 +356,24 @@ class TensorCommunicationManager(ABC):
         device: str,
         communicator: BaseCommunicator,
         transfer_engine: TensorTransferEngine,
+        enable_prof: bool=False
     ):
         self.my_entity_id = my_entity_id
         self.my_session_id = my_session_id
+        self.enable_prof = enable_prof
         self.device = device
         self.communicator = communicator
         self.transfer_engine = transfer_engine
         self.tensor_store = TensorStore()
         self.pending: list[FutureAndPointers] = []
         self.read_finished: dict[str, set[str]] = {}
+
+        self.req_rx_info: dict[str, SourceAndEdgeToRxInfo] = {}
+        self.req_tx_info: dict[str, EdgeNameToTxInfo] = {}
+        # uuid -> edge/signal name, so register_for_send (which only sees uuids)
+        # can attribute TX bytes/time to the right edge. Only tracked under
+        # ``enable_prof``.
+        self.uuid_to_edge_name: dict[str, str] = {}
 
         # req_id -> cfg
         self.sharding_configs: dict[str, ShardingConfig] = {}
@@ -418,6 +448,8 @@ class TensorCommunicationManager(ABC):
                 )
                 if cfg is not None:
                     self.uuid_to_shard_dim[tensor_uuid] = shard_dim
+                if self.enable_prof:
+                    self.uuid_to_edge_name[tensor_uuid] = name
 
                 logger.debug("Storing tensor name %s uuid %s", name, tensor_uuid)
                 tensor_info[name].append(TensorPointerInfo(
@@ -518,6 +550,8 @@ class TensorCommunicationManager(ABC):
         addresses are shared with peers. Callers must have already synced on
         their own (e.g. before a batched loop) — meant to cut N serialized
         syncs to 1 when registering many uuids in a row.
+
+        If self.enable_prof is set, this should also update self.req_tx_info
         """
         ...
 
@@ -561,6 +595,7 @@ class TensorCommunicationManager(ABC):
 
     def _cleanup_by_uuid(self, request_id: str, uuid: str):
         self.uuid_to_shard_dim.pop(uuid, None)
+        self.uuid_to_edge_name.pop(uuid, None)
 
     # ---- shared: polling & ACKs ----
 
@@ -602,6 +637,7 @@ class TensorCommunicationManager(ABC):
     def get_ready_tensors(self, graph_walk: str | None=None) -> dict[str, list[GraphEdge]]:
         ready: dict[str, list[GraphEdge]] = {}
         still_pending = []
+        uuid_to_time = {}
         for ep in self.pending:
             if ep.future is None or ep.future.done():
                 if ep.future is not None:
@@ -612,6 +648,9 @@ class TensorCommunicationManager(ABC):
                         "Finished reading in %d tensors %s for graph node %s",
                         len(edge.tensor_info), edge.name, edge.next_node
                     )
+                    if self.enable_prof:
+                        for info in edge.tensor_info:
+                            uuid_to_time[info.uuid] = ep.rx_time
             else:
                 still_pending.append(ep)
         self.pending = still_pending
@@ -620,6 +659,7 @@ class TensorCommunicationManager(ABC):
         for req_id, edges in ready.items():
             self._collect_and_send_acks(req_id, edges)
             seen_uuids = self.read_finished.setdefault(req_id, set())
+            rx_infos = self.req_rx_info.setdefault(req_id, {})
             for edge in edges:
                 if not edge.tensor_info:
                     final_ready.setdefault(req_id, []).append(edge)
@@ -629,6 +669,31 @@ class TensorCommunicationManager(ABC):
                 if any(info.uuid in seen_uuids for info in edge.tensor_info):
                     final_ready.setdefault(req_id, []).append(edge)
                     continue
+
+                if self.enable_prof:
+                    # Locally-produced (same-entity) tensors aren't received over
+                    # the wire — skip them. ``rx_time`` is the whole edge's read
+                    # batch, so attribute it once per source (not per tensor).
+                    per_source: dict[str, list[int]] = {}  # source -> [bytes, count]
+                    edge_rx_time = 0.0
+                    for info in edge.tensor_info:
+                        if info.source_entity == self.my_entity_id:
+                            continue
+                        agg = per_source.setdefault(info.source_entity, [0, 0])
+                        agg[0] += info.nbytes
+                        agg[1] += 1
+                        edge_rx_time = uuid_to_time.get(info.uuid) or edge_rx_time
+                    for source_entity, (nbytes, cnt) in per_source.items():
+                        rx_key = (source_entity, edge.name)
+                        if rx_key not in rx_infos:
+                            rx_infos[rx_key] = RxInfo(
+                                edge_name=edge.name,
+                                source_entity=source_entity,
+                                dest_entity=self.my_entity_id,
+                            )
+                        rx_infos[rx_key].update(
+                            num_bytes=nbytes, time=edge_rx_time, count_increment=cnt,
+                        )
 
                 shard_dim = edge._shard_dim
                 if edge.name not in self.buffered_shards.get(req_id, {}):
@@ -692,6 +757,31 @@ class TensorCommunicationManager(ABC):
         self.sharding_configs[request_id] = sharding_config
         self.buffered_shards[request_id] = {}
 
+    # ---- shared: profiling (tx/rx) ----
+
+    def _record_tx(
+        self, request_id: str, uuid: str, num_bytes: int, elapsed: float
+    ):
+        """Record bytes/time spent making ``uuid`` available to remote consumers.
+
+        Keyed by edge name (looked up from ``uuid_to_edge_name``); the sender
+        doesn't know the recipient at register time — and may even register data
+        that is never read — so TX carries no dest and is not per-connection.
+        """
+        edge_name = self.uuid_to_edge_name.get(uuid, "?")
+        tx = self.req_tx_info.setdefault(request_id, {})
+        if edge_name not in tx:
+            tx[edge_name] = TxInfo(
+                edge_name=edge_name, source_entity=self.my_entity_id
+            )
+        tx[edge_name].update(num_bytes=num_bytes, time=elapsed)
+
+    def get_tx_info(self, request_id: str) -> list[TxInfo]:
+        return list(self.req_tx_info.get(request_id, {}).values())
+
+    def get_rx_info(self, request_id: str) -> list[RxInfo]:
+        return list(self.req_rx_info.get(request_id, {}).values())
+
     # ---- shared: TensorStore delegation ----
 
     def get_tensor(self, request_id: str, uuid: str) -> torch.Tensor:
@@ -718,6 +808,8 @@ class TensorCommunicationManager(ABC):
         self.read_finished.pop(request_id, None)
         self.buffered_shards.pop(request_id, None)
         self.sharding_configs.pop(request_id, None)
+        self.req_rx_info.pop(request_id, None)
+        self.req_tx_info.pop(request_id, None)
         for uuid in self.tensor_store.get_all_uuids(request_id):
             self.uuid_to_shard_dim.pop(uuid, None)
             self.tensor_store.set_metadata(request_id, uuid, persist=False)
@@ -750,6 +842,7 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
         protocol: CommProtocol = CommProtocol.RDMA,
         metadata_server: str = "P2PHANDSHAKE",
         tcp_transfer_device: str = "",
+        enable_prof: bool=False
     ):
         engine = MooncakeTransferEngine(
             hostname=hostname,
@@ -763,23 +856,27 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
             device=device,
             communicator=communicator,
             transfer_engine=engine,
+            enable_prof=enable_prof
         )
         self.protocol = protocol
         self._async_reader = AsyncMooncakeReader(
-            engine._engine, device=device
+            engine._engine, device=device,
+            enable_prof=enable_prof
         )
 
     def register_for_send(self, request_id, uuids, skip_cuda_sync=False):
         if not skip_cuda_sync:
             torch.cuda.default_stream().synchronize()
         for uuid in uuids:
+            already_registered = self.tensor_store.is_registered(request_id, uuid)
             if self.protocol == CommProtocol.RDMA:
-                if self.tensor_store.is_registered(request_id, uuid):
+                if already_registered:
                     continue
                 logger.debug("Registering %s for send", uuid)
                 tensor = self.tensor_store.get_tensor(
                     request_id=request_id, uuid=uuid
                 )
+                t0 = time.perf_counter()
                 ret_value = self.transfer_engine.register_memory(
                     tensor.data_ptr(), tensor.nbytes
                 )
@@ -787,6 +884,15 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
                     raise RuntimeError(
                         f"Mooncake memory registration failed for request id {request_id}, uuid {uuid}."
                     )
+                if self.enable_prof:
+                    # RDMA: the receiver does the actual read, so the sender-side
+                    # cost is the memory-pinning (register) time.
+                    self._record_tx(
+                        request_id, uuid, tensor.nbytes, time.perf_counter() - t0
+                    )
+            elif self.enable_prof and not already_registered:
+                tensor = self.tensor_store.get_tensor(request_id, uuid)
+                self._record_tx(request_id, uuid, tensor.nbytes, 0.0)
             self.tensor_store.set_metadata(
                 request_id, uuid, mem_registered=True
             )
@@ -858,15 +964,21 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
                     nbytes=info.nbytes,
                 ))
                 logger.debug("Started transfer read for uuid %s", info.uuid)
+            # Create the FutureAndPointers before submit and point each read at
+            # it, so the async reader can stamp ``rx_time`` on it when the read
+            # completes (the reader runs on another thread; the object identity
+            # is stable, only ``.future`` is filled in after submit).
+            fp = FutureAndPointers(
+                future=None, graph_edges=[graph_edge], request_id=request_id
+            )
+            if self.enable_prof:
+                for ri in read_info:
+                    ri.fp = fp
             fut = self._async_reader.submit(read_info)
+            fp.future = fut
             if fut is not None:
                 futures.append(fut)
-            self.pending.append(
-                FutureAndPointers(
-                    future=fut, graph_edges=[graph_edge],
-                    request_id=request_id
-                )
-            )
+            self.pending.append(fp)
         return futures
 
 
@@ -919,6 +1031,7 @@ class SharedMemoryCommunicationManager(TensorCommunicationManager):
         device: str,
         communicator: BaseCommunicator,
         shm_dir: str | None = None,
+        enable_prof: bool=False
     ):
         engine = LocalTransferEngine(hostname=hostname)
         super().__init__(
@@ -927,6 +1040,7 @@ class SharedMemoryCommunicationManager(TensorCommunicationManager):
             device=device,
             communicator=communicator,
             transfer_engine=engine,
+            enable_prof=enable_prof
         )
 
         self.shm_dir = shm_dir or _default_shm_dir()
@@ -966,12 +1080,18 @@ class SharedMemoryCommunicationManager(TensorCommunicationManager):
                 if self.tensor_store.is_registered(request_id, uuid):
                     continue
                 tensor = self.tensor_store.get_tensor(request_id, uuid)
+                t0 = time.perf_counter()
                 data = _serialize_tensor(tensor)
                 path = self._shm_path(self.my_entity_id, uuid)
                 with open(path, "wb") as f:
                     f.write(data)
                 self._shm_files[uuid] = path
                 self.tensor_store.set_metadata(request_id, uuid, mem_registered=True)
+                if self.enable_prof:
+                    # SHM: the serialize + file write IS the send work.
+                    self._record_tx(
+                        request_id, uuid, len(data), time.perf_counter() - t0
+                    )
                 logger.debug("SHM: wrote tensor %s to %s (%d bytes)", uuid, path, len(data))
 
     def start_read_tensors(
@@ -995,6 +1115,7 @@ class SharedMemoryCommunicationManager(TensorCommunicationManager):
                     "SHM: starting read of %d tensors %s for graph node %s",
                     len(graph_edge.tensor_info), graph_edge.name, graph_edge.next_node,
                 )
+                rx_t0 = time.perf_counter()
                 for info in graph_edge.tensor_info:
                     if info.source_entity == self.my_entity_id:
                         self._slice_existing_tensor(
@@ -1023,6 +1144,7 @@ class SharedMemoryCommunicationManager(TensorCommunicationManager):
                     FutureAndPointers(
                         future=None, graph_edges=[graph_edge],
                         request_id=request_id,
+                        rx_time=time.perf_counter() - rx_t0,
                     )
                 )
         if h2d_did_work and self._h2d_stream is not None:
@@ -1058,6 +1180,7 @@ def create_tensor_communication_manager(
     metadata_server: str = "P2PHANDSHAKE",
     tcp_transfer_device: str = "",
     shm_dir: str | None = None,
+    enable_prof: bool=False
 ) -> TensorCommunicationManager:
     """Select tensor transport backend based on protocol."""
     if protocol == CommProtocol.SHM:
@@ -1067,6 +1190,7 @@ def create_tensor_communication_manager(
             device=device,
             communicator=communicator,
             shm_dir=shm_dir,
+            enable_prof=enable_prof
         )
     return MooncakeCommunicationManager(
         my_entity_id=my_entity_id,
@@ -1076,4 +1200,5 @@ def create_tensor_communication_manager(
         protocol=protocol,
         metadata_server=metadata_server,
         tcp_transfer_device=tcp_transfer_device,
+        enable_prof=enable_prof
     )

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -28,6 +28,7 @@ from mstar.engine.kv_store import KVCacheConfig
 from mstar.graph.base import GraphEdge, NodeAndGraphWalk, TensorPointerInfo
 from mstar.graph.loop_indices import NestedLoopIndices
 from mstar.model.base import ForwardPassArgs, Model, WorkerGraph
+from mstar.profile.format import RxInfo, TxInfo
 from mstar.profile.worker import GraphTimings
 from mstar.utils.ipc_format import (
     ConductorMessageType,
@@ -167,6 +168,11 @@ class RequestData:
     conductor_ingest_time: float = 0.0
     conductor_finish_time: float = 0.0
     graph_timings: GraphTimings = field(default_factory=dict)
+    # Tensor-transport profiling merged across workers. Keyed so repeated
+    # WorkerGraphsDone updates (cumulative per worker) replace rather than
+    # double-count: rx by (source, dest, edge), tx by (source, edge).
+    rx_info: dict[tuple[str, str, str], RxInfo] = field(default_factory=dict)
+    tx_info: dict[tuple[str, str], TxInfo] = field(default_factory=dict)
 
     def remove_persist_signal_uuids(self, uuids: list[str]):
         uuids = set(uuids)
@@ -205,6 +211,7 @@ class Conductor:
         self.socket_path_prefix = socket_path_prefix
         self.log_level = log_level
         self.enable_nvtx = enable_nvtx
+        self.enable_prof = enable_prof
         self.tensor_comm_protocol = tensor_comm_protocol
         self.tcp_transfer_device = tcp_transfer_device
 
@@ -809,6 +816,8 @@ class Conductor:
                     conductor_ingest_time=request_data.conductor_ingest_time,
                     conductor_finish_time=request_data.conductor_finish_time,
                     graph_timings=request_data.graph_timings,
+                    rx_info=list(request_data.rx_info.values()),
+                    tx_info=list(request_data.tx_info.values()),
                 )
             )
         )
@@ -832,7 +841,12 @@ class Conductor:
 
         request_data = self.requests[body.request_id]
         partition_name = body.partition_name
-        request_data.graph_timings.update(body.graph_timings)
+        if self.enable_prof:
+            request_data.graph_timings.update(body.graph_timings)
+            for rx in body.rx_info:
+                request_data.rx_info[(rx.source_entity, rx.dest_entity, rx.edge_name)] = rx
+            for tx in body.tx_info:
+                request_data.tx_info[(tx.source_entity, tx.edge_name)] = tx
 
         pstate = request_data.partition_states.get(partition_name)
         request_data.final_outputs.update(body.output_loop_indices)

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -28,6 +28,7 @@ from mstar.engine.kv_store import KVCacheConfig
 from mstar.graph.base import GraphEdge, NodeAndGraphWalk, TensorPointerInfo
 from mstar.graph.loop_indices import NestedLoopIndices
 from mstar.model.base import ForwardPassArgs, Model, WorkerGraph
+from mstar.profile.worker import GraphTimings
 from mstar.utils.ipc_format import (
     ConductorMessageType,
     InputSignals,
@@ -90,6 +91,7 @@ def _worker_process_target(
     socket_path_prefix: str,
     dist_init_method: str,
     enable_nvtx: bool = False,
+    enable_prof: bool = False,
     model: Model | None = None,
     device: str = "cuda",
     log_level: str = "INFO",
@@ -125,6 +127,7 @@ def _worker_process_target(
             socket_path_prefix=socket_path_prefix,
             dist_init_method=dist_init_method,
             enable_nvtx=enable_nvtx,
+            enable_prof=enable_prof,
             device=torch.device(device),
             tensor_comm_protocol=tensor_comm_protocol,
             tcp_transfer_device=tcp_transfer_device,
@@ -157,6 +160,14 @@ class RequestData:
     # for api server recv bookeeping
     final_outputs: dict[str, NestedLoopIndices] = field(default_factory=dict)
 
+    # Conductor-side profiling timestamps, in ``time.perf_counter()`` seconds.
+    # Comparable with the api-server stamps because perf_counter is
+    # CLOCK_MONOTONIC (boot-relative) and these processes share a host. 0 until
+    # stamped.
+    conductor_ingest_time: float = 0.0
+    conductor_finish_time: float = 0.0
+    graph_timings: GraphTimings = field(default_factory=dict)
+
     def remove_persist_signal_uuids(self, uuids: list[str]):
         uuids = set(uuids)
         for name in self.persist_signals:
@@ -183,6 +194,7 @@ class Conductor:
         socket_path_prefix: str = "/tmp/mstar",
         hostname: str = "localhost",
         enable_nvtx: bool = False,
+        enable_prof: bool = False,
         log_level: str = "INFO",
         tensor_comm_protocol=CommProtocol.RDMA,
         tcp_transfer_device=""
@@ -388,6 +400,7 @@ class Conductor:
                     "dist_init_method": self._dist_init_method,
                     "model": self.model,
                     "enable_nvtx": self.enable_nvtx,
+                    "enable_prof": self.enable_prof,
                     "device": f"cuda:{rank}",
                     "log_level": self.log_level,
                     "tensor_comm_protocol": self.tensor_comm_protocol,
@@ -591,6 +604,7 @@ class Conductor:
     ):
         """Actually dispatch a request to workers (no admission check)."""
         logger.debug("Conductor ingesting request %s", body.request_id)
+        ingest_time = time.perf_counter()
         worker_graph_to_workers = self._assign_worker_graphs_to_workers()
 
         model_kwargs = body.model_kwargs or {}
@@ -641,6 +655,7 @@ class Conductor:
             streaming_connections=streaming_connections,
             sampling_config=self._get_sampling_configs(model_kwargs),
             sharding_config=self._build_request_sharding_config(worker_graph_to_workers),
+            conductor_ingest_time=ingest_time,
         )
         for cfg in request_data.sampling_config.values():
             cfg.set_seed(seed)
@@ -775,6 +790,7 @@ class Conductor:
         """Called when all partitions are done."""
         logger.info("Request %s done", request_id)
         request_data = self.requests[request_id]
+        request_data.conductor_finish_time = time.perf_counter()
         for worker_ids in request_data.worker_graph_to_workers.values():
             for worker_id in worker_ids:
                 msg = WorkerMessage(
@@ -790,6 +806,9 @@ class Conductor:
                 body=RequestComplete(
                     request_id=request_id,
                     final_outputs=request_data.final_outputs,
+                    conductor_ingest_time=request_data.conductor_ingest_time,
+                    conductor_finish_time=request_data.conductor_finish_time,
+                    graph_timings=request_data.graph_timings,
                 )
             )
         )
@@ -813,6 +832,7 @@ class Conductor:
 
         request_data = self.requests[body.request_id]
         partition_name = body.partition_name
+        request_data.graph_timings.update(body.graph_timings)
 
         pstate = request_data.partition_states.get(partition_name)
         request_data.final_outputs.update(body.output_loop_indices)

--- a/mstar/engine/base.py
+++ b/mstar/engine/base.py
@@ -1,7 +1,7 @@
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
-import time
 from typing import Any
 
 import torch

--- a/mstar/engine/base.py
+++ b/mstar/engine/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
+import time
 from typing import Any
 
 import torch
@@ -9,6 +10,7 @@ from mstar.communication.tensors import NameToTensorList
 from mstar.conductor.request_info import CurrentForwardPassInfo
 from mstar.distributed.communication import WorkerTPGroups
 from mstar.engine.kv_store import KVCacheConfig, StoreWritePolicy
+from mstar.profile.worker import ExecTimings
 
 
 class EngineType(Enum):
@@ -45,6 +47,7 @@ class NodeBatch:
     # rids whose consumed streaming input was the final chunk — this pass
     # reports the partition done (see worker._postprocess_batch)
     final_stream_rids: set[str] = field(default_factory=set)
+    exec_timings: ExecTimings = field(default_factory=ExecTimings)
 
 
 @dataclass
@@ -126,8 +129,13 @@ class NodeOutput:
 
 
 class BaseEngine(ABC):
-    def __init__(self, enable_nvtx: bool = False, **kwargs):
+    def __init__(
+        self, enable_nvtx: bool = False,
+        enable_profile: bool=False,
+        **kwargs
+    ):
         self.enable_nvtx = enable_nvtx
+        self.enable_profile = enable_profile
 
     def has_autocast(self):
         return True
@@ -216,6 +224,8 @@ class BaseEngine(ABC):
         recovery, finally-block state writebacks) may override this entirely
         and call the hooks themselves to keep the cleanup invariant intact.
         """
+        if self.enable_profile and batch.exec_timings.start is None:
+            batch.exec_timings.start = time.perf_counter()
         prepared = self.prepare_batch(batch)
         if not prepared.active_request_ids:
             return NodeOutput(
@@ -329,6 +339,8 @@ class BaseEngine(ABC):
         return False
 
     def execute_with_max_batch_size(self, batch: NodeBatch) -> NodeOutput:
+        if self.enable_profile:
+            batch.exec_timings.start = time.perf_counter()
         bs = self.get_max_batch_size(batch.node_name, batch.graph_walk)
         n = len(batch.request_ids)
         if bs is None or n <= bs:
@@ -340,7 +352,7 @@ class BaseEngine(ABC):
 
         for i in range(0, n, bs):
             rids = batch.request_ids[i:min(i+bs, n)]
-            minibatch_out = self.execute_batch(NodeBatch(
+            minibatch = NodeBatch(
                 node_name=batch.node_name,
                 graph_walk=batch.graph_walk,
                 request_ids=rids,
@@ -353,7 +365,13 @@ class BaseEngine(ABC):
                         if rid in batch.per_request_info
                 },
                 metadata=batch.metadata
-            ))
+            )
+            minibatch_out = self.execute_batch(minibatch)
+            # Fold each sub-batch's forward window back into the parent batch's
+            # exec_timings (earliest launch wins); the worker sets fwd_end on the
+            # parent once the whole split forward has been submitted.
+            if self.enable_profile:
+                batch.exec_timings.update(minibatch.exec_timings)
             output.per_request_output_tensors.update(
                 minibatch_out.per_request_output_tensors
             )

--- a/mstar/engine/cuda_graph_runner.py
+++ b/mstar/engine/cuda_graph_runner.py
@@ -26,7 +26,6 @@ import torch
 from torch import nn
 
 from mstar.conductor.request_info import CurrentForwardPassInfo
-from mstar.profile.worker import ExecTimings
 from mstar.engine.cache_manager import BatchedCacheManager, WorkspaceBufferManager
 from mstar.engine.cuda_graph_config import (
     BasicBatchedCudaGraphConfig,
@@ -36,6 +35,7 @@ from mstar.engine.cuda_graph_config import (
 )
 from mstar.engine.kv_store import KVCacheConfig, PagedAllocationManager
 from mstar.model.submodule_base import ARNodeInputs, ARNodeSubmodule, ModelInputsFromEngine, NodeSubmodule
+from mstar.profile.worker import ExecTimings
 from mstar.utils.profiler import mark, range_pop, range_push
 from mstar.utils.sampling import Sampler, SamplerBuffers, SamplingConfig, make_sampler_from_buffers
 

--- a/mstar/engine/cuda_graph_runner.py
+++ b/mstar/engine/cuda_graph_runner.py
@@ -18,6 +18,7 @@ and PiecewiseCudaGraphRunner for capturing transformer block loops (VJepa2 predi
 import bisect
 import logging
 import os
+import time
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
@@ -25,6 +26,7 @@ import torch
 from torch import nn
 
 from mstar.conductor.request_info import CurrentForwardPassInfo
+from mstar.profile.worker import ExecTimings
 from mstar.engine.cache_manager import BatchedCacheManager, WorkspaceBufferManager
 from mstar.engine.cuda_graph_config import (
     BasicBatchedCudaGraphConfig,
@@ -1140,6 +1142,7 @@ class CudaGraphRunner:
         slot: int | None = None,
         advance_event: "object | None" = None,
         launch_started_event: "object | None" = None,
+        exec_timings: ExecTimings | None = None,
     ) -> dict:
         """Look up the matching captured graph and dispatch on config type.
 
@@ -1194,6 +1197,7 @@ class CudaGraphRunner:
                 request_ids, inputs, per_request_info, submodule,
                 advance_event=advance_event,
                 launch_started_event=launch_started_event,
+                exec_timings=exec_timings,
             )
         if cfg_type == CudaGraphConfigType.FLASH_INFER_PACKED:
             return self._run_flashinfer_packed(
@@ -1201,6 +1205,7 @@ class CudaGraphRunner:
                 request_ids, inputs, per_request_info, submodule,
                 advance_event=advance_event,
                 launch_started_event=launch_started_event,
+                exec_timings=exec_timings,
             )
         raise ValueError(f"Unknown CudaGraphConfigType: {cfg_type}")
 
@@ -1215,6 +1220,7 @@ class CudaGraphRunner:
         submodule: ARNodeSubmodule,
         advance_event: "object | None" = None,
         launch_started_event: "object | None" = None,
+        exec_timings: ExecTimings | None = None,
     ) -> dict:
         """Decode-style replay. Pads real inputs to padded_bs by cloning the capture
         template, then routes through submodule.preprocess (which re-plans attention
@@ -1352,6 +1358,8 @@ class CudaGraphRunner:
             # GIL inside C++, so main-thread postprocess can overlap.
             if launch_started_event is not None:
                 launch_started_event.set()
+            if exec_timings is not None:
+                exec_timings.fwd_start = time.perf_counter()
             graph.replay()
             if self.enable_nvtx:
                 range_pop(synchronize=False)
@@ -1431,6 +1439,7 @@ class CudaGraphRunner:
         submodule: ARNodeSubmodule,
         advance_event: "object | None" = None,
         launch_started_event: "object | None" = None,
+        exec_timings: ExecTimings | None = None,
     ) -> dict:
         """Prefill-style replay (vox-serve pattern).
 
@@ -1569,6 +1578,8 @@ class CudaGraphRunner:
             # GIL inside C++, so main-thread postprocess can overlap.
             if launch_started_event is not None:
                 launch_started_event.set()
+            if exec_timings is not None:
+                exec_timings.fwd_start = time.perf_counter()
             graph.replay()
             if self.enable_nvtx:
                 range_pop(synchronize=False)
@@ -2118,6 +2129,7 @@ class StatelessCudaGraphRunner:
         per_request_info: dict[str, CurrentForwardPassInfo],
         submodule: NodeSubmodule,
         launch_started_event: "object | None" = None,
+        exec_timings: ExecTimings | None = None,
     ) -> dict[str, dict[str, list[torch.Tensor]]]:
         """End-to-end replay: preprocess + replay + per-rid output split.
 
@@ -2181,6 +2193,8 @@ class StatelessCudaGraphRunner:
         # GIL inside C++, so main-thread postprocess can overlap.
         if launch_started_event is not None:
             launch_started_event.set()
+        if exec_timings is not None:
+            exec_timings.fwd_start = time.perf_counter()
         self.graphs[key].replay()
         if self.enable_nvtx:
             range_pop(synchronize=False)

--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 from dataclasses import asdict, dataclass, field
 
 import torch
@@ -67,8 +68,9 @@ class KVCacheEngine(BaseEngine):
         self,
         autocast_dtype=torch.bfloat16,
         enable_nvtx: bool = False,
+        enable_prof: bool = False,
     ):
-        super().__init__(enable_nvtx=enable_nvtx)
+        super().__init__(enable_nvtx=enable_nvtx, enable_profile=enable_prof)
 
         self.kv_management: dict[str, KVManagement] = {}
         self.submodule_management: dict[str, SubmoduleManagement] = {}
@@ -429,6 +431,8 @@ class KVCacheEngine(BaseEngine):
         launch_started_event = batch.metadata.get("launch_started_event")
         if launch_started_event is not None:
             launch_started_event.set()
+        if self.enable_profile:
+            batch.exec_timings.fwd_start = time.perf_counter()
         batched_output = submodule.forward_batched(
             graph_walk=batch.graph_walk,
             engine_inputs=engine_inputs,
@@ -512,6 +516,9 @@ class KVCacheEngine(BaseEngine):
             launch_started_event = batch.metadata.get("launch_started_event")
             if launch_started_event is not None and not launch_started_event.is_set():
                 launch_started_event.set()
+            # Batch-level fwd_start: stamp once, on the first rid's launch.
+            if self.enable_profile and batch.exec_timings.fwd_start is None:
+                batch.exec_timings.fwd_start = time.perf_counter()
             output = submodule.forward(
                 graph_walk=batch.graph_walk,
                 engine_inputs=engine_inputs,
@@ -645,6 +652,7 @@ class KVCacheEngine(BaseEngine):
             slot=batch.metadata.get("cuda_graph_slot"),
             advance_event=batch.metadata.get("advance_event"),
             launch_started_event=batch.metadata.get("launch_started_event"),
+            exec_timings=batch.exec_timings if self.enable_profile else None,
         )
 
         return NodeOutput(per_request_output_tensors=batched_output)

--- a/mstar/engine/stateless_engine.py
+++ b/mstar/engine/stateless_engine.py
@@ -12,6 +12,7 @@ Stateful engines (paged KV cache, FlashInfer planning, sampling, CFG) live in
 """
 
 import logging
+import time
 from dataclasses import dataclass
 
 import torch
@@ -107,9 +108,10 @@ class StatelessEngine(BaseEngine):
         config: StatelessEngineConfig | None = None,
         enable_nvtx: bool = False,
         autocast_dtype: torch.dtype | None = None,
+        enable_prof: bool = False,
         **kwargs,
     ):
-        super().__init__(enable_nvtx=enable_nvtx)
+        super().__init__(enable_nvtx=enable_nvtx, enable_profile=enable_prof)
         if config is None:
             config = StatelessEngineConfig()
         if autocast_dtype is not None and config.autocast_dtype is not None:
@@ -412,6 +414,7 @@ class StatelessEngine(BaseEngine):
             per_request_info=batch.per_request_info,
             submodule=submodule,
             launch_started_event=batch.metadata.get("launch_started_event"),
+            exec_timings=batch.exec_timings if self.enable_profile else None,
         )
         if self.enable_nvtx:
             range_pop(synchronize=False)
@@ -446,6 +449,8 @@ class StatelessEngine(BaseEngine):
         launch_started_event = batch.metadata.get("launch_started_event")
         if launch_started_event is not None:
             launch_started_event.set()
+        if self.enable_profile:
+            batch.exec_timings.fwd_start = time.perf_counter()
         outputs = submodule.forward_batched(
             graph_walk=batch.graph_walk,
             engine_inputs=engine_inputs,
@@ -485,6 +490,9 @@ class StatelessEngine(BaseEngine):
             launch_started_event = batch.metadata.get("launch_started_event")
             if launch_started_event is not None:
                 launch_started_event.set()
+            # Batch-level fwd_start: stamp once, on the first rid's launch.
+            if self.enable_profile and batch.exec_timings.fwd_start is None:
+                batch.exec_timings.fwd_start = time.perf_counter()
             outputs[rid] = submodule.forward(
                 graph_walk=batch.graph_walk,
                 engine_inputs=engine_inputs,

--- a/mstar/profile/display.py
+++ b/mstar/profile/display.py
@@ -25,8 +25,8 @@ def pretty_print_profile(prof: RequestProfile, filename=None):
 
     Writes to ``filename`` (appended) when given, otherwise to stdout. Stage
     timings are only shown for segments whose endpoints were both recorded, so
-    metrics that depend on the conductor (not yet wired up) are simply skipped
-    rather than reported as zero.
+    any checkpoint that wasn't stamped is simply skipped rather than reported
+    as zero.
     """
     lines: list[str] = []
     sep = "=" * _WIDTH
@@ -75,6 +75,22 @@ def pretty_print_profile(prof: RequestProfile, filename=None):
         lines.append(f"   {'total':<40} {_ms(present[0][1], present[-1][1])}")
     else:
         lines.append(" Timeline: (no timing recorded)")
+
+    # ---- per-node graph timings (summed over the request) -----------------
+    if prof.graph_timings:
+        lines.append(rule)
+        lines.append(" Graph timings (CPU, summed over the request) [ms]:")
+        for gt in sorted(prof.graph_timings, key=lambda g: g.total_time, reverse=True):
+            label = f"{gt.node}:{gt.graph_walk}"
+            if len(label) > 24:
+                label = label[:23] + "…"
+            lines.append(
+                f"   {label:<24} n={gt.exec_count:<5}"
+                f" tot {gt.total_time * 1e3:7.1f}"
+                f"  fwd {gt.forward_time * 1e3:7.1f}"
+                f"  pre {gt.preprocess_time * 1e3:6.1f}"
+                f"  post {gt.postprocess_time * 1e3:6.1f}"
+            )
     lines.append(sep)
 
     text = "\n".join(lines) + "\n"

--- a/mstar/profile/display.py
+++ b/mstar/profile/display.py
@@ -1,0 +1,87 @@
+
+import sys
+
+from mstar.profile.format import RequestProfile
+
+_WIDTH = 60
+
+
+def _human_bytes(n: int) -> str:
+    """Render a byte count with a binary-prefixed, human-friendly unit."""
+    size = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if size < 1024 or unit == "TiB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TiB"
+
+
+def _ms(start: float, end: float) -> str:
+    return f"{(end - start) * 1e3:8.1f} ms"
+
+
+def pretty_print_profile(prof: RequestProfile, filename=None):
+    """Render a single request's profile.
+
+    Writes to ``filename`` (appended) when given, otherwise to stdout. Stage
+    timings are only shown for segments whose endpoints were both recorded, so
+    metrics that depend on the conductor (not yet wired up) are simply skipped
+    rather than reported as zero.
+    """
+    lines: list[str] = []
+    sep = "=" * _WIDTH
+    rule = "-" * _WIDTH
+
+    lines.append(sep)
+    lines.append(f" Request profile: {prof.rid}")
+    lines.append(sep)
+
+    # ---- inputs / outputs -------------------------------------------------
+    if prof.inputs:
+        lines.append(" Inputs:")
+        for info in prof.inputs:
+            lines.append(
+                f"   {info.modality:<12} x{info.count:<4} {_human_bytes(info.total_bytes):>10}"
+            )
+    if prof.outputs:
+        lines.append(" Outputs:")
+        for info in prof.outputs:
+            lines.append(
+                f"   {info.modality:<12} x{info.count:<4} {_human_bytes(info.total_bytes):>10}"
+            )
+
+    # ---- timeline ---------------------------------------------------------
+    t = prof.timing
+    # Ordered checkpoints; consecutive pairs that are both present become a
+    # labelled stage. Missing checkpoints (e.g. conductor-side) collapse so the
+    # surrounding stages still join up.
+    checkpoints = [
+        ("recv", t.recv_time),
+        ("preprocess done", t.preprocess_finish_time),
+        ("conductor ingest", t.conductor_ingest_time),
+        ("first chunk", t.first_chunk_time),
+        ("last chunk", t.last_chunk_time),
+        ("conductor done", t.conductor_finish_time),
+        ("finish", t.finish_time),
+    ]
+    present = [(label, ts) for label, ts in checkpoints if ts is not None]
+
+    lines.append(rule)
+    if len(present) >= 2:
+        lines.append(" Timeline:")
+        for (a_label, a_ts), (b_label, b_ts) in zip(present, present[1:]):
+            lines.append(f"   {a_label + ' → ' + b_label:<40} {_ms(a_ts, b_ts)}")
+        # Total spans the first to last recorded checkpoint.
+        lines.append(f"   {'total':<40} {_ms(present[0][1], present[-1][1])}")
+    else:
+        lines.append(" Timeline: (no timing recorded)")
+    lines.append(sep)
+
+    text = "\n".join(lines) + "\n"
+
+    if filename:
+        with open(filename, "a") as f:
+            f.write(text)
+    else:
+        sys.stdout.write(text)
+        sys.stdout.flush()

--- a/mstar/profile/display.py
+++ b/mstar/profile/display.py
@@ -145,7 +145,7 @@ def pretty_print_profile(prof: RequestProfile, filename=None):
         if prof.tx_info:
             # No dest: the sender registers/writes data without knowing (a priori)
             # which worker reads it, and may register data that's never sent.
-            lines.append("\n   tx (registered/written for send; recipient n/a), by source:")
+            lines.append("\n   tx (registered/written for send), by source:")
             last = None
             for tx in sorted(prof.tx_info, key=lambda t: (t.source_entity, t.edge_name)):
                 if tx.source_entity != last:

--- a/mstar/profile/display.py
+++ b/mstar/profile/display.py
@@ -101,7 +101,7 @@ def pretty_print_profile(prof: RequestProfile, filename=None):
         lines.append(rule)
         lines.append(" Graph timings (CPU, ms) — total over request (avg per exec):")
         lines.append(
-            " " * prefix_w + "".join(f"{c:>20}" for c in ("all", "fwd", "pre", "post*"))
+            " " * prefix_w + "".join(f"{c:^20}" for c in ("all", "fwd", "pre", "post*"))
         )
         last_node = None
         for gt in timings:
@@ -118,7 +118,7 @@ def pretty_print_profile(prof: RequestProfile, filename=None):
                 + _cell(gt.postprocess_time, n)
             )
         lines.append(
-            "   * post overlaps the next step / another in-flight batch under"
+            "\n   * post overlaps the next step / another in-flight batch under"
         )
         lines.append(
             "     speculative scheduling, so it is not necessarily additive."
@@ -145,7 +145,7 @@ def pretty_print_profile(prof: RequestProfile, filename=None):
         if prof.tx_info:
             # No dest: the sender registers/writes data without knowing (a priori)
             # which worker reads it, and may register data that's never sent.
-            lines.append("   tx (registered/written for send; recipient n/a), by source:")
+            lines.append("\n   tx (registered/written for send; recipient n/a), by source:")
             last = None
             for tx in sorted(prof.tx_info, key=lambda t: (t.source_entity, t.edge_name)):
                 if tx.source_entity != last:

--- a/mstar/profile/display.py
+++ b/mstar/profile/display.py
@@ -20,6 +20,12 @@ def _ms(start: float, end: float) -> str:
     return f"{(end - start) * 1e3:8.1f} ms"
 
 
+def _fmt_ms(seconds: float) -> str:
+    """Milliseconds with 2 decimals under 10ms, 1 decimal otherwise."""
+    ms = seconds * 1e3
+    return f"{ms:.2f}" if ms < 10 else f"{ms:.1f}"
+
+
 def pretty_print_profile(prof: RequestProfile, filename=None):
     """Render a single request's profile.
 
@@ -65,32 +71,90 @@ def pretty_print_profile(prof: RequestProfile, filename=None):
         ("finish", t.finish_time),
     ]
     present = [(label, ts) for label, ts in checkpoints if ts is not None]
+    # Some checkpoints race — e.g. the api server's ``last chunk`` and the
+    # conductor's ``done`` signal arrive in either order — so order segments by
+    # the actual timestamp rather than the nominal sequence. This keeps every
+    # segment non-negative and reflects what really happened.
+    present.sort(key=lambda lt: lt[1])
 
     lines.append(rule)
     if len(present) >= 2:
         lines.append(" Timeline:")
-        for (a_label, a_ts), (b_label, b_ts) in zip(present, present[1:]):
+        for (a_label, a_ts), (b_label, b_ts) in zip(present, present[1:], strict=False):
             lines.append(f"   {a_label + ' → ' + b_label:<40} {_ms(a_ts, b_ts)}")
         # Total spans the first to last recorded checkpoint.
         lines.append(f"   {'total':<40} {_ms(present[0][1], present[-1][1])}")
     else:
         lines.append(" Timeline: (no timing recorded)")
 
-    # ---- per-node graph timings (summed over the request) -----------------
+    # ---- per-node graph timings ------------------------------------------
+    # Grouped by node with aligned columns so values stack and scan vertically.
+    # Each cell is "<total over request> (<avg per exec>)".
     if prof.graph_timings:
+        timings = sorted(prof.graph_timings, key=lambda g: (g.node, g.graph_walk))
+        walk_w = min(max(len(g.graph_walk) for g in timings), 18)
+        prefix_w = 5 + walk_w + 8  # indent + walk + " n=NNNN"
+
+        def _cell(total: float, n: int) -> str:
+            return f"  {_fmt_ms(total):>8} ({_fmt_ms(total / n):>7})"
+
         lines.append(rule)
-        lines.append(" Graph timings (CPU, summed over the request) [ms]:")
-        for gt in sorted(prof.graph_timings, key=lambda g: g.total_time, reverse=True):
-            label = f"{gt.node}:{gt.graph_walk}"
-            if len(label) > 24:
-                label = label[:23] + "…"
+        lines.append(" Graph timings (CPU, ms) — total over request (avg per exec):")
+        lines.append(
+            " " * prefix_w + "".join(f"{c:>20}" for c in ("all", "fwd", "pre", "post*"))
+        )
+        last_node = None
+        for gt in timings:
+            if gt.node != last_node:
+                lines.append(f"   {gt.node}")
+                last_node = gt.node
+            n = max(gt.exec_count, 1)
+            prefix = f"     {gt.graph_walk:<{walk_w}} n={gt.exec_count}"
             lines.append(
-                f"   {label:<24} n={gt.exec_count:<5}"
-                f" tot {gt.total_time * 1e3:7.1f}"
-                f"  fwd {gt.forward_time * 1e3:7.1f}"
-                f"  pre {gt.preprocess_time * 1e3:6.1f}"
-                f"  post {gt.postprocess_time * 1e3:6.1f}"
+                f"{prefix:<{prefix_w}}"
+                + _cell(gt.total_time, n)
+                + _cell(gt.forward_time, n)
+                + _cell(gt.preprocess_time, n)
+                + _cell(gt.postprocess_time, n)
             )
+        lines.append(
+            "   * post overlaps the next step / another in-flight batch under"
+        )
+        lines.append(
+            "     speculative scheduling, so it is not necessarily additive."
+        )
+
+    # ---- tensor transfer (rx / tx) ---------------------------------------
+    if prof.rx_info or prof.tx_info:
+        lines.append(rule)
+        lines.append(" Tensor transfer   size / transport-time / count:")
+        if prof.rx_info:
+            lines.append("   rx (received over the wire), by source → dest:")
+            last = None
+            for rx in sorted(
+                prof.rx_info, key=lambda r: (r.source_entity, r.dest_entity, r.edge_name)
+            ):
+                key = (rx.source_entity, rx.dest_entity)
+                if key != last:
+                    lines.append(f"     {rx.source_entity} → {rx.dest_entity}")
+                    last = key
+                lines.append(
+                    f"       {rx.edge_name:<22} {_human_bytes(rx.num_bytes):>10}"
+                    f"  {_fmt_ms(rx.time):>8} ms  (x{rx.count})"
+                )
+        if prof.tx_info:
+            # No dest: the sender registers/writes data without knowing (a priori)
+            # which worker reads it, and may register data that's never sent.
+            lines.append("   tx (registered/written for send; recipient n/a), by source:")
+            last = None
+            for tx in sorted(prof.tx_info, key=lambda t: (t.source_entity, t.edge_name)):
+                if tx.source_entity != last:
+                    lines.append(f"     {tx.source_entity}")
+                    last = tx.source_entity
+                lines.append(
+                    f"       {tx.edge_name:<22} {_human_bytes(tx.num_bytes):>10}"
+                    f"  {_fmt_ms(tx.time):>8} ms  (x{tx.count})"
+                )
     lines.append(sep)
 
     text = "\n".join(lines) + "\n"

--- a/mstar/profile/format.py
+++ b/mstar/profile/format.py
@@ -1,0 +1,71 @@
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class InputInfo:
+    modality: str
+    count: int
+    total_bytes: int
+
+
+@dataclass
+class OutputInfo:
+    modality: str
+    count: int
+    total_bytes: int
+
+
+@dataclass
+class GraphTiming:
+    node: str
+    graph_walk: str
+    exec_count: int
+    total_time: float # seconds
+    forward_time: float # actually from fwd start to end of postprocess
+    preprocess_time: float # preprocess + prepare_inputs
+    postprocess_time: float # CPU-level postprocess (minus async overlap)
+
+    def __add__(self, other: "GraphTiming"):
+        assert self.node == other.node and self.graph_walk == other.graph_walk
+        return GraphTiming(
+            node=self.node,
+            graph_walk=self.graph_walk,
+            exec_count=self.exec_count + other.exec_count,
+            total_time=self.total_time + other.total_time,
+            forward_time=self.forward_time + other.forward_time,
+            preprocess_time=self.preprocess_time + other.preprocess_time,
+            postprocess_time=self.postprocess_time + other.postprocess_time,
+        )
+
+
+def accumulate_graph_timing(timings: list[GraphTiming]) -> list[GraphTiming]:
+    """Accumulate timings by node and graph_walk."""
+    acc: dict[str, GraphTiming] = {}
+    for timing in timings:
+        key = f"{timing.node}:{timing.graph_walk}"
+        if key in acc:
+            acc[key] += timing
+        else:
+            acc[key] = timing
+    return list(acc.values())
+
+
+@dataclass
+class RequestTiming:
+    recv_time: float | None = None # all are time.perf_counter
+    preprocess_finish_time: float | None = None
+    conductor_ingest_time: float | None = None
+    first_chunk_time: float | None = None
+    last_chunk_time: float | None = None
+    conductor_finish_time: float | None = None
+    finish_time: float | None = None
+
+
+@dataclass
+class RequestProfile:
+    rid: str
+    timing: RequestTiming = field(default_factory=RequestTiming)
+    graph_timings: list[GraphTiming] = field(default_factory=list)
+    inputs: list[InputInfo] = field(default_factory=list)
+    outputs: list[OutputInfo] = field(default_factory=list)

--- a/mstar/profile/format.py
+++ b/mstar/profile/format.py
@@ -17,6 +17,34 @@ class OutputInfo:
 
 
 @dataclass
+class TxInfo:
+    edge_name: str
+    source_entity: str
+    count: int = 0
+    num_bytes: int = 0
+    time: float = 0.0 # seconds
+
+    def update(self, num_bytes: int, time: float, count_increment: int=1):
+        self.count += count_increment
+        self.num_bytes += num_bytes
+        self.time += time
+
+@dataclass
+class RxInfo:
+    edge_name: str
+    source_entity: str
+    dest_entity: str
+    count: int = 0
+    num_bytes: int = 0
+    time: float = 0.0 # seconds
+
+    def update(self, num_bytes: int, time: float, count_increment: int=1):
+        self.count += count_increment
+        self.num_bytes += num_bytes
+        self.time += time
+
+
+@dataclass
 class GraphTiming:
     node: str
     graph_walk: str
@@ -39,18 +67,6 @@ class GraphTiming:
         )
 
 
-def accumulate_graph_timing(timings: list[GraphTiming]) -> list[GraphTiming]:
-    """Accumulate timings by node and graph_walk."""
-    acc: dict[str, GraphTiming] = {}
-    for timing in timings:
-        key = f"{timing.node}:{timing.graph_walk}"
-        if key in acc:
-            acc[key] += timing
-        else:
-            acc[key] = timing
-    return list(acc.values())
-
-
 @dataclass
 class RequestTiming:
     recv_time: float | None = None # all are time.perf_counter
@@ -67,5 +83,7 @@ class RequestProfile:
     rid: str
     timing: RequestTiming = field(default_factory=RequestTiming)
     graph_timings: list[GraphTiming] = field(default_factory=list)
+    rx_info: list[RxInfo] = field(default_factory=list)
+    tx_info: list[TxInfo] = field(default_factory=list)
     inputs: list[InputInfo] = field(default_factory=list)
     outputs: list[OutputInfo] = field(default_factory=list)

--- a/mstar/profile/worker.py
+++ b/mstar/profile/worker.py
@@ -1,0 +1,107 @@
+
+from dataclasses import dataclass, field
+import time
+
+from mstar.profile.format import GraphTiming
+
+
+# (node, graph_walk) -> accumulated GraphTiming for a single request
+GraphTimings = dict[tuple[str, str], GraphTiming]
+
+
+@dataclass
+class ExecTimings:
+    """Per-node-execution timing for one batch. The dicts are keyed by
+    request_id (a batch executes the same node/walk for several requests at
+    once); all values are ``time.perf_counter()`` seconds."""
+    start: float | None = None
+    # Forward timing is batch-level, not per-request: with async GPU execution a
+    # CPU perf_counter measures the launch/enqueue span of the whole forward
+    # region, and a batched launch has no per-request boundary to attribute it
+    # to. ``fwd_end`` is only set for sequential / max-batch-size paths.
+    fwd_start: float | None = None
+    fwd_end: float | None = None
+
+    def update(self, other: "ExecTimings"):
+        # Merge sub-batch forward windows (execute_with_max_batch_size) into one
+        # span covering the whole batch: earliest launch to latest return.
+        if other.start is not None:
+            self.start = (
+                other.start if self.start is None
+                else min(self.start, other.start)
+            )
+        if other.fwd_start is not None:
+            self.fwd_start = (
+                other.fwd_start if self.fwd_start is None
+                else min(self.fwd_start, other.fwd_start)
+            )
+        if other.fwd_end is not None:
+            self.fwd_end = (
+                other.fwd_end if self.fwd_end is None
+                else max(self.fwd_end, other.fwd_end)
+            )
+
+
+@dataclass
+class WorkerProfileInfo:
+    """Accumulates per-request graph timings on a worker.
+
+    Every executed batch is recorded once, at postprocess time, via
+    ``register_end`` — by then the batch's :class:`ExecTimings` carries
+    ``start`` / ``fwd_start`` (stamped by the engine at the GPU-launch boundary)
+    and ``fwd_end`` (stamped by the worker after the GPU completion event). All
+    the data lives on the batch's ``ExecTimings`` (passed in by the caller), so
+    no per-batch state has to be carried across the pipeline here; speculative
+    and fallthrough batches alike flow through ``_postprocess_batch`` once and
+    are recorded there.
+
+    Timings accumulate per request and per ``(node, graph_walk)`` so repeated
+    steps for a request (e.g. decode) sum into one entry with ``exec_count``.
+    """
+    # request_id -> {(node, graph_walk) -> accumulated GraphTiming}
+    per_rid_graph_timings: dict[str, GraphTimings] = field(default_factory=dict)
+
+    def register_end(
+        self,
+        node: str,
+        walk: str,
+        rids: list[str],
+        timings: ExecTimings,
+        end_time: float | None = None,
+    ):
+        """Emit a per-request GraphTiming for every request in a finished batch.
+
+        ``timings`` is the batch's :class:`ExecTimings`; ``end_time`` defaults to
+        now (the postprocess point). Forward timing is batch-level and shared
+        across the batch's requests; the bracket bounds are used as fallbacks if
+        a stamp is missing.
+        """
+        if timings.start is None:
+            # Engine never stamped this batch (e.g. a path that ran no forward);
+            # nothing meaningful to record.
+            return
+        if end_time is None:
+            end_time = time.perf_counter()
+
+        start = timings.start
+        fwd_start = timings.fwd_start if timings.fwd_start is not None else start
+        fwd_end = timings.fwd_end if timings.fwd_end is not None else end_time
+        for rid in rids:
+            timing = GraphTiming(
+                node=node,
+                graph_walk=walk,
+                exec_count=1,
+                total_time=end_time - start,
+                forward_time=fwd_end - fwd_start,
+                preprocess_time=fwd_start - start,
+                postprocess_time=end_time - fwd_end,
+            )
+            rid_timings = self.per_rid_graph_timings.setdefault(rid, {})
+            if (node, walk) in rid_timings:
+                rid_timings[(node, walk)] += timing
+            else:
+                rid_timings[(node, walk)] = timing
+
+    def pop_request(self, rid: str) -> GraphTimings:
+        """Drop and return a request's accumulated timings (called on removal)."""
+        return self.per_rid_graph_timings.pop(rid, {})

--- a/mstar/profile/worker.py
+++ b/mstar/profile/worker.py
@@ -1,9 +1,8 @@
 
-from dataclasses import dataclass, field
 import time
+from dataclasses import dataclass, field
 
 from mstar.profile.format import GraphTiming
-
 
 # (node, graph_walk) -> accumulated GraphTiming for a single request
 GraphTimings = dict[tuple[str, str], GraphTiming]

--- a/mstar/utils/ipc_format.py
+++ b/mstar/utils/ipc_format.py
@@ -4,6 +4,7 @@ from enum import Enum, IntEnum
 from mstar.conductor.request_info import CurrentForwardPassInfo, PerLabelSeqInfo
 from mstar.graph.base import GraphEdge, TensorPointerInfo
 from mstar.graph.loop_indices import NestedLoopIndices
+from mstar.profile.format import RxInfo, TxInfo
 from mstar.profile.worker import GraphTimings
 
 
@@ -133,6 +134,8 @@ class WorkerGraphsDone(MessageBody):
     stream_tokens_consumed: dict[str, int] = field(default_factory=dict)  # edge_name -> tokens consumed from stream
     output_loop_indices: dict[str, NestedLoopIndices] = field(default_factory=dict)
     graph_timings: GraphTimings = field(default_factory=dict)
+    rx_info: list[RxInfo] = field(default_factory=list)
+    tx_info: list[TxInfo] = field(default_factory=list)
 
 
 @dataclass

--- a/mstar/utils/ipc_format.py
+++ b/mstar/utils/ipc_format.py
@@ -4,6 +4,7 @@ from enum import Enum, IntEnum
 from mstar.conductor.request_info import CurrentForwardPassInfo, PerLabelSeqInfo
 from mstar.graph.base import GraphEdge, TensorPointerInfo
 from mstar.graph.loop_indices import NestedLoopIndices
+from mstar.profile.worker import GraphTimings
 
 
 class Status(Enum):
@@ -131,6 +132,7 @@ class WorkerGraphsDone(MessageBody):
     partition_done: bool = field(default=False)
     stream_tokens_consumed: dict[str, int] = field(default_factory=dict)  # edge_name -> tokens consumed from stream
     output_loop_indices: dict[str, NestedLoopIndices] = field(default_factory=dict)
+    graph_timings: GraphTimings = field(default_factory=dict)
 
 
 @dataclass

--- a/mstar/worker/engine_manager.py
+++ b/mstar/worker/engine_manager.py
@@ -17,17 +17,24 @@ from mstar.engine.stateless_engine import (
 from mstar.model.base import Model
 
 
-def _make_kv_cache(autocast_dtype: torch.dtype, enable_nvtx: bool) -> BaseEngine:
-    return KVCacheEngine(autocast_dtype=autocast_dtype, enable_nvtx=enable_nvtx)
+def _make_kv_cache(
+    autocast_dtype: torch.dtype, enable_nvtx: bool, enable_prof: bool = False
+) -> BaseEngine:
+    return KVCacheEngine(
+        autocast_dtype=autocast_dtype, enable_nvtx=enable_nvtx, enable_prof=enable_prof
+    )
 
 
 def _make_stateless_factory(
     config_factory: Callable[[torch.dtype | None], StatelessEngineConfig],
-) -> Callable[[torch.dtype | None, bool], BaseEngine]:
-    def factory(autocast_dtype: torch.dtype | None, enable_nvtx: bool) -> BaseEngine:
+) -> Callable[[torch.dtype | None, bool, bool], BaseEngine]:
+    def factory(
+        autocast_dtype: torch.dtype | None, enable_nvtx: bool, enable_prof: bool = False
+    ) -> BaseEngine:
         return StatelessEngine(
             config=config_factory(autocast_dtype),
             enable_nvtx=enable_nvtx,
+            enable_prof=enable_prof,
         )
 
     return factory
@@ -36,7 +43,7 @@ def _make_stateless_factory(
 # Engine-type strings (``EngineType.value``) → factory. ``STATELESS`` is
 # resolved via ``STATELESS_FLAVOR_FACTORIES`` instead because its config
 # depends on the submodule (enc_dec vs audio_codec).
-ENGINE_TYPE_FACTORIES: dict[str, Callable[[torch.dtype | None, bool], BaseEngine]] = {
+ENGINE_TYPE_FACTORIES: dict[str, Callable[[torch.dtype | None, bool, bool], BaseEngine]] = {
     "kv_cache": _make_kv_cache,
 }
 
@@ -45,7 +52,7 @@ ENGINE_TYPE_FACTORIES: dict[str, Callable[[torch.dtype | None, bool], BaseEngine
 # ``NodeSubmodule.get_stateless_flavor()``; the EngineManager groups
 # ``STATELESS`` nodes by that flavor so each flavor gets one engine with the
 # right config (autocast, force_float32, torch.compile, piecewise runner).
-STATELESS_FLAVOR_FACTORIES: dict[str, Callable[[torch.dtype | None, bool], BaseEngine]] = {
+STATELESS_FLAVOR_FACTORIES: dict[str, Callable[[torch.dtype | None, bool, bool], BaseEngine]] = {
     "enc_dec": _make_stateless_factory(make_enc_dec_config),
     "audio_codec": _make_stateless_factory(make_audio_codec_config),
 }
@@ -69,6 +76,7 @@ class EngineManager:
         transfer_engine_info: TransferEngineInfo,
         model: Model,
         enable_nvtx: bool = False,
+        enable_prof: bool=False,
     ) -> "EngineManager":
         """
         Build an EngineManager from a list of engine configs.
@@ -127,7 +135,7 @@ class EngineManager:
                 factory = STATELESS_FLAVOR_FACTORIES[flavor]
             else:
                 factory = ENGINE_TYPE_FACTORIES[engine_type_str]
-            engine = factory(autocast_dtype, enable_nvtx)
+            engine = factory(autocast_dtype, enable_nvtx, enable_prof)
 
             submodules: dict[str, torch.nn.Module] = {}
             for name in engine_node_names:

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -2,13 +2,13 @@ import logging
 import os
 import sys
 import threading
+import time
 import time as _time
 from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum
 from time import sleep
-import time
 
 import torch
 
@@ -183,6 +183,7 @@ class Worker:
             device=self.device,
             communicator=self.communicator,
             tcp_transfer_device=tcp_transfer_device,
+            enable_prof=enable_prof
         )
 
         node_names = set()
@@ -1079,7 +1080,9 @@ class Worker:
                     partition_done=p_done,
                     stream_tokens_consumed=stream_consumed,
                     output_loop_indices=self.worker_graphs_manager.get_output_loop_indices(request_id),
-                    graph_timings=self.profile_info.per_rid_graph_timings.get(request_id, {})
+                    graph_timings=self.profile_info.per_rid_graph_timings.get(request_id, {}),
+                    rx_info=self.tensor_manager.get_rx_info(request_id),
+                    tx_info=self.tensor_manager.get_tx_info(request_id),
                 ),
             )
             self.communicator.send("conductor", message)
@@ -1658,7 +1661,7 @@ class Worker:
                     range_pop(synchronize=False)
             else:
                 torch.cuda.default_stream().synchronize()
-        
+
         if self.enable_prof:
             batch_N.node_batch.exec_timings.fwd_end = time.perf_counter()
 

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -8,6 +8,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum
 from time import sleep
+import time
 
 import torch
 
@@ -24,6 +25,7 @@ from mstar.graph.base import GraphEdge, GraphNode
 from mstar.graph.graph_io import format_graph_edge_list
 from mstar.graph.loop_indices import NestedLoopIndices
 from mstar.model.base import Model, WorkerGraph
+from mstar.profile.worker import WorkerProfileInfo
 from mstar.streaming.stream_buffer import StreamBuffer
 from mstar.utils.ipc_format import (
     ConductorMessage,
@@ -129,12 +131,16 @@ class Worker:
         tensor_comm_protocol: CommProtocol = CommProtocol.RDMA,
         device: torch.device = torch.device("cuda"),
         enable_nvtx: bool = False,
+        enable_prof: bool = False,
         tcp_transfer_device="",
         dist_init_method=None
     ):
         self.worker_id = worker_id
         self.device = device
         self.enable_nvtx = enable_nvtx
+
+        self.enable_prof = enable_prof
+        self.profile_info = WorkerProfileInfo()
 
         if self.device.type == "cuda" and self.device.index is not None:
             torch.cuda.set_device(self.device)
@@ -195,7 +201,8 @@ class Worker:
                 transfer_engine=self.tensor_manager.transfer_engine
             ),
             model=model,
-            enable_nvtx=self.enable_nvtx
+            enable_nvtx=self.enable_nvtx,
+            enable_prof=self.enable_prof
         )
 
         self.worker_graphs_manager = WorkerGraphsManager(
@@ -480,6 +487,7 @@ class Worker:
         self.engine_manager.remove_request(body.request_id)
         self.worker_graphs_manager.remove_request(body.request_id)
         self.tensor_manager.cleanup_request(body.request_id)
+        self.profile_info.pop_request(body.request_id)
         self.streaming_buffers.pop(body.request_id, None)
 
         for node_name in self.engine_manager.lru_tracked_nodes():
@@ -1071,6 +1079,7 @@ class Worker:
                     partition_done=p_done,
                     stream_tokens_consumed=stream_consumed,
                     output_loop_indices=self.worker_graphs_manager.get_output_loop_indices(request_id),
+                    graph_timings=self.profile_info.per_rid_graph_timings.get(request_id, {})
                 ),
             )
             self.communicator.send("conductor", message)
@@ -1649,6 +1658,9 @@ class Worker:
                     range_pop(synchronize=False)
             else:
                 torch.cuda.default_stream().synchronize()
+        
+        if self.enable_prof:
+            batch_N.node_batch.exec_timings.fwd_end = time.perf_counter()
 
         if self.enable_nvtx:
             range_pop(synchronize=False)
@@ -1775,6 +1787,14 @@ class Worker:
             if req_info is not None:
                 req_info.per_partition_info[batch_N.partition].stream_partition_done = True
 
+        # set this before send_outputs so that we can send updated profiling info to the conductor
+        if self.enable_prof:
+            self.profile_info.register_end(
+                batch_N.node_batch.node_name,
+                batch_N.node_batch.graph_walk,
+                batch_N.node_batch.request_ids,
+                batch_N.node_batch.exec_timings,
+            )
         for rid, routing in routing_per_request.items():
             self._send_outputs(
                 rid, routing,


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->
Addresses https://github.com/mstar-project/mstar/issues/140. Adds an option (`--log-stats`) to print request-level profiling to stdout (or a file, via `--log-stats-file <filename>`) after the completion of each request. This is based on https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/metrics/. 

After each request, logs summaries of:
- E2E request timing
- inputs and outputs (size and count)
- graph-level timing (e.g., time spent in each node / graph walk)
- tensor transport information (bytes transferred, rx/tx timing)

This  does **not** include:
- Summary of timing for the whole server upon shutdown (this is a TODO that can be added in another PR, or this PR if desired)
- Fine-grained scheduler/conductor overhead (the aggregate amount, however, can be partially inferred/estimated by the graph timings)

Example output for orpheus:
```
============================================================
 Request profile: e9a5e698-825c-442b-997d-44c44bd5ea5a
============================================================
 Inputs:
   text         x1          65 B
 Outputs:
   audio        x81    324.0 KiB
------------------------------------------------------------
 Timeline:
   recv → preprocess done                        2.2 ms
   preprocess done → conductor ingest            0.6 ms
   conductor ingest → first chunk              106.5 ms
   first chunk → conductor done               1920.2 ms
   conductor done → last chunk                   1.5 ms
   last chunk → finish                           2.5 ms
   total                                      2033.5 ms
------------------------------------------------------------
 Graph timings (CPU, ms) — total over request (avg per exec):
                               all                 fwd                 pre                post*        
   LLM
     decode     n=581      3185.1 (   5.48)    2781.4 (   4.79)     256.5 (   0.44)     147.2 (   0.25)
     prefill    n=1          7.14 (   7.14)      4.12 (   4.12)      2.47 (   2.47)      0.56 (   0.56)
   snac_decoder
     snac_chunk n=81        370.0 (   4.57)     302.2 (   3.73)      27.1 (   0.33)      40.7 (   0.50)

   * post overlaps the next step / another in-flight batch under
     speculative scheduling, so it is not necessarily additive.
------------------------------------------------------------
 Tensor transfer   size / transport-time / count:
   rx (received over the wire), by source → dest:
     api_server_preprocess_worker → worker_0
       text_inputs                 200 B      0.47 ms  (x1)
     worker_0 → api_server_preprocess_worker
       audio_output            324.0 KiB      8.44 ms  (x81)

   tx (registered/written for send; recipient n/a), by source:
     api_server_preprocess_worker
       text_inputs                 200 B      0.72 ms  (x1)
     worker_0
       audio_chunk             324.0 KiB      18.6 ms  (x81)
       new_token                     8 B      0.19 ms  (x1)
============================================================
```

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->
- Inspected stats logged for Orpheus, Bagel, and qwen3-omnni
- Spot-checked qwen3-omni and orpheus benchmarking, no regression


## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
