### PR TITLE
Tested; removal of conductor_new_token path in favor of token-counting

### DIFF
--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -868,12 +868,12 @@ class Conductor:
         if body.is_first_tp_rank:
             pstate.per_label_seq_info.update(body.per_label_seq_info)
 
-            if body.new_tokens:
-                for name, tokens in body.new_tokens.items():
-                    pstate.num_output_tokens += len(tokens)
+            if body.new_token_counts:
+                for name, count in body.new_token_counts.items():
+                    pstate.num_output_tokens += count
                     for conn in request_data.streaming_connections.values():
                         if conn.from_partition == partition_name and conn.edge_name == name:
-                            conn.token_count += len(tokens)
+                            conn.token_count += count
 
             if body.stream_tokens_consumed:
                 for conn in request_data.streaming_connections.values():

--- a/mstar/utils/ipc_format.py
+++ b/mstar/utils/ipc_format.py
@@ -126,7 +126,7 @@ class WorkerGraphsDone(MessageBody):
     worker_graph_ids: list[str]
     is_first_tp_rank: bool
     persist_signals: dict[str, list[TensorPointerInfo]] = field(default_factory=dict)
-    new_tokens: dict[str, list[int]] = field(default_factory=dict) # name to tokens
+    new_token_counts: dict[str, int] = field(default_factory=dict) # name to token counts
     output_signal_names: int = field(default=0)
     per_label_seq_info: PerLabelSeqInfo = field(default_factory=PerLabelSeqInfo)
     partition_name: str = field(default="default")

--- a/mstar/worker/node_manager_utils.py
+++ b/mstar/worker/node_manager_utils.py
@@ -220,7 +220,7 @@ class PerRequestInfo:
     sharding_config: ShardingConfig
 
     pending_persist_signals: list[GraphEdge] = field(default_factory=list)
-    pending_new_tokens: dict[str, list[int]] = field(default_factory=dict)
+    pending_new_token_counts: dict[str, int] = field(default_factory=dict)
     stream_buffers: dict[str, StreamBuffer] = field(default_factory=dict)  # edge_name -> StreamBuffer
     current_output_chunks: list[str] = field(default_factory=list)
     output_loop_indices: dict[str, NestedLoopIndices] = field(default_factory=dict)
@@ -685,15 +685,13 @@ class WorkerGraphsManager:
         """Extend the pending persist signals for a request."""
         self.per_request_info[request_id].pending_persist_signals.extend(signals)
 
-    def buffer_new_tokens(
-        self, request_id: str,
-        new_tokens: dict[str, list[int]]
-    ):
-        """Update the pending new tokens for a request."""
-        for name, tokens in new_tokens.items():
-            if name not in self.per_request_info[request_id].pending_new_tokens:
-                self.per_request_info[request_id].pending_new_tokens[name] = []
-            self.per_request_info[request_id].pending_new_tokens[name].extend(tokens)
+    def buffer_new_token_counts(
+        self, request_id: str, counts: dict[str, int]
+    ) -> None:
+        """Update the pending new token count for a request."""
+        pending = self.per_request_info[request_id].pending_new_token_counts
+        for name, count in counts.items():
+            pending[name] = pending.get(name, 0) + count
 
     def buffer_output_signals(self, request_id: str, out_signals: list[GraphEdge]):
         self.per_request_info[request_id].current_output_chunks += [
@@ -714,12 +712,12 @@ class WorkerGraphsManager:
             result[edge.name] = edge.tensor_info
         return result
 
-    def flush_new_tokens(self, request_id: str) -> dict[str, list[int]]:
-        """Pop and return all buffered new tokens for a request."""
+    def flush_new_token_counts(self, request_id: str) -> dict[str, int]:
+        """Pop and return all buffered new token counts for a request."""
         info = self.per_request_info[request_id]
-        new_tokens = info.pending_new_tokens
-        info.pending_new_tokens = {}
-        return new_tokens
+        counts = info.pending_new_token_counts
+        info.pending_new_token_counts = {}
+        return counts
 
     def flush_output_signals(self, request_id: str) -> list[str]:
         info = self.per_request_info[request_id]

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -948,21 +948,12 @@ class Worker:
         nested_loop_indices: NestedLoopIndices,
         graph_walk: str | None = None,
         partition_name: str | None = None,
-        prematerialized_new_tokens: dict[str, list[int]] | None = None,
         node_speculatively_scheduled: bool=False
     ) -> None:
         """
         Send outputs to other workers and to the conductor.
-        Persist signals are buffered and sent together with the
-        WORKER_GRAPHS_DONE message to avoid race conditions.
-
-        ``prematerialized_new_tokens`` (optional): `{signal_name: [int, ...]}`
-        for this request, where the caller has already done the D→H copy
-        for the new-token tensors. When provided, this function skips the
-        per-tensor ``.cpu()`` call — meaningful when the caller batched
-        multiple requests' new-token transfers into a single D→H to avoid
-        N serialized ``cudaMemcpyAsync`` + ``cudaStreamSynchronize`` per
-        step.
+        Persist signals and new-token counts are buffered and sent together
+        with the WORKER_GRAPHS_DONE message to avoid race conditions.
         """
         if graph_walk is None:
             graph_walk = self.worker_graphs_manager.get_graph_walk(request_id, partition_name)
@@ -985,28 +976,21 @@ class Worker:
             )
 
         if outputs.new_token_outputs:
-            name_to_new_token: dict = {}
+            name_to_count: dict[str, int] = {}
             for signal in outputs.new_token_outputs:
-                if signal.name in name_to_new_token:
-                    continue # don't double-count new tokens
-                if (
-                    prematerialized_new_tokens is not None
-                    and signal.name in prematerialized_new_tokens
-                ):
-                    new_tokens = prematerialized_new_tokens[signal.name]
-                else:
-                    new_tokens = []  # list[int]
-                    for tensor_info in signal.tensor_info:
-                        tensor = self.tensor_manager.get_tensor(
-                            request_id=request_id,
-                            uuid=tensor_info.uuid
-                        )
-                        new_tokens.extend(tensor.cpu().numpy().tolist())
-                name_to_new_token[signal.name] = new_tokens
-
-                self.worker_graphs_manager.buffer_new_tokens(
-                    request_id, name_to_new_token
-                )
+                if signal.name in name_to_count:
+                    continue  # don't double-count new tokens
+                count = 0
+                for tensor_info in signal.tensor_info:
+                    tensor = self.tensor_manager.get_tensor(
+                        request_id=request_id,
+                        uuid=tensor_info.uuid,
+                    )
+                    count += tensor.numel()
+                name_to_count[signal.name] = count
+            self.worker_graphs_manager.buffer_new_token_counts(
+                request_id, name_to_count
+            )
 
         if outputs.emit_to_client:
             self.worker_graphs_manager.buffer_output_signals(
@@ -1073,7 +1057,7 @@ class Worker:
                     worker_graph_ids=outputs.completed_worker_graph_ids,
                     is_first_tp_rank=outputs.is_first_tp_rank,
                     persist_signals=self.worker_graphs_manager.flush_persist_signals(request_id),
-                    new_tokens=self.worker_graphs_manager.flush_new_tokens(request_id),
+                    new_token_counts=self.worker_graphs_manager.flush_new_token_counts(request_id),
                     output_signal_names=self.worker_graphs_manager.flush_output_signals(request_id),
                     per_label_seq_info=self.worker_graphs_manager.get_seq_info(request_id, partition_name),
                     partition_name=partition_name,
@@ -1811,46 +1795,6 @@ class Worker:
             range_pop(synchronize=False)
 
         return routing_per_request
-
-    def _d2h_new_tokens(
-        self,
-        tensors: list[torch.Tensor],
-        completion_event: "torch.cuda.Event | None",
-    ) -> list[int]:
-        """Batched D→H copy of new-token tensors, gated on GPU(N)'s
-        completion event so it does not block on GPU(N+1) (which is queued
-        on default stream behind GPU(N)).
-
-        Falls back to the simple ``torch.cat([...]).cpu()`` when CUDA is
-        unavailable, the tensors are already on CPU, or no completion event
-        was recorded (non-CUDA execution).
-
-        Safety: assumes ``tensors`` are fresh allocations (not views into
-        CUDA-graph static buffers that GPU(N+1) will overwrite). Sampler
-        outputs from FlashInfer's ``top_p_sampling_from_probs`` qualify;
-        if a future change makes the new-token tensor a static-buffer
-        view, this needs an extra clone-on-default-stream-before-event-
-        record step on the GPU thread.
-        """
-        if not tensors:
-            return []
-        first = tensors[0]
-        on_cuda = first.is_cuda and torch.cuda.is_available()
-        if not on_cuda or completion_event is None:
-            return torch.cat([t.flatten() for t in tensors]).cpu().tolist()
-
-        if self._d2h_stream is None:
-            self._d2h_stream = torch.cuda.Stream(device=self.device)
-        side = self._d2h_stream
-        side.wait_event(completion_event)
-        with torch.cuda.stream(side):
-            flat_gpu = torch.cat([t.flatten() for t in tensors])
-            flat_cpu = self._get_pinned_d2h_buffer(
-                "new_tokens", flat_gpu.shape, flat_gpu.dtype,
-            )
-            flat_cpu.copy_(flat_gpu, non_blocking=True)
-        side.synchronize()
-        return flat_cpu.tolist()
 
     def _get_pinned_d2h_buffer(
         self,


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

Closes #124. 
Changed `new_tokens` in Worker->Conductor `WORKER_GRAPHS_DONE` message to `new_token_counts`. 
Modified `WorkerGraphsManager::(buffer|flush)_new_tokens()` to `WorkerGraphsManager::(buffer|flush)_new_token_counts()`. 
Replacement in `Worker::_send_outputs()` of `.cpu().numpy().tolist()` with `.numel()` and removed unused `prematerialized_new_tokens` parameter and `Worker::_d2h_new_tokens`. 
`Conductor::_process_worker_graphs_done()` now uses the transmitted `counts` rather than `len(tokens)`.

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->

Change is small enough that it can be very easily reasoned on, but ran 
```
# fix/conductor_new_token branch run
CUDA_VISIBLE_DEVICES=7 mstar serve orpheus --gpus 7 --port 8127 \
  --cache-dir /m-coriander/coriander/keisuke/mminf_cache/orpheus \
  --log-level DEBUG 2>&1 | tee /tmp/orpheus_fix.log

# main branch baseline
CUDA_VISIBLE_DEVICES=2 mstar serve orpheus --gpus 2 --port 8129 \
  --socket-path-prefix /tmp/mstar_main_cmp/ \
  --cache-dir /m-coriander/coriander/keisuke/mminf_cache/orpheus \
  --log-level DEBUG 2>&1 | tee /tmp/orpheus_main2.log

# Same request in both
HOST=127.0.0.1 PORT=<port> python test/orpheus/tts_request.py \
  --text "Hello world" --voice tara --output /tmp/out.wav

# Look at tokens/token-counts in logs
grep 'Partition LLM.*tokens=' /tmp/orpheus_*.log
```

Output shows us that token counts remain the same. We can also look directly at the log files and see that we now have `len(tokens)` in our `WORKER_GRAPHS_DONE` rather than the original `tokens`. 

## Checklist
- [X] `ruff check .` passes
- [X] Added or updated tests / docs where relevant
