### PR TITLE
Fix stale torch.compile docstring in _compile_submodules (#145)

### DIFF
--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -207,9 +207,12 @@ class KVCacheEngine(BaseEngine):
     def _compile_submodules(self) -> None:
         """Apply torch.compile to submodule forward paths.
 
-        Uses mode="max-autotune-no-cudagraphs" (SGLang's approach) so compiled
-        code gets baked into CUDA graphs when captured. Must be called BEFORE
-        CUDA graph capture.
+        Compiles each submodule's ``forward`` and ``forward_batched`` with the
+        default mode (fullgraph=False, dynamic=None). Called from ``warmup``
+        after CUDA graph capture. ``max-autotune-no-cudagraphs`` is intentionally
+        not used here: on variable-shape inputs it triggers frequent slow
+        recompiles, so that mode is applied on the CUDA-graph path instead
+        (see ``cuda_graph_runner``).
         """
         if not torch.cuda.is_available():
             return


### PR DESCRIPTION

<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

Closes Issue #145 

The _compile_submodules docstring described a superseded approach that no longer matches the code:

- It claimed mode="max-autotune-no-cudagraphs", but the torch.compile calls use the default mode (fullgraph=False, dynamic=None). That autotune mode is applied on the CUDA-graph path (cuda_graph_runner), not here.
- It said the method "Must be called BEFORE CUDA graph capture", but its sole caller, warmup(), invokes it AFTER capture (matching the existing call-site comment at the point of the call).

Rewrite the docstring to describe the actual behavior. 

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->

Comment-only change; no functional effect.

## Checklist
- [ ] `ruff check .` passes
- [ ] Added or updated tests / docs where relevant
