### PR TITLE
Remove sgl-kernel dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,13 +34,14 @@ console scripts, ``mstar`` and ``mstar-serve``.
 
 .. important::
 
-   **Always pass** ``--torch-backend=auto``. ``mstar`` pins **PyTorch 2.9**
-   (``torch==2.9.1`` / ``torchvision==0.24.1`` / ``torchaudio==2.9.1``); ``sgl-kernel``
-   (Qwen3-Omni) is built against torch 2.9, so newer torch won't work. The flag tells
-   ``uv`` to detect your driver's CUDA version and fetch the **matching** torch build —
-   cu128 on a CUDA 12.x box, cu130 on a CUDA 13.x box. This matters because the
-   source-compiled extensions (``flash-attn``, ``sgl-kernel``) build against your *system*
-   CUDA toolkit, whose major version must match torch's. Without the flag ``uv`` installs
+   **Always pass** ``--torch-backend=auto``. ``mstar`` floors PyTorch at 2.9
+   (``torch>=2.9.1`` / ``torchvision>=0.24.1`` / ``torchaudio>=2.9.1``) and no longer
+   pins it — the MoE alignment kernel is a vendored CUDA source JIT-built against your
+   local toolkit, so it is not tied to a torch ABI. The flag tells ``uv`` to detect your
+   driver's CUDA version and fetch the **matching** torch build — cu128 on a CUDA 12.x
+   box, cu130 on a CUDA 13.x box. This still matters because source-compiled extensions
+   (``flash-attn``) and the JIT-built MoE kernel compile against your *system* CUDA
+   toolkit, whose major version must match torch's. Without the flag ``uv`` installs
    PyPI's default (cu128) build, which then fails to compile ``flash-attn`` on a CUDA 13
    machine with a *"detected CUDA version mismatches … PyTorch"* error. You can set it once
    with ``export UV_TORCH_BACKEND=auto`` instead of repeating the flag. See `Matching your
@@ -62,8 +63,9 @@ Model families and some output formats need extra packages, exposed as pip *extr
        ``einops``, ``Pillow``, ``torchvision`` / ``torchaudio`` / ``torchcodec``,
        ``huggingface-hub``, ``regex``, and ``mooncake-transfer-engine`` (RDMA transport).
    * - ``.[qwen3_omni]``
-     - Qwen3-Omni runtime: the BAGEL set plus ``qwen-omni-utils``, ``sgl-kernel``, and
-       ``datasets``. **Also needs** ``flash-attn``, which is installed separately —
+     - Qwen3-Omni runtime: the BAGEL set plus ``qwen-omni-utils``, ``datasets``, and
+       ``ninja`` (speeds up the JIT build of the vendored MoE align kernel).
+       **Also needs** ``flash-attn``, which is installed separately —
        see `flash-attn (Qwen3-Omni)`_.
    * - ``.[orpheus]``
      - Orpheus TTS runtime: ``transformers``, ``flashinfer-python``, ``safetensors``,
@@ -131,21 +133,29 @@ flash-attn (Qwen3-Omni)
 ``flash-attn`` is only needed for **Qwen3-Omni**, and it is **not** pulled in by
 ``.[qwen3_omni]`` or ``.[all]`` — you install it as a separate step. The reason: flash-attn
 publishes no wheels on PyPI, so ``pip``/``uv`` fall back to compiling it from source, which is
-slow and **fails outright on CUDA 13** (its bundled CUTLASS predates CUDA 13's vector-type
-ABI change). Skip the build by installing the prebuilt wheel that matches your stack.
+slow. When a prebuilt GitHub wheel matches your stack, use it to skip the build; otherwise
+build from source (see `No matching wheel — build from source`_ below).
 
 The wheels live on flash-attn's `GitHub releases
 <https://github.com/Dao-AILab/flash-attention/releases>`_, named by CUDA major, torch
-version, Python tag, and C++ ABI. With the pinned **torch 2.9** and **Python 3.12** you want a
-``torch2.9 / cp312 / cxx11abiTRUE`` wheel — the only choice left is the CUDA major, which must
-match **your installed torch's** CUDA, not your system toolkit. Check it first:
+**minor** version, Python tag, and C++ ABI. ``mstar`` no longer pins torch (floor
+``>=2.9.1``), so the wheel's ``torchX.Y`` tag must match **whatever torch you actually
+installed**, and its ``cu1x`` must match that torch's CUDA build — not your system toolkit.
+Check both first:
 
 .. code-block:: bash
 
-   python -c "import torch; print(torch.version.cuda)"   # 12.8 -> cu12,  13.0 -> cu13
+   python -c "import torch; print(torch.__version__, torch.version.cuda)"
+   # e.g. 2.12.1+cu130 13.0  ->  torch2.12 / cu13
+   #      2.9.1+cu128  12.8  ->  torch2.9  / cu12
 
-Then install the matching wheel by **direct URL** (don't use ``--find-links`` — uv sorts the
-``+cu13…`` local version above ``+cu12…`` and will grab cu13 even on a CUDA 12 box):
+Pick the release that has a wheel for your torch minor (each flash-attn release lists which
+``torchX.Y`` tags it ships), then install it by **direct URL** (don't use ``--find-links`` —
+uv sorts the ``+cu13…`` local version above ``+cu12…`` and will grab cu13 even on a CUDA 12
+box). The examples below are for **torch 2.9**; substitute the ``torch2.9`` segment with your
+own tag. Note the prebuilt wheels **top out at** ``torch2.10`` (``cu13``, in release
+``v2.8.3``) — there is **no** ``torch2.11+`` wheel, so on newer torch (e.g. 2.12) you must
+build from source instead:
 
 .. code-block:: bash
 
@@ -164,17 +174,55 @@ only the torch build matters. Verify with:
 
    python -c "import flash_attn; print(flash_attn.__version__)"
 
-(An ``undefined symbol`` error on import means the wheel's ``cu1x`` / ``torch2.9`` tag doesn't
+(An ``undefined symbol`` error on import means the wheel's ``cu1x`` / ``torchX.Y`` tag doesn't
 match your installed torch — recheck ``python -c "import torch; print(torch.__version__,
 torch.version.cuda)"`` and pick the matching wheel.)
+
+No matching wheel — build from source
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If no prebuilt wheel matches your torch minor (the wheels stop at ``torch2.10``, so this is
+the case on **torch 2.11+**), compile from source. A source build compiles against **whatever
+torch you have installed**, so the torch-minor mismatch goes away. flash-attn 2.8.3 builds
+against a CUDA-13 toolkit, but **only if you restrict the target architectures** (see below) —
+the default arch list pulls in Blackwell targets that don't compile under nvcc 13.x. It is a
+long compile (tens of minutes).
+
+Three things to get right:
+
+* ``FLASH_ATTN_CUDA_ARCHS`` — set it to **only your GPU's compute capability** (H100 →
+  ``"90"``, A100 → ``"80"``). By default flash-attn builds ``80;90;100;120``, and on a CUDA 13
+  toolkit that includes the Blackwell targets (``sm_100``/``sm_120``). flash-attn 2.8.3's
+  kernels **fail to compile for Blackwell under nvcc 13.x** — the build dies on
+  ``flash_bwd_hdim256_*`` with a bare ``[code=255]`` (the only hint upstream is a ``double4``
+  *deprecation* warning, which is not itself the error). Restricting the arch list avoids the
+  broken targets and cuts build time several-fold.
+* ``--no-build-isolation`` — build against your *installed* torch. Without it, uv builds in an
+  isolated env that pulls a fresh (possibly different-minor) torch, defeating the point.
+* ``psutil`` must be importable **before** the build — flash-attn's ``setup.py`` imports it to
+  size the parallel compile, and it is not declared as a build dependency.
+
+.. code-block:: bash
+
+   uv pip install psutil
+   FLASH_ATTN_CUDA_ARCHS="90" uv pip install flash-attn==2.8.3.post1 --no-build-isolation
+   python -c "import flash_attn; print(flash_attn.__version__)"
+
+.. note::
+
+   FlashAttention **3** does not help here: it ships as a separate ``flash_attn_interface``
+   module built from the repo's ``hopper/`` subdir, not the ``flash_attn`` package this code
+   imports (and transformers' ``flash_attention_2`` path won't route to it). It is also a
+   source build, so it offers no shortcut over building FA2 above.
 
 Matching your CUDA toolkit
 --------------------------
 
 PyPI's default ``torch`` wheel targets one specific CUDA release (cu128), which may not match
-your machine. ``flash-attn`` and ``sgl-kernel`` compile from source against your *system*
-CUDA, so a mismatch with torch's CUDA breaks the build. The simplest fix is to let ``uv``
-choose the right build automatically:
+your machine. ``flash-attn`` compiles from source, and the vendored MoE align kernel
+JIT-compiles on first use, both against your *system* CUDA — so a mismatch with torch's
+CUDA breaks the build. The simplest fix is to let ``uv`` choose the right build
+automatically:
 
 .. code-block:: bash
 
@@ -182,7 +230,7 @@ choose the right build automatically:
 
 ``--torch-backend=auto`` detects your driver (via ``nvidia-smi``) and selects the matching
 PyTorch index — cu128 on CUDA 12.x, cu130 on CUDA 13.x — for the runtime *and* for the
-isolated environments that build ``flash-attn`` / ``sgl-kernel``. The same command therefore
+isolated environment that builds ``flash-attn``. The same command therefore
 works unchanged across machines. (Needs a recent ``uv`` — run ``uv pip install --help`` and
 look for ``--torch-backend`` if unsure; ``export UV_TORCH_BACKEND=auto`` is equivalent.)
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,15 +35,12 @@ console scripts, ``mstar`` and ``mstar-serve``.
 .. important::
 
    **Always pass** ``--torch-backend=auto``. ``mstar`` floors PyTorch at 2.9
-   (``torch>=2.9.1`` / ``torchvision>=0.24.1`` / ``torchaudio>=2.9.1``) and no longer
-   pins it — the MoE alignment kernel is a vendored CUDA source JIT-built against your
-   local toolkit, so it is not tied to a torch ABI. The flag tells ``uv`` to detect your
-   driver's CUDA version and fetch the **matching** torch build — cu128 on a CUDA 12.x
-   box, cu130 on a CUDA 13.x box. This still matters because source-compiled extensions
-   (``flash-attn``) and the JIT-built MoE kernel compile against your *system* CUDA
-   toolkit, whose major version must match torch's. Without the flag ``uv`` installs
-   PyPI's default (cu128) build, which then fails to compile ``flash-attn`` on a CUDA 13
-   machine with a *"detected CUDA version mismatches … PyTorch"* error. You can set it once
+   (``torch>=2.9.1`` / ``torchvision>=0.24.1`` / ``torchaudio>=2.9.1``). The flag tells 
+   ``uv`` to detect your driver's CUDA version and fetch the **matching** torch build
+   — cu128 on a CUDA 12.x box, cu130 on a CUDA 13.x box. This matters because source-
+   compiled extensions (``flash-attn``) and the JIT-built MoE kernel for Qwen3-Omni
+   compile against your *system* CUDA toolkit, whose major version must match torch's.
+   Without the flag ``uv`` installs PyPI's default (cu128) build. You can set it once
    with ``export UV_TORCH_BACKEND=auto`` instead of repeating the flag. See `Matching your
    CUDA toolkit`_ for details and the manual fallback.
 
@@ -207,13 +204,6 @@ Three things to get right:
    uv pip install psutil
    FLASH_ATTN_CUDA_ARCHS="90" uv pip install flash-attn==2.8.3.post1 --no-build-isolation
    python -c "import flash_attn; print(flash_attn.__version__)"
-
-.. note::
-
-   FlashAttention **3** does not help here: it ships as a separate ``flash_attn_interface``
-   module built from the repo's ``hopper/`` subdir, not the ``flash_attn`` package this code
-   imports (and transformers' ``flash_attention_2`` path won't route to it). It is also a
-   source build, so it offers no shortcut over building FA2 above.
 
 Matching your CUDA toolkit
 --------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -248,4 +248,31 @@ Verify the install
    mstar --help
    mstar-serve --help
 
+Troubleshooting
+---------------
+
+``CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Symptom — a convolution (or another cuDNN op) aborts with::
+
+   RuntimeError: ... cudnn_status: CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH
+
+This affects **CUDA 12** installs (a ``+cu12x`` torch) running on a host that *also* has a
+**newer system cuDNN (≥ 9.21)** on the default loader path (e.g. ``/usr/lib64``). PyTorch's
+cu12 wheels pin ``nvidia-cudnn-cu12==9.20.0.48``, and that slim wheel omits the
+``libcudnn_engines_tensor_ir`` engine. When cuDNN needs that engine it loads it from the
+system copy instead — and a 9.20 dispatcher paired with a ≥ 9.21 engine is the mismatch.
+Boxes with no system cuDNN, or a matching one, are unaffected, as are CUDA 13 installs
+(they use ``nvidia-cudnn-cu13``).
+
+Fix — complete the environment's own cuDNN so it never falls back to the system copy:
+
+.. code-block:: bash
+
+   uv pip install --no-deps -U "nvidia-cudnn-cu12>=9.21"
+
+``--no-deps`` leaves torch in place; pip may print a harmless warning that torch pins
+``9.20.0.48``. cuDNN is ABI-compatible within the v9 series, so the newer patch runs fine.
+
 Next: :doc:`quickstart`.

--- a/mstar/model/components/moe.py
+++ b/mstar/model/components/moe.py
@@ -16,10 +16,9 @@ Parallel (TP-aware) variants:
 * :class:`ParallelSparseMoeBlock`
 * :class:`ParallelSparseMoeBlockWithSharedExpert`
 
-When the optional ``sgl-kernel`` dependency is installed and inputs are
-on CUDA, dispatch goes through the Triton fused-MoE kernel in
-:mod:`mstar.utils.fused_moe`; otherwise it falls back to the naive
-per-expert loop in :func:`dispatch_experts_fused`.
+When triton is installed and inputs are on CUDA, dispatch goes through
+the Triton fused-MoE kernel in :mod:`mstar.utils.fused_moe`; otherwise it
+falls back to the naive per-expert loop in :func:`dispatch_experts_fused`.
 """
 from __future__ import annotations
 
@@ -35,15 +34,15 @@ from mstar.distributed.utils import divide
 logger = logging.getLogger(__name__)
 
 
-# Optional fused Triton MoE path. Imports succeed only on CUDA boxes
-# with sgl-kernel installed; any import failure (including the final
-# moe_align_block_size call) is treated as "fused path unavailable".
+# Optional fused Triton MoE path. Imports succeed wherever triton is
+# installed; the alignment op JIT-builds a vendored CUDA kernel on first use
+# (or falls back to a torch impl), so no sgl-kernel/vllm dep is needed. The
+# actual kernels only run on CUDA -- guarded by the ``is_cuda`` check below.
 try:
     from mstar.utils.fused_moe import fused_experts as _fused_experts
-    from mstar.utils.fused_moe.align import has_sgl_kernel
 
-    _HAS_FUSED = has_sgl_kernel()
-except Exception as e:  # pragma: no cover -- exercised only when optional dep missing
+    _HAS_FUSED = True
+except Exception as e:  # pragma: no cover -- exercised only when triton missing
     _fused_experts = None
     _HAS_FUSED = False
     logger.warning(f"Could not load fused MoE kernel: {e}")

--- a/mstar/utils/fused_moe/__init__.py
+++ b/mstar/utils/fused_moe/__init__.py
@@ -5,8 +5,9 @@ Replaces the naive per-expert Python loop in
 grouped-GEMM implementation adapted from sglang's ``fused_moe_triton``.
 
 Only the bf16 / fp16 unquantized path is provided.  The entry point is
-:func:`fused_experts`; if its dependency ``sgl_kernel`` is not installed
-the import fails and callers fall back to the naive dispatch.
+:func:`fused_experts`; if triton is not installed the import fails and
+callers fall back to the naive dispatch.  The token-alignment step uses a
+vendored CUDA kernel (JIT-built on first use) with a torch fallback.
 """
 from __future__ import annotations
 

--- a/mstar/utils/fused_moe/align.py
+++ b/mstar/utils/fused_moe/align.py
@@ -2,41 +2,64 @@
 
 The fused MoE kernel expects tokens sorted by expert index and padded to
 multiples of ``BLOCK_SIZE_M`` per expert.  The sort / pad is produced by
-sglang's ``moe_align_block_size`` CUDA op (from the ``sgl_kernel`` pip
-package).  This module wraps that op with the same allocation pattern
-sglang uses; if the ``sgl_kernel`` import fails we raise a
-``RuntimeError`` at call time so the caller can fall back to the naive
-per-expert dispatch path.
+vLLM's ``moe_align_block_size`` CUDA op, vendored (Apache-2.0) as
+``csrc/moe_align_block_size.cu`` and JIT-compiled on first use against the
+local CUDA toolkit -- no ``sgl_kernel`` / ``vllm`` dependency.
+
+If the CUDA op cannot be built (no ``nvcc`` / no CUDA device) we fall back
+to a vectorized PyTorch implementation with identical output semantics.
+The fallback runs entirely on-device but is slower than the fused kernel;
+it exists so the path is always *available*, not fast.
 """
 
 from __future__ import annotations
 
+import functools
 import logging
-from typing import Tuple
+import os
 
 import torch
 import triton
 
 logger = logging.getLogger(__name__)
 
-try:
-    from sgl_kernel import moe_align_block_size as _sgl_moe_align_block_size
-except ImportError as e:  # pragma: no cover -- exercised on boxes without sgl_kernel
-    _sgl_moe_align_block_size = None
-    logger.warning(f"Could not load _fused_experts: {e}")
+_CSRC = os.path.join(os.path.dirname(__file__), "csrc", "moe_align_block_size.cu")
 
 
-def has_sgl_kernel() -> bool:
-    """Whether the optional ``sgl_kernel`` dependency is available."""
-    return _sgl_moe_align_block_size is not None
+@functools.lru_cache(maxsize=1)
+def _cuda_op_available() -> bool:
+    """JIT-compile and load the vendored CUDA op; return whether it worked.
+
+    Cached so compilation is attempted once per process.  A failure (missing
+    ``nvcc``, no CUDA device, ABI mismatch) is logged and the caller uses the
+    torch fallback instead.
+    """
+    if not torch.cuda.is_available():
+        return False
+    try:
+        from torch.utils.cpp_extension import load
+
+        load(name="_mstar_moe_C", sources=[_CSRC], is_python_module=False, verbose=False)
+        # Touch the op so a registration failure surfaces here, not at call time.
+        _ = torch.ops._mstar_moe_C.moe_align_block_size
+        return True
+    except Exception as e:  # pragma: no cover -- depends on the build toolchain
+        logger.warning(
+            "fused MoE: could not build the CUDA moe_align_block_size op (%s); "
+            "using the slower torch fallback.",
+            e,
+        )
+        return False
 
 
 def moe_align_block_size(
     topk_ids: torch.Tensor,
     block_size: int,
     num_experts: int,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Sort ``topk_ids`` into expert-aligned blocks.
+
+    ``topk_ids`` must be int32 and contiguous (the CUDA op reads it directly).
 
     Returns
     -------
@@ -51,42 +74,79 @@ def moe_align_block_size(
     num_tokens_post_padded : torch.Tensor
         ``(1,)`` int32 scalar with the count of valid + padding slots;
         the Triton kernel early-returns on tiles past this count.
-
-    Notes
-    -----
-    ``topk_ids`` must be int32 and contiguous (the sglang CUDA op reads
-    from it directly).  The ``num_experts + 1`` shift and ``cumsum``
-    buffer width match sglang's own wrapper so the op sees the same
-    memory layout it was built against.
     """
-    if _sgl_moe_align_block_size is None:
-        raise RuntimeError(
-            "Fused MoE requires the optional 'sgl-kernel' package. "
-            "Install with: pip install sgl-kernel "
-            "(choose the wheel matching your torch/CUDA version: "
-            "https://github.com/sgl-project/sglang/releases)."
+    # vLLM's allocation: worst case is one partial block padded per expert.
+    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
+    sorted_ids = torch.empty(
+        (max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device
+    )
+    max_num_m_blocks = triton.cdiv(max_num_tokens_padded, block_size)
+    expert_ids = torch.empty(
+        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
+    )
+    num_tokens_post_pad = torch.empty((1,), dtype=torch.int32, device=topk_ids.device)
+
+    if _cuda_op_available():
+        torch.ops._mstar_moe_C.moe_align_block_size(
+            topk_ids,
+            num_experts,
+            block_size,
+            sorted_ids,
+            expert_ids,
+            num_tokens_post_pad,
+        )
+    else:
+        _moe_align_block_size_torch(
+            topk_ids, block_size, num_experts, sorted_ids, expert_ids, num_tokens_post_pad
         )
 
-    if topk_ids.numel() < num_experts + 1:
-        max_num_tokens_padded = topk_ids.numel() * block_size
-    else:
-        max_num_tokens_padded = topk_ids.numel() + (num_experts + 1) * (block_size - 1)
-
-    sorted_ids = torch.empty((max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device)
-    max_num_m_blocks = triton.cdiv(max_num_tokens_padded, block_size)
-    expert_ids = torch.empty((max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device)
-    num_tokens_post_pad = torch.empty((1,), dtype=torch.int32, device=topk_ids.device)
-    # Matches sglang's extra slot for the "filtered / padding" expert id.
-    cumsum_buffer = torch.empty((num_experts + 2,), dtype=torch.int32, device=topk_ids.device)
-
-    _sgl_moe_align_block_size(
-        topk_ids,
-        num_experts + 1,
-        block_size,
-        sorted_ids,
-        expert_ids,
-        num_tokens_post_pad,
-        cumsum_buffer,
-        True,
-    )
     return sorted_ids, expert_ids, num_tokens_post_pad
+
+
+def _moe_align_block_size_torch(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    sorted_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_pad: torch.Tensor,
+) -> None:
+    """Vectorized PyTorch equivalent of the CUDA op, filling the buffers
+    in place with the same semantics.
+
+    Assumes every entry of ``topk_ids`` is a valid expert in
+    ``[0, num_experts)`` (always true for mstar's routed dispatch).
+    """
+    device = topk_ids.device
+    flat = topk_ids.reshape(-1)
+    numel = flat.numel()
+
+    # Padding slots hold ``numel``; unused expert-id blocks hold 0.
+    sorted_ids.fill_(numel)
+    expert_ids.zero_()
+
+    # Per-expert token counts, each rounded up to a multiple of block_size.
+    counts = torch.bincount(flat, minlength=num_experts)[:num_experts]
+    padded = ((counts + block_size - 1) // block_size) * block_size
+
+    # Exclusive prefix sum of padded counts -> first slot of each expert.
+    cumsum = torch.zeros(num_experts + 1, dtype=torch.int64, device=device)
+    cumsum[1:] = torch.cumsum(padded, dim=0)
+    num_tokens_post_pad.copy_(cumsum[num_experts].reshape(1).to(torch.int32))
+
+    # expert_ids: block -> expert, one entry per (padded) block per expert.
+    nblocks = (padded // block_size).to(torch.int64)
+    expert_index = torch.repeat_interleave(
+        torch.arange(num_experts, device=device, dtype=torch.int32), nblocks
+    )
+    expert_ids[: expert_index.numel()] = expert_index
+
+    # sorted_token_ids: group original token indices by expert into the
+    # padded slot ranges. Intra-expert order is irrelevant to the GEMM kernel.
+    order = torch.argsort(flat, stable=True)
+    sorted_experts = flat[order].to(torch.int64)
+    ucounts = torch.zeros(num_experts + 1, dtype=torch.int64, device=device)
+    ucounts[1:] = torch.cumsum(counts, dim=0)  # unpadded prefix over sorted tokens
+    local_rank = torch.arange(numel, device=device, dtype=torch.int64) - ucounts[sorted_experts]
+    dest = cumsum[sorted_experts] + local_rank
+    sorted_ids[dest] = order.to(torch.int32)

--- a/mstar/utils/fused_moe/csrc/moe_align_block_size.cu
+++ b/mstar/utils/fused_moe/csrc/moe_align_block_size.cu
@@ -1,0 +1,282 @@
+// moe_align_block_size CUDA op, vendored from vLLM (Apache-2.0).
+//
+// Source: vllm-project/vllm @ v0.11.0
+//   csrc/moe/moe_align_sum_kernels.cu
+// Trimmed to just the ``moe_align_block_size`` host function + its kernels
+// (moe_sum was dropped) and made self-contained: WARP_SIZE / CEILDIV are
+// inlined and the type dispatch is hardcoded to int32 (mstar always passes
+// int32 topk_ids), so the vLLM cuda_compat.h / dispatch_utils.h headers are
+// not needed.  Registered under the ``_mstar_moe_C`` op namespace so it never
+// collides with a real vLLM ``_moe_C`` in the same process.
+//
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#include <torch/all.h>
+#include <torch/library.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cub/cub.cuh>
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/Atomic.cuh>
+
+#define WARP_SIZE 32
+#define CEILDIV(x, y) (((x) + (y) - 1) / (y))
+
+namespace mstar {
+namespace moe {
+
+template <typename scalar_t>
+__global__ void moe_align_block_size_kernel(
+    const scalar_t* __restrict__ topk_ids,
+    int32_t* __restrict__ sorted_token_ids, int32_t* __restrict__ expert_ids,
+    int32_t* __restrict__ total_tokens_post_pad, int32_t num_experts,
+    int32_t padded_num_experts, int32_t experts_per_warp, int32_t block_size,
+    size_t numel, int32_t* __restrict__ cumsum, int32_t max_num_tokens_padded) {
+  extern __shared__ int32_t shared_counts[];
+
+  // Initialize sorted_token_ids with numel
+  for (size_t it = threadIdx.x; it < max_num_tokens_padded; it += blockDim.x) {
+    sorted_token_ids[it] = numel;
+  }
+
+  const int warp_id = threadIdx.x / WARP_SIZE;
+  const int my_expert_start = warp_id * experts_per_warp;
+
+  for (int i = 0; i < experts_per_warp; ++i) {
+    if (my_expert_start + i < padded_num_experts) {
+      shared_counts[warp_id * experts_per_warp + i] = 0;
+    }
+  }
+
+  __syncthreads();
+
+  const size_t tid = threadIdx.x;
+  const size_t stride = blockDim.x;
+
+  for (size_t i = tid; i < numel; i += stride) {
+    int expert_id = topk_ids[i];
+    if (expert_id >= num_experts) {
+      continue;
+    }
+    int warp_idx = expert_id / experts_per_warp;
+    int expert_offset = expert_id % experts_per_warp;
+    atomicAdd(&shared_counts[warp_idx * experts_per_warp + expert_offset], 1);
+  }
+
+  __syncthreads();
+
+  // Compute prefix sum over token counts per expert
+  using BlockScan = cub::BlockScan<int32_t, 1024>;
+  __shared__ typename BlockScan::TempStorage temp_storage;
+
+  int expert_count = 0;
+  int expert_id = threadIdx.x;
+  if (expert_id < num_experts) {
+    int warp_idx = expert_id / experts_per_warp;
+    int expert_offset = expert_id % experts_per_warp;
+    expert_count = shared_counts[warp_idx * experts_per_warp + expert_offset];
+    expert_count = CEILDIV(expert_count, block_size) * block_size;
+  }
+
+  int cumsum_val;
+  BlockScan(temp_storage).ExclusiveSum(expert_count, cumsum_val);
+  if (expert_id <= num_experts) {
+    cumsum[expert_id] = cumsum_val;
+  }
+
+  if (expert_id == num_experts) {
+    *total_tokens_post_pad = cumsum_val;
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < num_experts) {
+    for (int i = cumsum[threadIdx.x]; i < cumsum[threadIdx.x + 1];
+         i += block_size) {
+      expert_ids[i / block_size] = threadIdx.x;
+    }
+  }
+
+  // Fill remaining expert_ids with 0
+  const size_t fill_start_idx = cumsum[num_experts] / block_size + threadIdx.x;
+  const size_t expert_ids_size = CEILDIV(max_num_tokens_padded, block_size);
+  for (size_t i = fill_start_idx; i < expert_ids_size; i += blockDim.x) {
+    expert_ids[i] = 0;
+  }
+}
+
+template <typename scalar_t>
+__global__ void count_and_sort_expert_tokens_kernel(
+    const scalar_t* __restrict__ topk_ids,
+    int32_t* __restrict__ sorted_token_ids, int32_t* __restrict__ cumsum_buffer,
+    size_t numel, int32_t num_experts) {
+  const size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t stride = blockDim.x * gridDim.x;
+
+  for (size_t i = tid; i < numel; i += stride) {
+    int32_t expert_id = topk_ids[i];
+    if (expert_id >= num_experts) {
+      continue;
+    }
+    int32_t rank_post_pad = atomicAdd(&cumsum_buffer[expert_id], 1);
+    sorted_token_ids[rank_post_pad] = i;
+  }
+}
+
+template <typename scalar_t>
+__global__ void moe_align_block_size_small_batch_expert_kernel(
+    const scalar_t* __restrict__ topk_ids,
+    int32_t* __restrict__ sorted_token_ids, int32_t* __restrict__ expert_ids,
+    int32_t* __restrict__ total_tokens_post_pad, int32_t num_experts,
+    int32_t block_size, size_t numel, int32_t max_num_tokens_padded) {
+  // Initialize sorted_token_ids with numel
+  for (size_t it = threadIdx.x; it < max_num_tokens_padded; it += blockDim.x) {
+    sorted_token_ids[it] = numel;
+  }
+
+  const size_t tid = threadIdx.x;
+  const size_t stride = blockDim.x;
+
+  extern __shared__ int32_t shared_mem[];
+  int32_t* cumsum = shared_mem;
+  int32_t* tokens_cnts = (int32_t*)(shared_mem + num_experts + 1);
+
+  for (int i = 0; i < num_experts; ++i) {
+    tokens_cnts[(threadIdx.x + 1) * num_experts + i] = 0;
+  }
+
+  for (size_t i = tid; i < numel; i += stride) {
+    ++tokens_cnts[(threadIdx.x + 1) * num_experts + topk_ids[i]];
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < num_experts) {
+    tokens_cnts[threadIdx.x] = 0;
+    for (int i = 1; i <= blockDim.x; ++i) {
+      tokens_cnts[i * num_experts + threadIdx.x] +=
+          tokens_cnts[(i - 1) * num_experts + threadIdx.x];
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    cumsum[0] = 0;
+    for (int i = 1; i <= num_experts; ++i) {
+      cumsum[i] =
+          cumsum[i - 1] +
+          CEILDIV(tokens_cnts[blockDim.x * num_experts + i - 1], block_size) *
+              block_size;
+    }
+    *total_tokens_post_pad = static_cast<int32_t>(cumsum[num_experts]);
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < num_experts) {
+    for (int i = cumsum[threadIdx.x]; i < cumsum[threadIdx.x + 1];
+         i += block_size) {
+      expert_ids[i / block_size] = threadIdx.x;
+    }
+  }
+
+  // Fill remaining expert_ids with 0
+  const size_t fill_start_idx = cumsum[num_experts] / block_size + threadIdx.x;
+  const size_t expert_ids_size = CEILDIV(max_num_tokens_padded, block_size);
+  for (size_t i = fill_start_idx; i < expert_ids_size; i += blockDim.x) {
+    expert_ids[i] = 0;
+  }
+
+  for (size_t i = tid; i < numel; i += stride) {
+    int32_t expert_id = topk_ids[i];
+    int32_t rank_post_pad =
+        tokens_cnts[threadIdx.x * num_experts + expert_id] + cumsum[expert_id];
+    sorted_token_ids[rank_post_pad] = i;
+    ++tokens_cnts[threadIdx.x * num_experts + expert_id];
+  }
+}
+
+}  // namespace moe
+}  // namespace mstar
+
+// taken from
+// https://github.com/sgl-project/sglang/blob/8b5f83ed3b7d2a49ad5c5cd5aa61c5d502f47dbc
+void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
+                          int64_t block_size, torch::Tensor sorted_token_ids,
+                          torch::Tensor experts_ids,
+                          torch::Tensor num_tokens_post_pad) {
+  TORCH_CHECK(topk_ids.scalar_type() == torch::kInt32,
+              "moe_align_block_size: topk_ids must be int32");
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(topk_ids));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  int64_t padded_num_experts =
+      ((num_experts + WARP_SIZE - 1) / WARP_SIZE) * WARP_SIZE;
+  int experts_per_warp = WARP_SIZE;
+  int threads = 1024;
+  threads = ((threads + WARP_SIZE - 1) / WARP_SIZE) * WARP_SIZE;
+
+  // BlockScan uses 1024 threads and assigns one thread per expert.
+  TORCH_CHECK(padded_num_experts < 1024,
+              "padded_num_experts must be less than 1024");
+
+  using scalar_t = int32_t;
+  // calc needed amount of shared mem for `cumsum` tensors
+  auto options_int =
+      torch::TensorOptions().dtype(torch::kInt).device(topk_ids.device());
+  torch::Tensor cumsum_buffer = torch::empty({num_experts + 1}, options_int);
+  bool small_batch_expert_mode =
+      (topk_ids.numel() < 1024) && (num_experts <= 64);
+
+  if (small_batch_expert_mode) {
+    const int32_t threads = max((int32_t)num_experts, WARP_SIZE);
+    const int32_t shared_mem_size =
+        ((threads + 1) * num_experts + (num_experts + 1)) * sizeof(int32_t);
+
+    auto small_batch_expert_kernel =
+        mstar::moe::moe_align_block_size_small_batch_expert_kernel<scalar_t>;
+    small_batch_expert_kernel<<<1, threads, shared_mem_size, stream>>>(
+        topk_ids.data_ptr<scalar_t>(), sorted_token_ids.data_ptr<int32_t>(),
+        experts_ids.data_ptr<int32_t>(),
+        num_tokens_post_pad.data_ptr<int32_t>(), num_experts, block_size,
+        topk_ids.numel(), sorted_token_ids.size(0));
+  } else {
+    auto align_kernel = mstar::moe::moe_align_block_size_kernel<scalar_t>;
+
+    size_t num_warps = CEILDIV(padded_num_experts, experts_per_warp);
+    size_t shared_mem_size = num_warps * experts_per_warp * sizeof(int32_t);
+
+    align_kernel<<<1, threads, shared_mem_size, stream>>>(
+        topk_ids.data_ptr<scalar_t>(), sorted_token_ids.data_ptr<int32_t>(),
+        experts_ids.data_ptr<int32_t>(),
+        num_tokens_post_pad.data_ptr<int32_t>(), num_experts,
+        padded_num_experts, experts_per_warp, block_size, topk_ids.numel(),
+        cumsum_buffer.data_ptr<int32_t>(), sorted_token_ids.size(0));
+
+    const int block_threads = std::min(256, (int)threads);
+    const int num_blocks =
+        (topk_ids.numel() + block_threads - 1) / block_threads;
+    const int max_blocks = 65535;
+    const int actual_blocks = std::min(num_blocks, max_blocks);
+
+    auto sort_kernel =
+        mstar::moe::count_and_sort_expert_tokens_kernel<scalar_t>;
+    sort_kernel<<<actual_blocks, block_threads, 0, stream>>>(
+        topk_ids.data_ptr<scalar_t>(), sorted_token_ids.data_ptr<int32_t>(),
+        cumsum_buffer.data_ptr<int32_t>(), topk_ids.numel(), num_experts);
+  }
+}
+
+TORCH_LIBRARY(_mstar_moe_C, m) {
+  m.def(
+      "moe_align_block_size(Tensor topk_ids, int num_experts, int block_size, "
+      "Tensor! sorted_token_ids, Tensor! experts_ids, "
+      "Tensor! num_tokens_post_pad) -> ()");
+}
+
+TORCH_LIBRARY_IMPL(_mstar_moe_C, CUDA, m) {
+  m.impl("moe_align_block_size", &moe_align_block_size);
+}

--- a/mstar/utils/fused_moe/runner.py
+++ b/mstar/utils/fused_moe/runner.py
@@ -86,7 +86,7 @@ def fused_experts(
     assert two_inter == 2 * inter, f"w1 dim[1] {two_inter} != 2 * w2 dim[2] {2 * inter}"
 
     top_k = topk_ids.shape[1]
-    # sgl_kernel's moe_align_block_size expects int32; torch.topk returns int64.
+    # moe_align_block_size expects int32; torch.topk returns int64.
     topk_ids = topk_ids.to(torch.int32).contiguous()
     topk_weights = topk_weights.contiguous()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,6 @@ dependencies = [
     "pyzmq",
     "python-multipart",
     "requests",
-    # The MoE alignment op is now a vendored CUDA kernel JIT-built against the
-    # local toolkit (mstar/utils/fused_moe/csrc), so torch is no longer pinned
-    # to sgl-kernel's ABI. Floors keep the torch/vision/audio trio matched while
-    # letting pip resolve a set compatible with your CUDA wheel index. See
-    # docs/installation.rst for choosing the build that matches your toolkit.
     "torch>=2.9.1",
     "torchvision>=0.24.1",
     "torchaudio>=2.9.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ bagel = [
     "safetensors",
     "torchvision",
     "torchaudio",
-    "torchcodec==0.8.*",
+    "torchcodec",
     "transformers",
 ]
 
@@ -73,7 +73,7 @@ qwen3_omni = [
     "numba>=0.61",
     "torchvision",
     "torchaudio",
-    "torchcodec==0.8.*",
+    "torchcodec",
     "transformers",
     "datasets",
     "ninja",  # speeds up the first-use JIT build of the vendored MoE align kernel
@@ -101,7 +101,7 @@ vjepa2 = [
     "huggingface-hub",
     "mooncake-transfer-engine",
     "safetensors",
-    "torchcodec==0.8.*",
+    "torchcodec",
 ]
 
 vjepa2_ac = [
@@ -109,7 +109,7 @@ vjepa2_ac = [
     "huggingface-hub",
     "mooncake-transfer-engine",
     "safetensors",
-    "torchcodec==0.8.*",
+    "torchcodec",
 ]
 
 all = [
@@ -125,7 +125,7 @@ all = [
     "safetensors",
     "torchvision",
     "torchaudio",
-    "torchcodec==0.8.*",
+    "torchcodec",
     "transformers",
     "safetensors",
     "triton",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,14 @@ dependencies = [
     "pyzmq",
     "python-multipart",
     "requests",
-    # PyTorch 2.9 is pinned: sgl-kernel (Qwen3-Omni) is built against torch 2.9,
-    # and newer torch defaults to CUDA 13 wheels. See docs/installation.rst for
-    # installing the build that matches your CUDA toolkit (e.g. cu128).
-    "torch==2.9.1",
-    "torchvision==0.24.1",
-    "torchaudio==2.9.1",
+    # The MoE alignment op is now a vendored CUDA kernel JIT-built against the
+    # local toolkit (mstar/utils/fused_moe/csrc), so torch is no longer pinned
+    # to sgl-kernel's ABI. Floors keep the torch/vision/audio trio matched while
+    # letting pip resolve a set compatible with your CUDA wheel index. See
+    # docs/installation.rst for choosing the build that matches your toolkit.
+    "torch>=2.9.1",
+    "torchvision>=0.24.1",
+    "torchaudio>=2.9.1",
     "uvicorn",
     "gdown",
     "datasets",
@@ -74,7 +76,7 @@ qwen3_omni = [
     "torchcodec==0.8.*",
     "transformers",
     "datasets",
-    "sgl-kernel",
+    "ninja",  # speeds up the first-use JIT build of the vendored MoE align kernel
 ]
 
 orpheus = [
@@ -129,7 +131,7 @@ all = [
     "triton",
     "qwen-omni-utils",
     "numba>=0.61",
-    "sgl-kernel",
+    "ninja",  # speeds up the first-use JIT build of the vendored MoE align kernel
     # flash-attn is intentionally omitted (Qwen3-Omni needs it) — install it
     # separately, see docs/installation.rst.
 ]
@@ -138,6 +140,10 @@ all = [
 where = ["."]
 include = ["mstar*"]
 exclude = ["tests*", "benchmark*", "examples*"]
+
+# Ship the vendored CUDA source so it can be JIT-compiled on first use.
+[tool.setuptools.package-data]
+"mstar.utils.fused_moe" = ["csrc/*.cu", "csrc/*.cuh", "csrc/*.h", "csrc/*.cpp"]
 
 [tool.ruff]
 exclude = [".git", ".ruff_cache", ".venv", "ref"]

--- a/test/modular/test_qwen3_omni_fused_moe.py
+++ b/test/modular/test_qwen3_omni_fused_moe.py
@@ -1,10 +1,9 @@
 """Parity tests for the Triton fused MoE dispatch vs the naive path.
 
-Skips automatically when CUDA or ``sgl-kernel`` is unavailable (both are
-required for the fused kernel).  The naive path in
-``_dispatch_experts_fused`` runs on CPU, but we need CUDA bf16 tensors
-to exercise the Triton kernels, so the comparison is done entirely on
-GPU.
+Skips automatically when CUDA is unavailable (required for the fused
+kernel).  The naive path in ``_dispatch_experts_fused`` runs on CPU, but
+we need CUDA bf16 tensors to exercise the Triton kernels, so the
+comparison is done entirely on GPU.
 
 Problem shapes mirror the live Qwen3-Omni configs:
 
@@ -26,14 +25,8 @@ import torch
 
 from mstar.model.components import GatedMLP, SparseMoeBlock, SparseMoeBlockWithSharedExpert
 from mstar.model.components.moe import dispatch_experts_fused as _dispatch_experts_fused
-from mstar.utils.fused_moe.align import has_sgl_kernel
 
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="fused MoE requires CUDA")
-
-
-def _skip_if_no_sgl_kernel():
-    if not has_sgl_kernel():
-        pytest.skip("sgl-kernel not installed; fused MoE path unavailable")
 
 
 def _random_router_output(
@@ -76,7 +69,6 @@ def _seed():
     ],
 )
 def test_fused_experts_numerical_parity(num_tokens, hidden, inter, num_experts, top_k):
-    _skip_if_no_sgl_kernel()
     from mstar.utils.fused_moe import fused_experts
 
     device = torch.device("cuda")
@@ -117,8 +109,6 @@ def test_fused_experts_numerical_parity(num_tokens, hidden, inter, num_experts, 
 
 @pytest.mark.parametrize("num_tokens", [1, 4, 16])
 def test_thinker_block_parity(num_tokens):
-    _skip_if_no_sgl_kernel()
-
     hidden = 2048
     inter = 768
     num_experts = 128
@@ -160,8 +150,6 @@ def test_thinker_block_parity(num_tokens):
 def test_talker_block_parity(num_tokens):
     """Talker block adds a shared expert + sigmoid gate on top of the routed
     dispatch.  Both shared and routed halves are exercised end-to-end."""
-    _skip_if_no_sgl_kernel()
-
     hidden = 1024
     inter = 384
     num_experts = 128
@@ -206,13 +194,13 @@ def test_talker_block_parity(num_tokens):
 
 
 # ------------------------------------------------------------------
-# Sanity checks that don't require sgl-kernel
+# Sanity check for the naive dispatch path
 # ------------------------------------------------------------------
 
 
 def test_dispatch_experts_fused_sanity_cuda():
     """The naive path must still work on CUDA so the fallback is viable
-    when sgl-kernel is missing."""
+    when the fused path is unavailable."""
     hidden = 64
     inter = 48
     num_experts = 4


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

Replace the sgl-kernel dependency (just a block alignment function) with a jit-compiled cuda kernel and corresponding wrapper pulled from vLLM. This allows us to unpin torch from version 2.9,  which is necessary for https://github.com/mstar-project/mstar/pull/121 to pull in an optional flash-attention-3 dependency.

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

## How was it tested?

- Did a  smoke test / benchmark for Qwen3-Omni TTS on PTC (cuda 13.0)
- Benchmarked TTS on coriander (cuda 13.0) with both my existing python environment and a newly-installed venv.
    - For BS=1,8 and my existing environment, there was less than 1% difference in RTF.
    - For the new environment (newer pytorch + cudnn, etc.), there was a 10% increase in RTF for BS=1 (diff between main with the old environment and this branch with the new environment), but the difference dissipates for higher batch sizes. This isn't an issue with the implementation because we have parity with the old environment, but it's maybe something to note.
- Tested single image/video/audio understanding requests to validate torchaudio/torchvision/torchcodec for a fresh install

**Note**: I will need at least one other person to double-check possible installation issues (e.g., doing a fresh install of mstar), since unpinning torch can potentially be a big issue.

<!-- Commands you ran, or why tests aren't applicable. -->

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
