### PR TITLE
Make the piecewise CUDA graph runner model-agnostic

### DIFF
--- a/docs/adding_models.rst
+++ b/docs/adding_models.rst
@@ -375,6 +375,161 @@ a packed ``prefill`` graph:
            ),
        ]
 
+Piecewise CUDA graphs (capturing an inner loop)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The configs above capture a submodule's **whole** ``forward_batched``; the engine
+drives the replay, including sampling and output remap. Sometimes you instead want to
+capture only a **hot inner region** of a forward, e.g., a transformer *block loop*,
+while eager Python runs the preamble (embeddings, sequence assembly) and postamble
+(norm, projection) around it. That is what a *piecewise* CUDA graph does.
+
+A submodule opts in by returning one or more configs from::
+
+   get_piecewise_cuda_graph_configs(self, device, autocast_dtype, tp_world_size=1)
+       -> dict[str, PiecewiseCudaGraphConfig]
+
+The dict key is a **label**, an arbitrary string naming the captured region (multiple
+labels capture multiple independent graphs). The engine builds one
+``PiecewiseCudaGraphRunner`` per label at warmup and threads them into
+``engine_inputs.piecewise_runners``; your forward looks the runner up by label and
+calls it. Nothing is stored on the submodule.
+
+Two config types live in ``mstar/engine/cuda_graph_config.py``, mirroring the
+whole-forward split:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 74
+
+   * - Config type
+     - When to use / what it captures
+   * - ``PiecewiseBatchedConfig``
+     - **Equal-length** batched inputs: the captured region sees ``[bs, seq_len, D]``
+       with every request the same ``seq_len``. You pass ``seq_len`` (tokens per
+       request). One graph is captured per batch size.
+   * - ``PiecewisePackedConfig``
+     - **Packed / ragged** inputs: the captured region sees ``[total_tokens, D]`` with
+       variable-length sequences packed together (FlashInfer-packed style). You pass
+       ``total_tokens`` (a list of token-count buckets). One graph is captured per
+       ``(batch size, bucket)``.
+
+Both share the base ``PiecewiseCudaGraphConfig`` fields:
+
+- ``capture_fn``: the callable that gets captured (see the contract below).
+- ``make_static_inputs``: a factory ``(shape: PiecewiseCaptureShape) -> dict[str, Tensor]``
+  returning the persistent buffers the captured region reads. The runner **owns** these
+  buffers; at replay it copies your real tensors into them by name. ``shape`` carries
+  ``bs``, ``seq_lens`` and ``total_tokens`` for the bucket being built. Allocate the
+  hidden state in ``autocast_dtype`` so the replay copy is a same-dtype memcpy.
+- ``forward_kwargs``: static keyword args threaded into ``capture_fn`` every call
+  (e.g. a layer count, ``is_causal``).
+- ``uses_kv_cache``: set ``True`` if the captured region reads a FlashInfer KV cache.
+  The runner then plans attention **outside** the graph before each replay and advances
+  seq-lens **after** it (both are Python-only and must never be inside the captured
+  region). Requires a ``KV_CACHE`` engine; stateless nodes leave this ``False``.
+- ``plan_fn``: optional ``(static_cm, shape) -> None`` override for attention planning.
+  Leave ``None`` to get the type-default (uniform ``seq_lens`` for batched, packed
+  indptr for packed; ``is_causal`` read from ``forward_kwargs``).
+- ``advance_seq_lens``: whether ``run`` advances cache seq-lens (Python-only,
+  post-replay) after each call (default ``True``). Set ``False`` when your forward
+  advances the cache itself. No effect when ``uses_kv_cache`` is ``False``.
+- ``cache_labels``: KV-cache labels the region touches (default ``["main"]``).
+- ``capture_batch_sizes`` — which batch sizes to record (``None`` → the runner default).
+- ``compile``: ``torch.compile`` the ``capture_fn`` before capture (default ``False``).
+
+**The capture-fn contract.** The captured callable takes the runner-owned buffers as an
+argument and returns a dict::
+
+   capture_fn(static_inputs: dict[str, Tensor],
+              static_cm: BatchedCacheManager | None = None,
+              **forward_kwargs) -> dict[str, Tensor]
+
+The one rule that makes it CUDA-graph-safe: **read tensors out of** ``static_inputs``
+**and never reassign them.** The runner calls ``capture_fn`` with the *same* dict object
+at capture and updates those buffers in place before each replay, so a fresh
+``static_inputs["x"] = ...`` would break the graph. (A bare ``Tensor`` return is also
+accepted and wrapped as ``{"x": ...}``.)
+
+**Calling the runner.** Look it up by label and hand it your real inputs; it returns a
+``PiecewiseOutput`` — a dict-like view where indexing / ``.get`` return an owned clone
+(safe to keep), and ``.get_view`` returns a zero-copy view valid only until the next
+``run`` (see ``mstar/engine/cuda_graph_runner.py``). The runner handles input padding,
+attention planning, replay, seq-len advance, and output slicing.
+
+A dummy submodule using piecewise cuda graphs for a VJepa2-like world model rollout step,
+with an eager preamble, a captured KV-cached block loop over a fixed per-step sequence,
+and an eager postamble:
+
+.. code-block:: python
+
+   from mstar.engine.cuda_graph_config import (
+       PiecewiseBatchedConfig, PiecewiseCaptureShape, PiecewiseCudaGraphConfig,
+   )
+
+   class MyRolloutSubmodule(ARNodeSubmodule):
+       def __init__(self, blocks, embed, proj, embed_dim, seq_len):
+           super().__init__()
+           self.blocks = blocks            # transformer blocks that read the KV cache
+           self.embed, self.proj = embed, proj
+           self.embed_dim, self.seq_len = embed_dim, seq_len
+
+       # --- the captured inner region ---
+       def _block_loop(self, static_inputs, static_cm=None, *, n_layers):
+           x = static_inputs["x"]          # READ, never reassign the dict entries
+           pos = static_inputs["pos"]
+           for i in range(n_layers):
+               if static_cm is not None:
+                   static_cm.set_layer_idx(i)
+               x = self.blocks[i](x, pos=pos, cache_handle=static_cm)
+           return {"x": x}
+
+       # --- declare the graph ---
+       def get_piecewise_cuda_graph_configs(self, device, autocast_dtype, tp_world_size=1):
+           def make_static_inputs(shape: PiecewiseCaptureShape):
+               return {
+                   "x":   torch.zeros(shape.bs, self.seq_len, self.embed_dim,
+                                      dtype=autocast_dtype, device=device),
+                   "pos": torch.zeros(self.seq_len, dtype=torch.float32, device=device),
+               }
+           return {
+               "block_loop": PiecewiseBatchedConfig(
+                   capture_fn=self._block_loop,
+                   make_static_inputs=make_static_inputs,
+                   seq_len=self.seq_len,
+                   forward_kwargs={"n_layers": len(self.blocks)},
+                   uses_kv_cache=True,
+                   cache_labels=["main"],
+                   capture_batch_sizes=[1, 2, 4, 8],
+               )
+           }
+
+       # --- invoke it inside the forward ---
+       def forward(self, graph_walk, engine_inputs, hidden, **kwargs):
+           x = self.embed(hidden)                              # eager preamble → [B, seq_len, D]
+           pos = self._positions(x.device)                    # hoisted out of the graph
+           runner = engine_inputs.piecewise_runners.get("block_loop")
+           if runner is not None and runner.can_run(x.size(0)):
+               out = runner.run(                              # plans + replays + advances
+                   static_inputs={"x": x, "pos": pos},
+                   request_ids=engine_inputs.request_ids,
+               )
+               x = out["x"]                                   # owned clone, [B, seq_len, D]
+           else:                                              # eager fallback (no capture)
+               cm = engine_inputs.cache_manager
+               x = self._block_loop({"x": x, "pos": pos}, cm,
+                                    n_layers=len(self.blocks))["x"]
+               cm.advance_seq_lens()
+           return {"pred": self.proj(x)}                      # eager postamble
+
+Notes carried by the example: positions are computed eagerly and passed through
+``static_inputs`` (so they are not re-derived inside the captured region); the same
+``_block_loop`` serves both the captured and eager paths, so there is one source of
+truth; and on the eager path *you* own attention planning (typically in ``preprocess``)
+and the ``advance_seq_lens`` call — the runner only performs those on the captured path.
+For a real, KV-cached instance see the V-JEPA2 AC predictor
+(``mstar/model/vjepa2/submodules.py``, label ``"block_loop"``).
+
 Step 6 — Choose engine types
 ----------------------------
 

--- a/mstar/engine/cuda_graph_config.py
+++ b/mstar/engine/cuda_graph_config.py
@@ -180,6 +180,12 @@ class PiecewiseCudaGraphConfig(ABC):
     #     seq_lens for BATCHED, packed indptr for PACKED).
     uses_kv_cache: bool = False
     plan_fn: Callable[["BatchedCacheManager", PiecewiseCaptureShape], None] | None = None
+    # Whether the runner advances cache seq_lens (Python-only, post-replay) after
+    # each ``run``. True suits the common case where the captured region consumes
+    # its planned tokens once per step. Set False when the caller advances the
+    # cache itself (e.g. a custom position-id scheme). No effect when
+    # ``uses_kv_cache`` is False.
+    advance_seq_lens: bool = True
     cache_labels: list[str] = field(default_factory=lambda: ["main"])
     # None => defer to the runner's default batch-size buckets.
     capture_batch_sizes: list[int] | None = None

--- a/mstar/engine/cuda_graph_config.py
+++ b/mstar/engine/cuda_graph_config.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from enum import Enum
+from typing import TYPE_CHECKING, Any, Callable
 
 import torch
 
 from mstar.model.submodule_base import ARNodeInputs
+
+if TYPE_CHECKING:
+    from mstar.engine.cache_manager import BatchedCacheManager
 
 
 class CudaGraphConfigType(Enum):
@@ -101,3 +107,141 @@ class FlashInferPackedCudaGraphConfig(CudaGraphConfig):
 
     def get_total_tokens(self, bs: int) -> list[int]:
         return list(self.num_token_to_inputs.keys())
+
+
+# ---------------------------------------------------------------------------
+# Piecewise CUDA graph configs
+#
+# These configure ``PiecewiseCudaGraphRunner``, which captures ONE inner
+# callable of a submodule's forward (e.g. a transformer block loop) as a CUDA
+# graph while the surrounding preamble/postamble stays eager. They intentionally
+# mirror the ``BASIC_BATCHED`` / ``FLASH_INFER_PACKED`` split above so the two
+# runners share vocabulary:
+#   - ``BATCHED`` captures ``[bs, seq_len, D]`` inputs, all sequences equal length.
+#   - ``PACKED`` captures ``[total_tokens, D]`` inputs, variable-length sequences
+#     packed together (FlashInfer-packed style).
+# ---------------------------------------------------------------------------
+
+
+def distribute_tokens(total_tokens: int, bs: int) -> list[int]:
+    """Split ``total_tokens`` across ``bs`` requests, remainder on the first.
+
+    Used to synthesize per-request capture-time seq_lens for a PACKED bucket
+    (the runner only needs *a* valid partition to plan the dummy attention; the
+    real per-request seq_lens arrive through ``PiecewiseCudaGraphRunner.run``).
+    Mirrors ``CudaGraphRunner._make_dummy_seq_lens`` so both paths partition the
+    same way.
+    """
+    seq_lens = [total_tokens // bs] * bs
+    seq_lens[0] += total_tokens % bs
+    return seq_lens
+
+
+class PiecewiseConfigType(Enum):
+    BATCHED = "batched"          # [bs, seq_len, D], uniform seq_lens
+    PACKED = "packed"            # [total_tokens, D], variable seq_lens via indptr
+
+
+@dataclass
+class PiecewiseCaptureShape:
+    """One capture bucket.
+
+    Handed to the static-input factory (``make_static_inputs``) and the plan
+    hook (``plan_fn``) so both generalize across config types.
+    """
+    bs: int
+    seq_lens: list[int]          # per-request lengths (uniform for BATCHED,
+                                 # an arbitrary partition of total_tokens for PACKED)
+    total_tokens: int            # sum(seq_lens); == bs * seq_len for BATCHED
+
+
+@dataclass(kw_only=True)
+class PiecewiseCudaGraphConfig(ABC):
+    """Base config for a single piecewise-captured callable.
+
+    ``kw_only`` so subclasses can add required fields (e.g. ``seq_len``) without
+    colliding with the defaulted fields declared here.
+    """
+    # (1) function that gets captured. Contract:
+    #     capture_fn(static_inputs: dict[str, Tensor],
+    #                static_cm: BatchedCacheManager | None = None,
+    #                **forward_kwargs) -> dict[str, Tensor]
+    # It must READ tensors out of ``static_inputs`` (never reassign them) so the
+    # runner-owned buffers stay the ones captured into the graph.
+    capture_fn: Callable[..., dict[str, torch.Tensor]]
+    # (2) factory: shape -> the static input buffers the runner will own + copy
+    #     real inputs into before each replay.
+    make_static_inputs: Callable[[PiecewiseCaptureShape], dict[str, torch.Tensor]]
+    # (3) static kwargs threaded into capture_fn (e.g. cond_tokens, is_causal).
+    forward_kwargs: dict[str, Any] = field(default_factory=dict)
+    # (4) attention planning. When ``uses_kv_cache`` is True the runner plans a
+    #     FlashInfer wrapper outside the graph before each replay: via
+    #     ``plan_fn(static_cm, shape)`` if given, else a type-default (uniform
+    #     seq_lens for BATCHED, packed indptr for PACKED).
+    uses_kv_cache: bool = False
+    plan_fn: Callable[["BatchedCacheManager", PiecewiseCaptureShape], None] | None = None
+    cache_labels: list[str] = field(default_factory=lambda: ["main"])
+    # None => defer to the runner's default batch-size buckets.
+    capture_batch_sizes: list[int] | None = None
+    # Whether to torch.compile capture_fn before capture. Default off; the block
+    # loop already benefits from graph capture alone.
+    compile: bool = False
+
+    @abstractmethod
+    def get_config_type(self) -> PiecewiseConfigType:
+        ...
+
+    @abstractmethod
+    def get_capture_shapes(self, batch_sizes: list[int]) -> list[PiecewiseCaptureShape]:
+        """Enumerate the (bs, seq_lens, total_tokens) buckets to capture.
+
+        ``batch_sizes`` is the resolved list the runner will iterate
+        (``capture_batch_sizes`` or the runner default).
+        """
+        ...
+
+
+@dataclass(kw_only=True)
+class PiecewiseBatchedConfig(PiecewiseCudaGraphConfig):
+    """Equal-length batched capture: static input ``[bs, seq_len, D]``."""
+    seq_len: int                 # tokens per request
+
+    def get_config_type(self) -> PiecewiseConfigType:
+        return PiecewiseConfigType.BATCHED
+
+    def get_capture_shapes(self, batch_sizes: list[int]) -> list[PiecewiseCaptureShape]:
+        return [
+            PiecewiseCaptureShape(
+                bs=bs,
+                seq_lens=[self.seq_len] * bs,
+                total_tokens=self.seq_len * bs,
+            )
+            for bs in batch_sizes
+        ]
+
+
+@dataclass(kw_only=True)
+class PiecewisePackedConfig(PiecewiseCudaGraphConfig):
+    """Packed variable-length capture: static input ``[total_tokens, D]``.
+
+    Captures one graph per (bs, token-bucket). Each token bucket in
+    ``total_tokens`` is partitioned across ``bs`` requests for the capture-time
+    dummy plan; real per-request seq_lens arrive through ``run``.
+    """
+    total_tokens: list[int]      # token-count buckets to capture
+
+    def get_config_type(self) -> PiecewiseConfigType:
+        return PiecewiseConfigType.PACKED
+
+    def get_capture_shapes(self, batch_sizes: list[int]) -> list[PiecewiseCaptureShape]:
+        shapes: list[PiecewiseCaptureShape] = []
+        for bs in batch_sizes:
+            for tt in self.total_tokens:
+                shapes.append(
+                    PiecewiseCaptureShape(
+                        bs=bs,
+                        seq_lens=distribute_tokens(tt, bs),
+                        total_tokens=tt,
+                    )
+                )
+        return shapes

--- a/mstar/engine/cuda_graph_runner.py
+++ b/mstar/engine/cuda_graph_runner.py
@@ -2683,8 +2683,13 @@ class PiecewiseCudaGraphRunner:
 
         # --- 4: advance seq_lens (Python-only, post-replay) ---
         # Uses the per-request lengths planned in step 2, so this is correct for
-        # both uniform (BATCHED) and variable (PACKED) sequences.
-        if static_cm is not None and request_ids is not None:
+        # both uniform (BATCHED) and variable (PACKED) sequences. Opt out via
+        # config.advance_seq_lens=False when the caller advances the cache itself.
+        if (
+            self.config.advance_seq_lens
+            and static_cm is not None
+            and request_ids is not None
+        ):
             for label in self.cache_labels:
                 static_cm.set_active_label(label)
                 static_cm.advance_seq_lens()

--- a/mstar/engine/cuda_graph_runner.py
+++ b/mstar/engine/cuda_graph_runner.py
@@ -32,6 +32,9 @@ from mstar.engine.cuda_graph_config import (
     CudaGraphConfig,
     CudaGraphConfigType,
     FlashInferPackedCudaGraphConfig,
+    PiecewiseCaptureShape,
+    PiecewiseConfigType,
+    PiecewiseCudaGraphConfig,
 )
 from mstar.engine.kv_store import KVCacheConfig, PagedAllocationManager
 from mstar.model.submodule_base import ARNodeInputs, ARNodeSubmodule, ModelInputsFromEngine, NodeSubmodule
@@ -71,13 +74,21 @@ class CudaGraphSlot:
 
 @dataclass
 class PiecewiseGraphData:
+    """One captured piecewise graph + the runner-owned buffers it replays into.
+
+    Keyed by ``(bs, total_tokens)`` in ``PiecewiseCudaGraphRunner.graphs``.
+    ``static_inputs`` holds every buffer the captured region reads (hidden
+    state, position tensors, ...) — the runner copies real inputs into these
+    by name before each replay. ``static_outputs`` are the captured graph's
+    outputs, sliced to the real leading count and returned via
+    ``PiecewiseOutput``.
+    """
     graph: torch.cuda.CUDAGraph
-    static_x: torch.Tensor                          # [bs, seq_len, embed_dim]
-    static_out: torch.Tensor                        # same shape — graph output
-    static_pos_bufs: dict[str, torch.Tensor]        # updated via .copy_() before each replay
+    static_inputs: dict[str, torch.Tensor]
+    static_outputs: dict[str, torch.Tensor]
     static_cache_manager: BatchedCacheManager | None
     dummy_rids: list[str]
-    bs: int
+    shape: PiecewiseCaptureShape
 
 @dataclass
 class CudaGraphData:
@@ -2228,66 +2239,125 @@ class StatelessCudaGraphRunner:
 # PiecewiseCudaGraphRunner
 # ---------------------------------------------------------------------------
 
-class PiecewiseCudaGraphRunner:
-    """Captures a transformer block-loop callable as one CUDA graph per batch-size bucket.
+class PiecewiseOutput:
+    """Dict-like view over a captured piecewise graph's output buffers.
 
-    Designed for the inner block loops of VJepa2 predictors
-    (VisionTransformerPredictorAC with KV cache, and VJEPA2Predictor without).
-    The caller supplies a ``fn_factory`` that builds the capturable
-    ``fn(x) -> x`` closure given a static BatchedCacheManager and a dict of
-    pre-allocated position-tensor buffers.  The runner owns those buffers;
-    callers update them via ``.copy_()`` through the ``pos_bufs`` argument of
-    ``run()``, making per-step position tensors visible to the captured GPU ops
-    without creating new tensors inside the captured region.
+    The runner replays into persistent buffers sized for the padded bucket;
+    only the leading ``real_len`` rows are meaningful (``real_bs`` for BATCHED
+    configs, the real total-token count for PACKED). Indexing and ``get``
+    return an owned CLONE of that leading slice — safe to keep past the next
+    replay. ``get_view`` returns the same slice WITHOUT copying.
+    """
+    __slots__ = ("_outputs", "_real_len")
+
+    def __init__(self, outputs: dict[str, torch.Tensor], real_len: int):
+        self._outputs = outputs
+        self._real_len = real_len
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._outputs
+
+    def keys(self):
+        return self._outputs.keys()
+
+    def __getitem__(self, key: str) -> torch.Tensor:
+        return self._outputs[key][:self._real_len].clone()
+
+    def get(self, key: str, default=None):
+        v = self._outputs.get(key)
+        if v is None:
+            return default
+        return v[:self._real_len].clone()
+
+    def get_view(self, key: str, default=None):
+        """Return the leading ``real_len`` slice WITHOUT copying.
+
+        The result is a VIEW aliasing the runner-owned static output buffer:
+        it shares graph memory and is OVERWRITTEN by the next ``run()`` replay.
+        Use it only for immediate reads within the same step; never store it
+        across replays or hand it to code that outlives the step. Use ``get``
+        / indexing when you need an owned tensor.
+        """
+        v = self._outputs.get(key)
+        if v is None:
+            return default
+        return v[:self._real_len]
+
+
+class PiecewiseCudaGraphRunner:
+    """Captures one inner callable of a submodule's forward as a CUDA graph.
+
+    Unlike ``CudaGraphRunner`` (which replays a whole ``forward_batched`` under
+    engine control, with sampling / CFG / double-buffer / output remap), this
+    captures a SUB-REGION of a forward — e.g. a transformer block loop — while
+    the surrounding preamble/postamble stays eager and the submodule itself
+    invokes ``run()``. It is configured entirely by a
+    ``PiecewiseCudaGraphConfig`` (see ``cuda_graph_config.py``):
+
+    - ``config.make_static_inputs(shape)`` allocates the persistent buffers the
+      captured region reads. The runner owns them; ``run`` copies real inputs
+      into them by name before each replay.
+    - ``config.capture_fn(static_inputs, static_cm, **forward_kwargs)`` is the
+      captured callable; it READS from ``static_inputs`` (never reassigns) and
+      returns a ``dict[str, Tensor]``.
+    - ``config.uses_kv_cache`` / ``config.plan_fn`` drive attention planning
+      (BATCHED: uniform seq_lens; PACKED: variable seq_lens via indptr).
+
+    One graph is captured per ``(bs, total_tokens)`` bucket enumerated by
+    ``config.get_capture_shapes``.
 
     Key invariants (matching CudaGraphRunner):
-    - FlashInfer wrappers are PERSISTENT (created once per bs bucket at capture).
+    - FlashInfer wrappers are PERSISTENT (created once per bucket at capture).
     - plan_attention is called OUTSIDE the graph before each replay.
-    - advance_seq_len is called OUTSIDE the graph after each replay.
+    - advance_seq_lens is called OUTSIDE the graph after each replay.
     - KV state is swapped onto dummy slots before replay and restored after.
     """
 
+    DEFAULT_CAPTURE_BATCH_SIZES = DEFAULT_AR_CAPTURE_BATCH_SIZES
+
     def __init__(
         self,
-        fn_factory: Callable[
-            [BatchedCacheManager | None, dict[str, torch.Tensor]],
-            Callable[[torch.Tensor], torch.Tensor],
-        ],
-        embed_dim: int,
-        capture_batch_sizes: list[int],
-        capture_seq_len: int,
+        config: PiecewiseCudaGraphConfig,
         device: torch.device,
         autocast_dtype: torch.dtype,
-        pos_buf_shapes: dict[str, tuple[int, ...]] | None = None,
         kv_cache_config: KVCacheConfig | None = None,
         alloc_manager: PagedAllocationManager | None = None,
         buffer_manager: WorkspaceBufferManager | None = None,
-        cache_labels: list[str] | None = None,
         tp_group=None,
     ):
         from mstar.distributed.communication import TPCommGroup
 
-        self.fn_factory = fn_factory
-        self.embed_dim = embed_dim
-        self.capture_batch_sizes = sorted(capture_batch_sizes)
-        self.capture_seq_len = capture_seq_len
+        self.config = config
         self.device = device
         self.autocast_dtype = autocast_dtype
-        self.pos_buf_shapes: dict[str, tuple[int, ...]] = pos_buf_shapes or {}
         self.kv_cache_config = kv_cache_config
         self.alloc_manager = alloc_manager
         self.buffer_manager = buffer_manager
-        self.cache_labels: list[str] = cache_labels or ["main"]
-        # ``tp_group`` is the per-node TP comm group. Defaults to the
-        # trivial single-rank group so the runner behaves identically for
-        # non-TP submodules (V-JEPA2 today). When ``world_size > 1`` the
-        # captured block-loop closure may include NCCL collectives via
-        # parallel layers — ``warmup_and_capture`` barriers before each
-        # per-bs capture to keep ranks in lockstep (the same race the
-        # standard ``CudaGraphRunner`` guards against).
+        # ``tp_group`` is the per-node TP comm group. Defaults to the trivial
+        # single-rank group so the runner behaves identically for non-TP
+        # submodules. When ``world_size > 1`` the captured region may include
+        # NCCL collectives via parallel layers — ``warmup_and_capture`` barriers
+        # before each capture to keep ranks in lockstep (same race the standard
+        # ``CudaGraphRunner`` guards against).
         self.tp_group: TPCommGroup = tp_group or TPCommGroup.trivial()
 
-        self.graphs: dict[int, PiecewiseGraphData] = {}
+        self.capture_batch_sizes = sorted(
+            config.capture_batch_sizes or self.DEFAULT_CAPTURE_BATCH_SIZES
+        )
+        self.cache_labels: list[str] = config.cache_labels
+
+        if config.uses_kv_cache:
+            assert (
+                kv_cache_config is not None
+                and alloc_manager is not None
+                and buffer_manager is not None
+            ), (
+                "PiecewiseCudaGraphRunner: config.uses_kv_cache=True requires "
+                "kv_cache_config, alloc_manager and buffer_manager"
+            )
+
+        # (bs, total_tokens) -> captured graph data.
+        self.graphs: dict[tuple[int, int], PiecewiseGraphData] = {}
         self.memory_pool = None
 
     # ------------------------------------------------------------------
@@ -2302,107 +2372,109 @@ class PiecewiseCudaGraphRunner:
         torch.cuda.set_device(self.device)
         self.memory_pool = torch.cuda.graphs.graph_pool_handle()
 
-        for bs in reversed(self.capture_batch_sizes):
-            # Sync TP ranks before each capture so a faster rank doesn't
-            # enter the warmup forward and issue NCCL while a slower one
-            # is still in pre-capture setup. No-op for trivial groups.
+        shapes = self.config.get_capture_shapes(self.capture_batch_sizes)
+        # Largest bucket first, matching CudaGraphRunner's capture ordering.
+        for shape in sorted(
+            shapes, key=lambda s: (s.bs, s.total_tokens), reverse=True
+        ):
+            # Sync TP ranks before each capture so a faster rank doesn't enter
+            # the warmup forward and issue NCCL while a slower one is still in
+            # pre-capture setup. No-op for trivial groups.
             self.tp_group.barrier()
             try:
-                self._capture_one(bs)
-                logger.info("PiecewiseCudaGraphRunner: captured bs=%d seq_len=%d", bs, self.capture_seq_len)
+                self._capture_one(shape)
+                logger.info(
+                    "PiecewiseCudaGraphRunner: captured bs=%d total_tokens=%d",
+                    shape.bs, shape.total_tokens,
+                )
             except Exception:
                 logger.warning(
-                    "PiecewiseCudaGraphRunner: failed to capture bs=%d", bs, exc_info=True
+                    "PiecewiseCudaGraphRunner: failed to capture bs=%d total_tokens=%d",
+                    shape.bs, shape.total_tokens, exc_info=True,
                 )
 
-    def _capture_one(self, bs: int) -> None:
-        # Match autocast_dtype so copy_() at replay is a same-dtype memcpy
-        # (no silent upcast from bfloat16 → float32 followed by an immediate
-        # cast back inside the first linear).
-        static_x = torch.zeros(
-            bs, self.capture_seq_len, self.embed_dim,
-            dtype=self.autocast_dtype, device=self.device,
-        )
+    def _capture_one(self, shape: PiecewiseCaptureShape) -> None:
+        static_inputs = self.config.make_static_inputs(shape)
+        static_cm, dummy_rids = self._setup_cache_manager(shape)
 
-        # Position buffers stay float32: they hold scalar position indices
-        # (frame id, height id, ...) and RoPE uses them as frequencies, where
-        # float32 precision matters more than matching the hidden state dtype.
-        static_pos_bufs: dict[str, torch.Tensor] = {
-            name: torch.zeros(shape, dtype=torch.float32, device=self.device)
-            for name, shape in self.pos_buf_shapes.items()
-        }
-
-        # KV cache support
-        static_cm: BatchedCacheManager | None = None
-        dummy_rids: list[str] = []
-        if self.kv_cache_config is not None:
-            assert self.alloc_manager is not None and self.buffer_manager is not None
-            dummy_rids = [f"__pcgr_{bs}_{i}__" for i in range(bs)]
-            for rid in dummy_rids:
-                self.alloc_manager.add_request(rid, labels=self.cache_labels)
-
-            plan_states = self._build_persistent_wrappers(bs)
-            static_cm = BatchedCacheManager(
-                request_ids=dummy_rids,
-                active_labels_per_request={rid: self.cache_labels[0] for rid in dummy_rids},
-                kv_cache=self.alloc_manager.kv_cache,
-                alloc_manager=self.alloc_manager,
-                buffer_manager=self.buffer_manager,
-                kv_cache_config=self.kv_cache_config,
-                device=self.device,
-                cuda_graph_plan_states=plan_states,
+        fn = self.config.capture_fn
+        if self.config.compile:
+            fn = torch.compile(
+                fn,
+                mode="max-autotune-no-cudagraphs",
+                fullgraph=False,
+                dynamic=False,
             )
 
-        fn = self.fn_factory(static_cm, static_pos_bufs)
+        def run_fn():
+            return fn(
+                static_inputs=static_inputs,
+                static_cm=static_cm,
+                **self.config.forward_kwargs,
+            )
 
-        def _plan():
+        def plan():
             if static_cm is not None:
-                static_cm.plan_attention(
-                    seq_lens=[self.capture_seq_len] * bs,
-                    is_causal=False,
-                )
+                self._plan(static_cm, shape)
 
-        def _reset_dummy_states():
-            for rid in dummy_rids:
-                for label in self.cache_labels:
-                    state = self.alloc_manager.get_state(rid, label)
-                    state.seq_len = 0
-                    state.position_id_start = 0
+        plan()
 
-        _plan()
-
-        # Warmup — 2 passes
+        # Warmup — 2 passes, resetting dummy state + re-planning between them so
+        # capture starts from a clean state (mirrors CudaGraphRunner).
         torch.cuda.synchronize()
         for _ in range(2):
             with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
-                fn(static_x)
-            _reset_dummy_states()
-            _plan()
+                run_fn()
+            self._reset_dummy_states(dummy_rids)
+            plan()
         torch.cuda.synchronize()
 
-        # Capture
         graph = torch.cuda.CUDAGraph()
         with torch.amp.autocast("cuda", enabled=True, dtype=self.autocast_dtype):
             with torch.cuda.graph(graph, pool=self.memory_pool):
-                static_out = fn(static_x)
+                static_out = self._normalize_output(run_fn())
         torch.cuda.synchronize()
 
-        # Free dummy KV state so it doesn't accumulate across bs captures
+        # Free dummy KV state so it doesn't accumulate across buckets.
         for rid in dummy_rids:
             for label in self.cache_labels:
                 self.alloc_manager.reset_label(rid, label, free=True)
 
-        self.graphs[bs] = PiecewiseGraphData(
+        self.graphs[(shape.bs, shape.total_tokens)] = PiecewiseGraphData(
             graph=graph,
-            static_x=static_x,
-            static_out=static_out,
-            static_pos_bufs=static_pos_bufs,
+            static_inputs=static_inputs,
+            static_outputs=static_out,
             static_cache_manager=static_cm,
             dummy_rids=dummy_rids,
-            bs=bs,
+            shape=shape,
         )
 
-    def _build_persistent_wrappers(self, bs: int) -> dict:
+    def _setup_cache_manager(
+        self, shape: PiecewiseCaptureShape,
+    ) -> tuple[BatchedCacheManager | None, list[str]]:
+        if not self.config.uses_kv_cache:
+            return None, []
+
+        dummy_rids = [
+            f"__pcgr_{shape.bs}_{shape.total_tokens}_{i}__" for i in range(shape.bs)
+        ]
+        for rid in dummy_rids:
+            self.alloc_manager.add_request(rid, labels=self.cache_labels)
+
+        plan_states = self._build_persistent_wrappers(shape)
+        static_cm = BatchedCacheManager(
+            request_ids=dummy_rids,
+            active_labels_per_request={rid: self.cache_labels[0] for rid in dummy_rids},
+            kv_cache=self.alloc_manager.kv_cache,
+            alloc_manager=self.alloc_manager,
+            buffer_manager=self.buffer_manager,
+            kv_cache_config=self.kv_cache_config,
+            device=self.device,
+            cuda_graph_plan_states=plan_states,
+        )
+        return static_cm, dummy_rids
+
+    def _build_persistent_wrappers(self, shape: PiecewiseCaptureShape) -> dict:
         from mstar.engine.cache_manager import _PlanState
         from mstar.utils.flashinfer_utils import FlashInferPrefillWrapper
 
@@ -2410,13 +2482,15 @@ class PiecewiseCudaGraphRunner:
         plan_states: dict = {}
         for label in self.cache_labels:
             wrapper = FlashInferPrefillWrapper(
-                workspace_buffer=self.buffer_manager.get(f"{label}_pcgr_{bs}"),
+                workspace_buffer=self.buffer_manager.get(
+                    f"{label}_pcgr_{shape.bs}_{shape.total_tokens}"
+                ),
                 num_qo_heads=cfg.num_qo_heads,
                 num_kv_heads=cfg.num_kv_heads,
                 head_dim=cfg.head_dim,
                 page_size=cfg.page_size,
-                batch_size=bs,
-                max_total_tokens=bs * self.capture_seq_len,
+                batch_size=shape.bs,
+                max_total_tokens=shape.total_tokens,
                 max_num_pages=cfg.max_num_pages,
                 device=self.device,
                 use_cuda_graph=True,
@@ -2424,12 +2498,63 @@ class PiecewiseCudaGraphRunner:
             plan_states[label] = _PlanState(wrapper=wrapper)
         return plan_states
 
+    def _plan(
+        self,
+        static_cm: BatchedCacheManager,
+        shape: PiecewiseCaptureShape,
+        seq_lens: list[int] | None = None,
+    ) -> None:
+        """Plan attention outside the graph for capture or replay.
+
+        ``seq_lens`` overrides ``shape.seq_lens`` (used at replay to plan the
+        real per-request lengths). A custom ``config.plan_fn`` receives a shape
+        carrying the effective seq_lens; the type-default plans every cache
+        label with those seq_lens (``is_causal`` read from forward_kwargs).
+        """
+        effective = list(seq_lens) if seq_lens is not None else shape.seq_lens
+        if self.config.plan_fn is not None:
+            self.config.plan_fn(
+                static_cm,
+                PiecewiseCaptureShape(
+                    bs=shape.bs, seq_lens=effective, total_tokens=sum(effective),
+                ),
+            )
+            return
+        is_causal = self.config.forward_kwargs.get("is_causal", False)
+        for label in self.cache_labels:
+            static_cm.plan_attention(
+                seq_lens=effective, is_causal=is_causal, label=label,
+            )
+
+    def _reset_dummy_states(self, dummy_rids: list[str]) -> None:
+        for rid in dummy_rids:
+            for label in self.cache_labels:
+                state = self.alloc_manager.get_state(rid, label)
+                state.seq_len = 0
+                state.position_id_start = 0
+
+    @staticmethod
+    def _normalize_output(out) -> dict[str, torch.Tensor]:
+        """Coerce a captured callable's return into a ``{name: Tensor}`` dict.
+
+        The contract is a dict, but a bare tensor is accepted (wrapped under
+        ``"x"``) so a single-output block loop can ``return x`` directly.
+        """
+        if isinstance(out, torch.Tensor):
+            return {"x": out}
+        if isinstance(out, dict):
+            return out
+        raise TypeError(
+            f"PiecewiseCudaGraphRunner: capture_fn must return a Tensor or "
+            f"dict[str, Tensor], got {type(out).__name__}"
+        )
+
     # ------------------------------------------------------------------
     # Runtime
     # ------------------------------------------------------------------
 
-    def can_run(self, batch_size: int) -> bool:
-        return bool(self.graphs) and self._padded_bs(batch_size) is not None
+    def can_run(self, batch_size: int, total_tokens: int | None = None) -> bool:
+        return bool(self.graphs) and self._resolve_key(batch_size, total_tokens) is not None
 
     def _padded_bs(self, batch_size: int) -> int | None:
         idx = bisect.bisect_left(self.capture_batch_sizes, batch_size)
@@ -2437,67 +2562,188 @@ class PiecewiseCudaGraphRunner:
             return None
         return self.capture_batch_sizes[idx]
 
+    def _resolve_key(
+        self, batch_size: int, total_tokens: int | None = None,
+    ) -> tuple[int, int] | None:
+        """Find the captured ``(bs, total_tokens)`` bucket serving this request.
+
+        BATCHED: ``total_tokens`` is determined by ``seq_len * padded_bs``.
+        PACKED: pick the smallest captured token bucket >= ``total_tokens`` for
+        the padded batch size (caller must pass ``total_tokens``).
+        """
+        padded_bs = self._padded_bs(batch_size)
+        if padded_bs is None:
+            return None
+
+        if self.config.get_config_type() == PiecewiseConfigType.BATCHED:
+            key = (padded_bs, self.config.seq_len * padded_bs)
+            return key if key in self.graphs else None
+
+        if total_tokens is None:
+            return None
+        candidates = sorted(tt for (bs, tt) in self.graphs if bs == padded_bs)
+        idx = bisect.bisect_left(candidates, total_tokens)
+        if idx >= len(candidates):
+            return None
+        return (padded_bs, candidates[idx])
+
+    def _replay_seq_lens(
+        self,
+        shape: PiecewiseCaptureShape,
+        seq_lens: list[int] | None,
+        real_bs: int,
+    ) -> list[int]:
+        """Per-request seq_lens to plan at replay, padded to ``shape.bs``.
+
+        BATCHED: uniform ``shape.seq_lens`` (real + padding all capture-length,
+        matching capture). PACKED: real ``seq_lens`` + zero-length padding rows
+        so the planned qo_indptr sums to the real token count and FlashInfer
+        skips the padded tail.
+        """
+        if self.config.get_config_type() == PiecewiseConfigType.BATCHED:
+            return list(shape.seq_lens)
+        if seq_lens is None:
+            raise ValueError(
+                "PiecewiseCudaGraphRunner.run: PACKED config requires seq_lens"
+            )
+        return list(seq_lens) + [0] * (shape.bs - real_bs)
+
     def run(
         self,
-        x: torch.Tensor,                                    # [real_bs, seq_len, D]
-        pos_bufs: dict[str, torch.Tensor] | None = None,   # updated into static buffers
+        static_inputs: dict[str, torch.Tensor],
         request_ids: list[str] | None = None,
-        ) -> torch.Tensor:
-        """Replay the captured graph for the given input.
+        seq_lens: list[int] | None = None,
+        real_bs: int | None = None,
+    ) -> PiecewiseOutput:
+        """Replay the captured graph for the given real inputs.
 
         Steps (mirroring CudaGraphRunner._run_basic_batched):
-          1. Copy real x into static buffer.
-          2. Update position buffers via .copy_().
-          3. Swap real KV states onto dummy slots + plan_attention.
-          4. graph.replay().
-          5. advance_seq_len (Python-only, outside graph).
-          6. Restore dummy states.
-          7. Return static_out[:real_bs].clone().
+          1. Copy each real input tensor into the runner-owned static buffer of
+             the same name (zeroing any padded tail).
+          2. Swap real KV states onto dummy slots + plan_attention (if KV).
+          3. graph.replay().
+          4. advance_seq_lens (Python-only, outside graph).
+          5. Restore dummy states.
+          6. Return a ``PiecewiseOutput`` over the captured output buffers.
+
+        ``real_bs`` is inferred from ``request_ids`` or ``seq_lens`` when not
+        given. PACKED configs require ``seq_lens`` (used for both the token
+        bucket lookup and attention planning).
         """
-        real_bs = x.size(0)
-        padded_bs = self._padded_bs(real_bs)
-        if padded_bs is None:
+        if real_bs is None:
+            if request_ids is not None:
+                real_bs = len(request_ids)
+            elif seq_lens is not None:
+                real_bs = len(seq_lens)
+            else:
+                raise ValueError(
+                    "PiecewiseCudaGraphRunner.run: pass real_bs, request_ids, "
+                    "or seq_lens to determine the batch size"
+                )
+
+        is_packed = self.config.get_config_type() == PiecewiseConfigType.PACKED
+        real_total_tokens = sum(seq_lens) if seq_lens is not None else None
+        key = self._resolve_key(
+            real_bs, real_total_tokens if is_packed else None
+        )
+        if key is None:
             raise RuntimeError(
-                f"PiecewiseCudaGraphRunner: no captured graph for bs={real_bs}"
+                f"PiecewiseCudaGraphRunner: no captured graph for bs={real_bs}, "
+                f"total_tokens={real_total_tokens}"
             )
-        data = self.graphs[padded_bs]
+        data = self.graphs[key]
 
-        # --- 1: copy input ---
-        data.static_x[:real_bs].copy_(x)
-        if real_bs < padded_bs:
-            data.static_x[real_bs:].zero_()
+        # --- 1: copy real inputs into runner-owned static buffers ---
+        for name, val in static_inputs.items():
+            buf = data.static_inputs.get(name)
+            if buf is None or not isinstance(val, torch.Tensor):
+                continue
+            n = val.shape[0]
+            buf[:n].copy_(val)
+            if n < buf.shape[0]:
+                buf[n:].zero_()
 
-        # --- 2: update position buffers ---
-        if pos_bufs:
-            for name, val in pos_bufs.items():
-                if name in data.static_pos_bufs:
-                    data.static_pos_bufs[name].copy_(val)
-
-        # --- 3: KV state swap + plan_attention ---
-        if data.static_cache_manager is not None and request_ids is not None:
+        # --- 2: KV state swap + plan_attention ---
+        static_cm = data.static_cache_manager
+        if static_cm is not None and request_ids is not None:
             for i, rid in enumerate(request_ids):
                 dummy_rid = data.dummy_rids[i]
                 for label in self.cache_labels:
                     real_state = self.alloc_manager.get_state(rid, label)
-                    self.alloc_manager.get_state(dummy_rid, label)   # ensure slot exists
+                    self.alloc_manager.get_state(dummy_rid, label)  # ensure slot exists
                     self.alloc_manager.request_states[dummy_rid][label] = real_state
-            data.static_cache_manager.plan_attention(
-                seq_lens=[self.capture_seq_len] * padded_bs,
-                is_causal=False,
+            self._plan(
+                static_cm,
+                data.shape,
+                seq_lens=self._replay_seq_lens(data.shape, seq_lens, real_bs),
             )
 
-        # --- 4: replay ---
+        # --- 3: replay ---
         data.graph.replay()
 
-        # --- 5: advance seq_len (Python-only, post-replay) ---
-        if data.static_cache_manager is not None and request_ids is not None:
-            data.static_cache_manager.advance_seq_len(n=self.capture_seq_len)
+        # --- 4: advance seq_lens (Python-only, post-replay) ---
+        # Uses the per-request lengths planned in step 2, so this is correct for
+        # both uniform (BATCHED) and variable (PACKED) sequences.
+        if static_cm is not None and request_ids is not None:
+            for label in self.cache_labels:
+                static_cm.set_active_label(label)
+                static_cm.advance_seq_lens()
 
-        # --- 6: restore dummy states ---
-        if data.static_cache_manager is not None and request_ids is not None:
+        # --- 5: restore dummy states ---
+        if static_cm is not None and request_ids is not None:
             for i, dummy_rid in enumerate(data.dummy_rids):
                 for label in self.cache_labels:
                     self.alloc_manager.reset_label(dummy_rid, label, free=i >= real_bs)
 
-        # --- 7: return output ---
-        return data.static_out[:real_bs].clone()
+        # --- 6: return output view ---
+        real_len = real_total_tokens if is_packed else real_bs
+        return PiecewiseOutput(data.static_outputs, real_len)
+
+
+def build_piecewise_runners(
+    submodule: NodeSubmodule,
+    device: torch.device,
+    autocast_dtype: torch.dtype,
+    tp_world_size: int = 1,
+    tp_group=None,
+    kv_cache_config: KVCacheConfig | None = None,
+    alloc_manager: PagedAllocationManager | None = None,
+    buffer_manager: WorkspaceBufferManager | None = None,
+) -> dict[str, PiecewiseCudaGraphRunner]:
+    """Build + warm up one ``PiecewiseCudaGraphRunner`` per label a submodule
+    declares via ``get_piecewise_cuda_graph_configs``.
+
+    Shared by ``KVCacheEngine`` and ``StatelessEngine`` so the install logic
+    lives in one place. KV-cache managers are only forwarded to configs whose
+    ``uses_kv_cache`` is True (stateless callers pass ``None`` for all three).
+    Returns only the runners that captured at least one graph; a submodule that
+    opts into none, or whose capture fails, yields an empty dict (eager path).
+    """
+    configs = submodule.get_piecewise_cuda_graph_configs(
+        device, autocast_dtype, tp_world_size
+    )
+    runners: dict[str, PiecewiseCudaGraphRunner] = {}
+    for label, config in configs.items():
+        try:
+            runner = PiecewiseCudaGraphRunner(
+                config=config,
+                device=device,
+                autocast_dtype=autocast_dtype,
+                kv_cache_config=kv_cache_config if config.uses_kv_cache else None,
+                alloc_manager=alloc_manager if config.uses_kv_cache else None,
+                buffer_manager=buffer_manager if config.uses_kv_cache else None,
+                tp_group=tp_group,
+            )
+            runner.warmup_and_capture()
+            if runner.graphs:
+                runners[label] = runner
+                logger.info(
+                    "build_piecewise_runners: installed label=%r for %s (%d buckets)",
+                    label, type(submodule).__name__, len(runner.graphs),
+                )
+        except Exception:
+            logger.warning(
+                "build_piecewise_runners: capture failed for label=%r on %s, "
+                "using eager path", label, type(submodule).__name__, exc_info=True,
+            )
+    return runners

--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -18,7 +18,11 @@ from mstar.engine.base import (
 )
 from mstar.engine.cache_manager import BatchedCacheManager, WorkspaceBufferManager
 from mstar.engine.cpu_page_pool import CPUPagePool
-from mstar.engine.cuda_graph_runner import CudaGraphRunner
+from mstar.engine.cuda_graph_runner import (
+    CudaGraphRunner,
+    PiecewiseCudaGraphRunner,
+    build_piecewise_runners,
+)
 from mstar.engine.kv_store import (
     AllocationFailedError,
     KVCacheConfig,
@@ -51,6 +55,9 @@ class SubmoduleManagement:
     default_sampling_config: SamplingConfig
     sampler: Sampler = field(default_factory=Sampler)
     cuda_graph_runner: CudaGraphRunner | None = None
+    # label -> PiecewiseCudaGraphRunner for inner-loop capture; spread into
+    # ModelInputsFromEngine so the submodule's forward can look them up.
+    piecewise_runners: dict[str, "PiecewiseCudaGraphRunner"] = field(default_factory=dict)
 
 
 class KVCacheEngine(BaseEngine):
@@ -235,11 +242,7 @@ class KVCacheEngine(BaseEngine):
 
     def warmup(self) -> None:
         """Compile submodules and capture CUDA graphs."""
-        from mstar.engine.cuda_graph_runner import (
-            DEFAULT_AR_CAPTURE_BATCH_SIZES,
-            CudaGraphRunner,
-            PiecewiseCudaGraphRunner,
-        )
+        from mstar.engine.cuda_graph_runner import CudaGraphRunner
 
         for node_name, submodule_mgmt in self.submodule_management.items():
             kv_mgmt = submodule_mgmt.kv_management
@@ -265,31 +268,20 @@ class KVCacheEngine(BaseEngine):
                 logger.info("KVCacheEngine: CUDA graphs captured for %s (%d configs)",
                             node_name, len(runner.graphs))
 
-            # Piecewise CUDA graph for transformer block loops (e.g. VJepa2 AC rollout).
-            # Submodules opt in by implementing get_piecewise_runner_config().
-            pcgr_config = getattr(submodule, "get_piecewise_runner_config", lambda: None)()
-            if pcgr_config is not None:
-                pcgr = PiecewiseCudaGraphRunner(
-                    fn_factory=pcgr_config["fn_factory"],
-                    embed_dim=pcgr_config["embed_dim"],
-                    capture_batch_sizes=pcgr_config.get("capture_batch_sizes", DEFAULT_AR_CAPTURE_BATCH_SIZES),
-                    capture_seq_len=pcgr_config["capture_seq_len"],
-                    device=self.device,
-                    autocast_dtype=self.autocast_dtype,
-                    pos_buf_shapes=pcgr_config.get("pos_buf_shapes"),
-                    kv_cache_config=kv_mgmt.kv_cache_config,
-                    alloc_manager=kv_mgmt.alloc_manager,
-                    buffer_manager=kv_mgmt.buffer_manager,
-                    cache_labels=pcgr_config.get("cache_labels", ["main"]),
-                    tp_group=submodule_mgmt.tp_group,
-                )
-                pcgr.warmup_and_capture()
-                if pcgr.graphs:
-                    submodule.set_piecewise_runner(pcgr)
-                    logger.info(
-                        "KVCacheEngine: PiecewiseCudaGraphRunner installed for %s (%d bs buckets)",
-                        node_name, len(pcgr.graphs),
-                    )
+            # Piecewise CUDA graphs for inner-loop capture (e.g. VJepa2 AC
+            # rollout block loop). Submodules opt in via
+            # get_piecewise_cuda_graph_configs; runners are spread into
+            # ModelInputsFromEngine at execute time.
+            submodule_mgmt.piecewise_runners = build_piecewise_runners(
+                submodule=submodule,
+                device=self.device,
+                autocast_dtype=self.autocast_dtype,
+                tp_world_size=submodule_mgmt.tp_group.world_size,
+                tp_group=submodule_mgmt.tp_group,
+                kv_cache_config=kv_mgmt.kv_cache_config,
+                alloc_manager=kv_mgmt.alloc_manager,
+                buffer_manager=kv_mgmt.buffer_manager,
+            )
 
         # torch.compile applied after CUDA graph capture so compiled kernels
         # are baked into the graphs.
@@ -411,7 +403,8 @@ class KVCacheEngine(BaseEngine):
             request_ids=batch.request_ids,
             per_request_info=batch.per_request_info,
             cache_manager=cache_manager,
-            sampler=sampler
+            sampler=sampler,
+            piecewise_runners=self.submodule_management[batch.node_name].piecewise_runners,
         )
         if self.enable_nvtx:
             range_push("ar.batched.preprocess", synchronize=False)
@@ -497,6 +490,7 @@ class KVCacheEngine(BaseEngine):
                 },
                 cache_manager=cache_manager,
                 sampler=sampler,
+                piecewise_runners=self.submodule_management[batch.node_name].piecewise_runners,
             )
 
             if self.enable_nvtx:

--- a/mstar/engine/stateless_engine.py
+++ b/mstar/engine/stateless_engine.py
@@ -57,8 +57,7 @@ class StatelessEngineConfig:
       during warmup. Audio codec disables this because the one-shot compile
       cost is too high for short forwards.
     - ``enable_piecewise_runner`` enables ``PiecewiseCudaGraphRunner`` for
-      submodules that return a config from ``get_piecewise_runner_config()``.
-      Used by VJepa2's masked predictor.
+      submodules that return configs from ``get_piecewise_cuda_graph_configs()``.
     - ``name`` is the NVTX range prefix.
     """
 
@@ -132,6 +131,9 @@ class StatelessEngine(BaseEngine):
         self.submodules: dict[str, NodeSubmodule] = {}
         self.device: torch.device | None = None
         self.cuda_graph_runners: dict[str, StatelessCudaGraphRunner] = {}
+        # node_name -> {label -> PiecewiseCudaGraphRunner}; spread into
+        # ModelInputsFromEngine at execute time.
+        self._piecewise_runners: dict[str, dict[str, "PiecewiseCudaGraphRunner"]] = {}
 
         # Dedup set for "captured graphs exist but don't match this shape"
         # warnings — each unique miss is logged at most once.
@@ -177,6 +179,10 @@ class StatelessEngine(BaseEngine):
             self.submodules = dict(submodules)
         self.device = device
         self.tp_groups = tp_groups
+        # Default every node to an empty runner map so execute paths can index
+        # ``self._piecewise_runners[node_name]`` directly; warmup overwrites
+        # entries for nodes that capture piecewise graphs.
+        self._piecewise_runners = {name: {} for name in self.submodules}
 
     def add_request(self, request_id: str, **kwargs) -> None:
         pass  # stateless
@@ -429,6 +435,7 @@ class StatelessEngine(BaseEngine):
         engine_inputs = ModelInputsFromEngine(
             request_ids=batch.request_ids,
             per_request_info=batch.per_request_info,
+            piecewise_runners=self._piecewise_runners[batch.node_name],
         )
 
         if self.enable_nvtx:
@@ -473,6 +480,7 @@ class StatelessEngine(BaseEngine):
             engine_inputs = ModelInputsFromEngine(
                 request_ids=[rid],
                 per_request_info={rid: fwd_info},
+                piecewise_runners=self._piecewise_runners[batch.node_name],
             )
 
             if self.enable_nvtx:
@@ -508,8 +516,8 @@ class StatelessEngine(BaseEngine):
         """Apply ``torch.compile`` and capture optional CUDA graphs.
 
         Each step is opt-in by the submodule (via ``get_cuda_graph_configs``
-        and ``get_piecewise_runner_config``) so submodules that don't support
-        a feature are skipped without error.
+        and ``get_piecewise_cuda_graph_configs``) so submodules that don't
+        support a feature are skipped without error.
         """
         if not torch.cuda.is_available() or self.device is None:
             return
@@ -577,49 +585,19 @@ class StatelessEngine(BaseEngine):
             )
 
     def _install_piecewise_runner(self, node_name: str, submodule: NodeSubmodule) -> None:
-        getter = getattr(submodule, "get_piecewise_runner_config", None)
-        if getter is None:
-            return
-        pcgr_config = getter()
-        if pcgr_config is None:
-            return
-        try:
-            from mstar.engine.cuda_graph_runner import (
-                DEFAULT_AR_CAPTURE_BATCH_SIZES,
-                PiecewiseCudaGraphRunner,
-            )
+        # Stateless submodules have no KV cache, so the KV managers are all
+        # None; a piecewise config with uses_kv_cache=True on a stateless node
+        # would fail its own assert and be skipped (eager path) by the builder.
+        from mstar.engine.cuda_graph_runner import build_piecewise_runners
 
-            pcgr = PiecewiseCudaGraphRunner(
-                fn_factory=pcgr_config["fn_factory"],
-                embed_dim=pcgr_config["embed_dim"],
-                capture_batch_sizes=pcgr_config.get(
-                    "capture_batch_sizes", DEFAULT_AR_CAPTURE_BATCH_SIZES
-                ),
-                capture_seq_len=pcgr_config["capture_seq_len"],
-                device=self.device,
-                autocast_dtype=self.config.autocast_dtype,
-                pos_buf_shapes=pcgr_config.get("pos_buf_shapes"),
-                kv_cache_config=None,
-                alloc_manager=None,
-                buffer_manager=None,
-                tp_group=self.tp_groups.get_tp_config_for_node(node_name),
-            )
-            pcgr.warmup_and_capture()
-            if pcgr.graphs:
-                submodule.set_piecewise_runner(pcgr)
-                logger.info(
-                    "StatelessEngine[%s]: PiecewiseCudaGraphRunner installed for %s (%d bs buckets)",
-                    self.config.name,
-                    node_name,
-                    len(pcgr.graphs),
-                )
-        except Exception:
-            logger.warning(
-                "StatelessEngine[%s]: PiecewiseCudaGraphRunner capture failed for %s, using eager mode",
-                self.config.name,
-                node_name,
-                exc_info=True,
-            )
+        tp_config = self.tp_groups.get_tp_config_for_node(node_name)
+        self._piecewise_runners[node_name] = build_piecewise_runners(
+            submodule=submodule,
+            device=self.device,
+            autocast_dtype=self.config.autocast_dtype,
+            tp_world_size=getattr(tp_config, "world_size", 1),
+            tp_group=tp_config,
+        )
 
 
 class _ComposedContext:

--- a/mstar/engine/stateless_engine.py
+++ b/mstar/engine/stateless_engine.py
@@ -26,7 +26,7 @@ from mstar.engine.base import (
     PlannedBatch,
     PreparedBatch,
 )
-from mstar.engine.cuda_graph_runner import StatelessCudaGraphRunner
+from mstar.engine.cuda_graph_runner import PiecewiseCudaGraphRunner, StatelessCudaGraphRunner
 from mstar.model.submodule_base import (
     ARNodeInputs,
     ModelInputsFromEngine,

--- a/mstar/model/submodule_base.py
+++ b/mstar/model/submodule_base.py
@@ -16,7 +16,8 @@ from mstar.engine.kv_store import PositionInfo
 from mstar.utils.sampling import BaseSampler, SeenTokenMask
 
 if TYPE_CHECKING:
-    from mstar.engine.cuda_graph_config import CudaGraphConfig
+    from mstar.engine.cuda_graph_config import CudaGraphConfig, PiecewiseCudaGraphConfig
+    from mstar.engine.cuda_graph_runner import PiecewiseCudaGraphRunner
 
 
 @dataclass
@@ -136,6 +137,11 @@ class ModelInputsFromEngine:
     cache_manager: BatchedCacheManager | None = None
     preallocated_buffers: dict[str, torch.Tensor] = field(default_factory=dict)
     sampler: BaseSampler | None = None
+    # label -> warmed-up PiecewiseCudaGraphRunner for inner-loop capture. Owned
+    # by the engine, spread in at execute time (like ``cache_manager`` /
+    # ``sampler``). Empty when the submodule opts into no piecewise graphs or
+    # capture failed. See ``NodeSubmodule.get_piecewise_cuda_graph_configs``.
+    piecewise_runners: dict[str, "PiecewiseCudaGraphRunner"] = field(default_factory=dict)
 
     @property
     @torch.compiler.disable
@@ -251,6 +257,32 @@ class NodeSubmodule(torch.nn.Module):
     # Note: do not import CudaGraphConfig; it causes a circular import situation
     def get_cuda_graph_configs(self, device: torch.device, tp_world_size: int = 1) -> list[CudaGraphConfig]:
         return []
+
+    def get_piecewise_cuda_graph_configs(
+        self, device: torch.device, autocast_dtype: torch.dtype, tp_world_size: int = 1
+    ) -> dict[str, PiecewiseCudaGraphConfig]:
+        """Return the piecewise CUDA graph configs this submodule opts into.
+
+        ``autocast_dtype`` is the engine's autocast dtype — passed so a config's
+        ``make_static_inputs`` can allocate the hidden-state buffer in the dtype
+        the captured region runs under (avoids a copy-time upcast at replay).
+
+        A piecewise CUDA graph captures ONE inner callable of this submodule's
+        forward (e.g. a transformer block loop) as a CUDA graph while the
+        surrounding compute stays eager. The engine builds one
+        ``PiecewiseCudaGraphRunner`` per returned label and threads the runners
+        into ``ModelInputsFromEngine.piecewise_runners`` so the submodule's
+        forward can look them up by label:
+
+            runner = engine_inputs.piecewise_runners.get("block_loop")
+            if runner is not None and runner.can_run(bs):
+                out = runner.run(static_inputs={...}, request_ids=..., seq_lens=...)
+
+        Default: no piecewise graphs. Override to return
+        ``{label: PiecewiseCudaGraphConfig}``; multiple labels capture multiple
+        independent graphs (i.e., one per outer function to be graphed).
+        """
+        return {}
 
     def can_use_cuda_graphs(
         self, batch: NodeBatch,

--- a/mstar/model/vjepa2/components/predictor.py
+++ b/mstar/model/vjepa2/components/predictor.py
@@ -18,8 +18,6 @@ Weight layout (prefix ``predictor.``):
 
 from __future__ import annotations
 
-from typing import Callable
-
 import torch
 from torch import nn
 

--- a/mstar/model/vjepa2/components/predictor.py
+++ b/mstar/model/vjepa2/components/predictor.py
@@ -110,66 +110,6 @@ class VJEPA2Predictor(nn.Module):
         gather_idx = reverse_argsort.unsqueeze(-1).expand(-1, -1, hidden_states.size(-1))
         return torch.gather(hidden_states, dim=1, index=gather_idx)
 
-    def _run_forward_piecewise(
-        self,
-        encoder_hidden_states: torch.Tensor,
-        context_mask: list[torch.Tensor],
-        target_mask: list[torch.Tensor],
-    ) -> tuple[torch.Tensor, int, torch.Tensor]:
-        """Preamble for PiecewiseCudaGraphRunner: embed, sort, and return layer-loop input.
-
-        Returns ``(hidden_states, n_ctxt, argsort)`` so the postamble
-        ``_finalize_forward_piecewise`` can unsort and slice correctly.
-        All ops here run eagerly (outside any CUDA-graph-captured region).
-        """
-        encoder_hidden_states = apply_masks(encoder_hidden_states, context_mask)
-        _, n_ctxt, _ = encoder_hidden_states.shape
-        hidden_states, position_masks = self.embeddings(encoder_hidden_states, context_mask, target_mask)
-        argsort = torch.argsort(position_masks, dim=1)
-        hidden_states, _ = self._sort_tokens(hidden_states, position_masks, argsort)
-        return hidden_states, n_ctxt, argsort
-
-    def _finalize_forward_piecewise(
-        self,
-        hidden_states: torch.Tensor,
-        n_ctxt: int,
-        argsort: torch.Tensor,
-    ) -> torch.Tensor:
-        """Postamble for PiecewiseCudaGraphRunner: layernorm, unsort, slice, project."""
-        hidden_states = self.layernorm(hidden_states)
-        hidden_states = self._unsort_tokens(hidden_states, argsort)
-        hidden_states = hidden_states[:, n_ctxt:]
-        return self.proj(hidden_states)
-
-    def make_layer_loop_fn(
-        self,
-        static_cm,                           # always None for masked predictor (no KV cache)
-        static_pos_bufs: dict[str, torch.Tensor],
-    ) -> Callable[[torch.Tensor], torch.Tensor]:
-        """Return a closure over the layer loop for PiecewiseCudaGraphRunner capture.
-
-        ``static_pos_bufs["position_mask"]`` must already be filled with the
-        static ``[n_seq]`` position IDs for this rollout config before this
-        method is called (the fn_factory in get_piecewise_runner_config does
-        this via ``.copy_()``).  At replay, the runner never updates this buffer
-        (callers pass ``pos_bufs=None``), so the captured ops always see the
-        same position IDs.
-
-        The ``unsqueeze(0)`` inside ``fn`` is a zero-copy view, CUDA-graph
-        compatible.  ``VJEPA2RopeAttention.get_position_ids`` broadcasts
-        ``[1, H, N]`` IDs against ``[B, H, N, D]`` Q/K tensors correctly.
-        """
-        layers = self.layer
-        pm = static_pos_bufs["position_mask"]   # [n_seq], device-resident
-
-        def fn(x: torch.Tensor) -> torch.Tensor:
-            position_mask = pm.unsqueeze(0)      # [1, n_seq] — view, no allocation
-            for layer in layers:
-                x = layer(x, position_mask=position_mask)
-            return x
-
-        return fn
-
     def forward(
         self,
         encoder_hidden_states: torch.Tensor,

--- a/mstar/model/vjepa2/submodules.py
+++ b/mstar/model/vjepa2/submodules.py
@@ -29,6 +29,16 @@ from mstar.communication.tensors import NameToTensorList
 from mstar.conductor.request_info import CurrentForwardPassInfo
 from mstar.engine.base import NodeBatch
 from mstar.engine.cache_manager import BatchedCacheManager
+from typing import TYPE_CHECKING
+
+from mstar.engine.cuda_graph_config import (
+    PiecewiseBatchedConfig,
+    PiecewiseCaptureShape,
+    PiecewiseCudaGraphConfig,
+)
+
+if TYPE_CHECKING:
+    from mstar.engine.cuda_graph_runner import PiecewiseCudaGraphRunner
 from mstar.model.submodule_base import ARNodeInputs, ARNodeSubmodule, ModelInputsFromEngine, NodeInputs, NodeSubmodule
 from mstar.model.vjepa2.components.ac_predictor import VisionTransformerPredictorAC
 from mstar.model.vjepa2.components.predictor import VJEPA2Predictor
@@ -483,63 +493,16 @@ class VJepa2RolloutPredictorSubmodule(ARNodeSubmodule):
         self.num_output_frames = max(int(num_output_frames), config.tubelet_size)
         self.frames_per_second = int(frames_per_second)
         self.anticipation_seconds = float(anticipation_seconds)
-        self._piecewise_runner = None
 
-    def set_piecewise_runner(self, runner) -> None:
-        """Attach a warmed-up PiecewiseCudaGraphRunner for the layer loop."""
-        self._piecewise_runner = runner
-
-    def get_piecewise_runner_config(self) -> dict | None:
-        """Return construction args for PiecewiseCudaGraphRunner.
-
-        Called by StatelessEngine.warmup() (masked predictor uses ENC_DEC).
-        kv_cache_config / alloc_manager / buffer_manager are all None since the
-        masked predictor is stateless — no KV cache between rollout steps.
-
-        The ``position_mask`` buffer is a static [n_seq] float32 tensor holding
-        the sorted position IDs for the rollout config.  For sequential context
-        (arange(n_ctxt)) + skip target, the positions are already sorted so
-        argsort in VJEPA2Predictor.forward is identity; the buffer is filled
-        once in fn_factory and never updated at replay.
-        """
-        # n_ctxt = self.config.grid_depth * self._grid_size ** 2
-        # n_pred = self._n_pred
-        # skip = n_ctxt + self._grid_size ** 2 * self._anticipation_steps
-        # n_seq = n_ctxt + n_pred
-
-        # position_ids = torch.cat([
-        #     torch.arange(n_ctxt, dtype=torch.float32),
-        #     torch.arange(n_pred, dtype=torch.float32) + skip,
-        # ])  # [n_seq], CPU; fn_factory .copy_()s it into the GPU buffer
-
-        # predictor = self.predictor
-
-        # def fn_factory(static_cm, static_pos_bufs):
-        #     static_pos_bufs["position_mask"].copy_(position_ids)
-        #     return predictor.make_layer_loop_fn(static_cm, static_pos_bufs)
-
-        # return {
-        #     "fn_factory": fn_factory,
-        #     "embed_dim": self.config.pred_hidden_size,
-        #     "capture_seq_len": n_seq,
-        #     "capture_batch_sizes": [1, 2, 4, 8],
-        #     "pos_buf_shapes": {"position_mask": (n_seq,)},
-        #     "cache_labels": ["main"],
-        # }
-
-        """Masked predictor rollout does not use piecewise CUDA graphs.
-
-        The non-AC predictor attends over n_ctxt + n_pred ≈ 8448 tokens using
-        plain SDPA (no FlashInfer).  At that sequence length the O(N²) attention
-        computation dominates completely — Python kernel-launch overhead is
-        negligible relative to the ~1.7 GB attention matrix per layer, so CUDA
-        graphs provide no meaningful speedup.  Attempting to capture them also
-        risks OOM on top of the already-loaded ViT-g encoder weights.
-
-        CUDA graphs are only useful for the AC predictor (capture_seq_len=258,
-        FlashInfer per-call overhead worth eliminating).
-        """
-        return None
+    # NOTE: this masked predictor does NOT opt into piecewise CUDA graphs
+    # (``get_piecewise_cuda_graph_configs`` returns the base default of {}).
+    # The non-AC predictor attends over n_ctxt + n_pred ≈ 8448 tokens using
+    # plain SDPA (no FlashInfer). At that sequence length the O(N²) attention
+    # dominates completely — Python kernel-launch overhead is negligible
+    # relative to the ~1.7 GB attention matrix per layer, so CUDA graphs give
+    # no meaningful speedup and capture risks OOM on top of the ViT-g weights.
+    # Piecewise graphs are only worth it for the AC predictor
+    # (capture_seq_len=258, FlashInfer per-call overhead worth eliminating).
 
     # ------------------------------------------------------------------
     # Rollout geometry (derived from config + hyperparams; shape-static)
@@ -637,10 +600,8 @@ class VJepa2RolloutPredictorSubmodule(ARNodeSubmodule):
         Returns ``(next_encoder_hidden [B, N, D], predicted [B, n_pred, D])``.
         Shape math is symmetric across B.
 
-        CUDA-graph path (when PiecewiseCudaGraphRunner is set): splits the
-        predictor forward into preamble (embed+sort), captured layer loop,
-        and postamble (layernorm+unsort+proj), with no KV cache involved.
-        Eager path calls predictor.forward end-to-end (unchanged).
+        Runs the predictor forward end-to-end (eager); see the class note on
+        why this predictor does not use piecewise CUDA graphs.
         """
         b, n_ctxt, _ = encoder_hidden.shape
         device = encoder_hidden.device
@@ -654,15 +615,7 @@ class VJepa2RolloutPredictorSubmodule(ARNodeSubmodule):
         skip = n_ctxt + self._grid_size * self._grid_size * self._anticipation_steps
         tgt_positions = (torch.arange(n_pred, device=device) + skip).unsqueeze(0).repeat(b, 1)
 
-        runner = self._piecewise_runner
-        if runner is not None and runner.can_run(b):
-            hidden_states, n_ctxt_out, argsort = self.predictor._run_forward_piecewise(
-                encoder_hidden, [ctxt_positions], [tgt_positions]
-            )
-            hidden_states = runner.run(hidden_states)
-            predicted = self.predictor._finalize_forward_piecewise(hidden_states, n_ctxt_out, argsort)
-        else:
-            predicted = self.predictor(encoder_hidden, [ctxt_positions], [tgt_positions])
+        predicted = self.predictor(encoder_hidden, [ctxt_positions], [tgt_positions])
 
         next_encoder_hidden = torch.cat([encoder_hidden[:, n_pred:, :], predicted], dim=1)
         return next_encoder_hidden, predicted
@@ -901,8 +854,9 @@ class VJepa2ACRolloutPredictorSubmodule(ARNodeSubmodule):
     """Action-conditioned autoregressive rollout.
 
     Optionally uses a PiecewiseCudaGraphRunner to accelerate the inner block
-    loop. Set via set_piecewise_runner() after construction (typically done by
-    the engine after warmup_and_capture).
+    loop. The submodule opts in via ``get_piecewise_cuda_graph_configs`` (label
+    ``"block_loop"``); the engine builds the runner at warmup and passes it in
+    through ``engine_inputs.piecewise_runners``.
 
     **Sliding-window rollout** — diverges from upstream
     ``vjepa2/notebooks/utils/mpc_utils.py::cem`` which uses growing-context
@@ -944,49 +898,67 @@ class VJepa2ACRolloutPredictorSubmodule(ARNodeSubmodule):
         super().__init__()
         self.predictor = predictor
         self.config = config
-        self._piecewise_runner = None   # set via set_piecewise_runner() after warmup
 
-    def set_piecewise_runner(self, runner) -> None:
-        """Attach a warmed-up PiecewiseCudaGraphRunner for the block loop."""
-        self._piecewise_runner = runner
+    def _block_loop_capture(
+        self,
+        static_inputs: dict[str, torch.Tensor],
+        static_cm: BatchedCacheManager | None = None,
+        *,
+        cond_tokens: int = 2,
+    ) -> dict[str, torch.Tensor]:
+        """Captured region for the ``block_loop`` piecewise graph.
 
-    def get_piecewise_runner_config(self) -> dict | None:
-        """Return construction args for PiecewiseCudaGraphRunner, or None.
+        Reads the hidden state and RoPE position tensors out of the
+        runner-owned ``static_inputs`` (never reassigns them) so the captured
+        graph replays against the buffers the runner updates via ``.copy_()``
+        before each replay. ``static_cm`` is the runner's persistent cache
+        manager (planned outside the graph).
+        """
+        fn = self.predictor.make_block_loop_fn(static_cm, static_inputs, cond_tokens)
+        return {"x": fn(static_inputs["x"])}
 
-        Called by KVCacheEngine.warmup() to build and install the runner without
-        the engine needing to know the model internals.  The returned dict
-        contains everything PiecewiseCudaGraphRunner.__init__ needs except
-        device/autocast_dtype/memory_pool (those come from the engine).
+    def get_piecewise_cuda_graph_configs(
+        self, device: torch.device, autocast_dtype: torch.dtype, tp_world_size: int = 1,
+    ) -> dict[str, PiecewiseCudaGraphConfig]:
+        """One BATCHED piecewise graph (``"block_loop"``) for the AC predictor.
 
-        Keys:
-          fn_factory    - (static_cm, static_pos_bufs) -> fn(x) -> x
-          embed_dim     - hidden dim of the intermediate sequence
-          capture_seq_len - tokens per frame (cond_tokens + grid_h * grid_w)
-          pos_buf_shapes  - {name: shape} for per-step position tensors
-          cache_labels    - KV cache labels (always ["main"] here)
+        ``capture_seq_len = cond_tokens + N*N`` is the per-frame token count
+        (one rollout step processes one frame). The block loop reads the
+        FlashInfer KV cache, so ``uses_kv_cache=True``.
         """
         ac = self.config.ac_predictor
         if ac is None:
-            return None
+            return {}
         N = ac.img_size[0] // ac.patch_size   # grid_height (== grid_width for square)
         cond_tokens = 3 if ac.use_extrinsics else 2
-        predictor = self.predictor
+        capture_seq_len = cond_tokens + N * N
+        embed_dim = ac.predictor_embed_dim
 
-        def fn_factory(static_cm, static_pos_bufs):
-            return predictor.make_block_loop_fn(static_cm, static_pos_bufs, cond_tokens)
+        def make_static_inputs(shape: PiecewiseCaptureShape) -> dict[str, torch.Tensor]:
+            # Hidden state matches autocast dtype so the replay copy_ is a
+            # same-dtype memcpy; position buffers stay float32 (RoPE frequency
+            # precision matters more than matching the hidden-state dtype).
+            return {
+                "x": torch.zeros(
+                    shape.bs, capture_seq_len, embed_dim,
+                    dtype=autocast_dtype, device=device,
+                ),
+                "d_pos": torch.zeros(N * N, dtype=torch.float32, device=device),
+                "h_pos": torch.zeros(N * N, dtype=torch.float32, device=device),
+                "w_pos": torch.zeros(N * N, dtype=torch.float32, device=device),
+                "time_pos": torch.zeros(cond_tokens, dtype=torch.float32, device=device),
+            }
 
         return {
-            "fn_factory": fn_factory,
-            "embed_dim": ac.predictor_embed_dim,
-            "capture_seq_len": cond_tokens + N * N,
-            "capture_batch_sizes": [1, 2, 4, 8],
-            "pos_buf_shapes": {
-                "d_pos":   (N * N,),
-                "h_pos":   (N * N,),
-                "w_pos":   (N * N,),
-                "time_pos": (cond_tokens,),
-            },
-            "cache_labels": ["main"],
+            "block_loop": PiecewiseBatchedConfig(
+                capture_fn=self._block_loop_capture,
+                make_static_inputs=make_static_inputs,
+                seq_len=capture_seq_len,
+                forward_kwargs={"cond_tokens": cond_tokens},
+                uses_kv_cache=True,
+                cache_labels=["main"],
+                capture_batch_sizes=[1, 2, 4, 8],
+            )
         }
 
     # ------------------------------------------------------------------
@@ -1123,10 +1095,12 @@ class VJepa2ACRolloutPredictorSubmodule(ARNodeSubmodule):
         cache_handle: BatchedCacheManager,
         extrinsics: torch.Tensor | None = None,  # [B, 1, action_embed_dim - 1] or None
         request_ids: list[str] | None = None,    # needed by PiecewiseCudaGraphRunner
+        runner: "PiecewiseCudaGraphRunner | None" = None,
     ) -> torch.Tensor:
         """One AC rollout step using either the CUDA-graph or eager path.
 
-        The CUDA-graph path (when PiecewiseCudaGraphRunner is attached):
+        The CUDA-graph path (when a ``block_loop`` PiecewiseCudaGraphRunner is
+        available on ``engine_inputs``):
           1. Preamble (predictor_embed + action/state concat) runs eagerly.
           2. Position tensors are computed eagerly (hoisted out of the graph).
           3. Block loop replays the captured graph.
@@ -1137,7 +1111,6 @@ class VJepa2ACRolloutPredictorSubmodule(ARNodeSubmodule):
         """
         p = self.predictor
 
-        runner = self._piecewise_runner
         if runner is not None and runner.can_run(encoder_hidden.size(0)):
             # --- CUDA-graph path ---
             x, cond_tokens, b, t = p._prepare_sequence(
@@ -1146,17 +1119,14 @@ class VJepa2ACRolloutPredictorSubmodule(ARNodeSubmodule):
             d_pos, h_pos, w_pos, time_pos = p._compute_rope_positions(
                 t_0, p.grid_height, p.grid_width, cond_tokens, x.device, x.dtype
             )
-            pos_bufs = {
-                "d_pos": d_pos, "h_pos": h_pos, "w_pos": w_pos,
+            static_inputs = {
+                "x": x, "d_pos": d_pos, "h_pos": h_pos, "w_pos": w_pos,
             }
             if time_pos is not None:
-                pos_bufs["time_pos"] = time_pos
+                static_inputs["time_pos"] = time_pos
 
-            x = runner.run(
-                x=x,
-                pos_bufs=pos_bufs,
-                request_ids=request_ids,
-            )
+            out = runner.run(static_inputs=static_inputs, request_ids=request_ids)
+            x = out["x"]
             # advance_seq_len already called by runner; skip it in _decode_sequence
             new_tg = p._decode_sequence(x, cond_tokens, b, t)
         else:
@@ -1197,6 +1167,7 @@ class VJepa2ACRolloutPredictorSubmodule(ARNodeSubmodule):
             cache_handle=engine_inputs.cache_manager,
             extrinsics=extrinsics,
             request_ids=engine_inputs.request_ids,
+            runner=engine_inputs.piecewise_runners.get("block_loop"),
         )
 
         logger.info(

--- a/mstar/model/vjepa2/submodules.py
+++ b/mstar/model/vjepa2/submodules.py
@@ -21,6 +21,7 @@ branch.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn.functional as F
@@ -29,8 +30,6 @@ from mstar.communication.tensors import NameToTensorList
 from mstar.conductor.request_info import CurrentForwardPassInfo
 from mstar.engine.base import NodeBatch
 from mstar.engine.cache_manager import BatchedCacheManager
-from typing import TYPE_CHECKING
-
 from mstar.engine.cuda_graph_config import (
     PiecewiseBatchedConfig,
     PiecewiseCaptureShape,


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

Reimplements PiecewiseCudaGraphRunner, which captures one hot inner region of a submodule's forward (e.g. a transformer block loop) as a CUDA graph while the preamble/postamble stay eager, so it's a general, typed tool instead of being hardwired to V-JEPA2's predictor. Migrates V-JEPA2 onto the new API and documents the feature for model authors.

### Why?
The previous implementation was VJepa2-shaped and hard to reuse:

- No base-class surface / undocumented; opt-in was a duck-typed get_piecewise_runner_config() read via getattr in two engines.
- Config was a raw dict, a model author couldn't tell what it needed.
- Runner lived as mutable state on the submodule (`set_piecewise_runner` / `self._piecewise_runner`).
- Only equal-length batched inputs, no packed/variable-length mode.
- Captured-fn contract was vjepa predictor-specific: an `fn_factory(static_cm, static_pos_bufs) -> (x -> x)` over closure-captured buffers.
- One captured function per submodule.

### Design
Typed config hierarchy in `cuda_graph_config.py`, mirroring the existing `BasicBatched` / `FlashInferPacked` split:
- `PiecewiseCudaGraphConfig` base + `PiecewiseBatchedConfig` (equal-length `[bs, seq_len, D]`) and `PiecewisePackedConfig` (ragged `[total_tokens, D]`), keyed by a `PiecewiseCaptureShape`.
- Dict-in/dict-out capture contract: `capture_fn(static_inputs, static_cm=None, **kwargs) -> dict`
- Attention planning: `uses_kv_cache: bool` + optional `plan_fn`, with runner defaults per config type; plus advance_seq_lens: bool (default True) to opt out of the post-replay seq-len advance.
- Engine-owned, threaded through `ModelInputsFromEngine.piecewise_runners` (same channel as `cache_manager`/`sampler`), keyed by a label so a submodule can declare multiple captured regions via `get_piecewise_cuda_graph_configs(device, autocast_dtype) -> dict[label, config]`. One `build_piecewise_runners` helper replaces the duplicated install code in `KVCacheEngine` and `StatelessEngine`.
- run returns a `PiecewiseOutput`: dict-like, where indexing/get return an owned clone and `get_view` returns a zero-copy view valid until the next replay.

## How was it tested?

Tested + benchmarked vjepa2.

### TODO:
- Test on a model where it is easier to verify the outputs
- Test the paths that are not used for vjepa: custom plan function, packed config, piecewise runner on the stateless engine

<!-- Commands you ran, or why tests aren't applicable. -->

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
