### PR TITLE
pin numba>=0.61 to avoid incompatible llvmlite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ all = [
     "safetensors",
     "triton",
     "qwen-omni-utils",
+    "numba>=0.61",
     "sgl-kernel",
     # flash-attn is intentionally omitted (Qwen3-Omni needs it) — install it
     # separately, see docs/installation.rst.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ qwen3_omni = [
     "Pillow",
     "regex",
     "qwen-omni-utils",
+    "numba>=0.61",
     "torchvision",
     "torchaudio",
     "torchcodec==0.8.*",


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

Closes #148 by pinning a newer version of `numba` that does not bring in an older `llvmlite` in `[all]` in `pyproject.toml`. 

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->

Quickstart now works, and models still inference without terrible runtime errors. 

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant

Edit: #151 -> #148 
