### PR TITLE
Pin worker executor threads to the worker's CUDA device

### DIFF
--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -1165,6 +1165,19 @@ class Worker:
         engine = self.engine_manager.get_engine(spec_node_batch.node_name)
         engine.reset_pre_plan_for_batch(spec_node_batch)
 
+    def _init_cuda_executor_thread(self) -> None:
+        """Pin this executor thread to the worker's CUDA device.
+
+        The CUDA current device is per-thread and defaults to 0. PyTorch
+        ops carry per-tensor device guards, but raw Triton launches and
+        bare ``torch.cuda.current_stream()`` / ``synchronize()`` calls
+        resolve against the THREAD's device — on a worker whose model
+        lives on a non-zero device, work issued from an unpinned thread
+        lands on device 0's stream, unordered with the real compute.
+        """
+        if self.device.type == "cuda" and self.device.index is not None:
+            torch.cuda.set_device(self.device)
+
     def _execute_on_gpu_thread(
         self,
         batch: ScheduledBatch,
@@ -1975,7 +1988,8 @@ class Worker:
         # with GPU execution. Run the engine unconditionally on a dedicated
         # 1-worker GPU thread.
         gpu_executor = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix=f"mstar-gpu-{self.worker_id}"
+            max_workers=1, thread_name_prefix=f"mstar-gpu-{self.worker_id}",
+            initializer=self._init_cuda_executor_thread,
         )
         logger.info(
             "Worker %s: engine runs on dedicated GPU thread",
@@ -1998,7 +2012,8 @@ class Worker:
         plan_executor = None
         if pre_plan_spec:
             plan_executor = ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix=f"mstar-plan-{self.worker_id}"
+                max_workers=1, thread_name_prefix=f"mstar-plan-{self.worker_id}",
+                initializer=self._init_cuda_executor_thread,
             )
             logger.info(
                 "Worker %s: plan_executor enabled — speculative plan() "

--- a/test/modular/test_worker_thread_device.py
+++ b/test/modular/test_worker_thread_device.py
@@ -1,0 +1,75 @@
+"""Worker executor threads must be pinned to the worker's CUDA device.
+
+The CUDA current device is per-thread and defaults to 0.
+``Worker.__init__`` pins only the main thread; the GPU/plan executor
+threads run engine forwards and attention pre-planning. PyTorch ops are
+covered by per-tensor device guards, but raw Triton launches (mstar's
+fused-MoE and sampling kernels) and bare ``torch.cuda`` stream/sync
+calls resolve against the THREAD device — on a worker driving a
+non-zero device, an unpinned thread issues that work against device 0,
+unordered with the real compute stream (silent corruption or illegal
+accesses on the eager fallback path, which launches Triton at request
+time).
+
+These tests exercise ``Worker._init_cuda_executor_thread`` exactly as
+``Worker.run`` wires it into its executors.
+"""
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mstar.worker.worker import Worker
+
+
+def _worker_with_device(device: torch.device) -> Worker:
+    w = object.__new__(Worker)
+    w.device = device
+    return w
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs 2 GPUs")
+def test_executor_thread_pinned_to_worker_device():
+    w = _worker_with_device(torch.device("cuda", 1))
+    ex = ThreadPoolExecutor(
+        max_workers=1, initializer=w._init_cuda_executor_thread
+    )
+    try:
+        assert ex.submit(torch.cuda.current_device).result() == 1
+    finally:
+        ex.shutdown()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs 2 GPUs")
+def test_triton_launch_from_pinned_thread_is_ordered():
+    """A Triton launch from the pinned executor thread lands on the
+    worker device's stream: it must observe a producer queued earlier on
+    that stream (the eager-fallback shape of the bug)."""
+    from mstar.utils.fused_moe.kernels import act_and_mul_triton
+
+    dev1 = torch.device("cuda", 1)
+    w = _worker_with_device(dev1)
+
+    with torch.cuda.device(dev1):
+        a = torch.zeros((512, 512), dtype=torch.bfloat16, device=dev1)
+        out = torch.full((512, 256), -1.0, dtype=torch.bfloat16, device=dev1)
+        torch.cuda._sleep(500_000_000)  # keep the stream busy
+        a.fill_(1.0)                    # produced late
+
+    ex = ThreadPoolExecutor(
+        max_workers=1, initializer=w._init_cuda_executor_thread
+    )
+    try:
+        ex.submit(act_and_mul_triton, a, out, "silu").result()
+    finally:
+        ex.shutdown()
+    torch.cuda.synchronize(dev1)
+
+    expected = torch.nn.functional.silu(torch.tensor(1.0)).item()
+    got = out.float().mean().item()
+    assert abs(got - expected) < 0.01, (
+        f"Triton launch did not order behind the device-1 producer "
+        f"(mean {got}, expected ~{expected})"
+    )

--- a/test/modular/test_worker_thread_device.py
+++ b/test/modular/test_worker_thread_device.py
@@ -14,14 +14,13 @@ time).
 These tests exercise ``Worker._init_cuda_executor_thread`` exactly as
 ``Worker.run`` wires it into its executors.
 """
-import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-torch = pytest.importorskip("torch")
-
 from mstar.worker.worker import Worker
+
+torch = pytest.importorskip("torch")
 
 
 def _worker_with_device(device: torch.device) -> Worker:


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

Pins the worker's GPU executor and plan executor threads to the worker's CUDA device.

`Worker.__init__` calls `torch.cuda.set_device` on the worker process's main thread only. The two ThreadPoolExecutors created in `Worker.run` never set a device, so their thread-current CUDA device stays 0. Regular PyTorch ops are unaffected (per-tensor device guards), but raw Triton launches and bare `torch.cuda.current_stream()` / `synchronize()` calls resolve against the  *thread's* device. On a worker whose model lives on a non-zero device, that work lands on device 0's empty default stream, unordered with the real compute, stale reads (garbage logits) or illegal instruction/memory access that kills the worker.

The visible symptom: on qwen3omni_2gpu (Thinker on cuda:1), any video whose vision-token count exceeds the largest CUDA-graph capture bucket falls back to the bs=1 eager prefill — the only request-time raw-Triton path (fused MoE) and returns 257 bytes of `!` garbage or dies with `CUDA error: an illegal instruction was encountered`. It is timing-dependent: torch 2.13 / triton 3.7 hits it every time, torch 2.9 / triton 3.5 usually gets lucky. Adding a bare `torch.cuda.synchronize()` at the end of the eager forward masks it for the same reason it exists: on the unpinned thread that syncs device 0 and drains the stray work.

The fix wires `Worker._init_cuda_executor_thread` (a `set_device` on the worker's device) as the `initializer=` of both executors. This also covers the other thread-device-sensitive call sites reachable from these threads (bare `current_stream()` in kv_store.py / cpu_page_pool.py, and the adaRMS Triton kernel should its model ever be placed on a rank > 0 worker). `fused_temperature_softmax` in sampling.py already carries a `with torch.cuda.device(...)` guard with a comment describing this exact symptom - the same bug class, previously fixed at a single call site; this fixes it at the thread level.

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->

 - New regression tests: `test/modular/test_worker_thread_device.py` (2 tests, skip without 2 GPUs). One asserts the executor thread reports the worker's device after init; one asserts a raw Triton launch issued from the pinned thread orders correctly behind in-flight work on the non-default device's stream. Both fail on main and pass on this branch.

- End-to-end on the reproducing stack (torch 2.13.0 / triton 3.7.1, qwen3omni_2gpu, Thinker on cuda:1): unpatched, every oversize video (vision-token counts 18922 / 24862 / 24422, past the largest capture bucket) produced garbage or killed the worker; patched, the same videos produce correct answers, matching the torch 2.9 control byte-for-byte.

- The 10-request VideoMME video_to_text benchmark that surfaced the bug: unfixed 3/10 real answers (7/10 were 257-byte `!` garbage), fixed 10/10 real answers with zero worker errors. In-bucket requests are unchanged (same answers as before - the fix only pins thread devices; the replay path never launches raw Triton at request time).

- 30-minute mixed-modality overload soak (text/image/audio/video in and out, arrival peaks of 25 req/s): 2653 requests, zero worker errors, zero CUDA errors. The identical mixture against an unfixed tree hit an illegal memory access within ~2 minutes, immediately after the first eager vision prefill.

- Multi-worker no-regression check on a non-Triton model: cosmos3 SP2 (DiT rank 1 on cuda:1, eager denoise forced at 480p+): 13/13 requests clean with valid outputs and equal latencies on both unfixed and fixed trees.

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
