### PR TITLE
[WIP] Multinode v1

### DIFF
--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -302,6 +302,11 @@ Multi-host notes:
   where the fabric exists, ``TCP`` otherwise. On machines without an active
   RDMA fabric the TCP transfer engine usually needs an explicit
   ``--tcp-transfer-device`` (or per-host ``rdma_device``) value.
+- Transfers between workers on the *same* host still use shared memory: each
+  tensor whose consumers are all co-hosted with its producer goes through
+  tmpfs, and only tensors with a cross-host (or not-yet-known, e.g.
+  persisted) consumer travel through the transfer engine. Set
+  ``MSTAR_NO_INTRA_HOST_SHM=1`` to force everything through the engine.
 - Model weights must be present on every host (shared filesystem or a
   per-host cache); agents construct the model locally rather than receiving
   weights over the network.

--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -253,6 +253,65 @@ Workers route tensors directly to one another using one of three transports, sel
 - ``RDMA`` — lowest latency for multi-GPU / multi-node, via the Mooncake transfer engine
   (requires RDMA-capable networking).
 
+Multi-host deployments
+----------------------
+
+A deployment spans several machines when the config carries a ``cluster:``
+section mapping hosts and their GPUs onto the global ranks that
+``node_groups`` already uses:
+
+.. code-block:: yaml
+
+   cluster:
+     hosts:
+       - addr: nodeA            # routable hostname/IP
+         gpus: [0, 1, 2, 3]     # local CUDA indices -> global ranks 0-3
+       - addr: nodeB
+         gpus: [0, 1]           # -> global ranks 4-5
+         env:                   # optional per-host worker env
+           NCCL_SOCKET_IFNAME: eth1
+         rdma_device: mlx5_0    # optional transfer-engine device filter
+
+   node_groups:                 # unchanged; ranks are global
+     - {node_names: [Thinker], ranks: [0, 1, 2, 3], tp_size: 4}
+     - {node_names: [Thinker], ranks: [4, 5], tp_size: 2, graph_walks: [decode]}
+
+The first host is the head: it runs ``mstar-serve`` (API server + conductor)
+plus its own workers, exactly as on a single machine. Every other host runs
+one agent that joins the conductor and spawns that host's workers:
+
+.. code-block:: bash
+
+   nodeA$ mstar-serve --config cfg.yaml --tensor-comm-protocol RDMA
+   nodeB$ mstar-node  --config cfg.yaml --node-rank 1
+
+Start order does not matter (the agent retries until the conductor is up);
+the server binds its HTTP port only once every worker on every host has
+finished loading and warmup, and startup aborts with a precise error if a
+host never joins or a worker dies while loading (``--startup-timeout``
+bounds the wait). If a worker dies at runtime, its in-flight requests fail
+with HTTP 500 and, when data-parallel replicas exist, new requests route
+around the dead worker.
+
+Multi-host notes:
+
+- The control plane switches from ipc sockets to TCP automatically; each
+  host's ports derive from its ``zmq_port_base`` (two logical hosts on one
+  machine — the loopback test rig — just need different bases).
+- ``SHM`` tensor transport is rejected for multi-host clusters; use ``RDMA``
+  where the fabric exists, ``TCP`` otherwise. On machines without an active
+  RDMA fabric the TCP transfer engine usually needs an explicit
+  ``--tcp-transfer-device`` (or per-host ``rdma_device``) value.
+- Model weights must be present on every host (shared filesystem or a
+  per-host cache); agents construct the model locally rather than receiving
+  weights over the network.
+- Keep TP groups within one host unless the hosts share an RDMA-class
+  interconnect — the conductor logs a warning when a group spans hosts.
+
+``test/multinode/`` contains a self-contained two-"host" loopback rig that
+exercises the full path (agent handshake, cross-host prefill→decode KV
+transfer, worker-failure handling) on one machine.
+
 .. _request-profiling:
 
 Request profiling

--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -119,6 +119,10 @@ mstar-serve
    * - ``--tensor-comm-protocol``
      - ``RDMA``
      - ``RDMA``, ``TCP``, or ``SHM``.
+   * - ``--intra-host-tensor-protocol``
+     - ``SHM``
+     - Transport for co-hosted tensor transfers in a multi-host cluster
+       (see :ref:`multi-host-deployments`); ignored on a single host.
    * - ``--cache-dir``
      - HF default
      - HuggingFace weight cache directory.
@@ -253,6 +257,8 @@ Workers route tensors directly to one another using one of three transports, sel
 - ``RDMA`` — lowest latency for multi-GPU / multi-node, via the Mooncake transfer engine
   (requires RDMA-capable networking).
 
+.. _multi-host-deployments:
+
 Multi-host deployments
 ----------------------
 
@@ -302,11 +308,12 @@ Multi-host notes:
   where the fabric exists, ``TCP`` otherwise. On machines without an active
   RDMA fabric the TCP transfer engine usually needs an explicit
   ``--tcp-transfer-device`` (or per-host ``rdma_device``) value.
-- Transfers between workers on the *same* host still use shared memory: each
-  tensor whose consumers are all co-hosted with its producer goes through
-  tmpfs, and only tensors with a cross-host (or not-yet-known, e.g.
-  persisted) consumer travel through the transfer engine. Set
-  ``MSTAR_NO_INTRA_HOST_SHM=1`` to force everything through the engine.
+- ``--intra-host-tensor-protocol`` picks the transport for tensors whose
+  producer and consumers all share a host. The default, ``SHM``, sends them
+  through tmpfs; only tensors with a cross-host (or not-yet-known, e.g.
+  persisted) consumer travel through the transfer engine. Any other value
+  routes co-hosted transfers through the engine as well. Single-host
+  deployments ignore the flag.
 - Model weights must be present on every host (shared filesystem or a
   per-host cache); agents construct the model locally rather than receiving
   weights over the network.

--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -131,9 +131,6 @@ mstar-serve
    * - ``--timeout``
      - ``600``
      - Per-request timeout (seconds).
-   * - ``--mooncake-port``
-     - ``8080``
-     - Port for the Mooncake RDMA transfer engine.
    * - ``--tcp-transfer-device``
      - (auto)
      - Network device for TCP tensor transport.

--- a/mstar/api_server/data_worker.py
+++ b/mstar/api_server/data_worker.py
@@ -55,7 +55,8 @@ class PreprocessWorker:
         socket_path_prefix: str = "/tmp/mstar",
         tensor_comm_protocol: CommProtocol = CommProtocol.RDMA,
         tcp_transfer_device="",
-        enable_prof: bool=False
+        enable_prof: bool=False,
+        endpoints=None,
     ):
         self.request_input_queue = queue.Queue()
         self.result_tensor_input_queue = queue.Queue()
@@ -78,6 +79,7 @@ class PreprocessWorker:
             my_id="api_server_preprocess_worker",
             push_ids=["conductor"],
             ipc_socket_path_prefix=socket_path_prefix,
+            endpoints=endpoints,
         )  # only used to send (from the worker thread)
         self.tensor_manager = create_tensor_communication_manager(
             protocol=tensor_comm_protocol,

--- a/mstar/api_server/data_worker.py
+++ b/mstar/api_server/data_worker.py
@@ -57,6 +57,7 @@ class PreprocessWorker:
         tcp_transfer_device="",
         enable_prof: bool=False,
         endpoints=None,
+        same_host_entities: set[str] | None = None,
     ):
         self.request_input_queue = queue.Queue()
         self.result_tensor_input_queue = queue.Queue()
@@ -89,6 +90,7 @@ class PreprocessWorker:
             communicator=self.communicator,
             tcp_transfer_device=tcp_transfer_device,
             enable_prof=enable_prof,
+            same_host_entities=same_host_entities,
         )
 
         self.thread = threading.Thread(

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -107,7 +107,8 @@ def _conductor_process_target(
         enable_prof=enable_prof,
         log_level=log_level,
         tensor_comm_protocol=tensor_comm_protocol,
-        tcp_transfer_device=tcp_transfer_device
+        tcp_transfer_device=tcp_transfer_device,
+        model_cache_dir=cache_dir,
     )
     try:
         conductor.run()
@@ -123,7 +124,9 @@ def _shutdown_conductor_process(
         return
 
     try:
-        conductor_proc.send_signal(signal.SIGINT)
+        # mp.Process has no send_signal; deliver SIGINT by pid so the
+        # conductor's KeyboardInterrupt path can terminate its workers.
+        os.kill(conductor_proc.pid, signal.SIGINT)
         conductor_proc.join(timeout=timeout)
     except BaseException:
         logger.exception("Failed graceful conductor shutdown")
@@ -153,6 +156,7 @@ class PendingRequest:
     chunks: list[ResultChunk] = field(default_factory=list)
     final_outputs: dict = field(default_factory=dict)
     consumed_chunks: int = 0
+    error: str | None = None  # server-side failure (e.g. a worker died)
 
 
 class APIServer:
@@ -364,6 +368,10 @@ class APIServer:
                                 logger.info("API server received %s done", rid)
                                 self.recently_completed[rid] = time.time()
                                 req = self.pending_requests[rid]
+                                # On server-side failure final_outputs is empty,
+                                # so the normal prune path releases the waiter
+                                # on its next tick without special casing.
+                                req.error = message.body.error
                                 req.final_outputs = message.body.final_outputs
                                 req.profile.timing.conductor_ingest_time = \
                                     message.body.conductor_ingest_time
@@ -468,6 +476,12 @@ class APIServer:
                         self._finalize_profile(finished_req)
                     for chunk in remaining:
                         yield chunk
+                    if finished_req is not None and finished_req.error is not None:
+                        yield ResultChunk(
+                            request_id=request_id,
+                            modality="error",
+                            data=finished_req.error.encode("utf-8"),
+                        )
                     finished = True
                     break
 
@@ -520,6 +534,10 @@ class APIServer:
         # Profiling (incl. the optional file write) runs outside the lock; the
         # popped request is no longer shared with other threads.
         self._finalize_profile(req)
+        if req.error is not None:
+            raise HTTPException(
+                status_code=500, detail=f"request failed: {req.error}"
+            )
         return list(req.chunks)
 
     def _finalize_profile(self, req: PendingRequest) -> None:

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -23,6 +23,7 @@ from starlette.concurrency import run_in_threadpool
 
 from mstar.api_server.data_worker import PreprocessWorker
 from mstar.api_server.request_types import APIServerMessage, PreprocessInput, ResultChunk
+from mstar.cluster.spec import ClusterSpec
 from mstar.communication.communicator import CommProtocol, ZMQCommunicator
 from mstar.model.registry import HF_MODELS
 from mstar.profile.display import pretty_print_profile
@@ -732,7 +733,6 @@ def main(argv: list[str] | None = None):
     parser.add_argument("--config", type=str, required=True, help="Path to YAML config file")
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
-    parser.add_argument("--mooncake-port", type=int, default=8080)
     parser.add_argument(
         "--socket-path-prefix", type=str, default="/tmp/mstar",
         help="ZMQ IPC socket path prefix (shared with conductor/workers)",
@@ -787,6 +787,9 @@ def main(argv: list[str] | None = None):
     with open(args.config) as f:
         config = yaml.safe_load(f)
 
+    cluster_spec = ClusterSpec.from_config(config)
+    logger.info("Cluster: %s", cluster_spec.summary())
+
     model_name = config.get("model", "dummy")
     # Forward yaml-level model_kwargs to the API-server-side lightweight
     # model instance too, so it sees the same Pi05Config (action_horizon, etc.)
@@ -807,6 +810,7 @@ def main(argv: list[str] | None = None):
     api_server = APIServer(
         socket_path_prefix=args.socket_path_prefix,
         upload_dir=args.upload_dir,
+        hostname=cluster_spec.head_addr,
         timeout_seconds=args.timeout,
         tensor_comm_protocol=CommProtocol(args.tensor_comm_protocol),
         model=model,

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -63,7 +63,8 @@ def _conductor_process_target(
     log_level: str = "INFO",
     cache_dir: str | None = None,
     tensor_comm_protocol=CommProtocol.RDMA,
-    tcp_transfer_device=""
+    tcp_transfer_device="",
+    intra_host_tensor_protocol=CommProtocol.SHM,
 ):
     """Runs DummyConductor.run() in a spawned process."""
     logging.basicConfig(
@@ -108,6 +109,7 @@ def _conductor_process_target(
         log_level=log_level,
         tensor_comm_protocol=tensor_comm_protocol,
         tcp_transfer_device=tcp_transfer_device,
+        intra_host_tensor_protocol=intra_host_tensor_protocol,
         model_cache_dir=cache_dir,
     )
     try:
@@ -124,8 +126,6 @@ def _shutdown_conductor_process(
         return
 
     try:
-        # mp.Process has no send_signal; deliver SIGINT by pid so the
-        # conductor's KeyboardInterrupt path can terminate its workers.
         os.kill(conductor_proc.pid, signal.SIGINT)
         conductor_proc.join(timeout=timeout)
     except BaseException:
@@ -176,6 +176,7 @@ class APIServer:
         log_stats_file: str | None = None,
         endpoints=None,
         multi_host: bool = False,
+        intra_host_tensor_protocol=CommProtocol.SHM,
     ):
         self.upload_dir = Path(upload_dir)
         self.upload_dir.mkdir(parents=True, exist_ok=True)
@@ -210,7 +211,7 @@ class APIServer:
             # entities.
             same_host_entities=(
                 set()
-                if multi_host and not os.environ.get("MSTAR_NO_INTRA_HOST_SHM")
+                if multi_host and intra_host_tensor_protocol == CommProtocol.SHM
                 else None
             ),
         )
@@ -790,6 +791,16 @@ def main(argv: list[str] | None = None):
         help="Tensor transfer protocol: RDMA, TCP, or SHM (shared memory)"
     )
     parser.add_argument(
+        "--intra-host-tensor-protocol",
+        type=str, default="SHM", choices=["SHM", "RDMA", "TCP"],
+        help=(
+            "Transport for tensors whose producer and consumers share a host in a "
+            "multi-host cluster. SHM (default) uses shared memory; any other value "
+            "routes co-hosted transfers through the transfer engine alongside "
+            "cross-host traffic. Single-host deployments ignore this flag."
+        ),
+    )
+    parser.add_argument(
         "--tcp-transfer-device",
         type=str, default="",
     )
@@ -854,6 +865,7 @@ def main(argv: list[str] | None = None):
         log_stats=log_stats,
         log_stats_file=args.log_stats_file,
         multi_host=cluster_spec.is_multi_host(),
+        intra_host_tensor_protocol=CommProtocol(args.intra_host_tensor_protocol),
     )
 
     # Spawn conductor in a separate process
@@ -869,7 +881,8 @@ def main(argv: list[str] | None = None):
             args.log_level,
             args.cache_dir,
             CommProtocol(args.tensor_comm_protocol),
-            args.tcp_transfer_device
+            args.tcp_transfer_device,
+            CommProtocol(args.intra_host_tensor_protocol),
         ),
     )
     conductor_proc.start()

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -23,6 +23,7 @@ from starlette.concurrency import run_in_threadpool
 
 from mstar.api_server.data_worker import PreprocessWorker
 from mstar.api_server.request_types import APIServerMessage, PreprocessInput, ResultChunk
+from mstar.cluster.endpoints import ControlPlaneEndpoints
 from mstar.cluster.spec import ClusterSpec
 from mstar.communication.communicator import CommProtocol, ZMQCommunicator
 from mstar.model.registry import HF_MODELS
@@ -169,6 +170,7 @@ class APIServer:
         model_name: str = "dummy",
         log_stats: bool = False,
         log_stats_file: str | None = None,
+        endpoints=None,
     ):
         self.upload_dir = Path(upload_dir)
         self.upload_dir.mkdir(parents=True, exist_ok=True)
@@ -193,7 +195,8 @@ class APIServer:
             socket_path_prefix=socket_path_prefix,
             tensor_comm_protocol=tensor_comm_protocol,
             tcp_transfer_device=tcp_transfer_device,
-            enable_prof=self.log_stats
+            enable_prof=self.log_stats,
+            endpoints=endpoints,
         )
 
         # Concurrent request tracking
@@ -210,6 +213,7 @@ class APIServer:
             my_id="api_server",
             push_ids=["conductor"],
             ipc_socket_path_prefix=socket_path_prefix,
+            endpoints=endpoints,
         )
 
         # Background thread that drains results from the conductor. Started by
@@ -811,6 +815,7 @@ def main(argv: list[str] | None = None):
         socket_path_prefix=args.socket_path_prefix,
         upload_dir=args.upload_dir,
         hostname=cluster_spec.head_addr,
+        endpoints=ControlPlaneEndpoints(cluster_spec),
         timeout_seconds=args.timeout,
         tensor_comm_protocol=CommProtocol(args.tensor_comm_protocol),
         model=model,

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -175,6 +175,7 @@ class APIServer:
         log_stats: bool = False,
         log_stats_file: str | None = None,
         endpoints=None,
+        multi_host: bool = False,
     ):
         self.upload_dir = Path(upload_dir)
         self.upload_dir.mkdir(parents=True, exist_ok=True)
@@ -201,6 +202,17 @@ class APIServer:
             tcp_transfer_device=tcp_transfer_device,
             enable_prof=self.log_stats,
             endpoints=endpoints,
+            # The preprocess worker never picks shm for its own sends (a
+            # request's initial tensors can be consumed by workers on any
+            # host), but in multi-host mode it must be able to READ shm
+            # tensors that head-host workers emit to the client. The empty
+            # set enables the hybrid manager without claiming co-hosted
+            # entities.
+            same_host_entities=(
+                set()
+                if multi_host and not os.environ.get("MSTAR_NO_INTRA_HOST_SHM")
+                else None
+            ),
         )
 
         # Concurrent request tracking
@@ -841,6 +853,7 @@ def main(argv: list[str] | None = None):
         tcp_transfer_device=cluster_spec.head.rdma_device or args.tcp_transfer_device,
         log_stats=log_stats,
         log_stats_file=args.log_stats_file,
+        multi_host=cluster_spec.is_multi_host(),
     )
 
     # Spawn conductor in a separate process

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -838,7 +838,7 @@ def main(argv: list[str] | None = None):
         tensor_comm_protocol=CommProtocol(args.tensor_comm_protocol),
         model=model,
         model_name=model_name,
-        tcp_transfer_device=args.tcp_transfer_device,
+        tcp_transfer_device=cluster_spec.head.rdma_device or args.tcp_transfer_device,
         log_stats=log_stats,
         log_stats_file=args.log_stats_file,
     )

--- a/mstar/api_server/request_types.py
+++ b/mstar/api_server/request_types.py
@@ -37,6 +37,9 @@ class RequestComplete:
     graph_timings: GraphTimings = field(default_factory=dict)
     rx_info: list[RxInfo] = field(default_factory=list)
     tx_info: list[TxInfo] = field(default_factory=list)
+    # Set when the request was aborted by the server (e.g. a worker died);
+    # the API server surfaces it as an HTTP error instead of empty output.
+    error: str | None = None
 
 
 @dataclass

--- a/mstar/cluster/__init__.py
+++ b/mstar/cluster/__init__.py
@@ -1,0 +1,3 @@
+from mstar.cluster.spec import ClusterSpec, HostSpec, WorkerSpec
+
+__all__ = ["ClusterSpec", "HostSpec", "WorkerSpec"]

--- a/mstar/cluster/endpoints.py
+++ b/mstar/cluster/endpoints.py
@@ -1,0 +1,86 @@
+"""Deterministic control-plane endpoints for every entity in a deployment.
+
+Each entity binds one PULL socket at a well-known address derived purely from
+the cluster spec, so peers can dial each other with zero discovery traffic:
+
+    api_server                     head host, zmq_port_base + 0
+    conductor                      head host, zmq_port_base + 1
+    api_server_preprocess_worker   head host, zmq_port_base + 2
+    node_agent_{k}                 hosts[k],  zmq_port_base + 50 + k
+    worker_{r}                     r's host,  zmq_port_base + 100 + r
+
+Ports come from each host's own ``zmq_port_base``, so two logical hosts that
+share one machine address (loopback test rigs) stay disjoint by using
+different bases. Single-host deployments never consult this: their control
+plane stays on ``ipc://`` sockets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mstar.cluster.spec import ClusterSpec
+
+_HEAD_OFFSETS = {"api_server": 0, "conductor": 1, "api_server_preprocess_worker": 2}
+_AGENT_OFFSET = 50
+_WORKER_OFFSET = 100
+
+
+@dataclass(frozen=True)
+class ControlPlaneEndpoints:
+    """Resolves entity ids to TCP endpoints. Pickleable; shipped to workers."""
+
+    cluster: ClusterSpec
+
+    def use_tcp(self) -> bool:
+        return self.cluster.is_multi_host()
+
+    def _host_and_port(self, entity_id: str):
+        if entity_id in _HEAD_OFFSETS:
+            host = self.cluster.head
+            return host, host.zmq_port_base + _HEAD_OFFSETS[entity_id]
+        if entity_id.startswith("node_agent_"):
+            idx_str = entity_id.removeprefix("node_agent_")
+            if idx_str.isdigit() and int(idx_str) < len(self.cluster.hosts):
+                idx = int(idx_str)
+                host = self.cluster.hosts[idx]
+                return host, host.zmq_port_base + _AGENT_OFFSET + idx
+        if entity_id.startswith("worker_"):
+            rank_str = entity_id.removeprefix("worker_")
+            if rank_str.isdigit():
+                spec = self.cluster.worker_spec(int(rank_str))
+                host = self.cluster.hosts[spec.host_index]
+                return host, host.zmq_port_base + _WORKER_OFFSET + spec.global_rank
+        raise ValueError(f"no control-plane endpoint defined for entity {entity_id!r}")
+
+    def connect_endpoint(self, entity_id: str) -> str:
+        host, port = self._host_and_port(entity_id)
+        return f"tcp://{host.addr}:{port}"
+
+    def bind_endpoint(self, entity_id: str) -> str:
+        host, port = self._host_and_port(entity_id)
+        return f"tcp://{host.bind_addr}:{port}"
+
+    def validate_ports(self, ranks) -> None:
+        """Fail if two entities would bind the same (addr, port).
+
+        Only bites when logical hosts share one machine address (loopback
+        rigs); their ``zmq_port_base`` values must keep every derived port
+        disjoint.
+        """
+        used: dict[tuple[str, int], str] = {}
+        entities = (
+            list(_HEAD_OFFSETS)
+            + [f"node_agent_{k}" for k in range(len(self.cluster.hosts))]
+            + [f"worker_{r}" for r in ranks]
+        )
+        for entity in entities:
+            host, port = self._host_and_port(entity)
+            key = (host.addr, port)
+            if key in used:
+                raise ValueError(
+                    f"control-plane port collision: {entity!r} and {used[key]!r} both "
+                    f"resolve to {host.addr}:{port}; give same-addr hosts disjoint "
+                    f"zmq_port_base values"
+                )
+            used[key] = entity

--- a/mstar/cluster/launcher.py
+++ b/mstar/cluster/launcher.py
@@ -1,0 +1,209 @@
+"""Worker process launchers.
+
+The conductor does not care where worker processes come from; it hands each
+launcher the specs it is responsible for and consumes a stream of lifecycle
+events. Two implementations exist: ``LocalLauncher`` spawns processes on the
+conductor's own host (the historical single-host path), and
+``NodeAgentLauncher`` hands launch specs to ``mstar-node`` agents that joined
+from other hosts and relays the worker-death reports they send back.
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing as mp
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Callable
+
+from mstar.utils.ipc_format import (
+    AgentJoin,
+    AgentJoinRejected,
+    AgentMessage,
+    AgentMessageType,
+    AgentShutdown,
+    AgentWorkerDied,
+    LaunchSpec,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WorkerEvent:
+    worker_id: str
+    exitcode: int | None
+
+
+class Launcher(ABC):
+    @abstractmethod
+    def ensure_workers(self) -> None:
+        """Start (or arrange the starting of) this launcher's workers."""
+
+    @abstractmethod
+    def poll(self) -> list[WorkerEvent]:
+        """Return newly observed worker deaths. May raise on startup failure."""
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Stop this launcher's workers. Safe to call more than once."""
+
+
+class LocalLauncher(Launcher):
+    """Spawns one process per worker on this host via the spawn context."""
+
+    def __init__(
+        self,
+        worker_ids: list[str],
+        model,
+        build_spawn_kwargs: Callable[[str], dict],
+        target: Callable | None = None,
+    ):
+        if target is None:
+            from mstar.conductor.conductor import _worker_process_target
+            target = _worker_process_target
+        self._worker_ids = worker_ids
+        self._model = model
+        self._build_spawn_kwargs = build_spawn_kwargs
+        self._target = target
+        self._procs: dict[str, mp.Process] = {}
+        self._reported: set[str] = set()
+
+    def ensure_workers(self) -> None:
+        ctx = mp.get_context("spawn")
+        for worker_id in self._worker_ids:
+            kwargs = dict(self._build_spawn_kwargs(worker_id))
+            kwargs["model"] = self._model
+            p = ctx.Process(target=self._target, kwargs=kwargs, daemon=False)
+            p.start()
+            self._procs[worker_id] = p
+
+    def poll(self) -> list[WorkerEvent]:
+        events = []
+        for worker_id, p in self._procs.items():
+            if worker_id not in self._reported and not p.is_alive():
+                self._reported.add(worker_id)
+                events.append(WorkerEvent(worker_id=worker_id, exitcode=p.exitcode))
+        return events
+
+    def shutdown(self) -> None:
+        for p in self._procs.values():
+            if p.is_alive():
+                p.terminate()
+        for p in self._procs.values():
+            p.join(timeout=5)
+        for p in self._procs.values():
+            if p.is_alive():
+                p.kill()
+                p.join(timeout=5)
+        self._procs.clear()
+
+
+class NodeAgentLauncher(Launcher):
+    """Ships launch specs to remote ``mstar-node`` agents as they join.
+
+    The conductor owns the message pump; it forwards ``AgentMessage`` traffic
+    to :meth:`handle_agent_message`. ``poll`` surfaces relayed worker deaths
+    and enforces the join deadline while any expected agent is missing.
+    """
+
+    def __init__(
+        self,
+        communicator,
+        launch_specs: dict[int, LaunchSpec],
+        join_timeout_s: float,
+    ):
+        self._communicator = communicator
+        self._launch_specs = launch_specs
+        self._expected = set(launch_specs)
+        self._joined: set[int] = set()
+        self._join_timeout_s = join_timeout_s
+        self._deadline: float | None = None
+        self._events: list[WorkerEvent] = []
+
+    def ensure_workers(self) -> None:
+        self._deadline = time.monotonic() + self._join_timeout_s
+        logger.info(
+            "Waiting for node agent(s) %s to join (timeout %.0fs)",
+            sorted(self._expected), self._join_timeout_s,
+        )
+
+    def handle_agent_message(self, message: AgentMessage) -> None:
+        body = message.body
+        if message.message_type == AgentMessageType.AGENT_JOIN:
+            self._handle_join(body)
+        elif message.message_type == AgentMessageType.AGENT_WORKER_DIED:
+            logger.error(
+                "Node agent %d reports worker %s died (exit %s)",
+                body.node_rank, body.worker_id, body.exitcode,
+            )
+            self._events.append(
+                WorkerEvent(worker_id=body.worker_id, exitcode=body.exitcode)
+            )
+        else:
+            logger.warning("Unexpected agent message: %s", message.message_type)
+
+    def _handle_join(self, body: AgentJoin) -> None:
+        k = body.node_rank
+        if k not in self._expected:
+            logger.error("Rejecting join from unexpected node rank %d", k)
+            try:
+                self._communicator.send(
+                    f"node_agent_{k}",
+                    AgentMessage(
+                        AgentMessageType.AGENT_JOIN_REJECTED,
+                        AgentJoinRejected(
+                            f"node rank {k} is not part of this deployment "
+                            f"(expected {sorted(self._expected)})"
+                        ),
+                    ),
+                )
+            except Exception:
+                # A rank outside the cluster spec has no addressable endpoint;
+                # dropping the join is all we can do.
+                logger.exception("Could not notify rejected node agent %d", k)
+            return
+        if k in self._joined:
+            logger.warning("Duplicate join from node agent %d; resending spec", k)
+        else:
+            logger.info(
+                "Node agent %d joined from %s (%d visible gpu(s), pid %d)",
+                k, body.addr, body.visible_gpus, body.pid,
+            )
+        self._joined.add(k)
+        self._communicator.send(
+            f"node_agent_{k}",
+            AgentMessage(AgentMessageType.LAUNCH_SPEC, self._launch_specs[k]),
+        )
+
+    def poll(self) -> list[WorkerEvent]:
+        missing = self._expected - self._joined
+        if missing and self._deadline is not None and time.monotonic() > self._deadline:
+            raise RuntimeError(
+                f"node agent(s) {sorted(missing)} did not join within "
+                f"{self._join_timeout_s:.0f}s — start `mstar-node --config <cfg> "
+                f"--node-rank <k>` on those hosts"
+            )
+        events, self._events = self._events, []
+        return events
+
+    def shutdown(self) -> None:
+        for k in sorted(self._joined):
+            try:
+                self._communicator.send(
+                    f"node_agent_{k}",
+                    AgentMessage(AgentMessageType.AGENT_SHUTDOWN, AgentShutdown()),
+                )
+            except Exception:
+                logger.exception("Failed to send shutdown to node agent %d", k)
+        self._joined.clear()
+
+
+__all__ = [
+    "Launcher",
+    "LocalLauncher",
+    "NodeAgentLauncher",
+    "WorkerEvent",
+    "AgentWorkerDied",
+]

--- a/mstar/cluster/node_agent.py
+++ b/mstar/cluster/node_agent.py
@@ -1,0 +1,217 @@
+"""Per-host worker supervisor for multi-host deployments.
+
+One ``mstar-node`` process runs on every non-head host:
+
+    mstar-node --config <same config as the head> --node-rank <k>
+
+It joins the conductor (whose address it derives from the config's
+``cluster:`` section), receives a launch spec, spawns this host's worker
+processes, and reports worker deaths back. The model object is constructed
+locally from the registry so weights load from this host's own cache rather
+than crossing the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import multiprocessing as mp
+import os
+import signal
+import time
+
+import yaml
+
+from mstar.cluster.endpoints import ControlPlaneEndpoints
+from mstar.cluster.spec import ClusterSpec
+from mstar.communication.communicator import ZMQCommunicator
+from mstar.utils.ipc_format import (
+    AgentJoin,
+    AgentMessage,
+    AgentMessageType,
+    AgentWorkerDied,
+    LaunchSpec,
+)
+from mstar.utils.logging_config import quiet_noisy_loggers
+
+logger = logging.getLogger(__name__)
+
+
+class NodeAgent:
+    def __init__(self, config_path: str, node_rank: int):
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+        self.cluster_spec = ClusterSpec.from_config(config)
+        if not self.cluster_spec.is_multi_host():
+            raise ValueError(
+                "mstar-node only applies to multi-host deployments; this config "
+                "has no (multi-host) cluster: section"
+            )
+        if not 0 < node_rank < len(self.cluster_spec.hosts):
+            raise ValueError(
+                f"--node-rank must name a non-head host (1..{len(self.cluster_spec.hosts) - 1}); "
+                f"host 0 is launched by mstar-serve itself"
+            )
+        self.node_rank = node_rank
+        self.my_id = f"node_agent_{node_rank}"
+        self.host = self.cluster_spec.hosts[node_rank]
+        self.communicator = ZMQCommunicator(
+            my_id=self.my_id,
+            push_ids=["conductor"],
+            endpoints=ControlPlaneEndpoints(self.cluster_spec),
+        )
+        self._procs: dict[str, mp.Process] = {}
+        self._reported_dead: set[str] = set()
+        self._launched = False
+        self._running = True
+        self._exit_code = 0
+
+    # ------------------------------------------------------------------
+
+    def run(self) -> int:
+        signal.signal(signal.SIGINT, self._on_signal)
+        signal.signal(signal.SIGTERM, self._on_signal)
+
+        import torch
+
+        visible_gpus = torch.cuda.device_count() if torch.cuda.is_available() else 0
+        expected = len(self.host.gpus)
+        if visible_gpus < expected:
+            logger.warning(
+                "Host declares %d gpu(s) in the cluster spec but only %d are "
+                "visible here", expected, visible_gpus,
+            )
+        self.communicator.send(
+            "conductor",
+            AgentMessage(
+                AgentMessageType.AGENT_JOIN,
+                AgentJoin(
+                    node_rank=self.node_rank,
+                    addr=self.host.addr,
+                    visible_gpus=visible_gpus,
+                    pid=os.getpid(),
+                ),
+            ),
+        )
+        logger.info(
+            "Joined as %s (%s); waiting for launch spec", self.my_id, self.host.addr
+        )
+
+        while self._running:
+            for message in self.communicator.get_all_new_messages():
+                if not isinstance(message, AgentMessage):
+                    logger.warning("Unexpected message type: %s", type(message))
+                    continue
+                if message.message_type == AgentMessageType.LAUNCH_SPEC:
+                    self._launch(message.body)
+                elif message.message_type == AgentMessageType.AGENT_SHUTDOWN:
+                    logger.info("Conductor requested shutdown")
+                    self._running = False
+                elif message.message_type == AgentMessageType.AGENT_JOIN_REJECTED:
+                    logger.error("Join rejected: %s", message.body.reason)
+                    self._running = False
+                    self._exit_code = 1
+                else:
+                    logger.warning("Unhandled agent message: %s", message.message_type)
+            self._check_children()
+            time.sleep(0.05)
+
+        self._terminate_children()
+        return self._exit_code
+
+    def _on_signal(self, signum, frame):
+        logger.info("Received signal %d; shutting down", signum)
+        self._running = False
+
+    # ------------------------------------------------------------------
+
+    def _launch(self, spec: LaunchSpec) -> None:
+        if self._launched:
+            logger.warning("Launch spec already applied; ignoring duplicate")
+            return
+        self._launched = True
+
+        for key, value in spec.host_env.items():
+            os.environ[key] = value
+
+        from mstar.model.registry import HF_MODELS, get_model_class
+
+        model = get_model_class(spec.model_name)(
+            model_path_hf=HF_MODELS.get(spec.model_name, {}).get("model_path_hf", ""),
+            cache_dir=spec.cache_dir,
+            **spec.model_kwargs,
+        )
+
+        from mstar.conductor.conductor import _worker_process_target
+
+        ctx = mp.get_context("spawn")
+        for kwargs in spec.workers:
+            kwargs = dict(kwargs)
+            kwargs["model"] = model
+            p = ctx.Process(target=_worker_process_target, kwargs=kwargs, daemon=False)
+            p.start()
+            self._procs[kwargs["worker_id"]] = p
+            logger.info(
+                "Spawned %s on device %s (pid %d)",
+                kwargs["worker_id"], kwargs.get("device"), p.pid,
+            )
+
+    def _check_children(self) -> None:
+        for worker_id, p in self._procs.items():
+            if worker_id not in self._reported_dead and not p.is_alive():
+                self._reported_dead.add(worker_id)
+                logger.error("%s exited with code %s", worker_id, p.exitcode)
+                self.communicator.send(
+                    "conductor",
+                    AgentMessage(
+                        AgentMessageType.AGENT_WORKER_DIED,
+                        AgentWorkerDied(
+                            node_rank=self.node_rank,
+                            worker_id=worker_id,
+                            exitcode=p.exitcode,
+                        ),
+                    ),
+                )
+
+    def _terminate_children(self) -> None:
+        for p in self._procs.values():
+            if p.is_alive():
+                p.terminate()
+        for p in self._procs.values():
+            p.join(timeout=5)
+        for p in self._procs.values():
+            if p.is_alive():
+                p.kill()
+                p.join(timeout=5)
+        self._procs.clear()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="mstar-node",
+        description="mstar per-host worker agent for multi-host deployments",
+    )
+    parser.add_argument(
+        "--config", required=True,
+        help="Path to the deployment's YAML config (same file the head uses)",
+    )
+    parser.add_argument("--node-rank", required=True, type=int,
+                        help="Index of this host in the config's cluster.hosts list")
+    parser.add_argument(
+        "--log-level", default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format=f"%(asctime)s %(levelname)s [node_agent_{args.node_rank}] %(name)s: %(message)s",
+    )
+    quiet_noisy_loggers()
+
+    agent = NodeAgent(config_path=args.config, node_rank=args.node_rank)
+    raise SystemExit(agent.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/mstar/cluster/node_agent.py
+++ b/mstar/cluster/node_agent.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 class NodeAgent:
     def __init__(self, config_path: str, node_rank: int):
+        self.config_path = config_path
         with open(config_path) as f:
             config = yaml.safe_load(f)
         self.cluster_spec = ClusterSpec.from_config(config)
@@ -141,6 +142,13 @@ class NodeAgent:
             cache_dir=spec.cache_dir,
             **spec.model_kwargs,
         )
+        # Models may specialize themselves from the deployment config (e.g.
+        # BAGEL only registers its CFG-parallel walks when the placement names
+        # those nodes). The conductor's model instance goes through these
+        # calls before its local workers spawn; make the same calls here so
+        # agent-spawned workers build identical graphs.
+        model.get_worker_graphs(self.config_path)
+        model.get_sharding_config(self.config_path)
 
         from mstar.conductor.conductor import _worker_process_target
 

--- a/mstar/cluster/spec.py
+++ b/mstar/cluster/spec.py
@@ -1,0 +1,209 @@
+"""Cluster topology: mapping global worker ranks onto hosts and local GPUs.
+
+A deployment is described by an optional ``cluster:`` section in the model
+config YAML:
+
+.. code-block:: yaml
+
+    cluster:
+      hosts:
+        - addr: nodeA            # routable hostname/IP for control + data planes
+          gpus: [0, 1, 2, 3]     # local CUDA indices, in global-rank order
+        - addr: nodeB
+          gpus: [0, 1]
+          zmq_port_base: 19500   # optional; per-host base for TCP control sockets
+
+Global ranks are assigned by concatenating ``gpus`` across hosts in order:
+nodeA's four GPUs are global ranks 0-3, nodeB's two GPUs are ranks 4-5. The
+``ranks`` lists in ``node_groups`` continue to use these global ranks, so the
+placement vocabulary is unchanged.
+
+When the section is absent the deployment is a single host and every global
+rank maps to the same-numbered local CUDA device (``rank r`` -> ``cuda:r``),
+exactly matching the historical single-host behavior — including configs whose
+rank sets are non-contiguous.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ZMQ_PORT_BASE = 19000
+LOCALHOST = "localhost"
+
+_HOST_KEYS = {"addr", "gpus", "zmq_port_base", "bind_addr", "env", "rdma_device"}
+
+
+@dataclass(frozen=True)
+class HostSpec:
+    """One machine in the deployment."""
+
+    addr: str  # routable hostname or IP; used for control sockets, transfer-engine sessions, and NCCL rendezvous
+    gpus: tuple[int, ...]  # local CUDA indices, in global-rank order
+    zmq_port_base: int = DEFAULT_ZMQ_PORT_BASE
+    bind_addr: str = "0.0.0.0"  # interface to bind listening sockets on (multi-NIC hosts)
+    env: dict[str, str] = field(default_factory=dict)  # extra env for this host's workers (e.g. NCCL_SOCKET_IFNAME)
+    rdma_device: str = ""  # optional device filter for the RDMA transfer engine
+
+
+@dataclass(frozen=True)
+class WorkerSpec:
+    """Where one worker (one global rank) runs."""
+
+    worker_id: str
+    global_rank: int
+    host_index: int
+    local_device: int  # CUDA index on its host: the worker's device is cuda:{local_device}
+    addr: str  # the host's routable address
+
+
+class ClusterSpec:
+    """Parsed, validated view of the ``cluster:`` config section.
+
+    ``identity_single_host=True`` is the synthesized default used when the
+    config has no ``cluster:`` section: one host at ``localhost`` where any
+    global rank maps to the identically-numbered CUDA device. Explicit specs
+    instead enumerate every GPU and reject ranks outside the enumeration.
+    """
+
+    def __init__(self, hosts: list[HostSpec], identity_single_host: bool = False):
+        if not hosts:
+            raise ValueError("cluster: `hosts` must contain at least one host")
+        if identity_single_host and (len(hosts) != 1 or hosts[0].gpus):
+            raise ValueError("identity_single_host requires exactly one host with no explicit gpus")
+        for i, host in enumerate(hosts):
+            if not host.addr:
+                raise ValueError(f"cluster: hosts[{i}] has an empty `addr`")
+            if not identity_single_host and not host.gpus:
+                raise ValueError(f"cluster: hosts[{i}] ({host.addr}) has an empty `gpus` list")
+            if any((not isinstance(g, int)) or g < 0 for g in host.gpus):
+                raise ValueError(f"cluster: hosts[{i}] ({host.addr}) gpus must be non-negative integers: {host.gpus}")
+            if len(set(host.gpus)) != len(host.gpus):
+                raise ValueError(f"cluster: hosts[{i}] ({host.addr}) lists a duplicate GPU index: {host.gpus}")
+
+        self.hosts = list(hosts)
+        self._identity = identity_single_host
+
+        # global rank -> (host index, local CUDA index), in enumeration order.
+        self._rank_map: dict[int, tuple[int, int]] = {}
+        if not self._identity:
+            rank = 0
+            for host_idx, host in enumerate(self.hosts):
+                for local_device in host.gpus:
+                    self._rank_map[rank] = (host_idx, local_device)
+                    rank += 1
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def single_host(cls) -> "ClusterSpec":
+        return cls([HostSpec(addr=LOCALHOST, gpus=())], identity_single_host=True)
+
+    @classmethod
+    def from_config(cls, config: dict | None) -> "ClusterSpec":
+        """Build from a loaded model-config dict; absent section => single host."""
+        cluster = (config or {}).get("cluster")
+        if cluster is None:
+            return cls.single_host()
+        if not isinstance(cluster, dict) or "hosts" not in cluster:
+            raise ValueError("cluster: section must be a mapping with a `hosts` list")
+        hosts = []
+        for i, entry in enumerate(cluster["hosts"]):
+            if not isinstance(entry, dict):
+                raise ValueError(f"cluster: hosts[{i}] must be a mapping, got {type(entry).__name__}")
+            unknown = set(entry) - _HOST_KEYS
+            if unknown:
+                raise ValueError(
+                    f"cluster: hosts[{i}] has unknown key(s) {sorted(unknown)}; known keys: {sorted(_HOST_KEYS)}"
+                )
+            if "addr" not in entry or "gpus" not in entry:
+                raise ValueError(f"cluster: hosts[{i}] must define `addr` and `gpus`")
+            hosts.append(HostSpec(
+                addr=str(entry["addr"]),
+                gpus=tuple(entry["gpus"]),
+                zmq_port_base=int(entry.get("zmq_port_base", DEFAULT_ZMQ_PORT_BASE)),
+                bind_addr=str(entry.get("bind_addr", "0.0.0.0")),
+                env={str(k): str(v) for k, v in (entry.get("env") or {}).items()},
+                rdma_device=str(entry.get("rdma_device", "")),
+            ))
+        return cls(hosts)
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def is_multi_host(self) -> bool:
+        return len(self.hosts) > 1
+
+    @property
+    def head(self) -> HostSpec:
+        return self.hosts[0]
+
+    @property
+    def head_addr(self) -> str:
+        return self.head.addr
+
+    def worker_spec(self, global_rank: int) -> WorkerSpec:
+        if self._identity:
+            if global_rank < 0:
+                raise ValueError(f"invalid global rank {global_rank}")
+            return WorkerSpec(
+                worker_id=f"worker_{global_rank}",
+                global_rank=global_rank,
+                host_index=0,
+                local_device=global_rank,
+                addr=self.head_addr,
+            )
+        if global_rank not in self._rank_map:
+            raise ValueError(
+                f"global rank {global_rank} is not in the cluster "
+                f"(cluster enumerates ranks 0..{len(self._rank_map) - 1})"
+            )
+        host_idx, local_device = self._rank_map[global_rank]
+        return WorkerSpec(
+            worker_id=f"worker_{global_rank}",
+            global_rank=global_rank,
+            host_index=host_idx,
+            local_device=local_device,
+            addr=self.hosts[host_idx].addr,
+        )
+
+    def host_of_rank(self, global_rank: int) -> int:
+        return self.worker_spec(global_rank).host_index
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate_ranks(self, ranks) -> None:
+        """Every rank referenced by the placement must exist in the cluster."""
+        for rank in ranks:
+            self.worker_spec(rank)  # raises with a precise message
+
+    def validate_protocol(self, protocol) -> None:
+        """Reject transports that cannot cross hosts.
+
+        The SHM tensor transport moves bytes through host-local files, so it
+        is only valid when every worker shares one machine.
+        """
+        name = getattr(protocol, "value", protocol)
+        if self.is_multi_host() and str(name).upper() == "SHM":
+            raise ValueError(
+                "tensor-comm-protocol SHM cannot be used with a multi-host cluster; "
+                "use RDMA or TCP"
+            )
+
+    # ------------------------------------------------------------------
+    # Logging
+    # ------------------------------------------------------------------
+
+    def summary(self) -> str:
+        if self._identity:
+            return "single host (localhost), global rank == local CUDA device"
+        per_host = ", ".join(f"{h.addr}: {len(h.gpus)} gpu(s)" for h in self.hosts)
+        return f"{len(self.hosts)} host(s), {len(self._rank_map)} gpu(s) [{per_host}]"

--- a/mstar/communication/communicator.py
+++ b/mstar/communication/communicator.py
@@ -41,13 +41,24 @@ class ZMQCommunicator(BaseCommunicator):
         push_ids: list[str],
         protocol: CommProtocol=CommProtocol.IPC,
         ipc_socket_path_prefix: str="/tmp/mstar/",
-        # TODO: for TCP
+        endpoints=None,
     ):
+        """``endpoints`` is an optional ControlPlaneEndpoints resolver. When it
+        is provided and reports a multi-host cluster, every socket uses TCP at
+        the resolver's per-entity addresses (env overrides do not apply — the
+        cluster spec is authoritative). Otherwise behavior is unchanged: ipc
+        sockets under ``ipc_socket_path_prefix`` by default, or the legacy
+        single-host TCP mode via MSTAR_ZMQ_* env vars.
+        """
         self.context = zmq.Context.instance()
-        transport = os.getenv("MSTAR_ZMQ_TRANSPORT", protocol.value).upper()
-        self.protocol = CommProtocol(transport)
+        self._resolver = endpoints if (endpoints is not None and endpoints.use_tcp()) else None
+        if self._resolver is not None:
+            self.protocol = CommProtocol.TCP
+        else:
+            transport = os.getenv("MSTAR_ZMQ_TRANSPORT", protocol.value).upper()
+            self.protocol = CommProtocol(transport)
         self.pull_socket = self.context.socket(zmq.PULL)
-        if self.protocol == CommProtocol.IPC:
+        if self._resolver is None and self.protocol == CommProtocol.IPC:
             os.makedirs(ipc_socket_path_prefix, exist_ok=True)
 
         # TODO: maybe only open sockets as we need them, and close sockets
@@ -56,7 +67,17 @@ class ZMQCommunicator(BaseCommunicator):
         self.my_id = my_id
         self.ipc_socket_path_prefix = ipc_socket_path_prefix
 
-        if self.protocol == CommProtocol.IPC:
+        if self._resolver is not None:
+            self.pull_socket.bind(self._resolver.bind_endpoint(my_id))
+            self.pull_socket.setsockopt(zmq.LINGER, 0)
+        elif self.protocol == CommProtocol.IPC:
+            # A socket file left behind by an unclean shutdown must not
+            # survive into this bind: a peer that connects to the stale inode
+            # never reaches the new process, silently black-holing messages.
+            stale = f"{ipc_socket_path_prefix}/{my_id}.ipc"
+            if os.path.exists(stale):
+                logger.warning("Removing stale ipc socket file %s", stale)
+                os.unlink(stale)
             self.pull_socket.bind(self._endpoint(my_id))
             self.pull_socket.setsockopt(zmq.LINGER, 0)
         elif self.protocol == CommProtocol.TCP:
@@ -85,6 +106,8 @@ class ZMQCommunicator(BaseCommunicator):
             self.event.drain()
 
     def _endpoint(self, entity_id: str) -> str:
+        if self._resolver is not None:
+            return self._resolver.connect_endpoint(entity_id)
         if self.protocol == CommProtocol.IPC:
             return f"ipc://{self.ipc_socket_path_prefix}/{entity_id}.ipc"
         if self.protocol == CommProtocol.TCP:
@@ -122,6 +145,13 @@ class ZMQCommunicator(BaseCommunicator):
             sock.setsockopt(zmq.LINGER, 0)
             self.push_sockets[entity_id] = sock
         self.push_sockets[entity_id].send_pyobj(msg)
+
+    def close(self):
+        """Close all sockets. Safe to call more than once."""
+        for sock in self.push_sockets.values():
+            sock.close(linger=0)
+        self.push_sockets.clear()
+        self.pull_socket.close(linger=0)
 
     def get_all_new_messages(self, blocking=False) -> list:
         messages = []

--- a/mstar/communication/tensors.py
+++ b/mstar/communication/tensors.py
@@ -549,6 +549,7 @@ class TensorCommunicationManager(ABC):
     def register_for_send(
         self, request_id: str, uuids: list[str],
         skip_cuda_sync: bool = False,
+        shm_uuids: set[str] | None = None,
     ):
         """Mark these uuids ready for remote consumers to RDMA-read.
 
@@ -557,6 +558,11 @@ class TensorCommunicationManager(ABC):
         addresses are shared with peers. Callers must have already synced on
         their own (e.g. before a batched loop) — meant to cut N serialized
         syncs to 1 when registering many uuids in a row.
+
+        ``shm_uuids`` is the subset of ``uuids`` whose consumers are all
+        co-hosted with this entity; a hybrid manager sends those through
+        shared memory instead of the transfer engine. Single-transport
+        managers ignore it (they have exactly one way to send).
 
         If self.enable_prof is set, this should also update self.req_tx_info
         """
@@ -871,7 +877,9 @@ class MooncakeCommunicationManager(TensorCommunicationManager):
             enable_prof=enable_prof
         )
 
-    def register_for_send(self, request_id, uuids, skip_cuda_sync=False):
+    def register_for_send(
+        self, request_id, uuids, skip_cuda_sync=False, shm_uuids=None,
+    ):
         if not skip_cuda_sync:
             torch.cuda.default_stream().synchronize()
         for uuid in uuids:
@@ -1070,6 +1078,7 @@ class SharedMemoryCommunicationManager(TensorCommunicationManager):
     def register_for_send(
         self, request_id: str, uuids: list[str],
         skip_cuda_sync: bool = False,
+        shm_uuids: set[str] | None = None,
     ):
         if not skip_cuda_sync and torch.cuda.is_available():
             torch.cuda.default_stream().synchronize()
@@ -1175,6 +1184,186 @@ class SharedMemoryCommunicationManager(TensorCommunicationManager):
 
 
 # ---------------------------------------------------------------------------
+# HybridCommunicationManager
+# ---------------------------------------------------------------------------
+
+class HybridCommunicationManager(MooncakeCommunicationManager):
+    """Transfer engine for cross-host consumers, shared memory for co-hosted ones.
+
+    One manager, one ``TensorStore``, one pending/ack lifecycle — only the
+    byte movement differs per tensor. The producer decides the transport at
+    registration time (``shm_uuids``: tensors whose every consumer is on this
+    host) and marks it on the ``TensorPointerInfo`` (``via_shm``), so a
+    sharded edge can fan in shards over both transports at once. Tensors sent
+    through shared memory are never engine-registered; the reverse also holds.
+    """
+
+    def __init__(
+        self,
+        my_entity_id: str,
+        hostname: str,
+        device: str,
+        communicator: BaseCommunicator,
+        protocol: CommProtocol = CommProtocol.RDMA,
+        metadata_server: str = "P2PHANDSHAKE",
+        tcp_transfer_device: str = "",
+        shm_dir: str | None = None,
+        enable_prof: bool = False,
+    ):
+        super().__init__(
+            my_entity_id=my_entity_id,
+            hostname=hostname,
+            device=device,
+            communicator=communicator,
+            protocol=protocol,
+            metadata_server=metadata_server,
+            tcp_transfer_device=tcp_transfer_device,
+            enable_prof=enable_prof,
+        )
+        self.shm_dir = shm_dir or _default_shm_dir()
+        os.makedirs(self.shm_dir, exist_ok=True)
+        # uuid → file path; doubles as the "already written" send dedup, so
+        # shm-sent uuids keep ``mem_registered`` False and the engine cleanup
+        # path never tries to unregister memory it never pinned.
+        self._shm_files: dict[str, str] = {}
+        self._d2h_stream: torch.cuda.Stream | None = None
+        self._h2d_stream: torch.cuda.Stream | None = None
+        if torch.cuda.is_available() and str(device) != "cpu":
+            self._d2h_stream = torch.cuda.Stream(device=device)
+            self._h2d_stream = torch.cuda.Stream(device=device)
+
+    def _shm_path(self, entity_id: str, uuid: str) -> str:
+        return os.path.join(self.shm_dir, f"mstar_{entity_id}_{uuid}")
+
+    def register_for_send(
+        self, request_id, uuids, skip_cuda_sync=False, shm_uuids=None,
+    ):
+        shm_uuids = shm_uuids or set()
+        if not skip_cuda_sync and torch.cuda.is_available():
+            torch.cuda.default_stream().synchronize()
+        engine_uuids = [u for u in uuids if u not in shm_uuids]
+        if engine_uuids:
+            super().register_for_send(
+                request_id, engine_uuids, skip_cuda_sync=True,
+            )
+        if not shm_uuids:
+            return
+        ctx = (
+            torch.cuda.stream(self._d2h_stream)
+            if self._d2h_stream is not None
+            else _nullcontext()
+        )
+        with ctx:
+            for uuid in shm_uuids:
+                if uuid in self._shm_files:
+                    continue
+                tensor = self.tensor_store.get_tensor(request_id, uuid)
+                t0 = time.perf_counter()
+                data = _serialize_tensor(tensor)
+                path = self._shm_path(self.my_entity_id, uuid)
+                with open(path, "wb") as f:
+                    f.write(data)
+                self._shm_files[uuid] = path
+                if self.enable_prof:
+                    self._record_tx(
+                        request_id, uuid, len(data), time.perf_counter() - t0
+                    )
+
+    def start_read_tensors(
+        self, request_id: str, graph_edges: list[GraphEdge],
+        graph_walk: str | None = None
+    ) -> list[Future]:
+        futures = []
+        h2d_did_work = False
+        for graph_edge in graph_edges:
+            if len(graph_edge.tensor_info) == 0:
+                continue
+            read_info = []
+            shm_elapsed = 0.0
+            for info in graph_edge.tensor_info:
+                if info.source_entity == self.my_entity_id:
+                    self._slice_existing_tensor(
+                        request_id=request_id, name=graph_edge.name,
+                        next_node=graph_edge.next_node,
+                        graph_walk=graph_walk, info=info
+                    )
+                    self.tensor_store.increment_ref(request_id, info.uuid, 1)
+                    continue
+                if self.tensor_store.check_uuid_presence(request_id, info.uuid):
+                    self.tensor_store.increment_ref(request_id, info.uuid, 1)
+                    continue
+                if info.via_shm:
+                    rx_t0 = time.perf_counter()
+                    path = self._shm_path(info.source_entity, info.uuid)
+                    with open(path, "rb") as f:
+                        f.seek(info.offset)
+                        data = f.read(info.nbytes)
+                    ctx = (
+                        torch.cuda.stream(self._h2d_stream)
+                        if self._h2d_stream is not None
+                        else _nullcontext()
+                    )
+                    with ctx:
+                        tensor = _deserialize_tensor(data, self.device, tensor_info=info)
+                    h2d_did_work = True
+                    shm_elapsed += time.perf_counter() - rx_t0
+                    self.tensor_store.put_tensor(request_id, info.uuid, tensor)
+                    # +1 for transit (released by get_ready_tensors)
+                    # +1 for graph-node usage (released by _cleanup_consumed_inputs)
+                    self.tensor_store.increment_ref(request_id, info.uuid, 2)
+                    continue
+                buffer = torch.empty(
+                    info.dims, dtype=info.dtype, device=self.device
+                ).as_strided(info.dims, stride=info.stride)
+                self.tensor_store.put_tensor(
+                    request_id=request_id, uuid=info.uuid, tensor=buffer
+                )
+                self.tensor_store.set_metadata(
+                    request_id, info.uuid, mem_registered=True
+                )
+                # +1 for transit (released by get_ready_tensors)
+                # +1 for graph-node usage (released by _cleanup_consumed_inputs)
+                self.tensor_store.increment_ref(request_id, info.uuid, 2)
+                if self.protocol == CommProtocol.RDMA:
+                    self.transfer_engine.register_memory(buffer.data_ptr(), info.nbytes)
+                read_info.append(TransferReadInfo(
+                    source_session_id=info.source_session_id,
+                    local_ptr=buffer.data_ptr(),
+                    remote_ptr=info.address + info.offset,
+                    nbytes=info.nbytes,
+                ))
+            # One pending entry per edge regardless of how its tensors
+            # arrived. The shm part completed inline (rx_time pre-set); if an
+            # engine read is also in flight, the async reader re-stamps
+            # rx_time when it finishes and the future gates edge readiness.
+            fp = FutureAndPointers(
+                future=None, graph_edges=[graph_edge], request_id=request_id,
+                rx_time=shm_elapsed or None,
+            )
+            if read_info:
+                if self.enable_prof:
+                    for ri in read_info:
+                        ri.fp = fp
+                fut = self._async_reader.submit(read_info)
+                fp.future = fut
+                if fut is not None:
+                    futures.append(fut)
+            self.pending.append(fp)
+        if h2d_did_work and self._h2d_stream is not None:
+            torch.cuda.default_stream(self.device).wait_stream(self._h2d_stream)
+        return futures
+
+    def _cleanup_by_uuid(self, request_id: str, uuid: str):
+        path = self._shm_files.pop(uuid, None)
+        if path is not None:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+        super()._cleanup_by_uuid(request_id, uuid)
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
@@ -1187,9 +1376,17 @@ def create_tensor_communication_manager(
     metadata_server: str = "P2PHANDSHAKE",
     tcp_transfer_device: str = "",
     shm_dir: str | None = None,
-    enable_prof: bool=False
+    enable_prof: bool=False,
+    same_host_entities: set[str] | None = None,
 ) -> TensorCommunicationManager:
-    """Select tensor transport backend based on protocol."""
+    """Select tensor transport backend based on protocol.
+
+    ``same_host_entities`` (the entities co-hosted with this one, supplied
+    only for multi-host deployments) upgrades TCP/RDMA to the hybrid manager:
+    the engine carries cross-host transfers while co-hosted transfers use
+    shared memory. ``None`` keeps the single-transport managers, so
+    single-host deployments behave exactly as before.
+    """
     if protocol == CommProtocol.SHM:
         return SharedMemoryCommunicationManager(
             my_entity_id=my_entity_id,
@@ -1198,6 +1395,18 @@ def create_tensor_communication_manager(
             communicator=communicator,
             shm_dir=shm_dir,
             enable_prof=enable_prof
+        )
+    if same_host_entities is not None:
+        return HybridCommunicationManager(
+            my_entity_id=my_entity_id,
+            hostname=hostname,
+            device=device,
+            communicator=communicator,
+            protocol=protocol,
+            metadata_server=metadata_server,
+            tcp_transfer_device=tcp_transfer_device,
+            shm_dir=shm_dir,
+            enable_prof=enable_prof,
         )
     return MooncakeCommunicationManager(
         my_entity_id=my_entity_id,

--- a/mstar/communication/tensors.py
+++ b/mstar/communication/tensors.py
@@ -260,20 +260,27 @@ class MooncakeTransferEngine(TensorTransferEngine):
                 "Install mooncake-transfer-engine or use SHM protocol."
             )
 
-        if protocol == CommProtocol.RDMA:
-            transfer_device = ""
-        elif protocol == CommProtocol.TCP:
-            transfer_device = tcp_transfer_device
-        else:
+        if protocol not in (CommProtocol.RDMA, CommProtocol.TCP):
             raise NotImplementedError(f"Unknown protocol {protocol} for mooncake")
+        # Device filter for the engine: an HCA name (or comma list) under RDMA,
+        # a segment/interface string under TCP. Empty means auto-discovery.
+        transfer_device = tcp_transfer_device
 
         self._engine = TransferEngine()
-        self._engine.initialize(
+        ret = self._engine.initialize(
             hostname,
             metadata_server,
             protocol.value.lower(),
             transfer_device,
         )
+        if ret != 0:
+            raise RuntimeError(
+                f"Mooncake TransferEngine initialize failed (rc={ret}) for "
+                f"hostname={hostname!r} protocol={protocol.value} "
+                f"device={transfer_device!r}. On hosts without an active RDMA "
+                "fabric, TCP mode typically needs an explicit device/segment "
+                "(e.g. --tcp-transfer-device 0.0.0.0.0)."
+            )
         self._session_id = f"{hostname}:{self._engine.get_rpc_port()}"
 
     def register_memory(self, ptr: int, nbytes: int) -> int:

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -126,7 +126,10 @@ def find_cross_host_cuts(
 
     Returns tuples of (walk, source node, dest node, edge name, source hosts,
     dest hosts). An edge is a potential cut unless both endpoints resolve to
-    the same single host for every replica.
+    the same single host for every replica. Cross-walk transfers mediated by
+    persisted signals are not counted: a persist edge ships pointer metadata
+    to the conductor, and the tensor itself moves only when a later walk's
+    consumer — assigned per request — reads it.
     """
     cuts: set[tuple] = set()
     for wg in worker_graphs.values():
@@ -297,6 +300,7 @@ class Conductor:
         log_level: str = "INFO",
         tensor_comm_protocol=CommProtocol.RDMA,
         tcp_transfer_device="",
+        intra_host_tensor_protocol=CommProtocol.SHM,
         model_cache_dir: str | None = None,
         startup_timeout_s: float = 600.0,
     ):
@@ -308,6 +312,7 @@ class Conductor:
         self.enable_prof = enable_prof
         self.tensor_comm_protocol = tensor_comm_protocol
         self.tcp_transfer_device = tcp_transfer_device
+        self.intra_host_tensor_protocol = intra_host_tensor_protocol
         self.model_cache_dir = model_cache_dir
         self._startup_timeout_s = startup_timeout_s
 
@@ -541,12 +546,13 @@ class Conductor:
         """Entities co-hosted with workers on ``host_index``.
 
         None outside multi-host mode (single-host keeps the single-transport
-        managers), and under MSTAR_NO_INTRA_HOST_SHM — the escape hatch that
-        forces every transfer through the transfer engine.
+        managers), and when ``intra_host_tensor_protocol`` is anything but
+        SHM — then co-hosted transfers ride the transfer engine like
+        cross-host ones.
         """
         if not self.cluster_spec.is_multi_host():
             return None
-        if os.environ.get("MSTAR_NO_INTRA_HOST_SHM"):
+        if self.intra_host_tensor_protocol != CommProtocol.SHM:
             return None
         entities = {
             wid for wid, spec in self.worker_specs.items()

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -71,6 +71,87 @@ class NoLiveReplicaError(RuntimeError):
     """Every replica that could serve a worker graph contains a dead worker."""
 
 
+def assign_worker_graphs(
+    worker_graphs: dict[str, WorkerGraph],
+    cluster_spec: ClusterSpec,
+    dead_workers: set[str],
+) -> dict[str, list[str]]:
+    """Pick a DP replica per node group and map worker graphs to workers.
+
+    Picks are coordinated by ``_group_id`` so all wgs derived from the same
+    node_group land on the same replica's workers. Replicas containing dead
+    workers are skipped. Among live replicas, ones on hosts this request
+    already uses are preferred, so adjacent stages avoid cross-host hops when
+    the placement offers a choice; ties break uniformly at random (on a single
+    host every replica ties, preserving the uniform-random behavior).
+    """
+    group_id_to_replica_idx: dict[int, int] = {}
+    chosen_hosts: set[int] = set()
+    result: dict[str, list[str]] = {}
+    for wg_id, wg in worker_graphs.items():
+        replicas = wg._tp_ranks if wg._tp_ranks else [[r] for r in wg.ranks]
+        if wg._group_id not in group_id_to_replica_idx:
+            live = [
+                i for i, ranks in enumerate(replicas)
+                if not any(f"worker_{r}" in dead_workers for r in ranks)
+            ]
+            if not live:
+                raise NoLiveReplicaError(
+                    f"no live replica remains for nodes "
+                    f"{sorted(wg.section.get_nodes())} "
+                    f"(dead workers: {sorted(dead_workers)})"
+                )
+
+            scores = [
+                len({cluster_spec.host_of_rank(r) for r in replicas[i]} & chosen_hosts)
+                for i in live
+            ]
+            best = max(scores)
+            candidates = [i for i, s in zip(live, scores, strict=True) if s == best]
+            group_id_to_replica_idx[wg._group_id] = candidates[
+                int(np.random.randint(len(candidates)))
+            ]
+        ranks = replicas[group_id_to_replica_idx[wg._group_id]]
+        chosen_hosts.update(cluster_spec.host_of_rank(r) for r in ranks)
+        result[wg_id] = [f"worker_{r}" for r in ranks]
+    return result
+
+
+def find_cross_host_cuts(
+    worker_graphs: dict[str, WorkerGraph],
+    node_walk_to_wg: dict[tuple[str, str], WorkerGraph],
+    cluster_spec: ClusterSpec,
+) -> set[tuple]:
+    """Graph edges that can cross hosts under this placement.
+
+    Returns tuples of (walk, source node, dest node, edge name, source hosts,
+    dest hosts). An edge is a potential cut unless both endpoints resolve to
+    the same single host for every replica.
+    """
+    cuts: set[tuple] = set()
+    for wg in worker_graphs.values():
+        wg_nodes = set(wg.section.get_nodes())
+        src_hosts = tuple(sorted({cluster_spec.host_of_rank(r) for r in wg.ranks}))
+        for walk in wg.graph_walks:
+            for node_name, node in wg.section.get_nodes().items():
+                for edge in node.outputs:
+                    if edge.next_node in wg_nodes:
+                        continue
+                    dest_wg = node_walk_to_wg.get((edge.next_node, walk))
+                    if dest_wg is None:
+                        continue
+                    dst_hosts = tuple(sorted({
+                        cluster_spec.host_of_rank(r) for r in dest_wg.ranks
+                    }))
+                    if src_hosts == dst_hosts and len(src_hosts) == 1:
+                        continue
+                    cuts.add((
+                        walk, node_name, edge.next_node, edge.name,
+                        src_hosts, dst_hosts,
+                    ))
+    return cuts
+
+
 def _pick_free_tcp_port() -> int:
     """Ask the OS for an unused ephemeral TCP port.
 
@@ -436,6 +517,24 @@ class Conductor:
             local_devices=[self.worker_specs[wid].local_device for wid in self.worker_ids],
         )
 
+        if self.cluster_spec.is_multi_host():
+            cuts = find_cross_host_cuts(
+                self.worker_graphs, self.node_walk_to_wg, self.cluster_spec,
+            )
+            proto = getattr(
+                self.tensor_comm_protocol, "value", self.tensor_comm_protocol
+            )
+            for walk, src, dst, edge_name, src_hosts, dst_hosts in sorted(cuts):
+                logger.info(
+                    "Cross-host edge: [%s] %s -> %s (%s), hosts %s -> %s, via %s",
+                    walk, src, dst, edge_name,
+                    list(src_hosts), list(dst_hosts), proto,
+                )
+            logger.info(
+                "%d graph edge(s) may cross hosts under this placement",
+                len(cuts),
+            )
+
     def _worker_spawn_kwargs(self, worker_id: str) -> dict:
         """Keyword arguments for one worker's process target, minus the model.
 
@@ -577,39 +676,9 @@ class Conductor:
             launcher.shutdown()
 
     def _assign_worker_graphs_to_workers(self) -> dict[str, list[str]]:
-        """
-        For a request, assign worker graphs to workers. DP picks are
-        coordinated by ``_group_id`` so all wgs derived from the same
-        node_group land on the same (replica's) workers — without this,
-        two wgs sharing a TP group could end up on different DP replicas
-        and break model topology.
-
-        TODO: smarter assignment that minimizes cross-graph-walk tensor
-        transfer (e.g., bias toward keeping prefill→decode handoff local
-        for the same request).
-        """
-        # _group_id -> chosen DP-replica index within that group's ranks
-        group_id_to_replica_idx: dict[int, int] = {}
-        result = {}
-        for wg_id, wg in self.worker_graphs.items():
-            replicas = wg._tp_ranks if wg._tp_ranks else [[r] for r in wg.ranks]
-            if wg._group_id not in group_id_to_replica_idx:
-                live = [
-                    i for i, ranks in enumerate(replicas)
-                    if not any(f"worker_{r}" in self._dead_workers for r in ranks)
-                ]
-                if not live:
-                    raise NoLiveReplicaError(
-                        f"no live replica remains for nodes "
-                        f"{sorted(wg.section.get_nodes())} "
-                        f"(dead workers: {sorted(self._dead_workers)})"
-                    )
-                group_id_to_replica_idx[wg._group_id] = live[
-                    int(np.random.randint(len(live)))
-                ]
-            replica_idx = group_id_to_replica_idx[wg._group_id]
-            result[wg_id] = [f"worker_{r}" for r in replicas[replica_idx]]
-        return result
+        return assign_worker_graphs(
+            self.worker_graphs, self.cluster_spec, self._dead_workers,
+        )
 
     def _build_request_sharding_config(
         self, worker_graph_to_workers: dict[str, list[str]],

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -13,6 +13,7 @@ import torch
 import yaml
 
 from mstar.api_server.request_types import APIServerMessage, RequestComplete
+from mstar.cluster.endpoints import ControlPlaneEndpoints
 from mstar.cluster.spec import ClusterSpec
 from mstar.communication.communicator import CommProtocol, ZMQCommunicator
 from mstar.conductor.request_info import (
@@ -92,6 +93,7 @@ def _worker_process_target(
     hostname: str,
     socket_path_prefix: str,
     dist_init_method: str,
+    endpoints=None,
     enable_nvtx: bool = False,
     enable_prof: bool = False,
     model: Model | None = None,
@@ -127,6 +129,7 @@ def _worker_process_target(
             tp_groups=tp_groups,
             hostname=hostname,
             socket_path_prefix=socket_path_prefix,
+            endpoints=endpoints,
             dist_init_method=dist_init_method,
             enable_nvtx=enable_nvtx,
             enable_prof=enable_prof,
@@ -232,6 +235,7 @@ class Conductor:
         self.cluster_spec = ClusterSpec.from_config(self.model_config)
         self.cluster_spec.validate_protocol(tensor_comm_protocol)
         self.head_addr = hostname if hostname is not None else self.cluster_spec.head_addr
+        self.control_endpoints = ControlPlaneEndpoints(self.cluster_spec)
         logger.info("Cluster: %s", self.cluster_spec.summary())
 
         self.default_sharding_config = model.get_sharding_config(model_config_file)
@@ -314,6 +318,7 @@ class Conductor:
             my_id="conductor",
             push_ids=self.worker_ids + ["api_server", "api_server_preprocess_worker"],
             ipc_socket_path_prefix=socket_path_prefix,
+            endpoints=self.control_endpoints,
         )
 
     def _get_kv_config(self):
@@ -357,6 +362,8 @@ class Conductor:
         # placement fails here with a precise message instead of inside a
         # spawned worker.
         self.cluster_spec.validate_ranks(self._sorted_ranks)
+        if self.cluster_spec.is_multi_host():
+            self.control_endpoints.validate_ports(self._sorted_ranks)
         self.worker_specs = {
             worker_id: self.cluster_spec.worker_spec(rank)
             for rank, worker_id in zip(self._sorted_ranks, self.worker_ids, strict=True)
@@ -433,6 +440,7 @@ class Conductor:
                     "tp_groups": self.tp_config.per_worker_config[worker_id],
                     "hostname": spec.addr,
                     "socket_path_prefix": self.socket_path_prefix,
+                    "endpoints": self.control_endpoints,
                     "dist_init_method": self._dist_init_method,
                     "model": self.model,
                     "enable_nvtx": self.enable_nvtx,

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -188,6 +188,7 @@ def _worker_process_target(
     log_level: str = "INFO",
     tensor_comm_protocol=CommProtocol.RDMA,
     tcp_transfer_device="",
+    same_host_entities: set[str] | None = None,
 ):
     """Top-level target for spawned worker processes. Must be module-level for picklability."""
     logging.basicConfig(
@@ -223,6 +224,7 @@ def _worker_process_target(
             device=torch.device(device),
             tensor_comm_protocol=tensor_comm_protocol,
             tcp_transfer_device=tcp_transfer_device,
+            same_host_entities=same_host_entities,
         )
     except BaseException as e:
         logger.exception("Worker %s failed to initialize: %s", worker_id, str(e))
@@ -535,6 +537,25 @@ class Conductor:
                 len(cuts),
             )
 
+    def _same_host_entities(self, host_index: int) -> set[str] | None:
+        """Entities co-hosted with workers on ``host_index``.
+
+        None outside multi-host mode (single-host keeps the single-transport
+        managers), and under MSTAR_NO_INTRA_HOST_SHM — the escape hatch that
+        forces every transfer through the transfer engine.
+        """
+        if not self.cluster_spec.is_multi_host():
+            return None
+        if os.environ.get("MSTAR_NO_INTRA_HOST_SHM"):
+            return None
+        entities = {
+            wid for wid, spec in self.worker_specs.items()
+            if spec.host_index == host_index
+        }
+        if host_index == 0:
+            entities |= {"conductor", "api_server", "api_server_preprocess_worker"}
+        return entities
+
     def _worker_spawn_kwargs(self, worker_id: str) -> dict:
         """Keyword arguments for one worker's process target, minus the model.
 
@@ -569,6 +590,7 @@ class Conductor:
                 self.cluster_spec.hosts[spec.host_index].rdma_device
                 or self.tcp_transfer_device
             ),
+            "same_host_entities": self._same_host_entities(spec.host_index),
         }
 
     def _build_launchers(self) -> list["Launcher"]:

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -464,7 +464,12 @@ class Conductor:
             "device": f"cuda:{spec.local_device}",
             "log_level": self.log_level,
             "tensor_comm_protocol": self.tensor_comm_protocol,
-            "tcp_transfer_device": self.tcp_transfer_device,
+            # Per-host transfer-engine device filter wins over the global CLI
+            # value (multi-host clusters can have differently named NICs/HCAs).
+            "tcp_transfer_device": (
+                self.cluster_spec.hosts[spec.host_index].rdma_device
+                or self.tcp_transfer_device
+            ),
         }
 
     def _build_launchers(self) -> list["Launcher"]:

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -81,12 +81,14 @@ def assign_worker_graphs(
     Picks are coordinated by ``_group_id`` so all wgs derived from the same
     node_group land on the same replica's workers. Replicas containing dead
     workers are skipped. Among live replicas, ones on hosts this request
-    already uses are preferred, so adjacent stages avoid cross-host hops when
-    the placement offers a choice; ties break uniformly at random (on a single
-    host every replica ties, preserving the uniform-random behavior).
+    already uses are preferred, and among those, ones sharing workers with
+    earlier picks (a same-worker handoff is a zero-copy slice, cheaper than
+    any transport); remaining ties break uniformly at random, so a request's
+    first pick stays uniform across replicas.
     """
     group_id_to_replica_idx: dict[int, int] = {}
     chosen_hosts: set[int] = set()
+    chosen_ranks: set[int] = set()
     result: dict[str, list[str]] = {}
     for wg_id, wg in worker_graphs.items():
         replicas = wg._tp_ranks if wg._tp_ranks else [[r] for r in wg.ranks]
@@ -103,7 +105,10 @@ def assign_worker_graphs(
                 )
 
             scores = [
-                len({cluster_spec.host_of_rank(r) for r in replicas[i]} & chosen_hosts)
+                (
+                    len({cluster_spec.host_of_rank(r) for r in replicas[i]} & chosen_hosts),
+                    len(set(replicas[i]) & chosen_ranks),
+                )
                 for i in live
             ]
             best = max(scores)
@@ -113,6 +118,7 @@ def assign_worker_graphs(
             ]
         ranks = replicas[group_id_to_replica_idx[wg._group_id]]
         chosen_hosts.update(cluster_spec.host_of_rank(r) for r in ranks)
+        chosen_ranks.update(ranks)
         result[wg_id] = [f"worker_{r}" for r in ranks]
     return result
 

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -13,6 +13,7 @@ import torch
 import yaml
 
 from mstar.api_server.request_types import APIServerMessage, RequestComplete
+from mstar.cluster.spec import ClusterSpec
 from mstar.communication.communicator import CommProtocol, ZMQCommunicator
 from mstar.conductor.request_info import (
     CurrentForwardConductorMetadata,
@@ -198,7 +199,7 @@ class Conductor:
         model: Model,
         model_config_file: str,
         socket_path_prefix: str = "/tmp/mstar",
-        hostname: str = "localhost",
+        hostname: str | None = None,
         enable_nvtx: bool = False,
         enable_prof: bool = False,
         log_level: str = "INFO",
@@ -207,7 +208,6 @@ class Conductor:
     ):
         self.requests: dict[str, RequestData] = {}
         self.model = model
-        self.hostname = hostname
         self.socket_path_prefix = socket_path_prefix
         self.log_level = log_level
         self.enable_nvtx = enable_nvtx
@@ -225,6 +225,14 @@ class Conductor:
         )
         assert "max_seq_len" in self.model_config
         assert "node_groups" in self.model_config
+
+        # Host topology. Without a ``cluster:`` section this is a single
+        # localhost deployment where global rank == local CUDA device. An
+        # explicit ``hostname`` argument overrides the head address.
+        self.cluster_spec = ClusterSpec.from_config(self.model_config)
+        self.cluster_spec.validate_protocol(tensor_comm_protocol)
+        self.head_addr = hostname if hostname is not None else self.cluster_spec.head_addr
+        logger.info("Cluster: %s", self.cluster_spec.summary())
 
         self.default_sharding_config = model.get_sharding_config(model_config_file)
         self.worker_graphs = {
@@ -296,7 +304,7 @@ class Conductor:
         # ``dist_init_method`` so two ``mstar`` instances on the same host
         # don't collide on a hard-coded port.
         self._dist_init_port = _pick_free_tcp_port()
-        self._dist_init_method = f"tcp://{hostname}:{self._dist_init_port}"
+        self._dist_init_method = f"tcp://{self.head_addr}:{self._dist_init_port}"
 
         os.makedirs(socket_path_prefix, exist_ok=True)
         self._derive_worker_info()
@@ -345,6 +353,25 @@ class Conductor:
         self._sorted_ranks = sorted(rank_to_worker_graphs.keys())
         self.worker_ids = [f"worker_{rank}" for rank in self._sorted_ranks]
 
+        # Resolve every rank to its host + local CUDA device up front so a bad
+        # placement fails here with a precise message instead of inside a
+        # spawned worker.
+        self.cluster_spec.validate_ranks(self._sorted_ranks)
+        self.worker_specs = {
+            worker_id: self.cluster_spec.worker_spec(rank)
+            for rank, worker_id in zip(self._sorted_ranks, self.worker_ids, strict=True)
+        }
+        for wg in self.worker_graphs.values():
+            for rank_group in wg._tp_ranks:
+                group_hosts = {self.worker_specs[f"worker_{r}"].host_index for r in rank_group}
+                if len(group_hosts) > 1:
+                    logger.warning(
+                        "TP group %s spans hosts %s; its collectives cross the "
+                        "network on every layer, which is slow without an "
+                        "RDMA-class interconnect between those hosts.",
+                        list(rank_group), sorted(group_hosts),
+                    )
+
         # Messages that arrive before all workers report SETUP_DONE; replayed
         # on the first main-loop iteration. See _wait_for_workers_ready.
         self._startup_message_backlog: list = []
@@ -383,12 +410,14 @@ class Conductor:
         self.tp_config = GlobalTPConfig(
             worker_graphs=self.worker_graphs,
             worker_ids=self.worker_ids,
+            local_devices=[self.worker_specs[wid].local_device for wid in self.worker_ids],
         )
 
     def _launch_workers(self):
         """Spawn one process per worker rank using spawn context."""
         ctx = mp.get_context("spawn")
-        for rank, worker_id in zip(self._sorted_ranks, self.worker_ids, strict=True):
+        for worker_id in self.worker_ids:
+            spec = self.worker_specs[worker_id]
             p = ctx.Process(
                 target=_worker_process_target,
                 kwargs={
@@ -402,13 +431,13 @@ class Conductor:
                     "all_worker_graph_ids_to_dyn_loops": self._all_worker_graph_ids_to_dyn_loops,
                     "sharding_config": self.per_worker_sharding_config[worker_id],
                     "tp_groups": self.tp_config.per_worker_config[worker_id],
-                    "hostname": self.hostname,
+                    "hostname": spec.addr,
                     "socket_path_prefix": self.socket_path_prefix,
                     "dist_init_method": self._dist_init_method,
                     "model": self.model,
                     "enable_nvtx": self.enable_nvtx,
                     "enable_prof": self.enable_prof,
-                    "device": f"cuda:{rank}",
+                    "device": f"cuda:{spec.local_device}",
                     "log_level": self.log_level,
                     "tensor_comm_protocol": self.tensor_comm_protocol,
                     "tcp_transfer_device": self.tcp_transfer_device

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -1,7 +1,6 @@
 import atexit
 import hashlib
 import logging
-import multiprocessing as mp
 import os
 import socket
 import time
@@ -14,6 +13,7 @@ import yaml
 
 from mstar.api_server.request_types import APIServerMessage, RequestComplete
 from mstar.cluster.endpoints import ControlPlaneEndpoints
+from mstar.cluster.launcher import Launcher, LocalLauncher, NodeAgentLauncher
 from mstar.cluster.spec import ClusterSpec
 from mstar.communication.communicator import CommProtocol, ZMQCommunicator
 from mstar.conductor.request_info import (
@@ -33,8 +33,10 @@ from mstar.model.base import ForwardPassArgs, Model, WorkerGraph
 from mstar.profile.format import RxInfo, TxInfo
 from mstar.profile.worker import GraphTimings
 from mstar.utils.ipc_format import (
+    AgentMessage,
     ConductorMessageType,
     InputSignals,
+    LaunchSpec,
     NewRequest,
     NewRequestConductor,
     RemoveRequest,
@@ -63,6 +65,10 @@ def _req_id_to_seed(req_id: str):
     """
     digest = hashlib.md5(req_id.encode("utf-8")).digest()
     return int.from_bytes(digest[:4], "little")
+
+
+class NoLiveReplicaError(RuntimeError):
+    """Every replica that could serve a worker graph contains a dead worker."""
 
 
 def _pick_free_tcp_port() -> int:
@@ -207,7 +213,9 @@ class Conductor:
         enable_prof: bool = False,
         log_level: str = "INFO",
         tensor_comm_protocol=CommProtocol.RDMA,
-        tcp_transfer_device=""
+        tcp_transfer_device="",
+        model_cache_dir: str | None = None,
+        startup_timeout_s: float = 600.0,
     ):
         self.requests: dict[str, RequestData] = {}
         self.model = model
@@ -217,8 +225,9 @@ class Conductor:
         self.enable_prof = enable_prof
         self.tensor_comm_protocol = tensor_comm_protocol
         self.tcp_transfer_device = tcp_transfer_device
+        self.model_cache_dir = model_cache_dir
+        self._startup_timeout_s = startup_timeout_s
 
-        self._worker_processes: list[mp.Process] = []
         self.waiting_queue: list[NewRequestConductor] = []
 
         with open(model_config_file, "r") as f:
@@ -312,14 +321,21 @@ class Conductor:
 
         os.makedirs(socket_path_prefix, exist_ok=True)
         self._derive_worker_info()
-        self._launch_workers()
 
+        # The conductor's inbound socket must exist before any worker or node
+        # agent starts, so their first messages have somewhere to land.
         self.communicator = ZMQCommunicator(
             my_id="conductor",
             push_ids=self.worker_ids + ["api_server", "api_server_preprocess_worker"],
             ipc_socket_path_prefix=socket_path_prefix,
             endpoints=self.control_endpoints,
         )
+
+        self._dead_workers: set[str] = set()
+        self._launchers: list[Launcher] = self._build_launchers()
+        for launcher in self._launchers:
+            launcher.ensure_workers()
+        atexit.register(self.shutdown)
 
     def _get_kv_config(self):
         kv_cache_config = self.model.get_kv_cache_config()
@@ -420,52 +436,140 @@ class Conductor:
             local_devices=[self.worker_specs[wid].local_device for wid in self.worker_ids],
         )
 
-    def _launch_workers(self):
-        """Spawn one process per worker rank using spawn context."""
-        ctx = mp.get_context("spawn")
-        for worker_id in self.worker_ids:
-            spec = self.worker_specs[worker_id]
-            p = ctx.Process(
-                target=_worker_process_target,
-                kwargs={
-                    "worker_id": worker_id,
-                    "worker_ids": self.worker_ids,
-                    "my_worker_graphs": self._per_worker_graphs[worker_id],
-                    "kv_config": self._get_kv_config(),
-                    "model_config": self.model_config,
-                    "all_worker_graph_ids_to_graph_walks": self._all_worker_graph_ids_to_graph_walks,
-                    "all_worker_graph_ids_to_nodes": self._all_worker_graph_ids_to_nodes,
-                    "all_worker_graph_ids_to_dyn_loops": self._all_worker_graph_ids_to_dyn_loops,
-                    "sharding_config": self.per_worker_sharding_config[worker_id],
-                    "tp_groups": self.tp_config.per_worker_config[worker_id],
-                    "hostname": spec.addr,
-                    "socket_path_prefix": self.socket_path_prefix,
-                    "endpoints": self.control_endpoints,
-                    "dist_init_method": self._dist_init_method,
-                    "model": self.model,
-                    "enable_nvtx": self.enable_nvtx,
-                    "enable_prof": self.enable_prof,
-                    "device": f"cuda:{spec.local_device}",
-                    "log_level": self.log_level,
-                    "tensor_comm_protocol": self.tensor_comm_protocol,
-                    "tcp_transfer_device": self.tcp_transfer_device
-                },
-                daemon=False,
-            )
-            p.start()
-            self._worker_processes.append(p)
+    def _worker_spawn_kwargs(self, worker_id: str) -> dict:
+        """Keyword arguments for one worker's process target, minus the model.
 
-        atexit.register(self.shutdown)
+        The local launcher adds the in-memory model object; launch specs for
+        remote hosts ship these kwargs as-is and the node agent reconstructs
+        the model there from the registry.
+        """
+        spec = self.worker_specs[worker_id]
+        return {
+            "worker_id": worker_id,
+            "worker_ids": self.worker_ids,
+            "my_worker_graphs": self._per_worker_graphs[worker_id],
+            "kv_config": self._get_kv_config(),
+            "model_config": self.model_config,
+            "all_worker_graph_ids_to_graph_walks": self._all_worker_graph_ids_to_graph_walks,
+            "all_worker_graph_ids_to_nodes": self._all_worker_graph_ids_to_nodes,
+            "all_worker_graph_ids_to_dyn_loops": self._all_worker_graph_ids_to_dyn_loops,
+            "sharding_config": self.per_worker_sharding_config[worker_id],
+            "tp_groups": self.tp_config.per_worker_config[worker_id],
+            "hostname": spec.addr,
+            "socket_path_prefix": self.socket_path_prefix,
+            "endpoints": self.control_endpoints,
+            "dist_init_method": self._dist_init_method,
+            "enable_nvtx": self.enable_nvtx,
+            "enable_prof": self.enable_prof,
+            "device": f"cuda:{spec.local_device}",
+            "log_level": self.log_level,
+            "tensor_comm_protocol": self.tensor_comm_protocol,
+            "tcp_transfer_device": self.tcp_transfer_device,
+        }
+
+    def _build_launchers(self) -> list["Launcher"]:
+        local_ids = [
+            wid for wid in self.worker_ids if self.worker_specs[wid].host_index == 0
+        ]
+        launchers: list[Launcher] = []
+        if local_ids:
+            launchers.append(LocalLauncher(
+                worker_ids=local_ids,
+                model=self.model,
+                build_spawn_kwargs=self._worker_spawn_kwargs,
+                target=_worker_process_target,
+            ))
+        remote_nodes = sorted({
+            spec.host_index
+            for spec in self.worker_specs.values()
+            if spec.host_index != 0
+        })
+        if remote_nodes:
+            launchers.append(NodeAgentLauncher(
+                communicator=self.communicator,
+                launch_specs={k: self._build_launch_spec(k) for k in remote_nodes},
+                join_timeout_s=self._startup_timeout_s,
+            ))
+        return launchers
+
+    def _build_launch_spec(self, node_rank: int) -> LaunchSpec:
+        worker_ids = [
+            wid for wid in self.worker_ids
+            if self.worker_specs[wid].host_index == node_rank
+        ]
+        return LaunchSpec(
+            node_rank=node_rank,
+            model_name=self.model_config.get("model", "dummy"),
+            model_kwargs=self.model_config.get("model_kwargs", {}) or {},
+            cache_dir=self.model_cache_dir,
+            log_level=self.log_level,
+            host_env=dict(self.cluster_spec.hosts[node_rank].env),
+            workers=[self._worker_spawn_kwargs(wid) for wid in worker_ids],
+        )
+
+    def _handle_agent_message(self, message: AgentMessage) -> None:
+        for launcher in self._launchers:
+            if isinstance(launcher, NodeAgentLauncher):
+                launcher.handle_agent_message(message)
+                return
+        logger.warning(
+            "Agent message %s received but no node-agent launcher exists",
+            message.message_type,
+        )
+
+    def _poll_launchers(self) -> None:
+        for launcher in self._launchers:
+            for event in launcher.poll():
+                self._on_worker_died(event.worker_id, event.exitcode)
+
+    def _on_worker_died(self, worker_id: str, exitcode: int | None) -> None:
+        if worker_id in self._dead_workers:
+            return
+        self._dead_workers.add(worker_id)
+        logger.error(
+            "Worker %s died (exit %s); failing its in-flight requests and "
+            "masking its replicas", worker_id, exitcode,
+        )
+        affected = [
+            rid for rid, data in self.requests.items()
+            if any(worker_id in ws for ws in data.worker_graph_to_workers.values())
+        ]
+        for rid in affected:
+            self._fail_request(rid, f"worker {worker_id} died (exit {exitcode})")
+
+    def _fail_request(self, request_id: str, error: str) -> None:
+        request_data = self.requests.pop(request_id, None)
+        if request_data is None:
+            return
+        for worker_ids in request_data.worker_graph_to_workers.values():
+            for wid in set(worker_ids) - self._dead_workers:
+                self.communicator.send(
+                    wid,
+                    WorkerMessage(
+                        message_type=WorkerMessageType.REMOVE_REQUEST,
+                        body=RemoveRequest(request_id),
+                    ),
+                )
+        self.communicator.send(
+            "api_server",
+            APIServerMessage(
+                message_type="request_complete",
+                body=RequestComplete(
+                    request_id=request_id,
+                    final_outputs=request_data.final_outputs,
+                    conductor_ingest_time=request_data.conductor_ingest_time,
+                    conductor_finish_time=time.perf_counter(),
+                    error=error,
+                ),
+            ),
+        )
+        logger.error("Request %s failed: %s", request_id, error)
+        self._try_admit_waiting()
 
     def shutdown(self):
         logger.info("Shutting down conductor...")
-        """Terminate and join all worker processes."""
-        for p in self._worker_processes:
-            if p.is_alive():
-                p.terminate()
-        for p in self._worker_processes:
-            p.join(timeout=5)
-        self._worker_processes.clear()
+        for launcher in getattr(self, "_launchers", []):
+            launcher.shutdown()
 
     def _assign_worker_graphs_to_workers(self) -> dict[str, list[str]]:
         """
@@ -483,17 +587,23 @@ class Conductor:
         group_id_to_replica_idx: dict[int, int] = {}
         result = {}
         for wg_id, wg in self.worker_graphs.items():
-            if wg._tp_ranks:
-                replica_idx = group_id_to_replica_idx.setdefault(
-                    wg._group_id, np.random.randint(len(wg._tp_ranks)),
-                )
-                ranks = wg._tp_ranks[replica_idx]
-                result[wg_id] = [f"worker_{r}" for r in ranks]
-            else:
-                replica_idx = group_id_to_replica_idx.setdefault(
-                    wg._group_id, np.random.randint(len(wg.ranks)),
-                )
-                result[wg_id] = [f"worker_{wg.ranks[replica_idx]}"]
+            replicas = wg._tp_ranks if wg._tp_ranks else [[r] for r in wg.ranks]
+            if wg._group_id not in group_id_to_replica_idx:
+                live = [
+                    i for i, ranks in enumerate(replicas)
+                    if not any(f"worker_{r}" in self._dead_workers for r in ranks)
+                ]
+                if not live:
+                    raise NoLiveReplicaError(
+                        f"no live replica remains for nodes "
+                        f"{sorted(wg.section.get_nodes())} "
+                        f"(dead workers: {sorted(self._dead_workers)})"
+                    )
+                group_id_to_replica_idx[wg._group_id] = live[
+                    int(np.random.randint(len(live)))
+                ]
+            replica_idx = group_id_to_replica_idx[wg._group_id]
+            result[wg_id] = [f"worker_{r}" for r in replicas[replica_idx]]
         return result
 
     def _build_request_sharding_config(
@@ -619,7 +729,32 @@ class Conductor:
                 body.request_id, len(self.requests),
                 str(self.max_concurrent_requests),
             )
+            self._safe_ingest(body)
+
+    def _safe_ingest(self, body: NewRequestConductor):
+        """Dispatch a request; reject it cleanly when no live replica exists.
+
+        The replica check runs before any per-request state is created, so a
+        rejected request leaves nothing behind to clean up.
+        """
+        try:
             self._do_ingest_request(body)
+        except NoLiveReplicaError as e:
+            logger.error("Rejecting request %s: %s", body.request_id, e)
+            now = time.perf_counter()
+            self.communicator.send(
+                "api_server",
+                APIServerMessage(
+                    message_type="request_complete",
+                    body=RequestComplete(
+                        request_id=body.request_id,
+                        final_outputs={},
+                        conductor_ingest_time=now,
+                        conductor_finish_time=now,
+                        error=str(e),
+                    ),
+                ),
+            )
 
     def _ingest_request(
         self, body: NewRequestConductor
@@ -639,7 +774,7 @@ class Conductor:
             return
         if self.enable_nvtx:
             range_push("conductor._do_ingest_request")
-        self._do_ingest_request(body)
+        self._safe_ingest(body)
         if self.enable_nvtx:
             range_pop()
 
@@ -1099,15 +1234,32 @@ class Conductor:
         replayed on the first main-loop iteration so it isn't lost.
         """
         pending = set(self.worker_ids)
+        deadline = time.monotonic() + self._startup_timeout_s
         logger.info(
             "Conductor waiting for %d worker(s) to finish setup", len(pending)
         )
         while pending:
             for message in self.communicator.get_all_new_messages():
-                if message.message_type == ConductorMessageType.SETUP_DONE:
+                if isinstance(message, AgentMessage):
+                    self._handle_agent_message(message)
+                elif message.message_type == ConductorMessageType.SETUP_DONE:
                     pending.discard(message.body.worker_id)
                 else:
                     self._startup_message_backlog.append(message)
+            # A worker dying (or an expected node agent never joining) during
+            # startup is fatal: fail fast with a precise message rather than
+            # letting the deployment hang.
+            for launcher in self._launchers:
+                for event in launcher.poll():
+                    raise RuntimeError(
+                        f"worker {event.worker_id} died during startup "
+                        f"(exit {event.exitcode})"
+                    )
+            if pending and time.monotonic() > deadline:
+                raise RuntimeError(
+                    f"startup timed out after {self._startup_timeout_s:.0f}s; "
+                    f"still waiting for: {sorted(pending)}"
+                )
             if pending:
                 time.sleep(0.01)
         logger.info("Conductor: all %d worker(s) ready", len(self.worker_ids))
@@ -1129,9 +1281,14 @@ class Conductor:
             try:
                 done_partition_forwards: list[tuple[str, str, bool]] = []
 
+                self._poll_launchers()
+
                 startup_backlog = self._startup_message_backlog
                 self._startup_message_backlog = []
                 for message in startup_backlog + self.communicator.get_all_new_messages():
+                    if isinstance(message, AgentMessage):
+                        self._handle_agent_message(message)
+                        continue
                     if message.message_type == ConductorMessageType.NEW_REQUEST:
                         self._ingest_request(message.body)
                     elif message.message_type == ConductorMessageType.ABORT_REQUEST:

--- a/mstar/distributed/communication.py
+++ b/mstar/distributed/communication.py
@@ -117,6 +117,10 @@ class WorkerTPGroups:
     # on; asymmetric call counts deadlock the participating ranks.
     world_tp_groups: list[tuple[int, ...]] = field(default_factory=list)
     node_to_group: dict[str, TPCommGroup] = field(default_factory=dict)
+    # CUDA device index on this worker's host. This equals the worker's dense
+    # index only when all workers share one host with an identity GPU mapping;
+    # ``None`` falls back to that historical behavior for standalone uses.
+    local_device: int | None = None
 
     def add(self, node: str, comm_group: TPCommGroup):
         # disallow colocation of multiple comm groups on the same node
@@ -145,7 +149,8 @@ class WorkerTPGroups:
         every rank — members keep the returned handle, non-members
         discard it.
         """
-        torch.cuda.set_device(self.global_rank)
+        device_index = self.local_device if self.local_device is not None else self.global_rank
+        torch.cuda.set_device(device_index)
         if not self.any_tp:
             return
 
@@ -196,7 +201,8 @@ class GlobalTPConfig:
     def __init__(
         # leaving type annotation as Any due to circular import
         self, worker_graphs: dict[str, Any],
-        worker_ids: list[str]
+        worker_ids: list[str],
+        local_devices: list[int] | None = None,
     ):
         self.num_workers = len(worker_ids)
         any_tp = any(wg.tp_size > 1 for wg in worker_graphs.values())
@@ -211,6 +217,7 @@ class GlobalTPConfig:
                 global_rank=i, num_workers=self.num_workers,
                 any_tp=any_tp,
                 world_tp_groups=world_tp_groups,
+                local_device=None if local_devices is None else local_devices[i],
             ) for i, wid in enumerate(worker_ids)
         }
 

--- a/mstar/graph/base.py
+++ b/mstar/graph/base.py
@@ -28,6 +28,10 @@ class TensorPointerInfo:
                     # in tensor parallel configurations)
     source_tp_size: int = 1
     source_tp_rank: int = 0
+    # The producer wrote this tensor to shared memory (same-host tmpfs) instead
+    # of registering it with the transfer engine; consumers must read the shm
+    # file. Only ever set when every consumer is co-hosted with the producer.
+    via_shm: bool = False
 
     _source_node_name: str | None = None
     _source_graph_walk: str | None = None
@@ -45,6 +49,7 @@ class TensorPointerInfo:
             offset=self.offset,
             source_tp_size=self.source_tp_size,
             source_tp_rank=self.source_tp_rank,
+            via_shm=self.via_shm,
             _source_node_name=self._source_node_name,
             _source_graph_walk=self._source_graph_walk
         )

--- a/mstar/utils/ipc_format.py
+++ b/mstar/utils/ipc_format.py
@@ -152,3 +152,64 @@ class AbortRequest(MessageBody):
 class ConductorMessage:
     message_type: ConductorMessageType
     body: MessageBody
+
+
+######################################
+# Node-agent control (multi-host launch)
+######################################
+
+class AgentMessageType(Enum):
+    AGENT_JOIN = "agent_join"                  # agent -> conductor
+    AGENT_JOIN_REJECTED = "agent_join_rejected"  # conductor -> agent
+    LAUNCH_SPEC = "launch_spec"                # conductor -> agent
+    AGENT_WORKER_DIED = "agent_worker_died"    # agent -> conductor
+    AGENT_SHUTDOWN = "agent_shutdown"          # conductor -> agent
+
+
+@dataclass
+class AgentJoin(MessageBody):
+    node_rank: int
+    addr: str
+    visible_gpus: int
+    pid: int
+
+
+@dataclass
+class AgentJoinRejected(MessageBody):
+    reason: str
+
+
+@dataclass
+class LaunchSpec(MessageBody):
+    """Everything a node agent needs to spawn its host's workers.
+
+    ``workers`` holds one spawn-kwargs dict per worker — the exact keyword
+    arguments of the worker process target, minus the model object, which the
+    agent reconstructs locally from ``model_name``/``model_kwargs`` so weights
+    load from the host's own cache instead of being pickled across the wire.
+    """
+    node_rank: int
+    model_name: str
+    model_kwargs: dict
+    cache_dir: str | None
+    log_level: str
+    host_env: dict[str, str]
+    workers: list[dict]
+
+
+@dataclass
+class AgentWorkerDied(MessageBody):
+    node_rank: int
+    worker_id: str
+    exitcode: int | None
+
+
+@dataclass
+class AgentShutdown(MessageBody):
+    reason: str = ""
+
+
+@dataclass
+class AgentMessage:
+    message_type: AgentMessageType
+    body: MessageBody

--- a/mstar/worker/node_manager_utils.py
+++ b/mstar/worker/node_manager_utils.py
@@ -21,6 +21,9 @@ from mstar.streaming.stream_buffer import StreamBuffer
 
 logger = logging.getLogger(__name__)
 
+# Entity that reads EMIT_TO_CLIENT output tensors (it runs on the head host).
+PREPROCESS_WORKER_ENTITY = "api_server_preprocess_worker"
+
 
 @dataclass
 class NodeOutputRouting:
@@ -33,6 +36,44 @@ class NodeOutputRouting:
     completed_worker_graph_ids: list[str] = field(default_factory=list)
     streaming_to_workers: dict[str, list[GraphEdge]] = field(default_factory=dict)  # streaming edges to other workers
     streaming_local: list[GraphEdge] = field(default_factory=list)  # streaming edges staying on this worker
+
+
+def mark_intra_host_uuids(
+    routing: NodeOutputRouting, same_host_entities: set[str],
+) -> set[str]:
+    """Mark output tensors whose every consumer is co-hosted with this worker.
+
+    Returns the uuids a hybrid tensor manager may send over shared memory,
+    after stamping ``via_shm`` on their pointer infos across all outbound
+    edges. Persisted tensors never qualify — the conductor can hand them to
+    workers on any host in later graph walks. A tensor with both co-hosted
+    and remote consumers stays on the transfer engine: co-hosted consumers
+    can read the engine too, whereas preparing both transports would double
+    the producer-side send work.
+    """
+    persist_uuids = {
+        info.uuid for edge in routing.persist for info in edge.tensor_info
+    }
+    outbound: list[tuple[str, list[GraphEdge]]] = [
+        *routing.to_workers.items(),
+        *routing.streaming_to_workers.items(),
+        (PREPROCESS_WORKER_ENTITY, routing.emit_to_client),
+    ]
+    consumers: dict[str, set[str]] = {}
+    for dest, edges in outbound:
+        for edge in edges:
+            for info in edge.tensor_info:
+                consumers.setdefault(info.uuid, set()).add(dest)
+    intra = {
+        uuid for uuid, dests in consumers.items()
+        if uuid not in persist_uuids and dests <= same_host_entities
+    }
+    for _, edges in outbound:
+        for edge in edges:
+            for info in edge.tensor_info:
+                if info.uuid in intra:
+                    info.via_shm = True
+    return intra
 
 
 @dataclass

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -50,6 +50,7 @@ from mstar.worker.node_manager_utils import (
     NodeOutputRouting,
     WorkerGraphQueues,
     WorkerGraphsManager,
+    mark_intra_host_uuids,
 )
 
 logger = logging.getLogger(__name__)
@@ -135,10 +136,14 @@ class Worker:
         tcp_transfer_device="",
         dist_init_method=None,
         endpoints=None,
+        same_host_entities: set[str] | None = None,
     ):
         self.worker_id = worker_id
         self.device = device
         self.enable_nvtx = enable_nvtx
+        # Entities co-hosted with this worker; None outside multi-host mode.
+        # Drives per-tensor transport dispatch in ``_register_outputs``.
+        self.same_host_entities = same_host_entities
 
         self.enable_prof = enable_prof
         self.profile_info = WorkerProfileInfo()
@@ -185,7 +190,8 @@ class Worker:
             device=self.device,
             communicator=self.communicator,
             tcp_transfer_device=tcp_transfer_device,
-            enable_prof=enable_prof
+            enable_prof=enable_prof,
+            same_host_entities=same_host_entities,
         )
 
         node_names = set()
@@ -933,9 +939,15 @@ class Worker:
                 uuids.update([
                     info.uuid for info in edge.tensor_info
                 ])
+            shm_uuids = None
+            if self.same_host_entities is not None:
+                shm_uuids = mark_intra_host_uuids(
+                    routing, self.same_host_entities
+                )
             self.tensor_manager.register_for_send(
                 request_id=request_id, uuids=uuids,
                 skip_cuda_sync=True,
+                shm_uuids=shm_uuids,
             )
 
             for edge in routing.persist:

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -133,7 +133,8 @@ class Worker:
         enable_nvtx: bool = False,
         enable_prof: bool = False,
         tcp_transfer_device="",
-        dist_init_method=None
+        dist_init_method=None,
+        endpoints=None,
     ):
         self.worker_id = worker_id
         self.device = device
@@ -172,6 +173,7 @@ class Worker:
             my_id=worker_id,
             push_ids=worker_ids + ["conductor", "api_server", "api_server_preprocess_worker"],
             ipc_socket_path_prefix=socket_path_prefix,
+            endpoints=endpoints,
         )
         self.wakeup_event = EventWakeup()
         self.communicator.register_event_for_poll(self.wakeup_event)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 [project.scripts]
 mstar = "mstar.cli.main:main"
 mstar-serve = "mstar.api_server.entrypoint:main"
+mstar-node = "mstar.cluster.node_agent:main"
 
 [project.optional-dependencies]
 dev = [

--- a/test/modular/test_assignment_and_cuts.py
+++ b/test/modular/test_assignment_and_cuts.py
@@ -80,6 +80,42 @@ class TestAssignment:
             )
             assert out[flexible.worker_graph_id] == ["worker_3"]  # host 1, co-located
 
+    def test_rank_tiebreak_prefers_shared_worker(self):
+        spec = ClusterSpec.single_host()
+        anchored = _wg(["A"], ranks=[1], group_id=0)
+        flexible = _wg(["B"], ranks=[0, 1], group_id=1)       # host scores tie
+        for _ in range(20):
+            out = assign_worker_graphs(
+                {anchored.worker_graph_id: anchored, flexible.worker_graph_id: flexible},
+                spec, set(),
+            )
+            assert out[flexible.worker_graph_id] == ["worker_1"]  # same worker as A
+
+    def test_rank_tiebreak_within_host_ties(self):
+        spec = ClusterSpec.from_config({
+            "cluster": {"hosts": [
+                {"addr": "a", "gpus": [0, 1, 2]},             # ranks 0-2 on host 0
+                {"addr": "b", "gpus": [0], "zmq_port_base": 19600},  # rank 3 on host 1
+            ]}
+        })
+        anchored = _wg(["A"], ranks=[1], group_id=0)          # host 0, worker_1
+        flexible = _wg(["B"], ranks=[0, 1], group_id=1)       # both replicas on host 0
+        for _ in range(20):
+            out = assign_worker_graphs(
+                {anchored.worker_graph_id: anchored, flexible.worker_graph_id: flexible},
+                spec, set(),
+            )
+            assert out[flexible.worker_graph_id] == ["worker_1"]
+
+    def test_first_pick_uniform(self):
+        spec = ClusterSpec.single_host()
+        wg = _wg(["A"], ranks=[0, 1], group_id=0)
+        seen = set()
+        for _ in range(40):
+            out = assign_worker_graphs({wg.worker_graph_id: wg}, spec, set())
+            seen.add(out[wg.worker_graph_id][0])
+        assert seen == {"worker_0", "worker_1"}
+
 
 class TestCrossHostCuts:
     def _maps(self, wgs):

--- a/test/modular/test_assignment_and_cuts.py
+++ b/test/modular/test_assignment_and_cuts.py
@@ -1,0 +1,116 @@
+"""Tests for replica assignment (masking + locality) and cross-host cut detection."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from mstar.cluster.spec import ClusterSpec
+from mstar.conductor.conductor import (
+    NoLiveReplicaError,
+    assign_worker_graphs,
+    find_cross_host_cuts,
+)
+from mstar.graph.base import GraphEdge
+from mstar.model.base import WorkerGraph
+
+
+def _wg(nodes, ranks, tp_size=1, group_id=0, walks=("decode",), edges=()):
+    section = SimpleNamespace(
+        get_nodes=lambda: {
+            n: SimpleNamespace(outputs=[
+                GraphEdge(next_node=dst, name=name) for (src, dst, name) in edges if src == n
+            ])
+            for n in nodes
+        },
+    )
+    return WorkerGraph(
+        section=section, graph_walks=set(walks), ranks=list(ranks),
+        tp_size=tp_size, _group_id=group_id,
+    )
+
+
+def _two_host_spec():
+    return ClusterSpec.from_config({
+        "cluster": {"hosts": [
+            {"addr": "a", "gpus": [0, 1]},              # ranks 0,1 on host 0
+            {"addr": "b", "gpus": [0, 1], "zmq_port_base": 19600},  # ranks 2,3 on host 1
+        ]}
+    })
+
+
+class TestAssignment:
+    def test_group_coordination(self):
+        spec = ClusterSpec.single_host()
+        wg1 = _wg(["A"], ranks=[0, 1], group_id=0)
+        wg2 = _wg(["A"], ranks=[0, 1], group_id=0, walks=("prefill",))
+        for _ in range(10):
+            out = assign_worker_graphs(
+                {wg1.worker_graph_id: wg1, wg2.worker_graph_id: wg2}, spec, set()
+            )
+            assert out[wg1.worker_graph_id] == out[wg2.worker_graph_id]
+
+    def test_dead_replica_masked(self):
+        spec = ClusterSpec.single_host()
+        wg = _wg(["A"], ranks=[0, 1], group_id=0)
+        for _ in range(10):
+            out = assign_worker_graphs({wg.worker_graph_id: wg}, spec, {"worker_0"})
+            assert out[wg.worker_graph_id] == ["worker_1"]
+
+    def test_no_live_replica_raises(self):
+        spec = ClusterSpec.single_host()
+        wg = _wg(["A"], ranks=[0], group_id=0)
+        with pytest.raises(NoLiveReplicaError):
+            assign_worker_graphs({wg.worker_graph_id: wg}, spec, {"worker_0"})
+
+    def test_tp_replicas(self):
+        spec = ClusterSpec.single_host()
+        wg = _wg(["A"], ranks=[0, 1, 2, 3], tp_size=2, group_id=0)
+        out = assign_worker_graphs({wg.worker_graph_id: wg}, spec, {"worker_0"})
+        # replica [0,1] contains the dead worker; only [2,3] is live
+        assert out[wg.worker_graph_id] == ["worker_2", "worker_3"]
+
+    def test_locality_prefers_used_host(self):
+        spec = _two_host_spec()
+        anchored = _wg(["A"], ranks=[2], group_id=0)          # host 1 only
+        flexible = _wg(["B"], ranks=[0, 3], group_id=1)       # replicas on host 0 and host 1
+        for _ in range(20):
+            out = assign_worker_graphs(
+                {anchored.worker_graph_id: anchored, flexible.worker_graph_id: flexible},
+                spec, set(),
+            )
+            assert out[flexible.worker_graph_id] == ["worker_3"]  # host 1, co-located
+
+
+class TestCrossHostCuts:
+    def _maps(self, wgs):
+        node_walk_to_wg = {}
+        for wg in wgs:
+            for walk in wg.graph_walks:
+                for n in wg.section.get_nodes():
+                    node_walk_to_wg[(n, walk)] = wg
+        return {wg.worker_graph_id: wg for wg in wgs}, node_walk_to_wg
+
+    def test_cut_detected_across_hosts(self):
+        spec = _two_host_spec()
+        prod = _wg(["A"], ranks=[0], edges=[("A", "B", "hidden")])
+        cons = _wg(["B"], ranks=[2])
+        wgs, nw = self._maps([prod, cons])
+        cuts = find_cross_host_cuts(wgs, nw, spec)
+        assert cuts == {("decode", "A", "B", "hidden", (0,), (1,))}
+
+    def test_same_host_edge_not_reported(self):
+        spec = _two_host_spec()
+        prod = _wg(["A"], ranks=[0], edges=[("A", "B", "hidden")])
+        cons = _wg(["B"], ranks=[1])  # also host 0
+        wgs, nw = self._maps([prod, cons])
+        assert find_cross_host_cuts(wgs, nw, spec) == set()
+
+    def test_special_destinations_ignored(self):
+        spec = _two_host_spec()
+        prod = _wg(["A"], ranks=[0], edges=[("A", "EMIT_TO_CLIENT", "out")])
+        wgs, nw = self._maps([prod])
+        assert find_cross_host_cuts(wgs, nw, spec) == set()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/modular/test_cluster_spec.py
+++ b/test/modular/test_cluster_spec.py
@@ -1,0 +1,177 @@
+"""Tests for the cluster topology spec (hosts x GPUs -> global ranks)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from mstar.cluster.spec import DEFAULT_ZMQ_PORT_BASE, ClusterSpec, HostSpec
+from mstar.communication.communicator import CommProtocol
+
+
+def _two_host_config():
+    return {
+        "cluster": {
+            "hosts": [
+                {"addr": "nodeA", "gpus": [0, 1, 2, 3]},
+                {"addr": "nodeB", "gpus": [0, 1], "zmq_port_base": 19500},
+            ]
+        }
+    }
+
+
+class TestSynthesizedSingleHost:
+    def test_absent_section_gives_identity_mapping(self):
+        spec = ClusterSpec.from_config({"model": "x", "node_groups": []})
+        assert not spec.is_multi_host()
+        assert spec.head_addr == "localhost"
+        for rank in (0, 3, 7, 42):
+            ws = spec.worker_spec(rank)
+            assert ws.worker_id == f"worker_{rank}"
+            assert ws.host_index == 0
+            assert ws.local_device == rank
+            assert ws.addr == "localhost"
+
+    def test_none_config(self):
+        spec = ClusterSpec.from_config(None)
+        assert spec.worker_spec(5).local_device == 5
+
+    def test_accepts_any_nonnegative_ranks(self):
+        spec = ClusterSpec.single_host()
+        spec.validate_ranks([0, 2, 5])  # non-contiguous is fine
+        with pytest.raises(ValueError):
+            spec.worker_spec(-1)
+
+    def test_protocols_all_allowed(self):
+        spec = ClusterSpec.single_host()
+        for proto in (CommProtocol.SHM, CommProtocol.RDMA, CommProtocol.TCP):
+            spec.validate_protocol(proto)
+
+
+class TestExplicitClusters:
+    def test_single_host_scrambled_gpus(self):
+        spec = ClusterSpec.from_config(
+            {"cluster": {"hosts": [{"addr": "nodeA", "gpus": [3, 1, 0]}]}}
+        )
+        assert not spec.is_multi_host()
+        assert [spec.worker_spec(r).local_device for r in range(3)] == [3, 1, 0]
+        assert all(spec.worker_spec(r).addr == "nodeA" for r in range(3))
+
+    def test_two_hosts_rank_assignment(self):
+        spec = ClusterSpec.from_config(_two_host_config())
+        assert spec.is_multi_host()
+        assert spec.head_addr == "nodeA"
+        assert spec.hosts[1].zmq_port_base == 19500
+        assert spec.hosts[0].zmq_port_base == DEFAULT_ZMQ_PORT_BASE
+
+        ws4 = spec.worker_spec(4)
+        assert (ws4.host_index, ws4.local_device, ws4.addr) == (1, 0, "nodeB")
+        ws5 = spec.worker_spec(5)
+        assert (ws5.host_index, ws5.local_device, ws5.addr) == (1, 1, "nodeB")
+        assert spec.worker_spec(3).host_index == 0
+        assert spec.host_of_rank(5) == 1
+
+    def test_same_addr_hosts_allowed(self):
+        # Two logical hosts on one machine (loopback), disjoint GPU sets.
+        spec = ClusterSpec.from_config({
+            "cluster": {"hosts": [
+                {"addr": "127.0.0.1", "gpus": [0, 1]},
+                {"addr": "127.0.0.1", "gpus": [2, 3], "zmq_port_base": 19500},
+            ]}
+        })
+        assert spec.is_multi_host()
+        assert spec.worker_spec(2).local_device == 2
+        assert spec.worker_spec(2).host_index == 1
+
+    def test_optional_host_fields(self):
+        spec = ClusterSpec.from_config({
+            "cluster": {"hosts": [{
+                "addr": "nodeA", "gpus": [0],
+                "bind_addr": "10.0.0.1",
+                "env": {"NCCL_SOCKET_IFNAME": "eth1"},
+                "rdma_device": "mlx5_0",
+            }]}
+        })
+        host = spec.head
+        assert host.bind_addr == "10.0.0.1"
+        assert host.env == {"NCCL_SOCKET_IFNAME": "eth1"}
+        assert host.rdma_device == "mlx5_0"
+
+
+class TestValidation:
+    def test_rank_out_of_range(self):
+        spec = ClusterSpec.from_config(_two_host_config())
+        with pytest.raises(ValueError, match="global rank 6"):
+            spec.validate_ranks([0, 6])
+
+    def test_shm_rejected_multi_host(self):
+        spec = ClusterSpec.from_config(_two_host_config())
+        with pytest.raises(ValueError, match="SHM"):
+            spec.validate_protocol(CommProtocol.SHM)
+        with pytest.raises(ValueError, match="SHM"):
+            spec.validate_protocol("SHM")
+        spec.validate_protocol(CommProtocol.RDMA)
+        spec.validate_protocol(CommProtocol.TCP)
+
+    @pytest.mark.parametrize("hosts, match", [
+        ([], "at least one host"),
+        ([{"addr": "", "gpus": [0]}], "empty `addr`"),
+        ([{"addr": "a", "gpus": []}], "empty `gpus`"),
+        ([{"addr": "a", "gpus": [0, 0]}], "duplicate GPU"),
+        ([{"addr": "a", "gpus": [-1]}], "non-negative"),
+        ([{"addr": "a", "gpus": [0], "port": 1}], "unknown key"),
+        ([{"gpus": [0]}], "must define"),
+        ([{"addr": "a"}], "must define"),
+    ])
+    def test_bad_host_entries(self, hosts, match):
+        with pytest.raises(ValueError, match=match):
+            ClusterSpec.from_config({"cluster": {"hosts": hosts}})
+
+    def test_bad_section_shape(self):
+        with pytest.raises(ValueError, match="hosts"):
+            ClusterSpec.from_config({"cluster": {}})
+        with pytest.raises(ValueError, match="mapping"):
+            ClusterSpec.from_config({"cluster": {"hosts": ["nodeA"]}})
+
+    def test_direct_construction_checks(self):
+        with pytest.raises(ValueError):
+            ClusterSpec([])
+        with pytest.raises(ValueError):
+            ClusterSpec(
+                [HostSpec(addr="a", gpus=(0,))], identity_single_host=True
+            )
+
+
+class TestTPConfigLocalDevices:
+    def _fake_worker_graphs(self):
+        from mstar.model.base import WorkerGraph
+
+        section = SimpleNamespace(get_nodes=lambda: {"LLM": None})
+        wg = WorkerGraph(
+            section=section, graph_walks={"decode"}, ranks=[0, 1], tp_size=2
+        )
+        return {wg.worker_graph_id: wg}
+
+    def test_local_devices_threaded(self):
+        from mstar.distributed.communication import GlobalTPConfig
+
+        tp = GlobalTPConfig(
+            worker_graphs=self._fake_worker_graphs(),
+            worker_ids=["worker_0", "worker_1"],
+            local_devices=[5, 3],
+        )
+        assert tp.per_worker_config["worker_0"].local_device == 5
+        assert tp.per_worker_config["worker_1"].local_device == 3
+        assert tp.per_worker_config["worker_1"].global_rank == 1
+
+    def test_local_devices_default_none(self):
+        from mstar.distributed.communication import GlobalTPConfig
+
+        tp = GlobalTPConfig(
+            worker_graphs=self._fake_worker_graphs(),
+            worker_ids=["worker_0", "worker_1"],
+        )
+        assert tp.per_worker_config["worker_0"].local_device is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/modular/test_endpoint_registry.py
+++ b/test/modular/test_endpoint_registry.py
@@ -1,0 +1,190 @@
+"""Tests for control-plane endpoint resolution and the ZMQ communicator modes."""
+
+import os
+import time
+
+import pytest
+
+from mstar.cluster.endpoints import ControlPlaneEndpoints
+from mstar.cluster.spec import ClusterSpec
+from mstar.communication.communicator import CommProtocol, ZMQCommunicator
+
+
+def _spec(hosts):
+    return ClusterSpec.from_config({"cluster": {"hosts": hosts}})
+
+
+def _two_host_endpoints(base_a=None, base_b=None, addr="127.0.0.1"):
+    pid_slot = (os.getpid() % 500) * 4
+    base_a = base_a if base_a is not None else 21000 + pid_slot
+    base_b = base_b if base_b is not None else base_a + 600
+    spec = _spec([
+        {"addr": addr, "gpus": [0], "zmq_port_base": base_a},
+        {"addr": addr, "gpus": [1], "zmq_port_base": base_b},
+    ])
+    return ControlPlaneEndpoints(spec), base_a, base_b
+
+
+class TestResolution:
+    def test_head_entities_on_head_host(self):
+        eps, base_a, _ = _two_host_endpoints()
+        assert eps.connect_endpoint("api_server") == f"tcp://127.0.0.1:{base_a}"
+        assert eps.connect_endpoint("conductor") == f"tcp://127.0.0.1:{base_a + 1}"
+        assert eps.connect_endpoint("api_server_preprocess_worker") == f"tcp://127.0.0.1:{base_a + 2}"
+
+    def test_workers_use_their_hosts(self):
+        eps, base_a, base_b = _two_host_endpoints()
+        # global rank 0 lives on host A, global rank 1 on host B; worker ports
+        # are keyed by global rank on the owning host's base.
+        assert eps.connect_endpoint("worker_0") == f"tcp://127.0.0.1:{base_a + 100}"
+        assert eps.connect_endpoint("worker_1") == f"tcp://127.0.0.1:{base_b + 101}"
+
+    def test_agents(self):
+        eps, base_a, base_b = _two_host_endpoints()
+        assert eps.connect_endpoint("node_agent_0") == f"tcp://127.0.0.1:{base_a + 50}"
+        assert eps.connect_endpoint("node_agent_1") == f"tcp://127.0.0.1:{base_b + 51}"
+
+    def test_bind_uses_bind_addr(self):
+        spec = _spec([
+            {"addr": "nodeA", "gpus": [0], "bind_addr": "10.0.0.5"},
+            {"addr": "nodeB", "gpus": [0]},
+        ])
+        eps = ControlPlaneEndpoints(spec)
+        assert eps.bind_endpoint("conductor").startswith("tcp://10.0.0.5:")
+        assert eps.connect_endpoint("conductor").startswith("tcp://nodeA:")
+        assert eps.bind_endpoint("worker_1").startswith("tcp://0.0.0.0:")
+
+    def test_unknown_entity_rejected(self):
+        eps, _, _ = _two_host_endpoints()
+        with pytest.raises(ValueError, match="no control-plane endpoint"):
+            eps.connect_endpoint("mystery_service")
+
+    def test_single_host_never_tcp(self):
+        assert not ControlPlaneEndpoints(ClusterSpec.single_host()).use_tcp()
+        assert not ControlPlaneEndpoints(_spec([{"addr": "a", "gpus": [0, 1]}])).use_tcp()
+
+    def test_pickle_round_trip(self):
+        # The resolver rides mp-spawn kwargs into worker processes.
+        import pickle
+
+        eps, base_a, _ = _two_host_endpoints()
+        restored = pickle.loads(pickle.dumps(eps))
+        assert restored.use_tcp()
+        assert restored.connect_endpoint("conductor") == f"tcp://127.0.0.1:{base_a + 1}"
+
+
+class TestPortValidation:
+    def test_same_addr_same_base_is_fine(self):
+        # Worker ports are keyed by global rank and agent ports by host index,
+        # so two loopback hosts sharing one base still get disjoint ports.
+        spec = _spec([
+            {"addr": "127.0.0.1", "gpus": [0]},
+            {"addr": "127.0.0.1", "gpus": [1]},
+        ])
+        ControlPlaneEndpoints(spec).validate_ports([0, 1])
+
+    def test_overlapping_ranges_collide(self):
+        # Host B's agent port (base+51) lands exactly on host A's preprocess
+        # port (base+2) when the bases differ by 49 on the same address.
+        spec = _spec([
+            {"addr": "127.0.0.1", "gpus": [0], "zmq_port_base": 20000},
+            {"addr": "127.0.0.1", "gpus": [1], "zmq_port_base": 19951},
+        ])
+        with pytest.raises(ValueError, match="port collision"):
+            ControlPlaneEndpoints(spec).validate_ports([0, 1])
+
+    def test_disjoint_bases_pass(self):
+        eps, _, _ = _two_host_endpoints()
+        eps.validate_ports([0, 1])
+
+    def test_different_addrs_never_collide(self):
+        spec = _spec([
+            {"addr": "nodeA", "gpus": [0]},
+            {"addr": "nodeB", "gpus": [1]},  # same base, different addr
+        ])
+        ControlPlaneEndpoints(spec).validate_ports([0, 1])
+
+
+def _drain_until(comm, want, timeout_s=5.0):
+    got = []
+    deadline = time.monotonic() + timeout_s
+    while len(got) < want and time.monotonic() < deadline:
+        got.extend(comm.get_all_new_messages())
+        time.sleep(0.01)
+    return got
+
+
+class TestTcpMesh:
+    def test_multi_host_message_exchange(self):
+        eps, _, _ = _two_host_endpoints()
+        conductor = ZMQCommunicator("conductor", ["worker_0", "worker_1"], endpoints=eps)
+        worker0 = ZMQCommunicator("worker_0", ["conductor", "worker_1"], endpoints=eps)
+        worker1 = ZMQCommunicator("worker_1", ["conductor", "worker_0"], endpoints=eps)
+        try:
+            assert conductor.protocol == CommProtocol.TCP
+            conductor.send("worker_1", {"kind": "work", "n": 1})
+            worker1.send("conductor", {"kind": "done", "n": 2})
+            worker0.send("worker_1", {"kind": "peer", "n": 3})
+
+            w1_msgs = _drain_until(worker1, want=2)
+            assert sorted(m["kind"] for m in w1_msgs) == ["peer", "work"]
+            c_msgs = _drain_until(conductor, want=1)
+            assert c_msgs[0] == {"kind": "done", "n": 2}
+        finally:
+            conductor.close()
+            worker0.close()
+            worker1.close()
+
+    def test_lazy_send_to_unlisted_entity(self):
+        eps, _, _ = _two_host_endpoints()
+        a = ZMQCommunicator("conductor", [], endpoints=eps)
+        b = ZMQCommunicator("api_server", [], endpoints=eps)
+        try:
+            a.send("api_server", "hello")  # push socket created on demand
+            assert _drain_until(b, want=1) == ["hello"]
+        finally:
+            a.close()
+            b.close()
+
+    def test_resolver_overrides_env_transport(self, monkeypatch):
+        monkeypatch.setenv("MSTAR_ZMQ_TRANSPORT", "IPC")
+        eps, base_a, _ = _two_host_endpoints()
+        comm = ZMQCommunicator("conductor", [], endpoints=eps)
+        try:
+            assert comm.protocol == CommProtocol.TCP
+            assert comm._endpoint("api_server") == f"tcp://127.0.0.1:{base_a}"
+        finally:
+            comm.close()
+
+
+class TestIpcMode:
+    def test_single_host_resolver_stays_ipc(self, tmp_path):
+        eps = ControlPlaneEndpoints(ClusterSpec.single_host())
+        comm = ZMQCommunicator(
+            "conductor", [], ipc_socket_path_prefix=str(tmp_path), endpoints=eps
+        )
+        try:
+            assert comm.protocol == CommProtocol.IPC
+            assert comm._endpoint("conductor").startswith("ipc://")
+        finally:
+            comm.close()
+
+    def test_stale_socket_file_is_replaced(self, tmp_path):
+        stale = tmp_path / "conductor.ipc"
+        stale.write_bytes(b"")  # plain file where a dead instance left its socket
+        comm = ZMQCommunicator("conductor", [], ipc_socket_path_prefix=str(tmp_path))
+        try:
+            sender = ZMQCommunicator(
+                "api_server", ["conductor"], ipc_socket_path_prefix=str(tmp_path)
+            )
+            try:
+                sender.send("conductor", "ping")
+                assert _drain_until(comm, want=1) == ["ping"]
+            finally:
+                sender.close()
+        finally:
+            comm.close()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/modular/test_hybrid_transport.py
+++ b/test/modular/test_hybrid_transport.py
@@ -1,10 +1,12 @@
 """Tests for per-tensor transport dispatch in multi-host deployments."""
 
 import os
+from types import SimpleNamespace
 from unittest import mock
 
 import torch
 
+from mstar.cluster.spec import ClusterSpec
 from mstar.communication.communicator import CommProtocol
 from mstar.communication.tensors import (
     HybridCommunicationManager,
@@ -12,6 +14,7 @@ from mstar.communication.tensors import (
     SharedMemoryCommunicationManager,
     create_tensor_communication_manager,
 )
+from mstar.conductor.conductor import Conductor
 from mstar.graph.base import GraphEdge, TensorPointerInfo
 from mstar.worker.node_manager_utils import (
     PREPROCESS_WORKER_ENTITY,
@@ -248,3 +251,43 @@ class TestHybridDataPath:
 
 def _edge_with(info, name, next_node):
     return GraphEdge(next_node=next_node, name=name, tensor_info=[info])
+
+
+# ---------------------------------------------------------------------------
+# conductor gate: when workers get a same-host entity set at all
+# ---------------------------------------------------------------------------
+
+class TestSameHostEntitiesGate:
+    def _conductor_like(self, spec, intra_protocol):
+        return SimpleNamespace(
+            cluster_spec=spec,
+            intra_host_tensor_protocol=intra_protocol,
+            worker_specs={
+                "worker_0": SimpleNamespace(host_index=0),
+                "worker_1": SimpleNamespace(host_index=1),
+            },
+        )
+
+    def _two_host_spec(self):
+        return ClusterSpec.from_config({
+            "cluster": {"hosts": [
+                {"addr": "a", "gpus": [0]},
+                {"addr": "b", "gpus": [0], "zmq_port_base": 19600},
+            ]}
+        })
+
+    def test_single_host_returns_none(self):
+        fake = self._conductor_like(ClusterSpec.single_host(), CommProtocol.SHM)
+        assert Conductor._same_host_entities(fake, 0) is None
+
+    def test_non_shm_intra_protocol_returns_none(self):
+        fake = self._conductor_like(self._two_host_spec(), CommProtocol.RDMA)
+        assert Conductor._same_host_entities(fake, 0) is None
+        assert Conductor._same_host_entities(fake, 1) is None
+
+    def test_shm_intra_protocol_returns_cohosted_entities(self):
+        fake = self._conductor_like(self._two_host_spec(), CommProtocol.SHM)
+        assert Conductor._same_host_entities(fake, 0) == {
+            "worker_0", "conductor", "api_server", "api_server_preprocess_worker",
+        }
+        assert Conductor._same_host_entities(fake, 1) == {"worker_1"}

--- a/test/modular/test_hybrid_transport.py
+++ b/test/modular/test_hybrid_transport.py
@@ -1,0 +1,250 @@
+"""Tests for per-tensor transport dispatch in multi-host deployments."""
+
+import os
+from unittest import mock
+
+import torch
+
+from mstar.communication.communicator import CommProtocol
+from mstar.communication.tensors import (
+    HybridCommunicationManager,
+    MooncakeCommunicationManager,
+    SharedMemoryCommunicationManager,
+    create_tensor_communication_manager,
+)
+from mstar.graph.base import GraphEdge, TensorPointerInfo
+from mstar.worker.node_manager_utils import (
+    PREPROCESS_WORKER_ENTITY,
+    NodeOutputRouting,
+    mark_intra_host_uuids,
+)
+
+
+def _info(uuid, source="worker_0"):
+    return TensorPointerInfo(
+        dims=[2], dtype=torch.float32, nbytes=8, address=0, stride=[1],
+        uuid=uuid, source_session_id="sess", source_entity=source,
+    )
+
+
+def _edge(name, next_node, infos):
+    return GraphEdge(next_node=next_node, name=name, tensor_info=infos)
+
+
+def _routing(**kwargs):
+    base = dict(
+        routed_to_this_worker_graph=[], is_first_tp_rank=True,
+        persist=[], to_workers={},
+    )
+    base.update(kwargs)
+    return NodeOutputRouting(**base)
+
+
+# ---------------------------------------------------------------------------
+# mark_intra_host_uuids
+# ---------------------------------------------------------------------------
+
+class TestMarkIntraHostUuids:
+    def test_all_consumers_co_hosted(self):
+        info = _info("u1")
+        routing = _routing(to_workers={"worker_1": [_edge("e", "n", [info])]})
+        got = mark_intra_host_uuids(routing, {"worker_0", "worker_1"})
+        assert got == {"u1"}
+        assert info.via_shm is True
+
+    def test_remote_consumer_excluded(self):
+        info = _info("u1")
+        routing = _routing(to_workers={"worker_2": [_edge("e", "n", [info])]})
+        got = mark_intra_host_uuids(routing, {"worker_0", "worker_1"})
+        assert got == set()
+        assert info.via_shm is False
+
+    def test_mixed_fanout_stays_on_engine(self):
+        local_copy, remote_copy = _info("u1"), _info("u1")
+        routing = _routing(to_workers={
+            "worker_1": [_edge("e", "n", [local_copy])],
+            "worker_2": [_edge("e", "n", [remote_copy])],
+        })
+        got = mark_intra_host_uuids(routing, {"worker_0", "worker_1"})
+        assert got == set()
+        assert local_copy.via_shm is False and remote_copy.via_shm is False
+
+    def test_persisted_tensor_excluded(self):
+        # Persisted outputs can be re-routed to any host in later walks, even
+        # when this walk's only consumer is co-hosted.
+        routed, persisted = _info("u1"), _info("u1")
+        routing = _routing(
+            persist=[_edge("e", "conductor", [persisted])],
+            to_workers={"worker_1": [_edge("e", "n", [routed])]},
+        )
+        got = mark_intra_host_uuids(routing, {"worker_0", "worker_1"})
+        assert got == set()
+        assert routed.via_shm is False
+
+    def test_emit_to_client_follows_preprocess_locality(self):
+        info = _info("u1")
+        routing = _routing(emit_to_client=[_edge("e", "EMIT_TO_CLIENT", [info])])
+        assert mark_intra_host_uuids(routing, {"worker_0"}) == set()
+        assert info.via_shm is False
+        got = mark_intra_host_uuids(
+            routing, {"worker_0", PREPROCESS_WORKER_ENTITY}
+        )
+        assert got == {"u1"}
+        assert info.via_shm is True
+
+    def test_streaming_edges_classified(self):
+        info = _info("u1")
+        routing = _routing(
+            streaming_to_workers={"worker_1": [_edge("e", "n", [info])]}
+        )
+        assert mark_intra_host_uuids(routing, {"worker_0", "worker_1"}) == {"u1"}
+        assert info.via_shm is True
+
+    def test_multiple_uuids_split(self):
+        near, far = _info("u1"), _info("u2")
+        routing = _routing(to_workers={
+            "worker_1": [_edge("e1", "n", [near])],
+            "worker_9": [_edge("e2", "n", [far])],
+        })
+        got = mark_intra_host_uuids(routing, {"worker_0", "worker_1"})
+        assert got == {"u1"}
+        assert near.via_shm is True and far.via_shm is False
+
+
+# ---------------------------------------------------------------------------
+# TensorPointerInfo wire format
+# ---------------------------------------------------------------------------
+
+def test_via_shm_default_and_clone():
+    info = _info("u1")
+    assert info.via_shm is False
+    assert info.clone().via_shm is False
+    info.via_shm = True
+    assert info.clone().via_shm is True
+
+
+# ---------------------------------------------------------------------------
+# Factory selection + hybrid data path (transfer engine stubbed out)
+# ---------------------------------------------------------------------------
+
+class _StubEngine:
+    def __init__(self, *args, **kwargs):
+        self._engine = None
+
+    def get_session_id(self):
+        return "stub:0"
+
+    def register_memory(self, ptr, nbytes):
+        return 0
+
+    def unregister_memory(self, ptr):
+        return 0
+
+    def get_async_reader(self, device):
+        return None
+
+
+class _StubReader:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def submit(self, read_info):
+        raise AssertionError("engine read submitted for an shm-only transfer")
+
+
+def _patched_engine():
+    return mock.patch.multiple(
+        "mstar.communication.tensors",
+        MooncakeTransferEngine=_StubEngine,
+        AsyncMooncakeReader=_StubReader,
+    )
+
+
+def _make(protocol, same_host_entities, entity="worker_0", tmpdir=None):
+    return create_tensor_communication_manager(
+        protocol=protocol,
+        my_entity_id=entity,
+        hostname="127.0.0.1",
+        device="cpu",
+        communicator=mock.Mock(),
+        shm_dir=tmpdir,
+        same_host_entities=same_host_entities,
+    )
+
+
+class TestFactorySelection:
+    def test_shm_protocol_unchanged(self, tmp_path):
+        mgr = _make(CommProtocol.SHM, {"worker_1"}, tmpdir=str(tmp_path))
+        assert type(mgr) is SharedMemoryCommunicationManager
+
+    def test_no_locality_info_keeps_mooncake(self, tmp_path):
+        with _patched_engine():
+            mgr = _make(CommProtocol.TCP, None, tmpdir=str(tmp_path))
+        assert type(mgr) is MooncakeCommunicationManager
+
+    def test_locality_info_upgrades_to_hybrid(self, tmp_path):
+        with _patched_engine():
+            for protocol in (CommProtocol.TCP, CommProtocol.RDMA):
+                mgr = _make(protocol, {"worker_1"}, tmpdir=str(tmp_path))
+                assert type(mgr) is HybridCommunicationManager
+
+
+class TestHybridDataPath:
+    def _pair(self, tmp_path):
+        with _patched_engine():
+            producer = _make(
+                CommProtocol.TCP, {"worker_1"}, "worker_0", str(tmp_path)
+            )
+            consumer = _make(
+                CommProtocol.TCP, {"worker_0"}, "worker_1", str(tmp_path)
+            )
+        return producer, consumer
+
+    def test_shm_round_trip(self, tmp_path):
+        producer, consumer = self._pair(tmp_path)
+        tensor = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        infos = producer.store_and_return_tensor_info("r1", {"edge": [tensor]})
+        info = infos["edge"][0]
+        producer.register_for_send("r1", [info.uuid], shm_uuids={info.uuid})
+        path = os.path.join(str(tmp_path), f"mstar_worker_0_{info.uuid}")
+        assert os.path.exists(path)
+
+        info.via_shm = True
+        consumer.start_read_tensors(
+            "r1", [_edge_with(info, name="edge", next_node="n")]
+        )
+        ready = consumer.get_ready_tensors()
+        assert [e.name for e in ready["r1"]] == ["edge"]
+        assert torch.equal(consumer.get_tensor("r1", info.uuid), tensor)
+
+    def test_send_dedup_and_cleanup(self, tmp_path):
+        producer, _ = self._pair(tmp_path)
+        tensor = torch.ones(4)
+        infos = producer.store_and_return_tensor_info("r1", {"edge": [tensor]})
+        uuid = infos["edge"][0].uuid
+        producer.register_for_send("r1", [uuid], shm_uuids={uuid})
+        producer.register_for_send("r1", [uuid], shm_uuids={uuid})
+        path = producer._shm_files[uuid]
+        # shm-sent uuids are not engine-registered, so the engine cleanup
+        # path must not try to unregister them.
+        assert not producer.tensor_store.is_registered("r1", uuid)
+        producer._cleanup_by_uuid("r1", uuid)
+        assert not os.path.exists(path)
+        assert uuid not in producer._shm_files
+        assert not producer.tensor_store.check_uuid_presence("r1", uuid)
+
+    def test_engine_uuids_still_registered(self, tmp_path):
+        producer, _ = self._pair(tmp_path)
+        infos = producer.store_and_return_tensor_info(
+            "r1", {"edge": [torch.ones(4), torch.ones(4)]}
+        )
+        near, far = (i.uuid for i in infos["edge"])
+        producer.register_for_send("r1", [near, far], shm_uuids={near})
+        assert near in producer._shm_files
+        assert far not in producer._shm_files
+        # Engine-path uuids take the normal registration bookkeeping.
+        assert producer.tensor_store.is_registered("r1", far)
+
+
+def _edge_with(info, name, next_node):
+    return GraphEdge(next_node=next_node, name=name, tensor_info=[info])

--- a/test/modular/test_launcher.py
+++ b/test/modular/test_launcher.py
@@ -1,0 +1,164 @@
+"""Tests for the worker launchers and the node-agent handshake."""
+
+import os
+import pickle
+import time
+
+import pytest
+
+from mstar.cluster.endpoints import ControlPlaneEndpoints
+from mstar.cluster.launcher import LocalLauncher, NodeAgentLauncher
+from mstar.cluster.spec import ClusterSpec
+from mstar.communication.communicator import ZMQCommunicator
+from mstar.utils.ipc_format import (
+    AgentJoin,
+    AgentMessage,
+    AgentMessageType,
+    AgentWorkerDied,
+    LaunchSpec,
+)
+
+
+def _endpoints(n_hosts=3):
+    base = 23000 + (os.getpid() % 400) * 8
+    hosts = [
+        {"addr": "127.0.0.1", "gpus": [i], "zmq_port_base": base + i * 250}
+        for i in range(n_hosts)
+    ]
+    return ControlPlaneEndpoints(ClusterSpec.from_config({"cluster": {"hosts": hosts}}))
+
+
+def _drain_until(comm, want, timeout_s=5.0):
+    got = []
+    deadline = time.monotonic() + timeout_s
+    while len(got) < want and time.monotonic() < deadline:
+        got.extend(comm.get_all_new_messages())
+        time.sleep(0.01)
+    return got
+
+
+def _spec_for(node_rank, worker_ids):
+    return LaunchSpec(
+        node_rank=node_rank,
+        model_name="dummy",
+        model_kwargs={},
+        cache_dir=None,
+        log_level="INFO",
+        host_env={"X": "1"},
+        workers=[{"worker_id": wid, "device": "cuda:0"} for wid in worker_ids],
+    )
+
+
+class TestNodeAgentHandshake:
+    def test_join_receives_launch_spec(self):
+        eps = _endpoints()
+        conductor = ZMQCommunicator("conductor", [], endpoints=eps)
+        agent = ZMQCommunicator("node_agent_1", ["conductor"], endpoints=eps)
+        try:
+            launcher = NodeAgentLauncher(
+                communicator=conductor,
+                launch_specs={1: _spec_for(1, ["worker_1"])},
+                join_timeout_s=30,
+            )
+            launcher.ensure_workers()
+            agent.send("conductor", AgentMessage(
+                AgentMessageType.AGENT_JOIN,
+                AgentJoin(node_rank=1, addr="127.0.0.1", visible_gpus=1, pid=1),
+            ))
+            for msg in _drain_until(conductor, want=1):
+                launcher.handle_agent_message(msg)
+            (reply,) = _drain_until(agent, want=1)
+            assert reply.message_type == AgentMessageType.LAUNCH_SPEC
+            assert [w["worker_id"] for w in reply.body.workers] == ["worker_1"]
+            assert reply.body.host_env == {"X": "1"}
+            assert launcher.poll() == []
+        finally:
+            conductor.close()
+            agent.close()
+
+    def test_unexpected_rank_rejected(self):
+        eps = _endpoints(n_hosts=3)
+        conductor = ZMQCommunicator("conductor", [], endpoints=eps)
+        stray = ZMQCommunicator("node_agent_2", ["conductor"], endpoints=eps)
+        try:
+            launcher = NodeAgentLauncher(
+                communicator=conductor,
+                launch_specs={1: _spec_for(1, ["worker_1"])},  # host 2 not expected
+                join_timeout_s=30,
+            )
+            launcher.ensure_workers()
+            stray.send("conductor", AgentMessage(
+                AgentMessageType.AGENT_JOIN,
+                AgentJoin(node_rank=2, addr="127.0.0.1", visible_gpus=1, pid=2),
+            ))
+            for msg in _drain_until(conductor, want=1):
+                launcher.handle_agent_message(msg)
+            (reply,) = _drain_until(stray, want=1)
+            assert reply.message_type == AgentMessageType.AGENT_JOIN_REJECTED
+            assert "not part of this deployment" in reply.body.reason
+        finally:
+            conductor.close()
+            stray.close()
+
+    def test_worker_death_relay_and_join_timeout(self):
+        eps = _endpoints()
+        conductor = ZMQCommunicator("conductor", [], endpoints=eps)
+        try:
+            launcher = NodeAgentLauncher(
+                communicator=conductor,
+                launch_specs={1: _spec_for(1, ["worker_1"])},
+                join_timeout_s=0.05,
+            )
+            launcher.ensure_workers()
+            launcher.handle_agent_message(AgentMessage(
+                AgentMessageType.AGENT_WORKER_DIED,
+                AgentWorkerDied(node_rank=1, worker_id="worker_1", exitcode=-9),
+            ))
+            time.sleep(0.1)
+            with pytest.raises(RuntimeError, match="did not join"):
+                launcher.poll()
+
+            # After the expected agent joins, poll returns queued events.
+            launcher._joined.add(1)
+            events = launcher.poll()
+            assert [(e.worker_id, e.exitcode) for e in events] == [("worker_1", -9)]
+        finally:
+            conductor.close()
+
+    def test_launch_spec_pickles(self):
+        spec = _spec_for(1, ["worker_1", "worker_2"])
+        assert pickle.loads(pickle.dumps(spec)).workers[1]["worker_id"] == "worker_2"
+
+
+class TestLocalLauncher:
+    def test_lifecycle(self):
+        durations = {"worker_0": 0.3, "worker_1": 60.0}
+        launcher = LocalLauncher(
+            worker_ids=["worker_0", "worker_1"],
+            model=None,
+            build_spawn_kwargs=lambda wid: {
+                "worker_id": wid, "seconds": durations[wid]
+            },
+            target=_sleep_target_no_model,
+        )
+        launcher.ensure_workers()
+        assert launcher.poll() == []
+
+        deadline = time.monotonic() + 10
+        events = []
+        while not events and time.monotonic() < deadline:
+            events = launcher.poll()
+            time.sleep(0.05)
+        assert [e.worker_id for e in events] == ["worker_0"]
+        assert events[0].exitcode == 0
+
+        launcher.shutdown()
+        assert launcher.poll() == []  # already-reported deaths are not repeated
+
+
+def _sleep_target_no_model(worker_id: str, seconds: float, model=None):
+    time.sleep(seconds)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/modular/test_model_config_warming.py
+++ b/test/modular/test_model_config_warming.py
@@ -1,0 +1,66 @@
+"""Models may specialize their walk graphs from the deployment config.
+
+Whoever constructs a model for workers (the conductor process, or a node
+agent on another host) must run the config-parsing calls before spawning, or
+the two sides disagree about which walks and nodes exist. BAGEL's
+CFG-parallel walks are the concrete case: they only register when the
+placement names the CFG nodes.
+"""
+
+import os
+
+import pytest
+
+pytest.importorskip("transformers")
+
+CFG = os.path.join(os.path.dirname(__file__), "..", "..", "configs", "bagel_cfg_parallel.yaml")
+
+
+def _fresh_bagel():
+    from mstar.model.bagel.bagel_model import BagelModel
+    from mstar.model.registry import HF_MODELS
+
+    os.environ.setdefault("HF_HUB_OFFLINE", "1")
+    try:
+        return BagelModel(
+            model_path_hf=HF_MODELS["bagel"]["model_path_hf"], cache_dir=None
+        )
+    except Exception as e:  # tokenizer assets not cached on this machine
+        pytest.skip(f"BAGEL tokenizer assets unavailable: {e}")
+
+
+class TestConfigWarming:
+    def test_fresh_model_lacks_cfg_walks(self):
+        model = _fresh_bagel()
+        walks = model.get_graph_walk_graphs()
+        assert "image_gen_cfg" not in walks
+
+    def test_config_call_registers_cfg_walks(self):
+        model = _fresh_bagel()
+        model.get_worker_graphs(CFG)
+        walks = model.get_graph_walk_graphs()
+        assert "image_gen_cfg" in walks
+        cfg_nodes = set(walks["image_gen_cfg"].get_nodes())
+        assert {"LLM_cfg_text", "LLM_cfg_img"} <= cfg_nodes
+
+    def test_node_agent_warms_like_the_conductor(self):
+        # The mapping workers build from the model (node -> partition) must
+        # cover the CFG nodes after the agent's warming calls; a miss there
+        # surfaces as scheduler KeyErrors on the remote host.
+        model = _fresh_bagel()
+        model.get_worker_graphs(CFG)
+        model.get_sharding_config(CFG)
+        node_to_partition = {}
+        for pdef in model.get_partitions():
+            walks = model.get_graph_walk_graphs()
+            for walk_name in pdef.graph_walks:
+                section = walks.get(walk_name)
+                if section:
+                    for node_name in section.get_nodes():
+                        node_to_partition[node_name] = pdef.name
+        assert "LLM_cfg_text" in node_to_partition
+        assert "LLM_cfg_img" in node_to_partition
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/multinode/README.md
+++ b/test/multinode/README.md
@@ -1,0 +1,26 @@
+# Multi-host tests
+
+`sim_two_hosts.sh` runs a complete two-host deployment on one machine: the
+head (`mstar-serve`) and a node agent (`mstar-node`) each get their own
+control-plane port base and GPU pin, so the BAGEL prefill/decode split in
+`bagel_pd_two_hosts_sim.yaml` exercises the real multi-host path — agent
+join/launch handshake, TCP control plane, cross-host KV transfer over the
+Mooncake TCP transport — without needing a second machine.
+
+```bash
+# both workers on GPU 0 (fits one H100/H200):
+test/multinode/sim_two_hosts.sh 0
+
+# prefill worker on GPU 0, decode worker on GPU 1:
+test/multinode/sim_two_hosts.sh 0 1
+```
+
+It serves two pinned-`request_id` prompts (fixed ids give fixed sampling
+seeds, so byte hashes are comparable across runs and against a single-host
+run of the same config), then kills the remote worker and asserts the next
+request fails fast with HTTP 500 instead of hanging.
+
+Requirements: BAGEL weights in the local HF cache (`HF_HUB_OFFLINE=1` is set
+by default so nothing is downloaded), and a working Mooncake TCP device —
+override with `MSTAR_TEST_TCP_DEVICE` if `0.0.0.0.0` does not suit the
+machine.

--- a/test/multinode/bagel_pd_two_hosts_sim.yaml
+++ b/test/multinode/bagel_pd_two_hosts_sim.yaml
@@ -1,0 +1,46 @@
+# Two-"host" loopback simulation of BAGEL prefill/decode disaggregation:
+# both logical hosts are this machine (disjoint control-plane port bases),
+# and each maps its single worker to local CUDA device 0 — so the head and
+# the agent can be pinned to GPUs via CUDA_VISIBLE_DEVICES independently.
+# For a real deployment, replace the addrs with routable hostnames and drop
+# the second port base.
+model: "bagel"
+max_seq_len: 32768
+
+cluster:
+  hosts:
+    - addr: 127.0.0.1
+      gpus: [0]
+      zmq_port_base: 24800
+    - addr: 127.0.0.1
+      gpus: [0]
+      zmq_port_base: 25400
+
+node_groups:
+  - node_names:
+      - vit_encoder
+    ranks:
+      - 0
+
+  - node_names:
+      - vae_encoder
+      - vae_decoder
+    ranks:
+      - 0
+
+  - node_names:
+      - LLM
+    ranks:
+      - 0
+    graph_walks:
+      - prefill_text
+      - prefill_vit
+      - prefill_vae
+
+  - node_names:
+      - LLM
+    ranks:
+      - 1
+    graph_walks:
+      - decode
+      - image_gen

--- a/test/multinode/sim_two_hosts.sh
+++ b/test/multinode/sim_two_hosts.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Two-"host" loopback rig: runs mstar-serve (head) and one mstar-node agent on
+# this machine, serves two pinned-seed requests across the host split, then
+# kills the remote worker and checks the failure surfaces as a fast HTTP 500.
+#
+# Usage:
+#   test/multinode/sim_two_hosts.sh [head_gpu] [agent_gpu] [port]
+#
+# Requirements: BAGEL weights in the local HF cache, and a tensor transport
+# that works on this machine (the rig uses Mooncake TCP; on hosts without an
+# active RDMA fabric the transfer engine needs the explicit device below).
+set -u
+HEAD_GPU="${1:-0}"; AGENT_GPU="${2:-$HEAD_GPU}"; PORT="${3:-8172}"
+TCP_DEVICE="${MSTAR_TEST_TCP_DEVICE:-0.0.0.0.0}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CFG="$HERE/bagel_pd_two_hosts_sim.yaml"
+WORKDIR="$(mktemp -d /tmp/mstar_sim2h_XXXX)"
+HEAD_LOG=$WORKDIR/head.log
+AGENT_LOG=$WORKDIR/agent.log
+
+if ss -ltn 2>/dev/null | grep -q ":$PORT "; then echo "port $PORT busy"; exit 3; fi
+
+setsid env HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-1}" CUDA_VISIBLE_DEVICES="$HEAD_GPU" \
+  mstar-serve --config "$CFG" --host 127.0.0.1 --port "$PORT" \
+  --socket-path-prefix "$WORKDIR/head_sockets" --upload-dir "$WORKDIR/uploads" \
+  --tensor-comm-protocol TCP --tcp-transfer-device "$TCP_DEVICE" \
+  > "$HEAD_LOG" 2>&1 &
+HEAD=$!
+
+setsid env HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-1}" CUDA_VISIBLE_DEVICES="$AGENT_GPU" \
+  mstar-node --config "$CFG" --node-rank 1 > "$AGENT_LOG" 2>&1 &
+AGENT=$!
+
+cleanup() {
+  kill -INT -- -$HEAD 2>/dev/null; kill -INT -- -$AGENT 2>/dev/null
+  sleep 6
+  kill -9 -- -$HEAD 2>/dev/null; kill -9 -- -$AGENT 2>/dev/null
+  echo "logs kept in $WORKDIR"
+}
+trap cleanup EXIT
+
+for i in $(seq 1 80); do
+  curl -s --max-time 2 "http://127.0.0.1:$PORT/health" 2>/dev/null | grep -q healthy && break
+  grep -qE "Traceback" "$HEAD_LOG" && { echo "head failed:"; tail -6 "$HEAD_LOG"; exit 1; }
+  grep -qE "Traceback" "$AGENT_LOG" && { echo "agent failed:"; tail -6 "$AGENT_LOG"; exit 1; }
+  kill -0 $HEAD 2>/dev/null || { echo "head exited:"; tail -6 "$HEAD_LOG"; exit 1; }
+  [ "$i" = 80 ] && { echo "startup timeout"; tail -4 "$HEAD_LOG" "$AGENT_LOG"; exit 1; }
+  sleep 10
+done
+echo "server ready"
+grep -m1 -o "Node agent 1 joined.*" "$HEAD_LOG"
+
+python - "$PORT" <<'EOF' || exit 1
+import base64, hashlib, sys, requests
+port = sys.argv[1]
+for rid, text in [
+    ("sim2h-1", "Describe a sunset over the ocean in two sentences."),
+    ("sim2h-2", "What is the capital of France? Answer in one word."),
+]:
+    r = requests.post(f"http://127.0.0.1:{port}/generate", timeout=180, data={
+        "text": text, "output_modalities": "text",
+        "streaming": "false", "request_id": rid,
+    })
+    r.raise_for_status()
+    payload = b"".join(base64.b64decode(c["data"]) for c in r.json()["outputs"].get("text", []))
+    assert payload, f"{rid}: empty output"
+    print(f"{rid}: bytes={len(payload)} sha256={hashlib.sha256(payload).hexdigest()[:16]} "
+          f"{payload[:60].decode('utf-8', 'replace')!r}")
+EOF
+
+WPID=$(pgrep -g $AGENT -f spawn_main | head -1)
+echo "killing remote worker pid=$WPID"
+kill -9 "$WPID"
+sleep 3
+code=$(curl -s -o "$WORKDIR/kill_probe.json" -w "%{http_code}" --max-time 60 -X POST \
+  "http://127.0.0.1:$PORT/generate" \
+  -F text='hello again' -F output_modalities=text -F streaming=false \
+  -F request_id=sim2h-post-kill)
+echo "post-kill request: http=$code $(head -c 160 "$WORKDIR/kill_probe.json")"
+[ "$code" = "500" ] || { echo "expected HTTP 500 after worker death"; exit 1; }
+
+echo "sim_two_hosts: OK"


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

This is a significant/important PR to here is a rather long description.

This PR lets one M* deployment span multiple machines. A config can now carry an optional `cluster:` section that maps hosts and their GPUs onto the global ranks `node_groups` already uses. The head host runs `mstar-serve` exactly as before; every other host runs a small agent (`mstar-node --config cfg.yaml --node-rank k`) that joins the conductor, receives a launch spec, and spawns/supervises that host's workers (building the model locally so weights load from its own cache). The ZMQ control plane switches from ipc to per-entity TCP endpoints derived from the cluster spec, tensors and KV keep moving over
the Mooncake engine (sessions now register routable addresses, with per-host device filters), and the NCCL bootstrap already was a TCP store, so TP across hosts just works. Configs without a `cluster:` section are untouched and single-host behavior is identical, which I verified.

I also fixed up lifecycle handling along the way: startup fails fast with a precise error instead of hanging when a host never joins or a worker dies while loading; at runtime a dead worker fails its in-flight requests with a real HTTP 500 and DP replicas route around it; replica choice now prefers keeping a request's stages on one host; and the conductor prints which graph edges will cross hosts at startup so a bad placement is visible before the first request. 

A few preeexisting bugs got fixed en route to my finishing this implementation - graceful conductor shutdown called a method `mp.Process` doesn't have (this is where all my zombie conductors on coriander were came from), Mooncake init failures were silently swallowed, and models that specialize themselves from the config (BAGEL only registers its CFG walks inside `get_worker_graphs()`) now get the same setup calls on agent hosts as on the head.
  
## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->

A lot of test have been added - around 50 or 60 new unit tests (cluster spec, endpoint resolution, launcher/agent handshake, replica assignment and cross-host cut detection, the model config-warming contract). The full existing suite has an identical pass/fail set to main throughout.

Also, verified single-host parity ie. served BAGEL with pinned request ids (pinned id --> pinned sampling seed) on this branch and on main and outputs are bit-identical.

A loopback two-"host" rig, checked in under `test/multinode/`, runs the real path on one machine: head + agent, TCP control plane, Mooncake TCP data plane. BAGEL prefill/decode split across the hosts is bit-identical to the same config on a single host with two GPUs, and CFG-parallel with both branches on the remote host produces bit-identical images. Orpheus (streaming split, and TP2 straddling hosts) serves correctly across the split. 

Failure paths: kill -9 a remote worker → the next request gets a fast 500 ("no live replica remains…") instead of hanging; a missing agent or a worker dying during load aborts startup with a message naming the culprit.

I also verified ooverhead - basically, same pinned requests, single-host vs split, we get 2.222s vs 2.229s end-to-end (within run-to-run noise).

## Checklist
- [ ] `ruff check .` passes
- [ ] Added or updated tests / docs where relevant
