### PR TITLE
Fix Food101 I2I Prompts

### DIFF
--- a/benchmark/dataset.py
+++ b/benchmark/dataset.py
@@ -389,7 +389,7 @@ class Food101Dataset(BaseDataset):
         self,
         num_requests: int = 100,
         req_type: RequestType = RequestType.I2T,
-        prompts: list[str] = FOOD101_IMAGE_PROMPTS,
+        prompts: list[str] | None = None,
         split: str = "validation",
         cache_dir: str | None = None,
     ):
@@ -400,6 +400,15 @@ class Food101Dataset(BaseDataset):
         from datasets import load_dataset
 
         self._num_requests = num_requests
+        # I2I edits the image, so it needs edit instructions; I2T/I2S ask a
+        # question about it. Using the understanding prompts for I2I makes the
+        # model render the "answer" as text onto the output image.
+        if prompts is None:
+            prompts = (
+                FOOD101_IMAGE_GEN_PROMPTS
+                if req_type == RequestType.I2I
+                else FOOD101_IMAGE_PROMPTS
+            )
         self.prompts = prompts
 
         raw = load_dataset(


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

The food101 image-to-image benchmark was using text-to-image prompts, which led to low-quality outputs that looked like a quality regression (e.g., the model doesn't know what to do with image-to-image with the prompt "provide a caption for this image"). This PR changes the benchmark to use the existing gen prompts for I2I requests.

## How was it tested?

Ran the benchmark on bagel and verified that the outputs looked reasonable for the set of prompts.


## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
