### PR TITLE
[fix] whisper cross-attn recompile blowup + higgs TPCommGroup startup

### DIFF
--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -1216,6 +1216,12 @@ class FlashInferCacheManager(BatchedCacheManager):
         ps.write_store = False
         ps.plan_cache_key = plan_key
 
+    # Match run_attention: keep this out of the torch.compiled decoder region.
+    # The decoder's compiled forward calls run_cross_attn with a query whose
+    # leading dim varies (1 on decode, prefill batch on prefill); tracing it
+    # blows dynamo's recompile_limit ("tensor 'q' size mismatch") and drops the
+    # whole decoder to eager — a large whisper throughput regression (#160).
+    @torch.compiler.disable
     def run_cross_attn(
         self,
         q: torch.Tensor,

--- a/mstar/model/higgs_audio/components/llm.py
+++ b/mstar/model/higgs_audio/components/llm.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.engine.kv_cache_engine import BatchedCacheManager
 from mstar.model.components import DecoderLayer, RMSNorm
 from mstar.model.components.distributed import (
@@ -29,7 +29,7 @@ from mstar.model.higgs_audio.config import HiggsAudioModelConfig
 
 
 def _build_decoder_layer(
-    config: HiggsAudioModelConfig, comm_group: TPCommGroup | None = None,
+    config: HiggsAudioModelConfig, comm_group: CommGroup | None = None,
 ) -> DecoderLayer:
     return DecoderLayer(
         self_attn=ParallelAttention(
@@ -57,11 +57,11 @@ def _build_decoder_layer(
 class HiggsAudioLLM(nn.Module):
     """Qwen3 causal LM; parameter paths mirror the (flat) HF checkpoint."""
 
-    def __init__(self, config: HiggsAudioModelConfig, comm_group: TPCommGroup | None = None):
+    def __init__(self, config: HiggsAudioModelConfig, comm_group: CommGroup | None = None):
         super().__init__()
         self.config = config
         if comm_group is None:
-            comm_group = TPCommGroup.trivial()
+            comm_group = CommGroup.trivial()
         self.embed_tokens = VocabParallelEmbedding(
             num_embeddings=config.vocab_size,
             embedding_dim=config.hidden_size,


### PR DESCRIPTION
Two fixes vs the pre-review snapshot (`1ee582b`), found while re-benchmarking the ASR models on a single H100.

## 1. whisper cross-attn torch.compile recompile blowup (~37% regression)

The decoder `language_model` forward is `torch.compile`d, and the cross-attn migration (#160/#161) routed decode-time cross-attn through `BatchedCacheManager.run_cross_attn` from inside that compiled region. Its query leading dim varies (1 on decode, the prefill batch on prefill), so dynamo recompiles on each shape until it hits `config.recompile_limit(84)`, then drops the whole decoder to eager:

```
[10/84] torch._dynamo hit config.recompile_limit (84)
   function: 'run_cross_attn'  last reason: tensor 'q' size mismatch at index 0. expected 1, actual 4
```

The sibling `run_attention` (self-attn) is decorated `@torch.compiler.disable`; `run_cross_attn` was not — the migration missed the same guard. Fix mirrors it.

## 2. higgs_audio no longer imports (startup blocker)

`TPCommGroup` was renamed to `CommGroup` (`5c4ab0b3`); the `main` merge into `asr-models` missed the 4 references in `higgs_audio/components/llm.py`, so the server crashes on import. `CommGroup.trivial()` matches usage.

## Results (whisper offline, batch 8, 100 req, 1×H100)

| Variant | req/s | recompiles | transcripts |
|---|---|---|---|
| head (broken) | 1.15 | hits limit(84) | correct |
| **head + this fix** | **1.44** | **0** | correct |
| pre-review `1ee582b` | 1.81 | 1 (warmup) | correct |

Recovers 1.15 → 1.44 req/s, zero steady-state recompiles, transcripts unchanged. A follow-up PR (`perf/whisper-crossattn-compile-inline`) closes the remaining gap to ~1.97.