### PR TITLE
[perf] whisper: run decode cross-attn inline in the compiled graph (1.44 → ~1.97 req/s)

### DIFF
--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -1216,6 +1216,12 @@ class FlashInferCacheManager(BatchedCacheManager):
         ps.write_store = False
         ps.plan_cache_key = plan_key
 
+    # Match run_attention: keep this out of the torch.compiled decoder region.
+    # The decoder's compiled forward calls run_cross_attn with a query whose
+    # leading dim varies (1 on decode, prefill batch on prefill); tracing it
+    # blows dynamo's recompile_limit ("tensor 'q' size mismatch") and drops the
+    # whole decoder to eager — a large whisper throughput regression (#160).
+    @torch.compiler.disable
     def run_cross_attn(
         self,
         q: torch.Tensor,

--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -1216,11 +1216,8 @@ class FlashInferCacheManager(BatchedCacheManager):
         ps.write_store = False
         ps.plan_cache_key = plan_key
 
-    # Match run_attention: keep this out of the torch.compiled decoder region.
-    # The decoder's compiled forward calls run_cross_attn with a query whose
-    # leading dim varies (1 on decode, prefill batch on prefill); tracing it
-    # blows dynamo's recompile_limit ("tensor 'q' size mismatch") and drops the
-    # whole decoder to eager — a large whisper throughput regression (#160).
+    # Like run_attention: kept out of the compiled decoder — its query's leading
+    # dim varies per step, which would blow dynamo's recompile limit (#160).
     @torch.compiler.disable
     def run_cross_attn(
         self,

--- a/mstar/model/higgs_audio/components/llm.py
+++ b/mstar/model/higgs_audio/components/llm.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from mstar.distributed.communication import TPCommGroup
+from mstar.distributed.communication import CommGroup
 from mstar.engine.kv_cache_engine import BatchedCacheManager
 from mstar.model.components import DecoderLayer, RMSNorm
 from mstar.model.components.distributed import (
@@ -29,7 +29,7 @@ from mstar.model.higgs_audio.config import HiggsAudioModelConfig
 
 
 def _build_decoder_layer(
-    config: HiggsAudioModelConfig, comm_group: TPCommGroup | None = None,
+    config: HiggsAudioModelConfig, comm_group: CommGroup | None = None,
 ) -> DecoderLayer:
     return DecoderLayer(
         self_attn=ParallelAttention(
@@ -57,11 +57,11 @@ def _build_decoder_layer(
 class HiggsAudioLLM(nn.Module):
     """Qwen3 causal LM; parameter paths mirror the (flat) HF checkpoint."""
 
-    def __init__(self, config: HiggsAudioModelConfig, comm_group: TPCommGroup | None = None):
+    def __init__(self, config: HiggsAudioModelConfig, comm_group: CommGroup | None = None):
         super().__init__()
         self.config = config
         if comm_group is None:
-            comm_group = TPCommGroup.trivial()
+            comm_group = CommGroup.trivial()
         self.embed_tokens = VocabParallelEmbedding(
             num_embeddings=config.vocab_size,
             embedding_dim=config.hidden_size,

--- a/mstar/model/whisper/components/decoder.py
+++ b/mstar/model/whisper/components/decoder.py
@@ -44,7 +44,42 @@ class WhisperSelfAttention(Attention):
 
 class WhisperCrossAttention(CrossAttention):
     """Shared ``CrossAttention`` with Whisper's bias layout (the default:
-    q/v/o biased, k unbiased), attending the single encoder context."""
+    q/v/o biased, k unbiased), attending the single encoder context.
+
+    Fast path (#160 recovery): when the caller supplies the request's
+    contiguous per-layer encoder K/V (``cross_kv``), cross-attention runs as
+    an inline ``scaled_dot_product_attention`` so it is *traced into the
+    torch.compiled decoder graph* — avoiding the per-layer graph break and
+    eager FlashInfer wrapper of ``cache_handle.run_cross_attn``. When
+    ``cross_kv`` is ``None`` it falls back to the engine cross-attention pool
+    (batched / concurrent serving still uses that path).
+
+    The inline path relies on whisper decode NOT being CUDA-graphed, so the
+    per-request K/V can ride in as compiled-forward args. Once the decode step
+    is CUDA-graphed (the #160 batching follow-up), captured tensor addresses are
+    fixed, so that path takes the ``cross_kv=None`` FlashInfer pool branch (or a
+    static capture buffer) rather than these varying-address args."""
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cache_handle: BatchedCacheManager,
+        cross_kv: CrossKV | None = None,
+    ) -> torch.Tensor:
+        if cross_kv is None:
+            return super().forward(hidden_states, cache_handle)
+        num_tokens = hidden_states.shape[0]
+        q = self.q_proj(hidden_states).view(num_tokens, self.num_heads, self.head_dim)
+        k, v = cross_kv  # each (enc_len, num_heads, head_dim), static per request
+        # SDPA wants (batch, heads, seq, dim); single stream -> batch 1.
+        q = q.transpose(0, 1).unsqueeze(0)
+        k = k.transpose(0, 1).unsqueeze(0)
+        v = v.transpose(0, 1).unsqueeze(0)
+        attn = F.scaled_dot_product_attention(q, k, v)  # non-causal, full context
+        attn = attn.squeeze(0).transpose(0, 1).reshape(
+            num_tokens, self.num_heads * self.head_dim
+        )
+        return self.out_proj(attn)
 
 
 class WhisperDecoderLayer(nn.Module):
@@ -73,6 +108,7 @@ class WhisperDecoderLayer(nn.Module):
         self,
         hidden_states: torch.Tensor,
         cache_handle: BatchedCacheManager,
+        cross_kv: CrossKV | None = None,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.self_attn_layer_norm(hidden_states)
@@ -80,7 +116,7 @@ class WhisperDecoderLayer(nn.Module):
 
         residual = hidden_states
         hidden_states = self.encoder_attn_layer_norm(hidden_states)
-        hidden_states = residual + self.encoder_attn(hidden_states, cache_handle)
+        hidden_states = residual + self.encoder_attn(hidden_states, cache_handle, cross_kv)
 
         residual = hidden_states
         hidden_states = self.final_layer_norm(hidden_states)
@@ -129,10 +165,17 @@ class WhisperDecoderModel(nn.Module):
         self,
         input_embeds: torch.Tensor,
         cache_handle: BatchedCacheManager,
+        cross_k: torch.Tensor | None = None,
+        cross_v: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        # cross_k/cross_v (when given): stacked contiguous encoder K/V,
+        # (num_layers, enc_len, num_heads, head_dim). Supplying them routes
+        # cross-attention through the inline SDPA fast path (compile-inline,
+        # #160 recovery) instead of the engine cross-attention pool.
         hidden_states = input_embeds
         for layer_idx, layer in enumerate(self.layers):
             cache_handle.set_layer_idx(layer_idx)
-            hidden_states = layer(hidden_states, cache_handle)
+            cross_kv = None if cross_k is None else (cross_k[layer_idx], cross_v[layer_idx])
+            hidden_states = layer(hidden_states, cache_handle, cross_kv)
         cache_handle.advance_seq_lens()
         return self.layer_norm(hidden_states)

--- a/mstar/model/whisper/submodules.py
+++ b/mstar/model/whisper/submodules.py
@@ -110,6 +110,12 @@ class WhisperDecoderSubmodule(ARNodeSubmodule):
         self.config = config
         self._suppress_ids: torch.Tensor | None = None
         self._begin_suppress_ids: torch.Tensor | None = None
+        # Compile-inline cross-attn fast path (#160 recovery): contiguous
+        # per-request encoder K/V, computed once at prefill and fed into the
+        # torch.compiled decoder forward every step so cross-attn is traced
+        # inline (see WhisperCrossAttention). Keyed by request_id; freed in
+        # check_stop. Each entry is (cross_k, cross_v), stacked over layers.
+        self._cross_kv: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
     def _apply_suppress(self, logits: torch.Tensor, is_first_token: bool) -> torch.Tensor:
         """HF generate parity: mask the always-suppressed token set, plus
@@ -171,8 +177,11 @@ class WhisperDecoderSubmodule(ARNodeSubmodule):
         # No plan_rope: Whisper has no RoPE (learned absolute positions).
 
         # Prefill: compute per-layer cross-attn K/V from the encoder output
-        # and write them into the engine's context pool — once per request;
-        # they are static for the whole generation.
+        # once per request (static for the whole generation) and stash them
+        # contiguous, stacked over layers. Fed into the compiled decoder every
+        # step for the inline-SDPA cross-attn fast path (#160 recovery) — no
+        # engine cross-attention pool write / per-step plan on this path.
+        request_id = engine_inputs.request_ids[0]
         encoder_states = inputs[0].tensor_inputs.get("encoder_states")
         if encoder_states is not None:
             device = self.decoder.embed_tokens.weight.device
@@ -180,27 +189,31 @@ class WhisperDecoderSubmodule(ARNodeSubmodule):
             encoder_states = encoder_states.to(device=device, dtype=dtype)
             with torch.no_grad():
                 cross_kvs = self.decoder.compute_cross_kv(encoder_states)
-            for layer_idx, (k, v) in enumerate(cross_kvs):
-                cache_manager.add_cross_attn_kv(
-                    engine_inputs.request_ids, k, v,
-                    layer_idx=layer_idx, label="main",
-                )
+            cross_k = torch.stack([k for k, _ in cross_kvs]).contiguous()
+            cross_v = torch.stack([v for _, v in cross_kvs]).contiguous()
+            self._cross_kv[request_id] = (cross_k, cross_v)
 
-        # Both prefill and decode attend to the full (fixed) context.
-        cache_manager.plan_cross_attention(q_seq_lens=seq_lens, label="main")
-
-        return {"input_embeds": inputs[0].input_embeds}
+        cross_k, cross_v = self._cross_kv[request_id]
+        return {
+            "input_embeds": inputs[0].input_embeds,
+            "cross_k": cross_k,
+            "cross_v": cross_v,
+        }
 
     def forward(
         self,
         graph_walk: str,
         engine_inputs: ModelInputsFromEngine,
         input_embeds: torch.Tensor,
+        cross_k: torch.Tensor,
+        cross_v: torch.Tensor,
         **kwargs,
     ) -> NameToTensorList:
         hidden = self.decoder(
             input_embeds=input_embeds,
             cache_handle=engine_inputs.cache_manager,
+            cross_k=cross_k,
+            cross_v=cross_v,
         )
         logits = self.decoder.lm_head(hidden[-1:])
         # The prefill step samples the first generated token.
@@ -238,4 +251,12 @@ class WhisperDecoderSubmodule(ARNodeSubmodule):
                 decoded_tokens >= request_info.max_tokens:
             return {"decode_loop"}
         return set()
+
+    def cleanup_request(self, request_id: str):
+        # Free the request's stashed contiguous cross-attn K/V. Done here (not
+        # in check_stop) because a pipelined next-step preprocess can still run
+        # for a just-finished request; the engine calls cleanup_request only
+        # after the request is fully torn down.
+        self._cross_kv.pop(request_id, None)
+        super().cleanup_request(request_id)
 


### PR DESCRIPTION
Follow-up to #174. Recovers the cross-attention migration's remaining ~15% single-request cost (#160) and then some.

## What

Run decode-time cross-attn as an inline `scaled_dot_product_attention` that is **traced into the compiled decoder graph**, instead of the `@torch.compiler.disable`d `run_cross_attn` pool path (a per-layer graph break + eager per-layer FlashInfer wrapper + per-step `plan_cross_attention`).

- At prefill, `WhisperDecoderSubmodule.preprocess` computes the per-layer cross K/V once, stacks them contiguous `(num_layers, enc_len, heads, head_dim)`, and stashes them by `request_id` (freed in `cleanup_request` — **not** `check_stop`, which races a pipelined trailing preprocess).
- They are returned from `preprocess`, so they pass as **tensor args to the `torch.compile`d `submodule.forward`**, threaded `WhisperDecoderModel.forward → WhisperDecoderLayer.forward → WhisperCrossAttention.forward`, which runs the inline SDPA inside the graph.
- On this path the pool write (`add_cross_attn_kv`) and per-step `plan_cross_attention` are dropped. `run_cross_attn` is retained as the `cross_kv=None` fallback for batched/concurrent serving.
- Whisper opts into no CUDA graphs (`get_cuda_graph_configs == []`), so passing per-request (varying-address) K/V as compiled-forward args is safe — same as the pre-review snapshot `1ee582b`.

## Results (whisper offline, batch 8, 100 req, 1×H100, 2 runs)

| Variant | req/s | wall | recompiles |
|---|---|---|---|
| head (broken) | 1.15 | 87s | hits limit(84) |
| #174 (`@compiler.disable`) | 1.44 | — | 0 |
| pre-review `1ee582b` | 1.81 | 55s | 1 (warmup) |
| **this PR (compile-inline)** | **1.96–1.97** | 51s | **0** |

+37% over #174, +8% over the pre-review snapshot; 100/100 succeeded, transcripts unchanged (clean LibriSpeech text).

## Scope / follow-ups

Whisper single-request fast path only; the engine cross-attention pool path is kept as the fallback. A TP/SP-parallel cross-attention variant and batched inline path remain future work (see the `CrossAttention` TODO / #160).