### PR TITLE
Worker Bug Fixes

### DIFF
--- a/mstar/model/qwen3_omni/submodules.py
+++ b/mstar/model/qwen3_omni/submodules.py
@@ -1171,7 +1171,7 @@ class ThinkerSubmodule(ARNodeSubmodule):
         request_info: CurrentForwardPassInfo,
         outputs: dict[str, list[torch.Tensor]],
     ) -> set[str]:
-        if "new_token" not in outputs:
+        if "new_token" not in outputs or request_info.graph_walk != "thinker_decode":
             return set()
         token = outputs["new_token"][0].item()
         ignore_eos = request_info.sampling_config["Thinker"].ignore_eos

--- a/mstar/worker/micro_scheduler.py
+++ b/mstar/worker/micro_scheduler.py
@@ -135,10 +135,24 @@ class MicroScheduler:
 
     def _try_schedule_tp_follow(
         self, worker_graphs_manager: WorkerGraphsManager,
+        target_node_name: str | None = None,
+        target_graph_walk: str | None = None,
+        exclude_target: tuple[str, str] | None = None,
     ) -> ScheduledBatch | None:
         if len(self.tp_batches_pending_schedule) == 0:
             return
         first_tp_node: ScheduleTPNode = self.tp_batches_pending_schedule[0]
+        # Respect the caller's filters: a targeted call (e.g. the speculation
+        # path asking for one specific node/walk) must not be handed a TP
+        # follower batch for some other node, or the caller will merge those
+        # node objects into a batch labeled with the target's name.
+        if target_node_name is not None and first_tp_node.node_name != target_node_name:
+            return
+        if target_graph_walk is not None and first_tp_node.graph_walk != target_graph_walk:
+            return
+        if exclude_target is not None and \
+                (first_tp_node.node_name, first_tp_node.graph_walk) == exclude_target:
+            return
         if self.num_consec_tp_follower_batches >= self.max_consec_tp_follower_batches and \
                 self.has_ready_excluding(
                     worker_graphs_manager,
@@ -147,8 +161,11 @@ class MicroScheduler:
             return
         # check if batch is ready
         node_partition = worker_graphs_manager.get_partition_for_node(first_tp_node.node_name)
+        # Use the leader's graph walk, not this worker's current one: the
+        # follower may lag or lead the leader's partition state.
         wgid = worker_graphs_manager.get_worker_graph_id_for_node(
-            first_tp_node.request_ids[0], first_tp_node.node_name
+            first_tp_node.request_ids[0], first_tp_node.node_name,
+            graph_walk=first_tp_node.graph_walk,
         )
         queue = worker_graphs_manager.queues[wgid]
         for rid in first_tp_node.request_ids:
@@ -217,7 +234,12 @@ class MicroScheduler:
             rid: t for rid, t in self.held_until.items() if t > now
         }
 
-        tp_follow_batch = self._try_schedule_tp_follow(worker_graphs_manager)
+        tp_follow_batch = self._try_schedule_tp_follow(
+            worker_graphs_manager,
+            target_node_name=target_node_name,
+            target_graph_walk=target_graph_walk,
+            exclude_target=exclude_target,
+        )
         if tp_follow_batch is None:
             self.num_consec_tp_follower_batches = 0
         else:

--- a/mstar/worker/node_manager_utils.py
+++ b/mstar/worker/node_manager_utils.py
@@ -682,10 +682,23 @@ class WorkerGraphsManager:
                 self.queues[queue_id].remove_request(request_id)
             del self.per_request_info[request_id]
 
-    def get_dyn_loop_workers(self, request_id: str, partition_name: str, loop_name: str):
-        return self.per_request_info[request_id].dyn_loop_to_workers[NodeAndGraphWalk(
+    def check_dyn_loop(self, request_id: str, partition_name: str, loop_name: str) -> bool:
+        ngw = NodeAndGraphWalk(
             node=loop_name, graph_walk=self.get_graph_walk(request_id, partition_name)
-        )]
+        )
+        if ngw not in self.per_request_info[request_id].dyn_loop_to_workers:
+            logger.error((
+                f"Tried to stop loop {loop_name} from graph walk {ngw.graph_walk}, which does not include this loop! "
+                "Ignoring this signal. This indicates a potential logical bug in the model."
+            ))
+            return False
+        return True
+
+    def get_dyn_loop_workers(self, request_id: str, partition_name: str, loop_name: str):
+        ngw = NodeAndGraphWalk(
+            node=loop_name, graph_walk=self.get_graph_walk(request_id, partition_name)
+        )
+        return self.per_request_info[request_id].dyn_loop_to_workers[ngw]
 
     def buffer_persist_signals(
             self, request_id: str,

--- a/mstar/worker/node_manager_utils.py
+++ b/mstar/worker/node_manager_utils.py
@@ -346,10 +346,19 @@ class WorkerGraphsManager:
         return inputs
 
     def get_worker_graph_id_for_node(
-        self, request_id: str, node_name: str
+        self, request_id: str, node_name: str,
+        graph_walk: str | None = None,
     ) -> str:
-        partition = self.get_partition_for_node(node_name)
-        graph_walk = self.get_graph_walk(request_id, partition)
+        """Worker graph that owns ``node_name`` for this request.
+
+        ``graph_walk`` defaults to the node's partition's current walk. Pass it
+        explicitly when the walk is dictated by someone else (e.g. a TP
+        follower acting on the leader's ``ScheduleTPNode``), since this
+        worker's own partition state may have advanced past it.
+        """
+        if graph_walk is None:
+            partition = self.get_partition_for_node(node_name)
+            graph_walk = self.get_graph_walk(request_id, partition)
         wg_id = self.walk_node_to_worker_graph_id.get((graph_walk, node_name))
         if wg_id is None:
             raise RuntimeError(

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -950,12 +950,6 @@ class Worker:
                 skip_cuda_sync=True,
             )
 
-            for edge in routing.persist:
-                for info in edge.tensor_info:
-                    self.tensor_manager.set_persist(
-                        request_id=request_id, uuid=info.uuid, persist=True
-                    )
-
 
     def _send_outputs(
         self, request_id: str, outputs: NodeOutputRouting,
@@ -1506,11 +1500,30 @@ class Worker:
         )
 
         if fresh_batch is not None:
+            # The merge below relabels these node objects with the spec
+            # target's name/walk, so a batch for any other node must not be
+            # merged in.
+            assert fresh_batch.node_name == spec_node_info.node_name, (
+                f"Speculation asked for {spec_node_info.node_name!r} but the "
+                f"scheduler returned {fresh_batch.node_name!r}"
+            )
             for rid, node in fresh_batch.node_objects.items():
                 if rid in new_node_objects:
                     # Shouldn't happen — continuing rids are held by the
                     # in-flight step and shouldn't be in ready queues —
                     # but if it does, the in-flight rid wins.
+                    #
+                    # KNOWN GAP (latent): if fresh_batch ever came from the
+                    # TP-follow path, ``_try_schedule_tp_follow`` has already
+                    # popped the leader's ScheduleTPNode. Pushing the node
+                    # back onto the ready queue does not undo that, and this
+                    # worker is a follower for that node so nothing will
+                    # reschedule it — the TP group stalls. Unreachable today
+                    # (spec targets exclude ``parallel_nodes``, so the
+                    # target_node_name filter never matches a TP batch), but
+                    # any future overlap needs the scheduler to re-queue the
+                    # message, or to defer the popleft until the caller
+                    # commits to the batch.
                     wg_id = fresh_batch.request_to_worker_graph[rid]
                     self.worker_graphs_manager.queues[wg_id].push_back_node(rid, node)
                     continue
@@ -1783,9 +1796,20 @@ class Worker:
 
             if rid in per_request_uuids:
                 routing = routing_per_request[rid]
+
+                for edge in routing.persist:
+                    for info in edge.tensor_info:
+                        self.tensor_manager.set_persist(
+                            request_id=rid, uuid=info.uuid, persist=True
+                        )
+
+                # NOTE: routing.persist is not included here because the tensors are
+                # (1) kept alive by the persist marker, and (2) would otherwise be
+                #  double-counted (e.g., we should not be incrementing the refcount of
+                # a persist signal that has EMPTY_DESTINATION; that's the conductor's
+                # job to properly compute the reference when unpersisting the signal)
                 routed_edges = (
                     routing.routed_to_this_worker_graph
-                    + routing.persist
                     + routing.emit_to_client
                     + routing.streaming_local
                     + sum(routing.to_workers.values(), start=[])

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -1721,6 +1721,12 @@ class Worker:
 
         # Stop loops, if applicable
         for rid, loop_names in new_stops.items():
+            loop_names = set([
+                ln for ln in loop_names if \
+                    self.worker_graphs_manager.check_dyn_loop(rid, batch_N.partition, ln)
+            ])
+            if not loop_names:
+                continue
             self.worker_graphs_manager.stop_loops(
                 rid, partition=batch_N.partition,
                 loop_names=loop_names,


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

Fixes a few (unrelated) bugs on the worker, one flagged in #168 and two found by running  qwen3-omni with the Thinker sharded TP2 over ranks 0/1 and the Talker on rank 1.

1. **Tensors marked as "persist" are erroneously ref-counted**: In `_postprocess_batch`, `routing.persist` is added to `self.tensor_manager.set_output_ref_counts`, where it is unconditionally ref-counted by 1, resulting in persist tensors leaking for each request. For persist signals, the `persist` flag on the tensor manager keeps it alive until the conductor sends an `UNPERSIST_TENSORS` message (with the actual number of times the tensor was read). This PR removes `routing.persist` from the call, instead calling `set_persist` before `set_output_ref_counts`.

2. **A node's inputs can be handed to a different node's submodule**: `MicroScheduler.get_next_batch` runs `_try_schedule_tp_follow` first and returns its result unconditionally, ignoring `target_node_name` / `target_graph_walk` / `exclude_target`. `_build_speculative_batch` calls `get_next_batch(target_node_name=<spec target>)` to merge in freshly-ready rids, so on a worker that is both a TP follower for one node and the owner of another, that call can return a TP-follower batch for the *wrong* node. The merge loop then copies those node objects (and their `ready_signals.ready_inputs`) into a batch labeled with the spec target's name and walk. This PR makes `_try_schedule_tp_follow` honor the caller's filters, and asserts `fresh_batch.node_name == spec_node_info.node_name` before the merge.

3. **TP followers resolve the worker graph from their own partition state**: `_try_schedule_tp_follow` calls `get_worker_graph_id_for_node`, which defaults the graph walk to the node partition's *current* walk on this worker. The walk is dictated by the leader's `ScheduleTPNode`, and the follower's partition state may have advanced past it, selecting the wrong worker graph. `get_worker_graph_id_for_node` now takes an optional `graph_walk`, and the TP-follow path passes the leader's.

Also documents a latent gap at the speculation merge: `_try_schedule_tp_follow` pops the leader's `ScheduleTPNode` before returning, so if the caller discards that batch (the `rid in new_node_objects` push-back branch), the message is lost and nothing reschedules the node on a follower. Unreachable today, as spec targets exclude `parallel_nodes`, so the `target_node_name` filter can never match a TP batch, but noted at the call site with the two possible fixes.

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->
- Ran the "Thinker sharded TP2 over ranks 0/1 and the Talker on rank 1" for T2S and A2S (max concurrency 8) and verified outputs / server logs.
- Ran BAGEL for all modalities, checked outputs
- Did `find /dev/shm -type f -user $(whoami) -name "mstar*" -delete`, ran a benchmark, and then verified that `find /dev/shm -type f -user $(whoami) -name "mstar*"` came up clean.

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
