### PR TITLE
streaming: guarantee a terminal StreamBuffer chunk after producer-done

### DIFF
--- a/mstar/streaming/stream_buffer.py
+++ b/mstar/streaming/stream_buffer.py
@@ -80,28 +80,23 @@ class StreamBuffer:
     def has_chunk_ready(self) -> bool:
         self._update_buffer()
         buf_len = len(self._buffer)
-        if self._producer_done_and_all_read() and buf_len > 0:
-            return True
+
+        if not self._producer_done_and_all_read():
+            return self.policy.is_ready(buf_len)
+        
         # When continue_after_producer_done is set, keep producing empty
         # chunks after the producer finishes and all items are consumed.
         # This allows the consumer to keep running (e.g., Talker continues
         # generating codec tokens after the Thinker hits text EOS).
-        if (self._producer_done_and_all_read()
-                and buf_len == 0
-                and self.policy.continue_after_producer_done()):
-            return True
         # Producer done and the buffer already drained to empty (all items
-        # were consumed in earlier chunks — happens when the total item count
-        # is an exact multiple of the chunk size and the consumer kept up).
-        # No chunk was ever marked final, so the consumer never runs its
-        # terminal flush and the request would hang. Emit exactly one final
+        # were consumed in earlier chunks. Emit exactly one final
         # (empty) chunk so ``is_final`` propagates and the stream closes.
-        if (self._producer_done_and_all_read()
-                and buf_len == 0
-                and not self._final_chunk_emitted
-                and not self.policy.continue_after_producer_done()):
-            return True
-        return self.policy.is_ready(buf_len)
+
+        return (
+            buf_len > 0
+            or self.policy.continue_after_producer_done()
+            or not self._final_chunk_emitted
+        )
 
     def pop_chunk(self) -> StreamChunk:
         """Pop the next chunk. Only call when has_chunk_ready() is True.

--- a/mstar/streaming/stream_buffer.py
+++ b/mstar/streaming/stream_buffer.py
@@ -40,6 +40,10 @@ class StreamBuffer:
     _consumed: int = 0
     _chunks_popped: int = 0
     producer_done: bool = False
+    # Set once a chunk has been popped with ``is_final=True`` (the terminal
+    # flush). Guards the empty-buffer final flush below so it fires exactly
+    # once and ``has_chunk_ready`` doesn't spin returning True forever.
+    _final_chunk_emitted: bool = False
 
     _num_tensors_registered = 0
     _num_buffer_writes = 0
@@ -86,6 +90,17 @@ class StreamBuffer:
                 and buf_len == 0
                 and self.policy.continue_after_producer_done()):
             return True
+        # Producer done and the buffer already drained to empty (all items
+        # were consumed in earlier chunks — happens when the total item count
+        # is an exact multiple of the chunk size and the consumer kept up).
+        # No chunk was ever marked final, so the consumer never runs its
+        # terminal flush and the request would hang. Emit exactly one final
+        # (empty) chunk so ``is_final`` propagates and the stream closes.
+        if (self._producer_done_and_all_read()
+                and buf_len == 0
+                and not self._final_chunk_emitted
+                and not self.policy.continue_after_producer_done()):
+            return True
         return self.policy.is_ready(buf_len)
 
     def pop_chunk(self) -> StreamChunk:
@@ -120,6 +135,8 @@ class StreamBuffer:
         # consumer decides when it's done via its own model logic.
         if self.policy.continue_after_producer_done():
             is_final = False
+        if is_final:
+            self._final_chunk_emitted = True
 
         chunk = StreamChunk(
             data=self._collate(items),

--- a/mstar/streaming/stream_buffer.py
+++ b/mstar/streaming/stream_buffer.py
@@ -83,7 +83,7 @@ class StreamBuffer:
 
         if not self._producer_done_and_all_read():
             return self.policy.is_ready(buf_len)
-        
+
         # When continue_after_producer_done is set, keep producing empty
         # chunks after the producer finishes and all items are consumed.
         # This allows the consumer to keep running (e.g., Talker continues

--- a/test/modular/test_stream_buffer_final_flush.py
+++ b/test/modular/test_stream_buffer_final_flush.py
@@ -1,0 +1,111 @@
+"""Regression tests for StreamBuffer terminal-chunk emission.
+
+A streaming consumer (e.g. the Zonos2 DAC vocoder) only runs its final
+flush — emitting the withheld crossfade tail and closing the client stream —
+when it receives a chunk marked ``is_final``. The bug this guards against:
+when a producer finishes at a moment its consumer has already drained the
+buffer to empty (which happens exactly when the total item count is a multiple
+of the chunk size and the consumer kept up), no chunk was ever marked final,
+so the request hung forever waiting on a terminal chunk that never came.
+
+See ``test/zonos2/BUG_realtext_concurrency_hang.md``.
+"""
+import pytest
+import torch
+
+from mstar.streaming.chunk_policy import (
+    FixedChunkPolicy,
+    LeftContextChunkPolicy,
+    SlidingWindowChunkPolicy,
+)
+from mstar.streaming.stream_buffer import StreamBuffer
+
+
+def _drive(policy, total_frames, drain_before_done):
+    """Feed ``total_frames`` one-frame items through a StreamBuffer and return
+    the ``is_final`` flag of every popped chunk.
+
+    ``drain_before_done`` models a consumer that keeps up with the producer,
+    popping every ready chunk as items arrive — the timing that empties the
+    buffer before ``signal_done`` and triggered the hang.
+    """
+    sb = StreamBuffer(
+        request_id="r", edge_name="new_token",
+        from_partition="LLM", policy=policy,
+    )
+    finals = []
+
+    def poll():
+        # Hard cap so a broken buffer that never terminates fails loudly
+        # instead of hanging the test.
+        for _ in range(total_frames + 50):
+            if not sb.has_chunk_ready():
+                return
+            finals.append(sb.pop_chunk().is_final)
+        raise AssertionError("has_chunk_ready never went False (spin/hang)")
+
+    for i in range(total_frames):
+        uid = f"t{i}"
+        sb.pre_read_register(uid)
+        sb.put(uid, torch.zeros(1, 4))
+        if drain_before_done:
+            poll()
+    sb.signal_done()
+    poll()
+    return finals
+
+
+@pytest.mark.parametrize("drain_before_done", [True, False])
+@pytest.mark.parametrize(
+    "total_frames",
+    [0, 1, 29, 30, 31, 60, 90, 100],  # 30/60/90 are exact multiples of chunk
+)
+def test_fixed_policy_emits_exactly_one_final(total_frames, drain_before_done):
+    finals = _drive(FixedChunkPolicy(chunk_size=30), total_frames, drain_before_done)
+    # Exactly one terminal chunk, regardless of how the frame count lines up
+    # with the chunk size or how eagerly the consumer drained.
+    assert sum(finals) == 1, finals
+    # The final chunk is the last one popped.
+    assert finals[-1] is True, finals
+
+
+@pytest.mark.parametrize("drain_before_done", [True, False])
+@pytest.mark.parametrize("total_frames", [0, 7, 14, 28, 35, 56])
+def test_sliding_window_policy_emits_exactly_one_final(total_frames, drain_before_done):
+    finals = _drive(
+        SlidingWindowChunkPolicy(window=28, stride=7), total_frames, drain_before_done
+    )
+    assert sum(finals) == 1, finals
+    assert finals[-1] is True, finals
+
+
+@pytest.mark.parametrize("drain_before_done", [True, False])
+@pytest.mark.parametrize("total_frames", [0, 5, 10, 20, 40])
+def test_left_context_policy_emits_exactly_one_final(total_frames, drain_before_done):
+    finals = _drive(
+        LeftContextChunkPolicy(chunk=10, left_context=2), total_frames, drain_before_done
+    )
+    assert sum(finals) == 1, finals
+    assert finals[-1] is True, finals
+
+
+def test_continue_after_producer_done_never_marks_final():
+    """Policies that keep the consumer running past producer-done (e.g. the
+    Qwen Thinker->Talker handoff) must never emit a final chunk — the consumer
+    decides completion via its own model logic. The final-flush fix must not
+    change that."""
+    policy = FixedChunkPolicy(chunk_size=30, continue_after_done=True)
+    sb = StreamBuffer(
+        request_id="r", edge_name="new_token", from_partition="LLM", policy=policy,
+    )
+    for i in range(90):  # exact multiple — the trigger for the plain-policy hang
+        uid = f"t{i}"
+        sb.pre_read_register(uid)
+        sb.put(uid, torch.zeros(1, 4))
+        while sb.has_chunk_ready():
+            assert sb.pop_chunk().is_final is False
+    sb.signal_done()
+    # Keeps offering (empty) chunks, none marked final.
+    for _ in range(5):
+        assert sb.has_chunk_ready() is True
+        assert sb.pop_chunk().is_final is False


### PR DESCRIPTION

<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

A streaming consumer only runs its final flush when it receives a chunk marked is_final. StreamBuffer only marked a chunk final while draining a non-empty buffer after producer-done.

When the consumer had already drained the buffer to empty at the moment the producer finished, no chunk was ever marked final. `has_chunk_ready()` then returned False forever, the consumer never ran its terminal pass, `stream_partition_done` was never set, and the request hung waiting on a terminal chunk that never came.

To fix this, we emit exactly one final (possibly empty) chunk once the producer is done and the buffer is empty, guarded by a _final_chunk_emitted flag so it fires once and has_chunk_ready() doesn't spin. The empty-chunk path already exists (`continue_after_producer_done` policies use it). `continue_after_producer_done` policies are unchanged.


<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

## How was it tested?

Adds `test/modular/test_stream_buffer_final_flush.py`: exactly-one-final across `Fixed`/`SlidingWindow`/`LeftContext` policies for both eager and lazy consumers, including exact-multiple and zero-frame cases (fails on the pre-fix buffer), plus a `continue_after_producer_done` guard.

<!-- Commands you ran, or why tests aren't applicable. -->

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
