### PR TITLE
Drain API result reads ahead of preprocess and fail requests on deliv…

### DIFF
--- a/mstar/api_server/data_worker.py
+++ b/mstar/api_server/data_worker.py
@@ -486,6 +486,34 @@ class PreprocessWorkerThread:
             did_work = False
             try:
                 did_work = self._process_messages()
+                # Output delivery is latency-sensitive: the API server holds a
+                # finished request open for its final chunks only briefly, so
+                # queued read-starts / acks / cleanups must never wait behind a
+                # multi-second media preprocess. Drain them fully every pass
+                # and take at most one preprocess item afterwards.
+                while not self.result_tensor_queue.empty():
+                    did_work = True
+                    self._read_result_tensor(self.result_tensor_queue.get())
+                while not self.abort_request_queue.empty():
+                    did_work = True
+                    self.communicator.send(
+                        "conductor",
+                        ConductorMessage(
+                            message_type=ConductorMessageType.ABORT_REQUEST,
+                            body=AbortRequest(request_id=self.abort_request_queue.get()),
+                        ),
+                    )
+                while not self.discard_tensor_queue.empty():
+                    did_work = True
+                    self._discard_result_tensor(self.discard_tensor_queue.get())
+                while not self.cleanup_request_queue.empty():
+                    did_work = True
+                    req_id = self.cleanup_request_queue.get()
+                    self.tensor_manager.cleanup_request(req_id)
+                    if req_id in self.tensor_uuid_to_metadata_per_request:
+                        del self.tensor_uuid_to_metadata_per_request[req_id]
+                    self.request_model_kwargs.pop(req_id, None)
+                did_work = self._process_read_tensors() or did_work
                 if not self.in_queue.empty():
                     did_work = True
                     pre_input = self.in_queue.get()
@@ -509,29 +537,6 @@ class PreprocessWorkerThread:
                         ))
                         self.tensor_manager.cleanup_request(pre_input.request_id)
                         self.request_model_kwargs.pop(pre_input.request_id, None)
-                if not self.result_tensor_queue.empty():
-                    did_work = True
-                    self._read_result_tensor(self.result_tensor_queue.get())
-                if not self.abort_request_queue.empty():
-                    did_work = True
-                    self.communicator.send(
-                        "conductor",
-                        ConductorMessage(
-                            message_type=ConductorMessageType.ABORT_REQUEST,
-                            body=AbortRequest(request_id=self.abort_request_queue.get()),
-                        ),
-                    )
-                if not self.discard_tensor_queue.empty():
-                    did_work = True
-                    self._discard_result_tensor(self.discard_tensor_queue.get())
-                if not self.cleanup_request_queue.empty():
-                    did_work = True
-                    req_id = self.cleanup_request_queue.get()
-                    self.tensor_manager.cleanup_request(req_id)
-                    if req_id in self.tensor_uuid_to_metadata_per_request:
-                        del self.tensor_uuid_to_metadata_per_request[req_id]
-                    self.request_model_kwargs.pop(req_id, None)
-                did_work = did_work or self._process_read_tensors()
             except Exception:
                 logger.exception("PreprocessWorkerThread error")
 

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -320,12 +320,28 @@ class APIServer:
                     rid, req.final_outputs
                 )
             )
-            if drained or req is None or (now - ts) >= self._recently_completed_ttl:
-                stale.append(rid)
-        for rid in stale:
+            if drained or req is None:
+                stale.append((rid, False))
+            elif (now - ts) >= self._recently_completed_ttl:
+                stale.append((rid, True))
+        for rid, lost_outputs in stale:
             # only set the event when there are no more pending chunks
             req = self.pending_requests.get(rid)
             if req is not None:
+                if lost_outputs:
+                    # The TTL is a last resort for chunks that never arrive;
+                    # closing the request as a silent success would hand the
+                    # client a truncated (possibly empty) response.
+                    logger.error(
+                        "Request %s finished but its result chunks were not "
+                        "delivered within %.0fs; failing the request",
+                        rid, self._recently_completed_ttl,
+                    )
+                    if req.error is None:
+                        req.error = (
+                            "result delivery timed out; response is incomplete"
+                        )
+                        req.error_status = 500
                 req.event.set()
                 # Snapshot the data worker's tx/rx now: the request is done (all
                 # final chunks received), so the worker thread is no longer mutating
@@ -507,6 +523,17 @@ class APIServer:
                         self._finalize_profile(finished_req)
                     for chunk in remaining:
                         yield chunk
+                    # A request can fail after the stream is already open
+                    # (preprocess error, result-delivery timeout); the HTTP
+                    # status is committed by then, so the error must travel
+                    # in-band as the final chunk.
+                    if finished_req is not None and finished_req.error is not None:
+                        yield ResultChunk(
+                            request_id=request_id,
+                            modality="error",
+                            data=str(finished_req.error).encode("utf-8"),
+                            metadata={"status": finished_req.error_status},
+                        )
                     finished = True
                     break
 

--- a/test/modular/test_api_result_delivery.py
+++ b/test/modular/test_api_result_delivery.py
@@ -13,9 +13,6 @@ import collections
 import queue
 import threading
 import time
-from dataclasses import dataclass, field
-
-import pytest
 
 from mstar.api_server.data_worker import PreprocessWorkerThread
 from mstar.api_server.entrypoint import APIServer, PendingRequest

--- a/test/modular/test_api_result_delivery.py
+++ b/test/modular/test_api_result_delivery.py
@@ -1,0 +1,213 @@
+"""API-server result delivery under load.
+
+Covers the completion-vs-delivery race: a finished request's chunks flow
+api-side through the data worker, whose single thread also runs media
+preprocessing. The worker must drain queued result reads ahead of (multi-
+second) preprocess items, and the API server's post-completion TTL must fail
+a request whose chunks never arrived instead of closing it as an empty
+success.
+"""
+
+import asyncio
+import collections
+import queue
+import threading
+import time
+from dataclasses import dataclass, field
+
+import pytest
+
+from mstar.api_server.data_worker import PreprocessWorkerThread
+from mstar.api_server.entrypoint import APIServer, PendingRequest
+from mstar.api_server.request_types import PreprocessInput, ResultChunk, ResultTensors
+from mstar.graph.base import GraphEdge
+from mstar.graph.loop_indices import NestedLoopIndices
+
+
+class _RecordingTensorManager:
+    def __init__(self):
+        self.read_started = []
+
+    def start_read_tensors(self, request_id, graph_edges, graph_walk=None):
+        self.read_started.append(request_id)
+        return []
+
+    def get_ready_tensors(self):
+        return {}
+
+    def cleanup_request(self, request_id):
+        pass
+
+    def store_and_return_tensor_info(self, request_id, tensors):
+        return {}
+
+    def register_for_send(self, request_id, tensor_infos):
+        pass
+
+    def set_persist(self, request_id, uuid, persist):
+        pass
+
+    def ack_unread_tensors(self, request_id, graph_edges):
+        pass
+
+
+class _RecordingCommunicator:
+    def get_all_new_messages(self):
+        return []
+
+    def send(self, entity, msg):
+        pass
+
+
+class _BlockingModel:
+    """process_prompt blocks until released, like a long video preprocess."""
+
+    def __init__(self):
+        self.release = threading.Event()
+        self.entered = threading.Event()
+
+    def process_prompt(self, *args, **kwargs):
+        self.entered.set()
+        assert self.release.wait(timeout=10)
+        return {}
+
+
+def _result_tensors(rid, name="new_token"):
+    return ResultTensors(
+        request_id=rid,
+        modality="text",
+        graph_edge=GraphEdge(next_node="emit_to_client", name=name),
+        loop_indices=NestedLoopIndices(
+            loop_name_order=[], loop_indices={}, wg_fwd_pass_idx=0,
+        ),
+    )
+
+
+def test_result_reads_drain_ahead_of_preprocess():
+    """Queued result-tensor reads must all start before a preprocess item
+    (which can block for seconds on media decode) is picked up."""
+    model = _BlockingModel()
+    tm = _RecordingTensorManager()
+    stop = threading.Event()
+    worker = PreprocessWorkerThread(
+        in_queue=queue.Queue(),
+        result_tensor_queue=queue.Queue(),
+        out_queue=queue.Queue(),
+        profile_queue=queue.Queue(),
+        cleanup_request_queue=queue.Queue(),
+        abort_request_queue=queue.Queue(),
+        discard_tensor_queue=queue.Queue(),
+        stop_event=stop,
+        communicator=_RecordingCommunicator(),
+        tensor_manager=tm,
+        model=model,
+    )
+
+    worker.in_queue.put(PreprocessInput(
+        request_id="req-preprocess",
+        text="hello",
+        file_paths=None,
+        input_modalities=["text"],
+        output_modalities=["text"],
+        model_kwargs={},
+    ))
+    n_results = 6
+    for i in range(n_results):
+        worker.result_tensor_queue.put(_result_tensors(f"req-out-{i}"))
+
+    thread = threading.Thread(target=worker.run)
+    thread.start()
+    try:
+        assert model.entered.wait(timeout=5), "preprocess never started"
+        # The preprocess is still blocked; every queued read must already
+        # have been started.
+        assert len(tm.read_started) == n_results
+    finally:
+        model.release.set()
+        stop.set()
+        thread.join(timeout=5)
+    assert not thread.is_alive()
+
+
+class _StubPreprocessWorker:
+    def __init__(self, pending=False, final=True):
+        self.pending = pending
+        self.final = final
+        self.cleaned = []
+
+    def has_pending_tensors(self, rid):
+        return self.pending
+
+    def received_final_chunks(self, rid, final_outputs):
+        return self.final
+
+    def cleanup_request(self, rid):
+        self.cleaned.append(rid)
+
+
+def _pending_request():
+    return PendingRequest(
+        streaming=True,
+        input_modalities=["text"],
+        output_modalities=["text"],
+        profile=None,
+    )
+
+
+def _api_server_stub(preprocess_worker):
+    server = object.__new__(APIServer)
+    server.recently_completed = collections.OrderedDict()
+    server._recently_completed_ttl = 15.0
+    server.pending_requests = {}
+    server.preprocess_worker = preprocess_worker
+    server.log_stats = False
+    server.request_lock = threading.Lock()
+    server.timeout_seconds = 5.0
+    return server
+
+
+def test_ttl_expiry_with_undelivered_chunks_fails_request():
+    pw = _StubPreprocessWorker(pending=True, final=False)
+    server = _api_server_stub(pw)
+    req = _pending_request()
+    server.pending_requests["r1"] = req
+    server.recently_completed["r1"] = time.time() - 20.0
+
+    server._prune_recently_completed()
+
+    assert req.event.is_set()
+    assert req.error is not None
+    assert req.error_status == 500
+    assert "r1" not in server.recently_completed
+    assert pw.cleaned == ["r1"]
+
+
+def test_drained_completion_stays_successful():
+    pw = _StubPreprocessWorker(pending=False, final=True)
+    server = _api_server_stub(pw)
+    req = _pending_request()
+    server.pending_requests["r2"] = req
+    server.recently_completed["r2"] = time.time()
+
+    server._prune_recently_completed()
+
+    assert req.event.is_set()
+    assert req.error is None
+
+
+def test_stream_carries_error_as_final_chunk():
+    pw = _StubPreprocessWorker()
+    server = _api_server_stub(pw)
+    req = _pending_request()
+    req.chunks.append(ResultChunk(request_id="r3", modality="text", data=b"partial"))
+    req.error = "result delivery timed out; response is incomplete"
+    req.error_status = 500
+    req.event.set()
+    server.pending_requests["r3"] = req
+
+    async def _collect():
+        return [chunk async for chunk in server.iter_result_chunks("r3")]
+
+    chunks = asyncio.run(_collect())
+    assert [c.modality for c in chunks] == ["text", "error"]
+    assert chunks[-1].metadata["status"] == 500


### PR DESCRIPTION

<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

Fixes finished requests returning empty or silently-truncated responses (HTTP 200, no error) under load.

The API server's data worker is a single thread that runs media preprocessing, result-tensor reads, and output postprocess. Its run loop took ONE queued result-read start per pass, in between preprocess items - and a video preprocess (torchcodec decode + vision features) blocks the loop for seconds. Under a video-heavy backlog, chunk delivery therefor lagged 30-40s behind the engine.

The entrypoint already anticipates the completion-vs-delivery race: aconductor-finished request is held open in `recently_completed` until its announced chunks drain (`has_pending_tensors` / `received_final_chunks`). But the 15 s TTL backstop fires first when delivery is starved, closing the stream as an EMPTY SUCCESS; the chunks then arrive into "Late result chunk for cleaned-up request, ignoring". In a 30-minute overload soak that warning fired 85,010 times (~32 per request): short answers (e.g. 2-token MCQ replies) came back fully empty, longer ones silently tail-truncated. Engine/conductor output was correct throughout - this is purely a delivery defect.

Three changes:
1. data_worker run loop: fully drain queued result-read starts, acks/discards, and cleanups, and deliver ready tensors, BEFORE taking at most one preprocess item per pass  one slow media preprocess can no longer starve every request's output delivery.
2. `_prune_recently_completed`: a TTL expiry with undelivered chunks now fails the request (ERROR log, `req.error`, status 500) instead of closing it as an empty success. The TTL remains the last resort for chunks that genuinely never arrive; it is just no longer silent.
3. `iter_result_chunks`: a request that fails after its stream is open (preprocess error, delivery timeout) now yields a final `modality="error"` chunk. Streaming clients previously got a silent empty stream even on the existing preprocess-failure path; only non-streaming clients saw the 500. The OpenAI-compatible adapters filter by known modalities and ignore the extra chunk; mapping it to a structured OpenAI error is left for a follow-up.

The defect is model-agnostic API-server behavior. It is expressed today by video traffic (multi-second preprocess units); it is latent for any media-heavy flow (video inputs elsewhere, mp4-encode outputs, long-audio floods). Models with millisecond-scale media work never accumulate the lag, which matches image/diffusion soaks staying clean.

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->

- New tests: `test/modular/test_api_result_delivery.py` (4 tests, CPU only). Queued result reads all start while a preprocess item is blocked (the fairness change); a TTL expiry with undelivered chunks fails the request; a drained completion stays successful (control); the stream carries the error as a final chunk. 4/4 pass on this branch; the three behavior tests fail on current main.

- Root-cause repro on main (qwen3omni 2-GPU, video-heavy mixture at a 25 req/s square wave, 32 in flight, 360 s): 207 of 630 completions delivered zero chunks. A DEBUG per-request trace shows the request computed correctly, both answer tokens handed to the API server before the conductor's done, their reads completing 31-39 s later - after the 15 s TTL had already closed the stream empty - and the chunks dropped as "Late result chunk for cleaned-up request".

- Same burst against this branch: 0 empty responses (was 222/924), 0 late-chunk drops (was 22,015), 0 delivery-timeout failures fired, and ~5% more completions in the same wall time (delivery no longer starved). The only remaining zero-chunk completions are shutdown-time client cancellations, which is correct abandonment handling.

- Sequential requests after the burst behave normally (light-load path  unchanged); no illegal/CUDA errors in any serve log.


## Checklist
- [ ] `ruff check .` passes
- [ ] Added or updated tests / docs where relevant
