### PR TITLE
Add engine cross-attention support; migrate Whisper decoder onto it (#160)

### DIFF
--- a/docs/adding_models.rst
+++ b/docs/adding_models.rst
@@ -110,6 +110,29 @@ The abstract methods you **must** implement:
    ``num_kv_heads``, ``head_dim``, ``max_seq_len``, ``num_qo_heads``). Return a single
    config if all AR nodes share one. Models with no AR node may return an empty list.
 
+   **Cross-attention (encoder-decoder models).** For a decoder that attends to a
+   fixed encoder context (Whisper, etc.), declare one or more context pools via
+   ``KVCacheConfig.cross_attn``, a ``{source_name: CrossAttnKVConfig}`` map.
+   ``CrossAttnKVConfig`` carries only what differs from the decoder's
+   self-attention — ``num_kv_heads``, ``head_dim``, ``max_context_len`` (per-request
+   context capacity in tokens) and ``max_num_pages`` (page budget); ``page_size``,
+   ``num_layers`` and ``num_qo_heads`` are inherited from the parent config. The
+   submodule then writes the context K/V once at prefill with
+   ``cache_handle.add_cross_attn_kv(...)`` and, every step, calls
+   ``cache_handle.plan_cross_attention(...)`` (in ``preprocess``) and
+   ``cache_handle.run_cross_attn(q, source=...)`` (in the layer forward). A
+   single-source model uses ``source="default"`` and can omit the argument.
+
+   *Pool sharing.* Sources whose ``num_kv_heads`` / ``head_dim`` / ``max_context_len``
+   match share **one physical pool**, and that pool's page budget is the **sum** of
+   the sharing sources' ``max_num_pages`` — so two same-geometry sources ("audio",
+   "image") asking for 256 pages each get a 512-page shared pool. Sources with
+   differing geometry get separate pools.
+
+   *YAML override.* Like the flat KV fields, cross-attention pools are overridable
+   from the model config's ``kv_cache:`` block via a nested ``cross_attn:`` map,
+   e.g. ``kv_cache: {cross_attn: {default: {max_num_pages: 384}}}``.
+
 ``get_node_engine_types(self) -> dict[str, EngineType]``
    Maps each graph-node name to an :class:`mstar.engine.base.EngineType`
    (``KV_CACHE`` or ``STATELESS``). See `Step 6 — Choose engine types`_ below.

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -317,11 +317,25 @@ class Conductor:
         # Apply any KV cache overrides from the YAML config
         yaml_kv_overrides = self.model_config.get("kv_cache", {})
         if yaml_kv_overrides:
-            from dataclasses import fields
+            from dataclasses import fields, replace
+            # cross_attn is a nested {source: CrossAttnKVConfig}; the YAML gives
+            # {source: {field: value}} and we patch each pool's fields (frozen
+            # dataclass -> dataclasses.replace). Everything else is a flat setattr.
+            cross_overrides = yaml_kv_overrides.get("cross_attn", {})
             for kv_cfg in kv_cache_config:
                 for f in fields(kv_cfg):
+                    if f.name == "cross_attn":
+                        continue
                     if f.name in yaml_kv_overrides:
                         setattr(kv_cfg, f.name, yaml_kv_overrides[f.name])
+                if cross_overrides and kv_cfg.cross_attn:
+                    kv_cfg.cross_attn = {
+                        source: (
+                            replace(pool, **cross_overrides[source])
+                            if source in cross_overrides else pool
+                        )
+                        for source, pool in kv_cfg.cross_attn.items()
+                    }
                 logger.info("KV cache config after YAML overrides: %s", kv_cfg)
         return kv_cache_config
 

--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -2,6 +2,7 @@ import functools
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import NamedTuple
 
 import torch
 
@@ -20,6 +21,57 @@ def cross_attn_label(label: str, source: str = "default") -> str:
     """Resolve the cache label under which a cross-attention plan/state for
     ``source`` is stored, relative to the base (self-attention) label."""
     return f"{label}::CROSS_ATTN::{source}"
+
+
+class PagedIndptrs(NamedTuple):
+    """The four int32 index tensors a FlashInfer prefill/decode wrapper's
+    ``plan`` consumes, built on CPU (so wrapper.plan's ``.to("cpu")`` is a
+    no-op — see ``_plan_attention_impl``)."""
+    qo_indptr: torch.Tensor
+    paged_kv_indptr: torch.Tensor
+    paged_kv_indices: torch.Tensor
+    paged_kv_last_page_len: torch.Tensor
+
+
+def build_paged_indptrs(
+    q_seq_lens: list[int],
+    page_indices_per_request: list[list[int]],
+    context_lens: list[int],
+    page_size: int,
+) -> PagedIndptrs:
+    """Assemble FlashInfer paged-attention index tensors from per-request
+    query lengths + already-allocated page lists. Shared by the self- and
+    cross-attention plan paths (the difference is only where the pages come
+    from: self grows them per step, cross reads a fixed context)."""
+    qo_indptr = [0]
+    kv_indptr = [0]
+    all_pages: list[int] = []
+    last_page_lens: list[int] = []
+    for q_len, pages, ctx_len in zip(
+        q_seq_lens, page_indices_per_request, context_lens, strict=True,
+    ):
+        qo_indptr.append(qo_indptr[-1] + q_len)
+        all_pages.extend(pages)
+        kv_indptr.append(kv_indptr[-1] + len(pages))
+        last_page_lens.append(ctx_len % page_size or page_size)
+    return PagedIndptrs(
+        qo_indptr=torch.tensor(qo_indptr, dtype=torch.int32),
+        paged_kv_indptr=torch.tensor(kv_indptr, dtype=torch.int32),
+        paged_kv_indices=torch.tensor(all_pages, dtype=torch.int32),
+        paged_kv_last_page_len=torch.tensor(last_page_lens, dtype=torch.int32),
+    )
+
+
+class PlanCacheKey(NamedTuple):
+    """Fingerprint of a wrapper ``plan`` call's inputs. When it is unchanged
+    between steps the re-plan is skippable. Used by cross-attention (context
+    pages are immutable after encode); the mechanism is label-generic, so a
+    fixed-shape self-attention label could reuse it (see the field on
+    ``_PlanState``)."""
+    q_seq_lens: tuple
+    page_indices: tuple
+    last_page_lens: tuple
+    dtype: torch.dtype
 
 
 @dataclass
@@ -51,15 +103,16 @@ class _PlanState:
     seq_lens: list[int] | None = None
     write_store: bool = True
     custom_pos_advance: list[int] | None = None
-    # Cross-attention plan memo (cross labels only): fingerprint of the last
-    # planned (query lengths, context pages). The context side is immutable
-    # after add_cross_attn_kv, so a step whose fingerprint matches skips the
-    # FlashInfer re-plan. NOTE: only effective where plan states persist
-    # across steps (the CUDA-graph runner's cuda_graph_plan_states); the
-    # eager path rebuilds the cache manager per step, so eager decode still
-    # re-plans — making cross plans persistent eagerly is the known
-    # multi-request throughput follow-up (see PR #161 benchmark notes).
-    cross_plan_key: tuple | None = None
+    # Plan memo: fingerprint of the last wrapper.plan() inputs for this
+    # label. When it matches, the re-plan is skipped. Label-generic (not
+    # cross-specific); today only the cross-attention path sets it, because
+    # its context pages are immutable after add_cross_attn_kv — a fixed-shape
+    # self-attention label (e.g. diffusion latents) could opt in the same way.
+    # NOTE: only effective where plan states persist across steps (the
+    # CUDA-graph runner's cuda_graph_plan_states); the eager path rebuilds the
+    # cache manager per step, so eager decode still re-plans (see PR #161
+    # benchmark notes — persisting eager plan state is the throughput follow-up).
+    plan_cache_key: "PlanCacheKey | None" = None
     # Set when DenseGenCacheManager planned this label dense: the per-segment
     # gather indices + varlen cu_seqlens needed to attend each generation
     # segment over its contiguous frozen prefix. None on paged plans, which
@@ -1112,32 +1165,34 @@ class FlashInferCacheManager(BatchedCacheManager):
         if dtype is None:
             dtype = pool.kv_cache.dtype
 
-        qo_indptr_list = [0]
-        kv_indptr_list = [0]
-        all_page_indices: list[int] = []
-        kv_last_page_lens: list[int] = []
-        for i, rid in enumerate(self.request_ids):
+        page_indices_per_request: list[list[int]] = []
+        context_lens: list[int] = []
+        for rid in self.request_ids:
             state = pool.alloc_manager.get_state(rid, cross_label)
             assert state.seq_len > 0, (
                 f"plan_cross_attention before add_cross_attn_kv for {rid!r} "
                 f"(source {source!r})"
             )
-            qo_indptr_list.append(qo_indptr_list[-1] + q_seq_lens[i])
-            all_page_indices.extend(state.page_indices)
-            kv_indptr_list.append(kv_indptr_list[-1] + len(state.page_indices))
-            kv_last_page_lens.append(state.seq_len % page_size or page_size)
+            page_indices_per_request.append(state.page_indices)
+            context_lens.append(state.seq_len)
+
+        indptrs = build_paged_indptrs(
+            q_seq_lens, page_indices_per_request, context_lens, page_size,
+        )
 
         # Skip the re-plan when nothing it depends on changed (the common
         # decode case: same request set, q_seq_lens all 1, fixed context
         # pages). Keyed on the page indices themselves so a request id
         # reused with a new context can't alias a stale plan.
-        plan_key = (
-            tuple(q_seq_lens), tuple(all_page_indices),
-            tuple(kv_last_page_lens), dtype,
+        plan_key = PlanCacheKey(
+            q_seq_lens=tuple(q_seq_lens),
+            page_indices=tuple(indptrs.paged_kv_indices.tolist()),
+            last_page_lens=tuple(indptrs.paged_kv_last_page_len.tolist()),
+            dtype=dtype,
         )
 
         ps = self._plan_states.get(cross_label)
-        if ps is not None and ps.wrapper is not None and ps.cross_plan_key == plan_key:
+        if ps is not None and ps.wrapper is not None and ps.plan_cache_key == plan_key:
             ps.seq_lens = q_seq_lens
             return
         if ps is None or ps.wrapper is None:
@@ -1154,16 +1209,16 @@ class FlashInferCacheManager(BatchedCacheManager):
             self._plan_states[cross_label] = ps
 
         ps.wrapper.plan(
-            qo_indptr=torch.tensor(qo_indptr_list, dtype=torch.int32),
-            paged_kv_indptr=torch.tensor(kv_indptr_list, dtype=torch.int32),
-            paged_kv_indices=torch.tensor(all_page_indices, dtype=torch.int32),
-            paged_kv_last_page_len=torch.tensor(kv_last_page_lens, dtype=torch.int32),
+            qo_indptr=indptrs.qo_indptr,
+            paged_kv_indptr=indptrs.paged_kv_indptr,
+            paged_kv_indices=indptrs.paged_kv_indices,
+            paged_kv_last_page_len=indptrs.paged_kv_last_page_len,
             causal=False,
             dtype=dtype,
         )
         ps.seq_lens = q_seq_lens
         ps.write_store = False
-        ps.cross_plan_key = plan_key
+        ps.plan_cache_key = plan_key
 
     def run_cross_attn(
         self,

--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -51,6 +51,15 @@ class _PlanState:
     seq_lens: list[int] | None = None
     write_store: bool = True
     custom_pos_advance: list[int] | None = None
+    # Cross-attention plan memo (cross labels only): fingerprint of the last
+    # planned (query lengths, context pages). The context side is immutable
+    # after add_cross_attn_kv, so a step whose fingerprint matches skips the
+    # FlashInfer re-plan. NOTE: only effective where plan states persist
+    # across steps (the CUDA-graph runner's cuda_graph_plan_states); the
+    # eager path rebuilds the cache manager per step, so eager decode still
+    # re-plans — making cross plans persistent eagerly is the known
+    # multi-request throughput follow-up (see PR #161 benchmark notes).
+    cross_plan_key: tuple | None = None
     # Set when DenseGenCacheManager planned this label dense: the per-segment
     # gather indices + varlen cu_seqlens needed to attend each generation
     # segment over its contiguous frozen prefix. None on paged plans, which
@@ -1118,7 +1127,19 @@ class FlashInferCacheManager(BatchedCacheManager):
             kv_indptr_list.append(kv_indptr_list[-1] + len(state.page_indices))
             kv_last_page_lens.append(state.seq_len % page_size or page_size)
 
+        # Skip the re-plan when nothing it depends on changed (the common
+        # decode case: same request set, q_seq_lens all 1, fixed context
+        # pages). Keyed on the page indices themselves so a request id
+        # reused with a new context can't alias a stale plan.
+        plan_key = (
+            tuple(q_seq_lens), tuple(all_page_indices),
+            tuple(kv_last_page_lens), dtype,
+        )
+
         ps = self._plan_states.get(cross_label)
+        if ps is not None and ps.wrapper is not None and ps.cross_plan_key == plan_key:
+            ps.seq_lens = q_seq_lens
+            return
         if ps is None or ps.wrapper is None:
             wrapper = FlashInferPrefillWrapper(
                 workspace_buffer=self.buffer_manager.get(cross_label),
@@ -1142,6 +1163,7 @@ class FlashInferCacheManager(BatchedCacheManager):
         )
         ps.seq_lens = q_seq_lens
         ps.write_store = False
+        ps.cross_plan_key = plan_key
 
     def run_cross_attn(
         self,

--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -2,8 +2,19 @@ from dataclasses import dataclass
 
 import torch
 
-from mstar.engine.kv_store import KVCacheConfig, KVRequestState, PagedAllocationManager
+from mstar.engine.kv_store import (
+    CrossAttnPool,
+    KVCacheConfig,
+    KVRequestState,
+    PagedAllocationManager,
+)
 from mstar.utils.flashinfer_utils import FlashInferDecodeWrapper, FlashInferPrefillWrapper
+
+
+def cross_attn_label(label: str, source: str = "default") -> str:
+    """Resolve the cache label under which a cross-attention plan/state for
+    ``source`` is stored, relative to the base (self-attention) label."""
+    return f"{label}::CROSS_ATTN::{source}"
 
 
 @dataclass
@@ -78,6 +89,7 @@ class BatchedCacheManager:
         cuda_graph_plan_states: dict[str, _PlanState] | None = None,
         auto_write_store: bool=False,
         enable_nvtx: bool=False,
+        cross_pools: dict[str, CrossAttnPool] | None = None,
     ):
         self.request_ids = request_ids
         self.active_labels = active_labels_per_request  # {req_id: label}
@@ -88,6 +100,8 @@ class BatchedCacheManager:
         self.device = device
         self.layer_idx = 0
         self.enable_nvtx = enable_nvtx
+        # source name -> CrossAttnPool (see KVCacheConfig.cross_attn)
+        self.cross_pools = cross_pools or {}
 
         self.auto_write_store = auto_write_store
 
@@ -699,6 +713,191 @@ class BatchedCacheManager:
                 )
 
         return ps.wrapper.run(q, self.kv_cache[layer_idx]).to(orig_dtype)
+
+    # ------------------------------------------------------------------
+    # Cross-attention (issue #160)
+    #
+    # Cross-attention is non-causal attention over a separate, fixed
+    # encoder-context KV: written once at encode time (add_cross_attn_kv),
+    # planned per step against the decoder's query lengths
+    # (plan_cross_attention), and executed per layer (run_cross_attn). The
+    # context KV lives in per-source pools (KVCacheConfig.cross_attn) whose
+    # head config may differ from the decoder's self-attention; plan/run
+    # state rides the existing per-label _PlanState machinery under the
+    # resolved ``{label}::CROSS_ATTN::{source}`` label. Cross labels never
+    # plan RoPE — context positions, if any, are baked in at encode time.
+    # ------------------------------------------------------------------
+
+    def _get_cross_pool(self, source: str) -> CrossAttnPool:
+        pool = self.cross_pools.get(source)
+        if pool is None:
+            raise KeyError(
+                f"No cross-attention pool for source {source!r}; declare it in "
+                f"KVCacheConfig.cross_attn (available: {list(self.cross_pools)})"
+            )
+        return pool
+
+    def _active_base_label(self, label: str | None) -> str:
+        if label is not None:
+            return label
+        labels = list(self.active_labels.values())
+        assert len(set(labels)) == 1, f"All active labels must be the same, got {labels}"
+        return next(iter(self.active_labels.values()))
+
+    @torch.compiler.disable
+    def add_cross_attn_kv(
+        self,
+        request_ids: list[str],
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer_idx: int,
+        seq_lens: list[int] | None = None,
+        source: str = "default",
+        label: str | None = None,
+    ) -> None:
+        """Write encoder-context K/V for one layer into ``source``'s pool.
+
+        Called once per request per layer at encode time. ``k``/``v`` are
+        packed ``(total_context_tokens, num_kv_heads, head_dim)`` across
+        ``request_ids``; ``seq_lens`` gives per-request context lengths
+        (defaults to a single request owning the whole tensor). Pages are
+        allocated on first write (layer 0) and reused for the rest.
+        """
+        pool = self._get_cross_pool(source)
+        base_label = self._active_base_label(label)
+        cross_label = cross_attn_label(base_label, source)
+        page_size = pool.alloc_config.page_size
+
+        if seq_lens is None:
+            assert len(request_ids) == 1, (
+                "add_cross_attn_kv needs seq_lens for multi-request batches"
+            )
+            seq_lens = [k.shape[0]]
+
+        offset = 0
+        for rid, ctx_len in zip(request_ids, seq_lens, strict=True):
+            state = pool.alloc_manager.get_state(rid, cross_label)
+            if state.seq_len == 0:
+                pool.alloc_manager.alloc(rid, label=cross_label, seq_len=ctx_len)
+                state.seq_len = ctx_len
+            else:
+                assert state.seq_len == ctx_len, (
+                    f"cross-attn context for {rid!r}/{source!r} already written "
+                    f"with length {state.seq_len}, got {ctx_len}"
+                )
+
+            positions = torch.arange(ctx_len, device=self.device)
+            page_indices = torch.tensor(
+                state.page_indices, dtype=torch.long, device=self.device,
+            )
+            token_to_page = page_indices[
+                torch.div(positions, page_size, rounding_mode="floor")
+            ]
+            token_to_cache = positions % page_size
+
+            layer_cache = pool.kv_cache[layer_idx]
+            dtype = pool.kv_cache.dtype
+            layer_cache[token_to_page, 0, token_to_cache] = \
+                k[offset:offset + ctx_len].to(dtype)
+            layer_cache[token_to_page, 1, token_to_cache] = \
+                v[offset:offset + ctx_len].to(dtype)
+            offset += ctx_len
+
+    def plan_cross_attention(
+        self,
+        q_seq_lens: list[int],
+        dtype: torch.dtype | None = None,
+        source: str = "default",
+        label: str | None = None,
+    ) -> None:
+        """Plan the cross-attention wrapper for this step's decoder queries.
+
+        ``q_seq_lens`` is the number of decoder query tokens per request
+        (matches the self-attention plan's seq_lens). The context side is
+        read from the pool state written by ``add_cross_attn_kv`` — pages
+        are fixed, so unlike ``plan_attention`` nothing is allocated here.
+        ``label`` is the base (self-attention) label; the plan is stored
+        under the resolved cross label. Always uses the prefill wrapper
+        with ``causal=False`` (decode-style single queries still attend to
+        the full context).
+        """
+        pool = self._get_cross_pool(source)
+        base_label = self._active_base_label(label)
+        cross_label = cross_attn_label(base_label, source)
+        cfg = pool.alloc_config
+        page_size = cfg.page_size
+
+        if dtype is None:
+            dtype = pool.kv_cache.dtype
+
+        qo_indptr_list = [0]
+        kv_indptr_list = [0]
+        all_page_indices: list[int] = []
+        kv_last_page_lens: list[int] = []
+        for i, rid in enumerate(self.request_ids):
+            state = pool.alloc_manager.get_state(rid, cross_label)
+            assert state.seq_len > 0, (
+                f"plan_cross_attention before add_cross_attn_kv for {rid!r} "
+                f"(source {source!r})"
+            )
+            qo_indptr_list.append(qo_indptr_list[-1] + q_seq_lens[i])
+            all_page_indices.extend(state.page_indices)
+            kv_indptr_list.append(kv_indptr_list[-1] + len(state.page_indices))
+            kv_last_page_lens.append(state.seq_len % page_size or page_size)
+
+        ps = self._plan_states.get(cross_label)
+        if ps is None or ps.wrapper is None:
+            wrapper = FlashInferPrefillWrapper(
+                workspace_buffer=self.buffer_manager.get(cross_label),
+                num_qo_heads=cfg.num_qo_heads,
+                num_kv_heads=cfg.num_kv_heads,
+                head_dim=cfg.head_dim,
+                page_size=page_size,
+                device=self.device,
+                enable_nvtx=self.enable_nvtx,
+            )
+            ps = _PlanState(wrapper=wrapper)
+            self._plan_states[cross_label] = ps
+
+        ps.wrapper.plan(
+            qo_indptr=torch.tensor(qo_indptr_list, dtype=torch.int32),
+            paged_kv_indptr=torch.tensor(kv_indptr_list, dtype=torch.int32),
+            paged_kv_indices=torch.tensor(all_page_indices, dtype=torch.int32),
+            paged_kv_last_page_len=torch.tensor(kv_last_page_lens, dtype=torch.int32),
+            causal=False,
+            dtype=dtype,
+        )
+        ps.seq_lens = q_seq_lens
+        ps.write_store = False
+
+    def run_cross_attn(
+        self,
+        q: torch.Tensor,
+        layer_idx: int | None = None,
+        source: str = "default",
+    ) -> torch.Tensor:
+        """Run pre-planned cross-attention against ``source``'s context pool.
+
+        Unlike ``run_attention``, the context K/V were written once by
+        ``add_cross_attn_kv`` — nothing is written here.
+
+        Args:
+            q: [total_query_tokens, num_qo_heads, head_dim]
+        Returns:
+            output: [total_query_tokens, num_qo_heads, head_dim]
+        """
+        if layer_idx is None:
+            layer_idx = self.layer_idx
+        pool = self._get_cross_pool(source)
+        base_label = self._active_base_label(None)
+        cross_label = cross_attn_label(base_label, source)
+
+        orig_dtype = q.dtype
+        ps = self._plan_states.get(cross_label)
+        assert ps is not None and ps.wrapper is not None, (
+            f"run_cross_attn before plan_cross_attention (label {cross_label!r})"
+        )
+        return ps.wrapper.run(q, pool.kv_cache[layer_idx]).to(orig_dtype)
 
     @torch.compiler.disable
     def apply_rope(

--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -29,7 +29,6 @@ from mstar.engine.cuda_graph_runner import (
 )
 from mstar.engine.kv_store import (
     AllocationFailedError,
-    CrossAttnKVConfig,
     CrossAttnPool,
     KVCacheConfig,
     PagedAllocationManager,
@@ -53,15 +52,71 @@ class KVManagement:
     buffer_manager: WorkspaceBufferManager
     # source name -> cross-attention context pool (see KVCacheConfig.cross_attn)
     cross_pools: dict[str, CrossAttnPool] = field(default_factory=dict)
+    # Distinct cross-attention alloc managers (pools may be shared between
+    # sources); precomputed at build time since it can't change after
+    # startup, so per-request add/remove doesn't re-walk cross_pools.
+    cross_alloc_managers: list[PagedAllocationManager] = field(default_factory=list)
 
-    def _cross_alloc_managers(self):
-        """Distinct alloc managers across cross pools (pools may be shared
-        between sources; dedupe by identity for lifecycle calls)."""
-        seen = []
-        for pool in self.cross_pools.values():
-            if all(pool.alloc_manager is not m for m in seen):
-                seen.append(pool.alloc_manager)
-        return seen
+
+def _build_cross_pools(
+    cfg: KVCacheConfig,
+    base_num_layers: int,
+    device,
+    kv_cache_type,
+    transfer_engine_info,
+) -> dict[str, CrossAttnPool]:
+    """Allocate the cross-attention context pools declared by ``cfg.cross_attn``.
+
+    Sources whose ``CrossAttnKVConfig.pool_key()`` match share one physical
+    pool whose page budget is the **sum** of their ``max_num_pages`` (so a
+    model author who gives two same-geometry sources 256 pages each gets a
+    512-page shared pool). Inherits ``page_size`` / ``num_layers`` /
+    ``num_qo_heads`` from the (already TP-sharded) base ``cfg``.
+    """
+    if not cfg.cross_attn:
+        return {}
+
+    # First pass: accumulate the page budget per shared pool key.
+    pages_by_key: dict[tuple, int] = {}
+    for cross_cfg in cfg.cross_attn.values():
+        key = cross_cfg.pool_key()
+        pages_by_key[key] = pages_by_key.get(key, 0) + cross_cfg.max_num_pages
+
+    # Second pass: build one pool per key, then map every source to it.
+    pool_by_key: dict[tuple, CrossAttnPool] = {}
+    cross_pools: dict[str, CrossAttnPool] = {}
+    for source, cross_cfg in cfg.cross_attn.items():
+        key = cross_cfg.pool_key()
+        pool = pool_by_key.get(key)
+        if pool is None:
+            alloc_config = KVCacheConfig(
+                num_layers=base_num_layers,
+                num_kv_heads=cross_cfg.num_kv_heads,
+                head_dim=cross_cfg.head_dim,
+                max_seq_len=cross_cfg.max_context_len,
+                max_num_pages=pages_by_key[key],
+                page_size=cfg.page_size,
+                num_qo_heads=cfg.num_qo_heads,
+            )
+            cross_kv = torch.zeros(
+                alloc_config.num_layers, alloc_config.max_num_pages, 2,
+                alloc_config.page_size, alloc_config.num_kv_heads,
+                alloc_config.head_dim,
+                dtype=kv_cache_type, device=device,
+            ).contiguous()
+            pool = CrossAttnPool(
+                config=cross_cfg,
+                alloc_config=alloc_config,
+                kv_cache=cross_kv,
+                alloc_manager=PagedAllocationManager(
+                    config=alloc_config,
+                    kv_cache=cross_kv,
+                    transfer_engine_info=transfer_engine_info,
+                ),
+            )
+            pool_by_key[key] = pool
+        cross_pools[source] = pool
+    return cross_pools
 
 
 @dataclass
@@ -186,41 +241,15 @@ class KVCacheEngine(BaseEngine):
                     cfg.cpu_offload_pages,
                 )
 
-            # Cross-attention context pools: one physical pool per distinct
-            # CrossAttnKVConfig; sources with equal configs share a pool.
-            cross_pools: dict[str, CrossAttnPool] = {}
-            if cfg.cross_attn:
-                pool_by_config: dict[CrossAttnKVConfig, CrossAttnPool] = {}
-                for source, cross_cfg in cfg.cross_attn.items():
-                    pool = pool_by_config.get(cross_cfg)
-                    if pool is None:
-                        alloc_config = KVCacheConfig(
-                            num_layers=cross_cfg.num_layers or num_layers,
-                            num_kv_heads=cross_cfg.num_kv_heads,
-                            head_dim=cross_cfg.head_dim,
-                            max_seq_len=cross_cfg.max_context_len,
-                            max_num_pages=cross_cfg.max_num_pages,
-                            page_size=cross_cfg.page_size,
-                            num_qo_heads=cross_cfg.num_qo_heads or cfg.num_qo_heads,
-                        )
-                        cross_kv = torch.zeros(
-                            alloc_config.num_layers, alloc_config.max_num_pages, 2,
-                            alloc_config.page_size, alloc_config.num_kv_heads,
-                            alloc_config.head_dim,
-                            dtype=kv_cache_type, device=device,
-                        ).contiguous()
-                        pool = CrossAttnPool(
-                            config=cross_cfg,
-                            alloc_config=alloc_config,
-                            kv_cache=cross_kv,
-                            alloc_manager=PagedAllocationManager(
-                                config=alloc_config,
-                                kv_cache=cross_kv,
-                                transfer_engine_info=transfer_engine_info,
-                            ),
-                        )
-                        pool_by_config[cross_cfg] = pool
-                    cross_pools[source] = pool
+            cross_pools = _build_cross_pools(
+                cfg, num_layers, device, kv_cache_type, transfer_engine_info,
+            )
+            # Distinct alloc managers, deduped by identity (shared pools),
+            # computed once here rather than per request.
+            cross_alloc_managers: list[PagedAllocationManager] = []
+            for pool in cross_pools.values():
+                if all(pool.alloc_manager is not m for m in cross_alloc_managers):
+                    cross_alloc_managers.append(pool.alloc_manager)
 
             kv_mgmt = KVManagement(
                 kv_cache_config=cfg,
@@ -236,6 +265,7 @@ class KVCacheEngine(BaseEngine):
                     device=device,
                 ),
                 cross_pools=cross_pools,
+                cross_alloc_managers=cross_alloc_managers,
             )
             self.kv_management[cfg.get_node_str()] = kv_mgmt
 
@@ -1137,7 +1167,7 @@ class KVCacheEngine(BaseEngine):
     ) -> None:
         for submodule_mgmt in self.submodule_management.values():
             submodule_mgmt.kv_management.alloc_manager.add_request(request_id, cache_labels or ["main"])
-            for cross_mgr in submodule_mgmt.kv_management._cross_alloc_managers():
+            for cross_mgr in submodule_mgmt.kv_management.cross_alloc_managers:
                 cross_mgr.add_request(request_id)
             submodule_mgmt.sampler.add_request(request_id)
             # Mirror into the cuda-graph runner's master sampler buffers so
@@ -1152,7 +1182,7 @@ class KVCacheEngine(BaseEngine):
             if cache_mgmt.cpu_page_pool is not None:
                 cache_mgmt.cpu_page_pool.remove_request(request_id)
             cache_mgmt.alloc_manager.remove_request(request_id)
-            for cross_mgr in cache_mgmt._cross_alloc_managers():
+            for cross_mgr in cache_mgmt.cross_alloc_managers:
                 cross_mgr.remove_request(request_id)
             submodule_mgmt.sampler.remove_request(request_id)
             submodule_mgmt.submodule.cleanup_request(request_id)

--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -25,6 +25,8 @@ from mstar.engine.cuda_graph_runner import (
 )
 from mstar.engine.kv_store import (
     AllocationFailedError,
+    CrossAttnKVConfig,
+    CrossAttnPool,
     KVCacheConfig,
     PagedAllocationManager,
     StoreWritePolicy,
@@ -45,6 +47,17 @@ class KVManagement:
     alloc_manager: PagedAllocationManager
     cpu_page_pool: CPUPagePool | None
     buffer_manager: WorkspaceBufferManager
+    # source name -> cross-attention context pool (see KVCacheConfig.cross_attn)
+    cross_pools: dict[str, CrossAttnPool] = field(default_factory=dict)
+
+    def _cross_alloc_managers(self):
+        """Distinct alloc managers across cross pools (pools may be shared
+        between sources; dedupe by identity for lifecycle calls)."""
+        seen = []
+        for pool in self.cross_pools.values():
+            if all(pool.alloc_manager is not m for m in seen):
+                seen.append(pool.alloc_manager)
+        return seen
 
 
 @dataclass
@@ -154,6 +167,42 @@ class KVCacheEngine(BaseEngine):
                     cfg.cpu_offload_pages,
                 )
 
+            # Cross-attention context pools: one physical pool per distinct
+            # CrossAttnKVConfig; sources with equal configs share a pool.
+            cross_pools: dict[str, CrossAttnPool] = {}
+            if cfg.cross_attn:
+                pool_by_config: dict[CrossAttnKVConfig, CrossAttnPool] = {}
+                for source, cross_cfg in cfg.cross_attn.items():
+                    pool = pool_by_config.get(cross_cfg)
+                    if pool is None:
+                        alloc_config = KVCacheConfig(
+                            num_layers=cross_cfg.num_layers or num_layers,
+                            num_kv_heads=cross_cfg.num_kv_heads,
+                            head_dim=cross_cfg.head_dim,
+                            max_seq_len=cross_cfg.max_context_len,
+                            max_num_pages=cross_cfg.max_num_pages,
+                            page_size=cross_cfg.page_size,
+                            num_qo_heads=cross_cfg.num_qo_heads or cfg.num_qo_heads,
+                        )
+                        cross_kv = torch.zeros(
+                            alloc_config.num_layers, alloc_config.max_num_pages, 2,
+                            alloc_config.page_size, alloc_config.num_kv_heads,
+                            alloc_config.head_dim,
+                            dtype=kv_cache_type, device=device,
+                        ).contiguous()
+                        pool = CrossAttnPool(
+                            config=cross_cfg,
+                            alloc_config=alloc_config,
+                            kv_cache=cross_kv,
+                            alloc_manager=PagedAllocationManager(
+                                config=alloc_config,
+                                kv_cache=cross_kv,
+                                transfer_engine_info=transfer_engine_info,
+                            ),
+                        )
+                        pool_by_config[cross_cfg] = pool
+                    cross_pools[source] = pool
+
             kv_mgmt = KVManagement(
                 kv_cache_config=cfg,
                 kv_cache=kv_cache,
@@ -167,6 +216,7 @@ class KVCacheEngine(BaseEngine):
                     int(os.environ.get("MSTAR_WORKSPACE_BUFFER_MB", "512")) * 1024 * 1024,
                     device=device,
                 ),
+                cross_pools=cross_pools,
             )
             self.kv_management[cfg.get_node_str()] = kv_mgmt
 
@@ -209,6 +259,7 @@ class KVCacheEngine(BaseEngine):
             device=self.device,
             auto_write_store=autowrite,
             enable_nvtx=self.enable_nvtx,
+            cross_pools=cache_mgmt.cross_pools,
         )
 
     def _compile_submodules(self) -> None:
@@ -1036,6 +1087,8 @@ class KVCacheEngine(BaseEngine):
     ) -> None:
         for submodule_mgmt in self.submodule_management.values():
             submodule_mgmt.kv_management.alloc_manager.add_request(request_id, cache_labels or ["main"])
+            for cross_mgr in submodule_mgmt.kv_management._cross_alloc_managers():
+                cross_mgr.add_request(request_id)
             submodule_mgmt.sampler.add_request(request_id)
             # Mirror into the cuda-graph runner's master sampler buffers so
             # the per-step path can index_select instead of rebuilding from
@@ -1049,6 +1102,8 @@ class KVCacheEngine(BaseEngine):
             if cache_mgmt.cpu_page_pool is not None:
                 cache_mgmt.cpu_page_pool.remove_request(request_id)
             cache_mgmt.alloc_manager.remove_request(request_id)
+            for cross_mgr in cache_mgmt._cross_alloc_managers():
+                cross_mgr.remove_request(request_id)
             submodule_mgmt.sampler.remove_request(request_id)
             if submodule_mgmt.cuda_graph_runner is not None:
                 submodule_mgmt.cuda_graph_runner.unregister_request(request_id)

--- a/mstar/engine/kv_store.py
+++ b/mstar/engine/kv_store.py
@@ -67,6 +67,30 @@ class PageAllocator:
         return self.free_pages.qsize()
 
 
+@dataclass(frozen=True)
+class CrossAttnKVConfig:
+    """Config for one cross-attention context KV pool.
+
+    Cross-attention K/V come from an encoder context: written once at
+    encode time, reused (read-only) by every decoder step, and possibly
+    shaped differently from the decoder's self-attention KV. Each entry
+    in ``KVCacheConfig.cross_attn`` describes the pool for one context
+    source; sources with identical configs share a physical pool
+    (deduped by value — hence frozen/hashable).
+
+    ``num_layers`` / ``num_qo_heads`` default to the parent
+    ``KVCacheConfig``'s values when None (one cross-attention block per
+    decoder layer, queried by the decoder's heads).
+    """
+    num_kv_heads: int
+    head_dim: int
+    max_context_len: int  # per-request context capacity (tokens)
+    max_num_pages: int = 256
+    page_size: int = 128
+    num_layers: int | None = None
+    num_qo_heads: int | None = None
+
+
 @dataclass
 class KVCacheConfig:
     num_layers: int
@@ -78,6 +102,9 @@ class KVCacheConfig:
     num_qo_heads: int | None = None  # Optional, defaults to num_kv_heads
     cpu_offload_pages: int = 0  # >0 enables CPU offloading with this many CPU pages
     nodes: list[str] = None # defaults to all AR nodes
+    # Cross-attention context pools, keyed by source name (e.g. "default",
+    # "audio_encoder"). See CrossAttnKVConfig.
+    cross_attn: dict[str, CrossAttnKVConfig] = None
 
     def __post_init__(self):
         if self.num_qo_heads is None:
@@ -390,6 +417,23 @@ class CudaIpcKVTransferEngine(KVTransferEngine):
         for fut in self._pending:
             fut.result()
         self._executor.shutdown(wait=True)
+
+
+@dataclass
+class CrossAttnPool:
+    """One physical cross-attention KV pool (possibly shared by several
+    sources whose ``CrossAttnKVConfig`` compare equal).
+
+    ``alloc_config`` is a synthesized ``KVCacheConfig`` carrying the
+    pool's page geometry so ``PagedAllocationManager`` and the FlashInfer
+    wrapper construction can reuse the self-attention code paths
+    unchanged.
+    """
+    config: CrossAttnKVConfig
+    alloc_config: "KVCacheConfig"
+    kv_cache: torch.Tensor
+    alloc_manager: "PagedAllocationManager"
+
 
 class PagedAllocationManager:
     def __init__(

--- a/mstar/engine/kv_store.py
+++ b/mstar/engine/kv_store.py
@@ -73,22 +73,30 @@ class CrossAttnKVConfig:
 
     Cross-attention K/V come from an encoder context: written once at
     encode time, reused (read-only) by every decoder step, and possibly
-    shaped differently from the decoder's self-attention KV. Each entry
-    in ``KVCacheConfig.cross_attn`` describes the pool for one context
-    source; sources with identical configs share a physical pool
-    (deduped by value — hence frozen/hashable).
+    shaped differently from the decoder's self-attention KV.
 
-    ``num_layers`` / ``num_qo_heads`` default to the parent
-    ``KVCacheConfig``'s values when None (one cross-attention block per
-    decoder layer, queried by the decoder's heads).
+    Only the fields that genuinely differ from the decoder's self-attention
+    are declared here; everything else is inherited from the parent
+    ``KVCacheConfig`` (``page_size``, ``num_layers`` — one cross-attention
+    block per decoder layer, and ``num_qo_heads`` — the decoder queries the
+    context with its own heads).
+
+    Pool sharing: sources whose configs match on everything *except*
+    ``max_num_pages`` (see ``pool_key``) share one physical pool, and that
+    pool's page budget is the **sum** of the sharing sources' ``max_num_pages``.
+    So two sources with identical head geometry asking for 256 pages each
+    get a 512-page shared pool. ``CrossAttnKVConfig`` is frozen/hashable so
+    it can key the dedup map.
     """
     num_kv_heads: int
     head_dim: int
     max_context_len: int  # per-request context capacity (tokens)
     max_num_pages: int = 256
-    page_size: int = 128
-    num_layers: int | None = None
-    num_qo_heads: int | None = None
+
+    def pool_key(self) -> tuple:
+        """Identity for pool sharing: everything except the page budget
+        (pages accumulate across sources that share a pool)."""
+        return (self.num_kv_heads, self.head_dim, self.max_context_len)
 
 
 @dataclass

--- a/mstar/model/whisper/components/decoder.py
+++ b/mstar/model/whisper/components/decoder.py
@@ -9,9 +9,10 @@ table added to the token embeddings by the submodule — so the
 self-attention subclass makes ``_apply_rope`` a no-op.
 
 Cross-attention K/V depend only on the (static) encoder output, so they
-are computed once per request at prefill via ``compute_cross_kv`` and
-re-used for every decode step; the engine's KV cache only holds the
-self-attention cache.
+are computed once per request at prefill (``compute_cross_kv``) and
+written into the engine's cross-attention context pool
+(``cache_handle.add_cross_attn_kv``); every step then runs the
+pre-planned ``cache_handle.run_cross_attn`` — see issue #160.
 
 HF checkpoint quirks handled here:
   * ``self_attn.out_proj`` → ``self_attn.o_proj`` (name_remapper in
@@ -42,7 +43,7 @@ class WhisperSelfAttention(Attention):
 
 
 class WhisperCrossAttention(nn.Module):
-    """Multi-head attention over precomputed encoder K/V."""
+    """Multi-head attention over the engine-managed encoder-context KV."""
 
     def __init__(self, hidden_size: int, num_heads: int, head_dim: int):
         super().__init__()
@@ -55,21 +56,19 @@ class WhisperCrossAttention(nn.Module):
         self.out_proj = nn.Linear(inner, hidden_size, bias=True)
 
     def compute_kv(self, encoder_states: torch.Tensor) -> CrossKV:
-        """(enc_len, hidden) -> per-head K/V, each (num_heads, enc_len, head_dim)."""
+        """(enc_len, hidden) -> K/V, each (enc_len, num_heads, head_dim)."""
         enc_len = encoder_states.shape[0]
         k = self.k_proj(encoder_states).view(enc_len, self.num_heads, self.head_dim)
         v = self.v_proj(encoder_states).view(enc_len, self.num_heads, self.head_dim)
-        return k.transpose(0, 1), v.transpose(0, 1)
+        return k, v
 
     def forward(
-        self, hidden_states: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+        self, hidden_states: torch.Tensor, cache_handle: BatchedCacheManager,
     ) -> torch.Tensor:
         num_tokens = hidden_states.shape[0]
         q = self.q_proj(hidden_states).view(num_tokens, self.num_heads, self.head_dim)
-        attn = F.scaled_dot_product_attention(
-            q.transpose(0, 1), k.to(q.dtype), v.to(q.dtype),
-        )  # (num_heads, num_tokens, head_dim)
-        attn = attn.transpose(0, 1).reshape(num_tokens, self.num_heads * self.head_dim)
+        attn = cache_handle.run_cross_attn(q)
+        attn = attn.reshape(num_tokens, self.num_heads * self.head_dim)
         return self.out_proj(attn)
 
 
@@ -99,7 +98,6 @@ class WhisperDecoderLayer(nn.Module):
         self,
         hidden_states: torch.Tensor,
         cache_handle: BatchedCacheManager,
-        cross_kv: CrossKV,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.self_attn_layer_norm(hidden_states)
@@ -107,7 +105,7 @@ class WhisperDecoderLayer(nn.Module):
 
         residual = hidden_states
         hidden_states = self.encoder_attn_layer_norm(hidden_states)
-        hidden_states = residual + self.encoder_attn(hidden_states, *cross_kv)
+        hidden_states = residual + self.encoder_attn(hidden_states, cache_handle)
 
         residual = hidden_states
         hidden_states = self.final_layer_norm(hidden_states)
@@ -156,11 +154,10 @@ class WhisperDecoderModel(nn.Module):
         self,
         input_embeds: torch.Tensor,
         cache_handle: BatchedCacheManager,
-        cross_kvs: list[CrossKV],
     ) -> torch.Tensor:
         hidden_states = input_embeds
         for layer_idx, layer in enumerate(self.layers):
             cache_handle.set_layer_idx(layer_idx)
-            hidden_states = layer(hidden_states, cache_handle, cross_kvs[layer_idx])
+            hidden_states = layer(hidden_states, cache_handle)
         cache_handle.advance_seq_lens()
         return self.layer_norm(hidden_states)

--- a/mstar/model/whisper/submodules.py
+++ b/mstar/model/whisper/submodules.py
@@ -27,7 +27,7 @@ from mstar.model.submodule_base import (
     NodeInputs,
     NodeSubmodule,
 )
-from mstar.model.whisper.components.decoder import CrossKV, WhisperDecoderModel
+from mstar.model.whisper.components.decoder import WhisperDecoderModel
 from mstar.model.whisper.config import WhisperModelConfig
 from mstar.utils.sampling import SeenTokenMask
 
@@ -91,21 +91,23 @@ class WhisperDecoderSubmodule(ARNodeSubmodule):
     Dispatches on graph_walk:
       - prefill: embed the forced decoder prompt
         (``<|startoftranscript|><|lang|><|task|><|notimestamps|>``),
-        compute per-layer cross-attn K/V from ``encoder_states`` (stored
-        per request — they're static for the whole generation), fill the
-        self-attn KV cache, and emit logits for the first token.
+        compute per-layer cross-attn K/V from ``encoder_states`` and
+        write them into the engine's cross-attention context pool (they
+        are static for the whole generation), fill the self-attn KV
+        cache, and emit logits for the first token.
       - decode: embed the previous token, single-step decode.
 
-    Cross-attn K/V live on the submodule (keyed by request_id), not in
-    the engine's KV cache, so batching and CUDA graphs are disabled for
-    now — requests run one per step.
+    Cross-attn K/V live in the engine's per-source context pool (see
+    ``KVCacheConfig.cross_attn`` / issue #160); the write + plan happen
+    in ``preprocess`` so ``forward`` is pure planned compute. Requests
+    still run one per step (``can_batch`` False) — batching is now an
+    engine-side follow-up rather than blocked on submodule state.
     """
 
     def __init__(self, decoder: WhisperDecoderModel, config: WhisperModelConfig):
         super().__init__()
         self.decoder = decoder
         self.config = config
-        self._cross_kv: dict[str, list[CrossKV]] = {}
         self._suppress_ids: torch.Tensor | None = None
         self._begin_suppress_ids: torch.Tensor | None = None
 
@@ -158,46 +160,47 @@ class WhisperDecoderSubmodule(ARNodeSubmodule):
         inputs: list[ARNodeInputs],
     ) -> dict[str, torch.Tensor | Any]:
         assert len(inputs) == 1, (
-            "WhisperDecoderSubmodule runs one request per step "
-            "(cross-attn K/V are per-request submodule state)."
+            "WhisperDecoderSubmodule runs one request per step."
         )
         cache_manager = engine_inputs.cache_manager
+        seq_lens = [inputs[0].input_seq_len]
         cache_manager.set_active_label("main")
         cache_manager.plan_attention(
-            seq_lens=[inputs[0].input_seq_len], is_causal=True, label="main",
+            seq_lens=seq_lens, is_causal=True, label="main",
         )
         # No plan_rope: Whisper has no RoPE (learned absolute positions).
 
-        out: dict[str, torch.Tensor | Any] = {
-            "input_embeds": inputs[0].input_embeds,
-        }
+        # Prefill: compute per-layer cross-attn K/V from the encoder output
+        # and write them into the engine's context pool — once per request;
+        # they are static for the whole generation.
         encoder_states = inputs[0].tensor_inputs.get("encoder_states")
         if encoder_states is not None:
-            out["encoder_states"] = encoder_states
-        return out
+            device = self.decoder.embed_tokens.weight.device
+            dtype = inputs[0].input_embeds.dtype
+            encoder_states = encoder_states.to(device=device, dtype=dtype)
+            with torch.no_grad():
+                cross_kvs = self.decoder.compute_cross_kv(encoder_states)
+            for layer_idx, (k, v) in enumerate(cross_kvs):
+                cache_manager.add_cross_attn_kv(
+                    engine_inputs.request_ids, k, v,
+                    layer_idx=layer_idx, label="main",
+                )
+
+        # Both prefill and decode attend to the full (fixed) context.
+        cache_manager.plan_cross_attention(q_seq_lens=seq_lens, label="main")
+
+        return {"input_embeds": inputs[0].input_embeds}
 
     def forward(
         self,
         graph_walk: str,
         engine_inputs: ModelInputsFromEngine,
         input_embeds: torch.Tensor,
-        encoder_states: torch.Tensor | None = None,
         **kwargs,
     ) -> NameToTensorList:
-        request_id = engine_inputs.request_ids[0]
-
-        if encoder_states is not None:
-            device = self.decoder.embed_tokens.weight.device
-            dtype = input_embeds.dtype
-            self._cross_kv[request_id] = self.decoder.compute_cross_kv(
-                encoder_states.to(device=device, dtype=dtype)
-            )
-        cross_kvs = self._cross_kv[request_id]
-
         hidden = self.decoder(
             input_embeds=input_embeds,
             cache_handle=engine_inputs.cache_manager,
-            cross_kvs=cross_kvs,
         )
         logits = self.decoder.lm_head(hidden[-1:])
         # The prefill step samples the first generated token.
@@ -236,5 +239,3 @@ class WhisperDecoderSubmodule(ARNodeSubmodule):
             return {"decode_loop"}
         return set()
 
-    def cleanup_request(self, request_id: str):
-        self._cross_kv.pop(request_id, None)

--- a/mstar/model/whisper/whisper_model.py
+++ b/mstar/model/whisper/whisper_model.py
@@ -92,6 +92,8 @@ class WhisperModel(Model):
     # -------------------------------------------------------------------
 
     def get_kv_cache_config(self) -> list[KVCacheConfig]:
+        from mstar.engine.kv_store import CrossAttnKVConfig
+
         return [KVCacheConfig(
             num_layers=self.config.decoder_layers,
             num_kv_heads=self.config.decoder_attention_heads,
@@ -103,6 +105,17 @@ class WhisperModel(Model):
             # request; 128 pages ≈ 32 concurrent requests at ~2.7 GB
             # (vs 43 GB with the 2048-page default).
             max_num_pages=128,
+            # Encoder-context pool for cross-attention (issue #160): the
+            # fixed 30 s window is max_source_positions (1500) tokens = 12
+            # pages per request; 192 pages ≈ 16 concurrent at ~4 GB.
+            cross_attn={
+                "default": CrossAttnKVConfig(
+                    num_kv_heads=self.config.decoder_attention_heads,
+                    head_dim=self.config.head_dim,
+                    max_context_len=self.config.max_source_positions,
+                    max_num_pages=192,
+                ),
+            },
         )]
 
     # -------------------------------------------------------------------

--- a/test/scratch/compare_whisper_decoder.py
+++ b/test/scratch/compare_whisper_decoder.py
@@ -16,11 +16,13 @@ MAX_NEW_TOKENS = 60
 
 
 class MockCacheHandle:
-    """Minimal stand-in for BatchedCacheManager: per-layer growing KV +
-    causal SDPA. Single request only."""
+    """Minimal stand-in for BatchedCacheManager: per-layer growing self-attn
+    KV + causal SDPA, plus the issue-#160 cross-attention surface (fixed
+    per-layer context KV + non-causal SDPA). Single request only."""
 
     def __init__(self, num_layers: int):
         self.kv = [None] * num_layers
+        self.cross_kv = [None] * num_layers
         self.layer_idx = 0
 
     def set_layer_idx(self, i):
@@ -38,6 +40,21 @@ class MockCacheHandle:
         out = torch.nn.functional.scaled_dot_product_attention(
             q.transpose(0, 1), fk.transpose(0, 1), fv.transpose(0, 1),
             is_causal=is_prefill,
+        )
+        return out.transpose(0, 1)
+
+    def add_cross_attn_kv(self, request_ids, k, v, layer_idx, **kw):
+        self.cross_kv[layer_idx] = (k, v)
+
+    def plan_cross_attention(self, q_seq_lens, **kw):
+        pass
+
+    def run_cross_attn(self, q, layer_idx=None, source="default"):
+        i = self.layer_idx if layer_idx is None else layer_idx
+        k, v = self.cross_kv[i]
+        out = torch.nn.functional.scaled_dot_product_attention(
+            q.transpose(0, 1), k.transpose(0, 1).to(q.dtype),
+            v.transpose(0, 1).to(q.dtype),
         )
         return out.transpose(0, 1)
 
@@ -78,10 +95,13 @@ def main():
     # --- mstar greedy loop ---
     with torch.no_grad():
         embeds = dec.embed(prompt_ids, 0)
-        out = dec_sub.forward(
-            "prefill", engine_inputs,
-            input_embeds=embeds, encoder_states=encoder_states,
-        )
+        # Mirror preprocess: write per-layer cross K/V into the (mock)
+        # engine context pool once, at prefill.
+        for layer_idx, (k, v) in enumerate(
+            dec.compute_cross_kv(encoder_states.to(embeds.dtype))
+        ):
+            mock.add_cross_attn_kv(["r0"], k, v, layer_idx=layer_idx)
+        out = dec_sub.forward("prefill", engine_inputs, input_embeds=embeds)
         tokens = []
         pos = prompt_ids.shape[0]
         tok = out["logits"][0][-1].argmax().reshape(1)


### PR DESCRIPTION
Implements #160 following the design sketched in the issue. Stacked on #159 (base branch `asr-models`) since Whisper is the testbed.

## Engine

New surface on `BatchedCacheManager`; all plan/run state rides the existing per-label `_PlanState` machinery under the resolved `{label}::CROSS_ATTN::{source}` cache label:

- **`KVCacheConfig.cross_attn: dict[source, CrossAttnKVConfig]`** — per-source context pools with their own head config and page geometry. `KVCacheEngine.load_model` allocates pools automatically, **coalescing sources whose configs compare equal into one physical pool** (dedup by value — `CrossAttnKVConfig` is frozen/hashable). Request add/remove enrolls every distinct pool's `PagedAllocationManager`.
- **`add_cross_attn_kv(request_ids, k, v, layer_idx, source, label)`** — writes encoder-context K/V into the source's pool, once per request at encode time; pages are allocated on the first layer's write and validated on subsequent layers.
- **`plan_cross_attention(q_seq_lens, source, label)`** — builds `qo_indptr` from decoder query lengths and the paged KV indices from the fixed context pages, then plans the existing `FlashInferPrefillWrapper` with `causal=False`. Because this reuses `_PlanState`, the persistent-wrapper / static-buffer CUDA-graph path applies unchanged, as the issue predicted.
- **`run_cross_attn(q, layer_idx, source)`** — runs the pre-planned wrapper against the pool. Unlike `run_attention` it never calls `set_kv_cache` (context K/V were written once at encode time).
- **RoPE**: cross labels simply never plan RoPE (`plan_rope`/`apply_rope` are label-keyed); context positions, if any, are baked in at encode time.

## Whisper migration (testbed)

- Cross-attn K/V move from per-request submodule state (`self._cross_kv` dict) into a `"default"` context pool: 12 pages/request for the fixed 1500-token encoder window; 192 pages ≈ 16 concurrent at ~4 GB.
- The K/V write + cross plan happen in `preprocess`, so `forward` is now pure planned compute — removing the CUDA-graph blocker the issue calls out. `cleanup_request` bookkeeping is deleted; the engine owns the lifecycle.

## Validation (RTX 5090, LibriSpeech test-clean)

| Check | Result |
|---|---|
| Offline token parity vs HF `generate` (60 greedy tokens) | unchanged, exact match |
| Served WER, n=50, **concurrency 8** | **3.17%, 0 errors, 0 server tracebacks** — identical to the pre-refactor baseline |
| Throughput | 1.93 req/s vs ~1.8 before (FlashInfer replaces the eager SDPA cross-attention loop) |

## Deferred (per the issue's "next-step concerns")

- KV transfer / PD-disaggregation enrollment of cross labels (`per_label_seq_info`) — waiting on a concrete disagg + cross-attention use case.
- Multiple cross-attention blocks per layer (sub-index beyond `layer_idx`) and non-dense patterns — the label resolver (`cross_attn_label(label, source)`) leaves naming room.
- Whisper decode batching + CUDA-graph capture — now unblocked, but a separate change.

Closes #160