### PR TITLE
Add Qwen3-TTS-12Hz-0.6B-CustomVoice support

### DIFF
--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -232,6 +232,16 @@ class Qwen3Omni(Model):
         }
 
 
+class Qwen3TTS(Model):
+    """Qwen3-TTS CustomVoice benchmark metadata for native M* requests."""
+
+    def get_hf_url(self):
+        return "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"
+
+    def get_supported_modalities(self):
+        return {RequestType.T2S}
+
+
 class Pi05(Model):
     """Physical Intelligence Pi0.5 VLA model.
 
@@ -317,6 +327,7 @@ class ModelType(Enum):
     BAGEL = "bagel"
     ORPHEUS = "orpheus"
     QWEN3OMNI = "qwen3omni"
+    QWEN3TTS = "qwen3_tts"
     PI05 = "pi05"
     VJEPA2AC = "vjepa2ac"
     WHISPER_LARGE = "whisper_large"
@@ -329,6 +340,8 @@ class ModelType(Enum):
             return Orpheus(**kwargs)
         if self == ModelType.QWEN3OMNI:
             return Qwen3Omni(**kwargs)
+        if self == ModelType.QWEN3TTS:
+            return Qwen3TTS(**kwargs)
         if self == ModelType.PI05:
             return Pi05(**kwargs)
         if self == ModelType.VJEPA2AC:

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -634,8 +634,11 @@ def parse_args() -> BenchmarkConfig:
             txtfile = "benchmark/assets/simple_text_queries.txt"
         elif request_type == RequestType.T2S:
             dataset = DatasetType.TEXT
-            if args.model == ModelType.ORPHEUS:
-                # T2S model, will just transcribe
+            if args.model in {
+                ModelType.ORPHEUS.value,
+                ModelType.QWEN3TTS.value,
+            }:
+                # Direct TTS models synthesize the prompt verbatim.
                 txtfile = "benchmark/assets/t2s.txt"
             else:
                 # thinker-talker type model that speaks its answer

--- a/configs/qwen3tts.yaml
+++ b/configs/qwen3tts.yaml
@@ -1,0 +1,9 @@
+model: "qwen3_tts"
+max_seq_len: 32768
+node_groups:
+  - node_names: [Talker]
+    ranks: [0]
+    graph_walks: [talker_prefill, talker_decode]
+  - node_names: [Codec]
+    ranks: [0]
+    graph_walks: [codec_chunk]

--- a/configs/qwen3tts.yaml
+++ b/configs/qwen3tts.yaml
@@ -1,5 +1,9 @@
 model: "qwen3_tts"
 max_seq_len: 32768
+# The supported deployment image cannot build FlashInfer's Hopper FA3 JIT
+# kernels yet. Keep the model default on "auto" and pin this deployment to FA2.
+kv_cache:
+  flashinfer_backend: fa2
 node_groups:
   - node_names: [Talker]
     ranks: [0]

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -71,10 +71,12 @@ Qwen3-TTS notes
   batch-16 capture can exhaust an H100 after Talker weights and CodePredictor
   graphs are resident; larger Codec batches therefore use the scheduler's safe
   ceiling.
-- Talker prefill and the outer recurrent walk remain eager. The 15-step inner
-  CodePredictor loop is CUDA-graph captured; capturing the complete recurrent
-  walk can replay stale residual state, miss codec EOS, and append silent
-  frames.
+- Talker prefill remains eager because it runs once with variable sequence
+  lengths. Decode uses a whole-walk CUDA Graph when residual sampling matches
+  the captured defaults; request-local EOS suppression is carried as a graph
+  tensor input so replay does not consult capture-slot dummy request state.
+  Requests with custom ``subtalker_*`` sampling fall back to eager Talker
+  execution while retaining the piecewise-captured 15-step CodePredictor loop.
 - The 12 Hz decoder does not require the system SoX executable. M* imports only
   the exact upstream decoder modules, avoiding qwen-tts's unrelated 25 Hz SoX
   probe during worker startup.

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -32,6 +32,9 @@ Registry keys live in ``mstar/model/registry.py`` (``MODEL_REGISTRY`` / ``HF_MOD
    * - ``qwen3_omni``
      - ``Qwen/Qwen3-Omni-30B-A3B-Instruct``
      - Omni-modal (text/image/audio/video in, text/audio out): Thinker + Talker + codec.
+   * - ``qwen3_tts``
+     - ``Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice``
+     - Streaming text-to-speech with built-in speakers: Talker + 12 Hz speech codec.
    * - ``vjepa2``
      - ``facebook/vjepa2-vitl-fpc64-256``
      - V-JEPA 2 video encoder + masked predictor.
@@ -54,6 +57,48 @@ Notes
 - Some families accept multimodal input (image/audio/video); see the model's
   ``process_prompt`` for the inputs it expects.
 - To add a new family, see :doc:`adding_models`.
+
+Qwen3-TTS notes
+---------------
+
+- Install the model-specific dependencies with ``pip install -e '.[qwen3_tts]'``
+  and launch the default single-GPU deployment with
+  ``mstar serve qwen3_tts --gpus 0``.
+- The first integration supports the CustomVoice checkpoint and text-to-audio
+  requests. ``voice`` selects one of the checkpoint's built-in speakers and
+  ``language`` defaults to automatic detection.
+- Codec CUDA graphs are captured through batch size 8. The upstream decoder's
+  batch-16 capture can exhaust an H100 after Talker weights and CodePredictor
+  graphs are resident; larger Codec batches therefore use the scheduler's safe
+  ceiling.
+- Talker prefill and the outer recurrent walk remain eager. The 15-step inner
+  CodePredictor loop is CUDA-graph captured; capturing the complete recurrent
+  walk can replay stale residual state, miss codec EOS, and append silent
+  frames.
+- The 12 Hz decoder does not require the system SoX executable. M* imports only
+  the exact upstream decoder modules, avoiding qwen-tts's unrelated 25 Hz SoX
+  probe during worker startup.
+
+For throughput/latency validation, run the native serving benchmark with the
+Qwen3-TTS model metadata rather than the Orpheus compatibility entry::
+
+   python -m benchmark.runner \
+       --url localhost:8000 \
+       --model qwen3_tts \
+       --profiling-type closed_loop \
+       --request-type text_to_speech \
+       --num-requests 20 \
+       --inference-system ours \
+       --num-warmup 2 \
+       --max-concurrency 4 \
+       --dataset seed_tts \
+       --output-dir .bench_outs
+
+The benchmark stops on the model's natural codec EOS by default. Use
+``--ignore-eos --output-len-min N --output-len-max N`` only when measuring
+fixed-length decode throughput rather than end-user latency.
+The first process-local request can include eager FlashInfer kernel JIT, so
+keep the warmup requests enabled when reporting steady-state latency.
 
 Cosmos3 environment requirements
 --------------------------------

--- a/mstar/cli/main.py
+++ b/mstar/cli/main.py
@@ -29,6 +29,7 @@ DEFAULT_CONFIGS: dict[str, str] = {
     "cosmos3_super": "cosmos3_super_tp2.yaml",
     "orpheus": "orpheus_colocated.yaml",
     "qwen3_omni": "qwen3omni_2gpu.yaml",
+    "qwen3_tts": "qwen3tts.yaml",
     "pi05": "pi05.yaml",
     "vjepa2": "vjepa2.yaml",
     "vjepa2_ac": "vjepa2_ac.yaml",
@@ -87,8 +88,12 @@ def _next_steps(model: str, host: str, port: int) -> str:
         lines.append("    res = client.generate(text=\"a robot arm cleaning a plate\", output_modalities=(\"video\",))")
     if model == "qwen3_omni":
         lines.append("    client.chat(\"Say hi\", output_modalities=(\"text\",\"audio\")).save_audio(\"out.wav\")")
-    if model in ("orpheus", "qwen3_omni"):
-        voice = "tara" if model == "orpheus" else "Ethan"
+    if model in ("orpheus", "qwen3_omni", "qwen3_tts"):
+        voice = {
+            "orpheus": "tara",
+            "qwen3_omni": "Ethan",
+            "qwen3_tts": "Vivian",
+        }[model]
         lines.append(f"    client.tts(\"Hello there\", voice=\"{voice}\").to_wav(\"out.wav\")")
     if model in ("pi05", "vjepa2", "vjepa2_ac"):
         lines.append("    res = client.generate(text=\"...\", output_modalities=(\"" +

--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -844,6 +844,7 @@ class FlashInferCacheManager(BatchedCacheManager):
                 page_size=page_size,
                 device=self.device,
                 enable_nvtx=self.enable_nvtx,
+                backend=cfg.flashinfer_backend,
             )
             ps = _PlanState(wrapper=wrapper)
             self._plan_states[effective_label] = ps
@@ -856,6 +857,7 @@ class FlashInferCacheManager(BatchedCacheManager):
                 page_size=page_size,
                 device=self.device,
                 enable_nvtx=self.enable_nvtx,
+                backend=cfg.flashinfer_backend,
             )
             ps = _PlanState(wrapper=wrapper)
             self._plan_states[effective_label] = ps
@@ -982,6 +984,7 @@ class FlashInferCacheManager(BatchedCacheManager):
                 device=self.device,
                 use_cuda_graph=True,
                 enable_nvtx=self.enable_nvtx,
+                backend=cfg.flashinfer_backend,
             )
             ps = _PlanState(wrapper=wrapper)
             self._plan_states[combined_label] = ps
@@ -995,6 +998,7 @@ class FlashInferCacheManager(BatchedCacheManager):
                 head_dim=head_dim,
                 page_size=page_size,
                 enable_nvtx=self.enable_nvtx,
+                backend=cfg.flashinfer_backend,
             )
             ps = _PlanState(wrapper=wrapper)
             self._plan_states[combined_label] = ps

--- a/mstar/engine/cuda_graph_runner.py
+++ b/mstar/engine/cuda_graph_runner.py
@@ -351,6 +351,7 @@ class CudaGraphRunner:
                     device=self.device,
                     use_cuda_graph=True,
                     enable_nvtx=self.enable_nvtx,
+                    backend=cfg.flashinfer_backend,
                 )
             else:
                 wrapper = FlashInferPrefillWrapper(
@@ -365,6 +366,7 @@ class CudaGraphRunner:
                     device=self.device,
                     use_cuda_graph=True,
                     enable_nvtx=self.enable_nvtx,
+                    backend=cfg.flashinfer_backend,
                 )
 
             # Static pos_ids buffer for RoPE — also per-slot (captured into
@@ -2604,6 +2606,7 @@ class PiecewiseCudaGraphRunner:
                 max_num_pages=cfg.max_num_pages,
                 device=self.device,
                 use_cuda_graph=True,
+                backend=cfg.flashinfer_backend,
             )
             plan_states[label] = _PlanState(wrapper=wrapper)
         return plan_states

--- a/mstar/engine/kv_store.py
+++ b/mstar/engine/kv_store.py
@@ -118,6 +118,10 @@ class KVCacheConfig:
     # "dense_gen" (adds the dense FA3 generation-attention fast path). The
     # model's get_kv_cache_config sets it; model yaml config may override.
     attention_backend: str = "flashinfer"
+    # Kernel selected inside FlashInfer's paged wrappers. ``auto`` may choose
+    # FA3 on Hopper; models can pin ``fa2`` when their deployment toolchain
+    # cannot compile the Hopper JIT kernels.
+    flashinfer_backend: str = "auto"
 
     def __post_init__(self):
         if self.num_qo_heads is None:

--- a/mstar/model/qwen3_tts/__init__.py
+++ b/mstar/model/qwen3_tts/__init__.py
@@ -1,0 +1,3 @@
+"""Qwen3-TTS model integration."""
+
+from mstar.model.qwen3_tts.qwen3_tts_model import Qwen3TTSModel as Qwen3TTSModel

--- a/mstar/model/qwen3_tts/components/__init__.py
+++ b/mstar/model/qwen3_tts/components/__init__.py
@@ -1,0 +1,8 @@
+"""Neural network components for Qwen3-TTS."""
+
+from mstar.model.qwen3_tts.components.talker import (
+    Qwen3TTSCodePredictor as Qwen3TTSCodePredictor,
+)
+from mstar.model.qwen3_tts.components.talker import (
+    Qwen3TTSTalkerModel as Qwen3TTSTalkerModel,
+)

--- a/mstar/model/qwen3_tts/components/talker.py
+++ b/mstar/model/qwen3_tts/components/talker.py
@@ -1,0 +1,326 @@
+"""Neural components for Qwen3-TTS Talker and residual CodePredictor.
+
+The checkpoint has two coupled autoregressive axes:
+
+* Across time, the 28-layer Talker predicts codec group 0 at 12 Hz and uses
+  M*'s paged KV cache. Its attention/MLP projections are tensor-parallel.
+* Within one time step, the 5-layer CodePredictor walks codec groups 1-15.
+  This short depth axis uses a fixed local KV tensor and is kept replicated.
+
+Class/module names intentionally follow Hugging Face checkpoint namespaces so
+``load_hf_weights`` can stream parameters without a model-specific state-dict
+rewrite beyond the standard fused Q/K/V and gate/up rules.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from mstar.distributed.communication import CommGroup
+from mstar.engine.cache_manager import BatchedCacheManager
+from mstar.model.components import RMSNorm
+from mstar.model.components.distributed import ParallelAttention, ParallelGatedMLP
+from mstar.model.qwen3_tts.config import Qwen3TTSModelConfig, Qwen3TTSTalkerConfig
+
+# ---------------------------------------------------------------------------
+# Talker backbone: autoregression across audio frames
+# ---------------------------------------------------------------------------
+
+
+class Qwen3TTSResizeMLP(nn.Module):
+    """Two-layer text-embedding projection used by the official Talker."""
+
+    def __init__(self, input_size: int, intermediate_size: int, output_size: int):
+        super().__init__()
+        self.linear_fc1 = nn.Linear(input_size, intermediate_size, bias=True)
+        self.linear_fc2 = nn.Linear(intermediate_size, output_size, bias=True)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.linear_fc2(F.silu(self.linear_fc1(hidden_states)))
+
+
+class Qwen3TTSTalkerLayer(nn.Module):
+    """One pre-norm Talker block backed by M* tensor-parallel layers."""
+
+    def __init__(
+        self,
+        config: Qwen3TTSTalkerConfig,
+        comm_group: CommGroup | None = None,
+    ) -> None:
+        super().__init__()
+        self.input_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.self_attn = ParallelAttention(
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            rope_theta=config.rope_theta,
+            qk_norm=True,
+            rms_norm_eps=config.rms_norm_eps,
+            comm_group=comm_group,
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, config.rms_norm_eps
+        )
+        self.mlp = ParallelGatedMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            activation="silu",
+            comm_group=comm_group,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cache_handle: BatchedCacheManager,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, cache_handle)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class Qwen3TTSTalkerLanguageModel(nn.Module):
+    """Backbone matching ``talker.model.*`` and the engine-managed KV cache."""
+
+    def __init__(
+        self,
+        config: Qwen3TTSTalkerConfig,
+        comm_group: CommGroup | None = None,
+    ) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([
+            Qwen3TTSTalkerLayer(config, comm_group=comm_group)
+            for _ in range(config.num_hidden_layers)
+        ])
+        self.norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.codec_embedding = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.text_embedding = nn.Embedding(
+            config.text_vocab_size, config.text_hidden_size
+        )
+
+    def forward(
+        self,
+        input_embeds: torch.Tensor,
+        cache_handle: BatchedCacheManager,
+    ) -> torch.Tensor:
+        hidden_states = input_embeds
+        for layer_idx, layer in enumerate(self.layers):
+            # One cache handle owns every layer's paged K/V tensor. Selecting
+            # the layer before attention keeps module code independent of the
+            # physical page allocator.
+            cache_handle.set_layer_idx(layer_idx)
+            hidden_states = layer(hidden_states, cache_handle)
+        # Sequence lengths advance once per forward, after every layer wrote
+        # K/V for the same packed token range.
+        cache_handle.advance_seq_lens()
+        return self.norm(hidden_states)
+
+
+class Qwen3TTSTalkerModel(nn.Module):
+    """Talker backbone, text projection, and codec-group-0 output head."""
+
+    def __init__(
+        self,
+        config: Qwen3TTSModelConfig,
+        comm_group: CommGroup | None = None,
+    ) -> None:
+        super().__init__()
+        talker = config.talker
+        self.model = Qwen3TTSTalkerLanguageModel(talker, comm_group=comm_group)
+        self.text_projection = Qwen3TTSResizeMLP(
+            talker.text_hidden_size,
+            talker.text_hidden_size,
+            talker.hidden_size,
+        )
+        self.codec_head = nn.Linear(
+            talker.hidden_size, talker.vocab_size, bias=False
+        )
+
+    def forward(
+        self,
+        input_embeds: torch.Tensor,
+        cache_handle: BatchedCacheManager,
+    ) -> torch.Tensor:
+        return self.model(input_embeds, cache_handle)
+
+
+# ---------------------------------------------------------------------------
+# CodePredictor: autoregression across codec groups within one frame
+# ---------------------------------------------------------------------------
+
+
+class Qwen3TTSCodePredictorLayer(nn.Module):
+    """Parameter container for one replicated residual-code decoder block."""
+
+    def __init__(self, config: Qwen3TTSModelConfig) -> None:
+        super().__init__()
+        cp = config.code_predictor
+        self.input_layernorm = RMSNorm(cp.hidden_size, cp.rms_norm_eps)
+        self.self_attn = ParallelAttention(
+            hidden_size=cp.hidden_size,
+            num_heads=cp.num_attention_heads,
+            num_kv_heads=cp.num_key_value_heads,
+            head_dim=cp.head_dim,
+            rope_theta=cp.rope_theta,
+            qk_norm=True,
+            rms_norm_eps=cp.rms_norm_eps,
+        )
+        self.post_attention_layernorm = RMSNorm(
+            cp.hidden_size, cp.rms_norm_eps
+        )
+        self.mlp = ParallelGatedMLP(
+            hidden_size=cp.hidden_size,
+            intermediate_size=cp.intermediate_size,
+            activation="silu",
+        )
+
+
+class Qwen3TTSCodePredictorInnerModel(nn.Module):
+    """Depth decoder and one embedding table per residual codec group."""
+
+    def __init__(self, config: Qwen3TTSModelConfig) -> None:
+        super().__init__()
+        cp = config.code_predictor
+        self.layers = nn.ModuleList([
+            Qwen3TTSCodePredictorLayer(config)
+            for _ in range(cp.num_hidden_layers)
+        ])
+        self.norm = RMSNorm(cp.hidden_size, cp.rms_norm_eps)
+        self.codec_embedding = nn.ModuleList([
+            nn.Embedding(cp.vocab_size, config.talker.hidden_size)
+            for _ in range(config.num_code_groups - 1)
+        ])
+
+
+def _apply_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+    theta: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply the checkpoint's non-interleaved RoPE to grouped Q/K tensors."""
+    head_dim = q.shape[-1]
+    inv_freq = 1.0 / (
+        theta ** (
+            torch.arange(0, head_dim, 2, device=q.device, dtype=torch.float32)
+            / head_dim
+        )
+    )
+    angles = position_ids.to(torch.float32).unsqueeze(-1) * inv_freq
+    cos = torch.cat([angles.cos(), angles.cos()], dim=-1).unsqueeze(2)
+    sin = torch.cat([angles.sin(), angles.sin()], dim=-1).unsqueeze(2)
+
+    def rotate_half(x: torch.Tensor) -> torch.Tensor:
+        first, second = x.chunk(2, dim=-1)
+        return torch.cat([-second, first], dim=-1)
+
+    return (
+        q * cos.to(q.dtype) + rotate_half(q) * sin.to(q.dtype),
+        k * cos.to(k.dtype) + rotate_half(k) * sin.to(k.dtype),
+    )
+
+
+class Qwen3TTSCodePredictor(nn.Module):
+    """Five-layer decoder that predicts codec groups 1 through 15.
+
+    ``forward_depth_unrolled`` performs one position on the group-depth axis.
+    Callers first write the Talker hidden state at position 0, then repeatedly
+    feed the preceding codec embedding at positions 1-15. Keeping this as
+    tensor-only code allows the complete depth loop to be CUDA-graph captured.
+    """
+
+    def __init__(self, config: Qwen3TTSModelConfig) -> None:
+        super().__init__()
+        cp = config.code_predictor
+        if cp.hidden_size != config.talker.hidden_size:
+            raise ValueError(
+                "M* currently requires equal Talker and CodePredictor hidden "
+                "sizes; the supported 0.6B checkpoint uses 1024 for both"
+            )
+        self.config = cp
+        self.model = Qwen3TTSCodePredictorInnerModel(config)
+        self.lm_head = nn.ModuleList([
+            nn.Linear(cp.hidden_size, cp.vocab_size, bias=False)
+            for _ in range(config.num_code_groups - 1)
+        ])
+        self.register_buffer(
+            # Populated after weight loading. A single contiguous tensor lets
+            # the piecewise loop select a residual head without traversing a
+            # Python ModuleList during CUDA Graph replay.
+            "lm_head_weight",
+            torch.empty(
+                config.num_code_groups - 1,
+                cp.vocab_size,
+                cp.hidden_size,
+            ),
+            persistent=False,
+        )
+
+    def consolidate_stacked_weights(self) -> None:
+        """Pack the 15 loaded LM heads into graph-friendly contiguous storage."""
+        self.lm_head_weight = torch.stack([
+            head.weight.data for head in self.lm_head
+        ]).contiguous()
+
+    def forward_depth_unrolled(
+        self,
+        inputs_embeds: torch.Tensor,
+        position_ids: torch.Tensor,
+        kv_cache: torch.Tensor,
+        cache_pos: int,
+    ) -> torch.Tensor:
+        """Run all CodePredictor layers for one or more adjacent depth tokens.
+
+        ``kv_cache`` layout is ``[layers, batch, K/V, groups, kv_heads,
+        head_dim]``. Unlike Talker cache, it is frame-local scratch space:
+        every generated frame starts at ``cache_pos=0`` and overwrites it.
+        """
+        hidden_states = inputs_embeds
+        batch_size, seq_len, _ = hidden_states.shape
+
+        for layer_idx, layer in enumerate(self.model.layers):
+            residual = hidden_states
+            hidden_states = layer.input_layernorm(hidden_states)
+            attn = layer.self_attn
+            qkv = attn.qkv_proj(hidden_states)
+            q_size = attn.num_heads * attn.head_dim
+            kv_size = attn.num_kv_heads * attn.head_dim
+            q, k, v = qkv.split((q_size, kv_size, kv_size), dim=-1)
+            q = q.view(batch_size, seq_len, attn.num_heads, attn.head_dim)
+            k = k.view(batch_size, seq_len, attn.num_kv_heads, attn.head_dim)
+            v = v.view(batch_size, seq_len, attn.num_kv_heads, attn.head_dim)
+            q, k = attn._apply_qk_norm(q, k)
+            q, k = _apply_rope(
+                q, k, position_ids, float(attn.rope_theta)
+            )
+
+            # Append this depth position, then attend over the prefix already
+            # generated within the same codec frame.
+            end = cache_pos + seq_len
+            kv_cache[layer_idx, :, 0, cache_pos:end].copy_(k)
+            kv_cache[layer_idx, :, 1, cache_pos:end].copy_(v)
+            keys = kv_cache[layer_idx, :, 0, :end]
+            values = kv_cache[layer_idx, :, 1, :end]
+            repeats = attn.num_heads // attn.num_kv_heads
+            keys = keys.repeat_interleave(repeats, dim=2).transpose(1, 2)
+            values = values.repeat_interleave(repeats, dim=2).transpose(1, 2)
+            queries = q.transpose(1, 2)
+            attn_output = F.scaled_dot_product_attention(
+                queries, keys, values, is_causal=False
+            ).transpose(1, 2)
+            attn_output = attn_output.reshape(batch_size, seq_len, -1)
+            hidden_states = residual + attn.o_proj(attn_output)
+
+            residual = hidden_states
+            hidden_states = layer.post_attention_layernorm(hidden_states)
+            hidden_states = residual + layer.mlp(hidden_states)
+
+        return self.model.norm(hidden_states)

--- a/mstar/model/qwen3_tts/components/talker.py
+++ b/mstar/model/qwen3_tts/components/talker.py
@@ -155,6 +155,11 @@ class Qwen3TTSTalkerModel(nn.Module):
 # ---------------------------------------------------------------------------
 # CodePredictor: autoregression across codec groups within one frame
 # ---------------------------------------------------------------------------
+# Qwen3-Omni has the same high-level residual-code loop, but currently uses a
+# different attention primitive, checkpoint/config namespace, sampling policy,
+# and CUDA-graph capture path.  Sharing the loop before the auxiliary-sampler
+# work tracked in #199 would couple two independently validated model ports;
+# factor the common implementation after that engine interface is available.
 
 
 class Qwen3TTSCodePredictorLayer(nn.Module):

--- a/mstar/model/qwen3_tts/components/talker.py
+++ b/mstar/model/qwen3_tts/components/talker.py
@@ -312,14 +312,15 @@ class Qwen3TTSCodePredictor(nn.Module):
             end = cache_pos + seq_len
             kv_cache[layer_idx, :, 0, cache_pos:end].copy_(k)
             kv_cache[layer_idx, :, 1, cache_pos:end].copy_(v)
-            keys = kv_cache[layer_idx, :, 0, :end]
-            values = kv_cache[layer_idx, :, 1, :end]
-            repeats = attn.num_heads // attn.num_kv_heads
-            keys = keys.repeat_interleave(repeats, dim=2).transpose(1, 2)
-            values = values.repeat_interleave(repeats, dim=2).transpose(1, 2)
+            keys = kv_cache[layer_idx, :, 0, :end].transpose(1, 2)
+            values = kv_cache[layer_idx, :, 1, :end].transpose(1, 2)
             queries = q.transpose(1, 2)
             attn_output = F.scaled_dot_product_attention(
-                queries, keys, values, is_causal=False
+                queries,
+                keys,
+                values,
+                is_causal=False,
+                enable_gqa=True,
             ).transpose(1, 2)
             attn_output = attn_output.reshape(batch_size, seq_len, -1)
             hidden_states = residual + attn.o_proj(attn_output)

--- a/mstar/model/qwen3_tts/config.py
+++ b/mstar/model/qwen3_tts/config.py
@@ -1,0 +1,309 @@
+"""Checkpoint-backed configuration for Qwen3-TTS 12 Hz CustomVoice.
+
+Qwen publishes configuration across three files rather than one monolithic
+object:
+
+* ``config.json``: Talker architecture, special IDs, speakers, and languages
+* ``generation_config.json``: main Talker and residual sampling defaults
+* ``speech_tokenizer/config.json``: neural audio decoder architecture/rates
+
+The dataclasses below preserve that ownership while exposing one
+``Qwen3TTSModelConfig`` to the M* model and submodules.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    """Read optional checkpoint metadata, leaving dataclass defaults intact."""
+    if not path.is_file():
+        return {}
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+@dataclass
+class Qwen3TTSCodePredictorConfig:
+    """Depth-wise transformer configuration for residual codec groups 1-15."""
+
+    num_hidden_layers: int = 5
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    hidden_size: int = 1024
+    intermediate_size: int = 3072
+    head_dim: int = 128
+    max_position_embeddings: int = 65536
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 1_000_000.0
+    vocab_size: int = 2048
+    num_code_groups: int = 16
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Qwen3TTSCodePredictorConfig":
+        return cls(**{
+            name: data[name]
+            for name in cls.__dataclass_fields__
+            if name in data
+        })
+
+
+def _default_speaker_ids() -> dict[str, int]:
+    return {
+        "serena": 3066,
+        "vivian": 3065,
+        "uncle_fu": 3010,
+        "ryan": 3061,
+        "aiden": 2861,
+        "ono_anna": 2873,
+        "sohee": 2864,
+        "eric": 2875,
+        "dylan": 2878,
+    }
+
+
+def _default_speaker_dialects() -> dict[str, str | bool]:
+    return {
+        "serena": False,
+        "vivian": False,
+        "uncle_fu": False,
+        "ryan": False,
+        "aiden": False,
+        "ono_anna": False,
+        "sohee": False,
+        "eric": "sichuan_dialect",
+        "dylan": "beijing_dialect",
+    }
+
+
+def _default_language_ids() -> dict[str, int]:
+    return {
+        "chinese": 2055,
+        "english": 2050,
+        "german": 2053,
+        "italian": 2070,
+        "portuguese": 2071,
+        "spanish": 2054,
+        "japanese": 2058,
+        "korean": 2064,
+        "french": 2061,
+        "russian": 2069,
+        "beijing_dialect": 2074,
+        "sichuan_dialect": 2062,
+    }
+
+
+@dataclass
+class Qwen3TTSTalkerConfig:
+    """Autoregressive 12 Hz Talker architecture and conditioning IDs."""
+
+    # Transformer geometry for the time-axis Talker.
+    num_hidden_layers: int = 28
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    hidden_size: int = 1024
+    intermediate_size: int = 3072
+    head_dim: int = 128
+    max_position_embeddings: int = 32768
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 1_000_000.0
+    vocab_size: int = 3072
+    text_hidden_size: int = 2048
+    text_vocab_size: int = 151936
+    num_code_groups: int = 16
+    position_id_per_seconds: int = 13
+
+    # Codec-side control tokens used to build the mixed prefill sequence.
+    codec_pad_id: int = 2148
+    codec_bos_id: int = 2149
+    codec_eos_token_id: int = 2150
+    codec_think_id: int = 2154
+    codec_nothink_id: int = 2155
+    codec_think_bos_id: int = 2156
+    codec_think_eos_id: int = 2157
+    codec_language_id: dict[str, int] = field(default_factory=_default_language_ids)
+    spk_id: dict[str, int] = field(default_factory=_default_speaker_ids)
+    spk_is_dialect: dict[str, str | bool] = field(default_factory=_default_speaker_dialects)
+    code_predictor: Qwen3TTSCodePredictorConfig = field(
+        default_factory=Qwen3TTSCodePredictorConfig
+    )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Qwen3TTSTalkerConfig":
+        values = {
+            name: data[name]
+            for name in cls.__dataclass_fields__
+            if name in data and name != "code_predictor"
+        }
+        values["code_predictor"] = Qwen3TTSCodePredictorConfig.from_dict(
+            data.get("code_predictor_config", {})
+        )
+        return cls(**values)
+
+
+@dataclass
+class Qwen3TTSCodecConfig:
+    """Official speech-tokenizer decoder plus M* streaming chunk controls."""
+
+    # Values forwarded to Qwen3TTSTokenizerV2DecoderConfig.
+    num_quantizers: int = 16
+    codebook_size: int = 2048
+    codebook_dim: int = 512
+    latent_dim: int = 1024
+    hidden_size: int = 512
+    intermediate_size: int = 1024
+    head_dim: int = 64
+    num_hidden_layers: int = 8
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 16
+    max_position_embeddings: int = 8000
+    sliding_window: int = 72
+    decoder_dim: int = 1536
+    rms_norm_eps: float = 1e-5
+    rope_theta: float = 10_000.0
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    hidden_act: str = "silu"
+    layer_scale_initial_scale: float = 0.01
+    upsample_rates: tuple[int, ...] = (8, 5, 4, 3)
+    upsampling_ratios: tuple[int, ...] = (2, 2)
+
+    # Runtime/output metadata from the speech tokenizer's top-level config.
+    input_sample_rate: int = 24000
+    output_sample_rate: int = 24000
+    decode_upsample_rate: int = 1920
+
+    # M* stream policy: 300 new 12 Hz frames with 25 frames of overlap.
+    chunk_frames: int = 300
+    left_context_frames: int = 25
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Qwen3TTSCodecConfig":
+        decoder = data.get("decoder_config", {})
+        values = {
+            name: decoder[name]
+            for name in cls.__dataclass_fields__
+            if name in decoder
+        }
+        values.update({
+            name: data[name]
+            for name in (
+                "input_sample_rate",
+                "output_sample_rate",
+                "decode_upsample_rate",
+            )
+            if name in data
+        })
+        return cls(**values)
+
+    def decoder_kwargs(self) -> dict[str, Any]:
+        """Arguments accepted by the official 12 Hz decoder config."""
+        excluded = {
+            "input_sample_rate",
+            "output_sample_rate",
+            "decode_upsample_rate",
+            "chunk_frames",
+            "left_context_frames",
+        }
+        return {
+            name: getattr(self, name)
+            for name in self.__dataclass_fields__
+            if name not in excluded
+        }
+
+
+@dataclass
+class Qwen3TTSGenerationConfig:
+    """Sampling defaults for the two codec-generation levels.
+
+    Unprefixed fields control codec group 0 through M*'s engine sampler.
+    ``subtalker_*`` fields control residual groups 1-15 in CodePredictor.
+    """
+
+    min_new_tokens: int = 2
+    do_sample: bool = True
+    temperature: float = 0.9
+    top_k: int = 50
+    top_p: float = 1.0
+    repetition_penalty: float = 1.05
+    subtalker_dosample: bool = True
+    subtalker_temperature: float = 0.9
+    subtalker_top_k: int = 50
+    subtalker_top_p: float = 1.0
+    max_new_tokens: int = 8192
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Qwen3TTSGenerationConfig":
+        return cls(**{
+            name: data[name]
+            for name in cls.__dataclass_fields__
+            if name in data
+        })
+
+
+@dataclass
+class Qwen3TTSModelConfig:
+    """Top-level model metadata composed from all checkpoint config files."""
+
+    model_type: str = "qwen3_tts"
+    tokenizer_type: str = "qwen3_tts_tokenizer_12hz"
+    tts_model_size: str = "0b6"
+    tts_model_type: str = "custom_voice"
+
+    assistant_token_id: int = 77091
+    im_start_token_id: int = 151644
+    im_end_token_id: int = 151645
+    tts_pad_token_id: int = 151671
+    tts_bos_token_id: int = 151672
+    tts_eos_token_id: int = 151673
+
+    default_speaker: str = "vivian"
+    default_language: str = "auto"
+    talker: Qwen3TTSTalkerConfig = field(default_factory=Qwen3TTSTalkerConfig)
+    codec: Qwen3TTSCodecConfig = field(default_factory=Qwen3TTSCodecConfig)
+    generation: Qwen3TTSGenerationConfig = field(
+        default_factory=Qwen3TTSGenerationConfig
+    )
+
+    @property
+    def code_predictor(self) -> Qwen3TTSCodePredictorConfig:
+        return self.talker.code_predictor
+
+    @property
+    def num_code_groups(self) -> int:
+        return self.talker.num_code_groups
+
+    @classmethod
+    def from_pretrained(cls, model_dir: str | Path) -> "Qwen3TTSModelConfig":
+        """Compose Talker, Codec, and generation configs from a local snapshot."""
+        root = Path(model_dir)
+        model_data = _read_json(root / "config.json")
+        generation_data = _read_json(root / "generation_config.json")
+        codec_data = _read_json(root / "speech_tokenizer" / "config.json")
+
+        values = {
+            name: model_data[name]
+            for name in (
+                "model_type",
+                "tokenizer_type",
+                "tts_model_size",
+                "tts_model_type",
+                "assistant_token_id",
+                "im_start_token_id",
+                "im_end_token_id",
+                "tts_pad_token_id",
+                "tts_bos_token_id",
+                "tts_eos_token_id",
+            )
+            if name in model_data
+        }
+        values.update(
+            talker=Qwen3TTSTalkerConfig.from_dict(
+                model_data.get("talker_config", {})
+            ),
+            codec=Qwen3TTSCodecConfig.from_dict(codec_data),
+            generation=Qwen3TTSGenerationConfig.from_dict(generation_data),
+        )
+        return cls(**values)

--- a/mstar/model/qwen3_tts/qwen3_tts_model.py
+++ b/mstar/model/qwen3_tts/qwen3_tts_model.py
@@ -1,0 +1,729 @@
+"""Qwen3-TTS model contract and two-partition streaming topology.
+
+The 0.6B CustomVoice checkpoint is a text-to-speech model without the large
+multimodal Thinker used by Qwen3-Omni. Its autoregressive Talker predicts one
+12 Hz codec frame per step: group 0 comes from the Talker language model and
+groups 1-15 come from a small depth-wise CodePredictor. The speech-tokenizer
+decoder turns those frames into 24 kHz PCM.
+
+Architecture (two asynchronous partitions):
+    Talker - text/voice prefill, then autoregressive 16-group codec frames
+    Codec  - stateless speech-tokenizer decoder producing PCM chunks
+
+Streaming topology:
+    Talker --[codec_tokens, LeftContextChunkPolicy(300, 25)]--> Codec
+
+Request state machine:
+    Talker: talker_prefill -> talker_decode loop -> done on EOS/token limit
+    Codec:  waits for streamed frames -> codec_chunk -> emits audio -> waits
+
+This class runs in the API/conductor side. It owns request validation, graph
+and partition declarations, state-machine transitions, sampling defaults, and
+lazy worker-side construction. Heavy weights are not loaded in ``__init__``.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import torch
+from transformers import AutoTokenizer
+
+from mstar.communication.tensors import NameToTensorList
+from mstar.conductor.request_info import (
+    CurrentForwardConductorMetadata,
+    PartitionDefinition,
+    StreamingConnectionState,
+)
+from mstar.engine.base import EngineType
+from mstar.engine.kv_cache_engine import KVCacheConfig
+from mstar.graph.base import (
+    GraphEdge,
+    GraphNode,
+    GraphSection,
+    Loop,
+    TensorPointerInfo,
+)
+from mstar.graph.special_destinations import EMIT_TO_CLIENT, EMPTY_DESTINATION
+from mstar.model.base import ForwardPassArgs, Model
+from mstar.model.qwen3_tts.config import Qwen3TTSModelConfig
+from mstar.model.submodule_base import NodeSubmodule
+from mstar.streaming.chunk_policy import LeftContextChunkPolicy
+from mstar.streaming.topology import Connection, PartitionTopology, StreamingGraphEdge
+from mstar.utils.sampling import SamplingConfig
+
+# ---------------------------------------------------------------------------
+# Checkpoint discovery
+# ---------------------------------------------------------------------------
+
+
+def _resolve_model_metadata(repo_id: str, cache_dir: str | None) -> str:
+    """Resolve only the files needed to construct config and tokenize input.
+
+    The API and conductor processes do not need model tensors. Downloading a
+    metadata-only snapshot here keeps them from allocating or transferring the
+    multi-gigabyte checkpoint. Workers fetch the complete snapshot lazily from
+    ``get_submodule``.
+    """
+    local_path = Path(repo_id)
+    if local_path.is_dir():
+        return str(local_path)
+
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(
+        repo_id=repo_id,
+        cache_dir=cache_dir,
+        allow_patterns=[
+            "config.json",
+            "generation_config.json",
+            "tokenizer_config.json",
+            "special_tokens_map.json",
+            "vocab.json",
+            "merges.txt",
+            "speech_tokenizer/config.json",
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model contract
+# ---------------------------------------------------------------------------
+
+
+class Qwen3TTSModel(Model):
+    """Qwen3-TTS 12 Hz CustomVoice model contract.
+
+    GPU computation is split into an autoregressive Talker partition and a
+    streaming Codec partition. This class owns only model-level scheduling,
+    prompt processing, configuration, and output encoding.
+    """
+
+    def __init__(
+        self,
+        model_path_hf: str,
+        cache_dir: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.model_path_hf = model_path_hf
+        self.cache_dir = cache_dir
+
+        # The lightweight API-side object needs config and tokenizer only.
+        self.local_dir = _resolve_model_metadata(model_path_hf, cache_dir)
+        self.config = Qwen3TTSModelConfig.from_pretrained(self.local_dir)
+        if self.config.tts_model_type != "custom_voice":
+            raise ValueError(
+                "The first Qwen3-TTS integration supports only CustomVoice "
+                f"checkpoints, got {self.config.tts_model_type!r}"
+            )
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.local_dir,
+            cache_dir=cache_dir,
+            fix_mistral_regex=True,
+        )
+
+        # Each worker asks only for nodes assigned to it. Cache the resulting
+        # wrappers so Talker and Codec weights are materialized at most once.
+        self._submodule_cache: dict[str, NodeSubmodule | None] = {}
+
+    def _ensure_full_snapshot(self) -> str:
+        """Make all weight files available immediately before worker loading."""
+        if (Path(self.local_dir) / "model.safetensors").is_file():
+            return self.local_dir
+        if Path(self.model_path_hf).is_dir():
+            raise FileNotFoundError(
+                f"No model.safetensors found in {self.model_path_hf}"
+            )
+        from huggingface_hub import snapshot_download
+
+        self.local_dir = snapshot_download(
+            repo_id=self.model_path_hf,
+            cache_dir=self.cache_dir,
+        )
+        return self.local_dir
+
+    # -----------------------------------------------------------------------
+    # Model ABC: KV cache and engine assignment
+    # -----------------------------------------------------------------------
+
+    def get_kv_cache_config(self) -> list[KVCacheConfig]:
+        """Declare the paged self-attention cache used only by the Talker."""
+        talker = self.config.talker
+        return [KVCacheConfig(
+            num_layers=talker.num_hidden_layers,
+            num_kv_heads=talker.num_key_value_heads,
+            head_dim=talker.head_dim,
+            max_seq_len=talker.max_position_embeddings,
+            num_qo_heads=talker.num_attention_heads,
+            nodes=["Talker"],
+            # FlashInfer 0.6.x auto-selects an FA3 JIT kernel on Hopper. The
+            # supported deployment toolchain uses the compatible FA2 kernel.
+            flashinfer_backend="fa2",
+        )]
+
+    def get_node_engine_types(self) -> dict[str, EngineType]:
+        """Talker keeps cross-step KV state; Codec is a pure frame decoder."""
+        return {
+            "Talker": EngineType.KV_CACHE,
+            "Codec": EngineType.STATELESS,
+        }
+
+    # -----------------------------------------------------------------------
+    # Model ABC: walk graph declaration
+    # -----------------------------------------------------------------------
+
+    def get_graph_walk_graphs(self) -> dict[str, GraphSection]:
+        """Declare prefill, autoregressive decode, and codec chunk walks.
+
+        ``talker_input_embeds`` is the recurrent Talker edge. ``codec_tokens``
+        crosses the asynchronous partition boundary and is buffered according
+        to ``get_partition_topology`` before Codec is scheduled.
+        """
+        # Prefill seeds both recurrent paths: the embedding for the next
+        # Talker step is persisted, while the first codec frame starts the
+        # Talker-to-Codec stream.
+        talker_prefill = GraphNode(
+            name="Talker",
+            input_names=["text_inputs", "speaker_id", "language_id"],
+            outputs=[
+                GraphEdge(
+                    next_node=EMPTY_DESTINATION,
+                    name="talker_input_embeds",
+                    persist=True,
+                ),
+                StreamingGraphEdge(
+                    next_node="Codec",
+                    name="codec_tokens",
+                    target_partition="Codec",
+                ),
+            ],
+        )
+
+        # Each loop iteration predicts one complete 16-group codec frame and
+        # feeds the summed codec embedding back into the next Talker step.
+        talker_decode = Loop(
+            name="talker_decode_loop",
+            section=GraphNode(
+                name="Talker",
+                input_names=["talker_input_embeds"],
+                outputs=[
+                    GraphEdge(
+                        next_node="Talker",
+                        name="talker_input_embeds",
+                    ),
+                    StreamingGraphEdge(
+                        next_node="Codec",
+                        name="codec_tokens",
+                        target_partition="Codec",
+                    ),
+                ],
+            ),
+            max_iters=self.get_max_output_tokens(),
+            outputs=[],
+        )
+
+        # Codec is deliberately a separate walk/engine so waveform decoding
+        # can overlap with subsequent Talker steps.
+        codec_chunk = GraphNode(
+            name="Codec",
+            input_names=["codec_tokens"],
+            outputs=[
+                GraphEdge(
+                    next_node=EMIT_TO_CLIENT,
+                    name="audio_chunk",
+                    output_modality="audio",
+                ),
+            ],
+        )
+        return {
+            "talker_prefill": talker_prefill,
+            "talker_decode": talker_decode,
+            "codec_chunk": codec_chunk,
+        }
+
+    # -----------------------------------------------------------------------
+    # Asynchronous partitions and stream buffering
+    # -----------------------------------------------------------------------
+
+    def get_partitions(self) -> list[PartitionDefinition]:
+        """Split autoregressive generation from independently scheduled audio."""
+        return [
+            PartitionDefinition(
+                name="Talker",
+                graph_walks={"talker_prefill", "talker_decode"},
+                initial_walk="talker_prefill",
+                producer_partitions=[],
+            ),
+            PartitionDefinition(
+                name="Codec",
+                graph_walks={"codec_chunk"},
+                initial_walk=None,
+                producer_partitions=["Talker"],
+            ),
+        ]
+
+    def get_partition_topology(self) -> PartitionTopology:
+        """Buffer codec frames with the decoder's required left context.
+
+        The first Codec invocation receives up to ``chunk_frames`` new frames.
+        Later invocations prepend ``left_context_frames`` old frames to avoid
+        convolution boundary artifacts; ``CodecSubmodule.postprocess`` removes
+        the duplicated PCM prefix before emission.
+        """
+        codec = self.config.codec
+        return PartitionTopology(
+            partitions=["Talker", "Codec"],
+            connections=[
+                Connection(
+                    from_partition="Talker",
+                    to_partition="Codec",
+                    edge_name="codec_tokens",
+                    chunk_policy_factory=lambda: LeftContextChunkPolicy(
+                        chunk=codec.chunk_frames,
+                        left_context=codec.left_context_frames,
+                    ),
+                ),
+            ],
+        )
+
+    # -----------------------------------------------------------------------
+    # API preprocessing
+    # -----------------------------------------------------------------------
+
+    def process_prompt(
+        self,
+        prompt: str | None,
+        input_modalities: list[str],
+        output_modalities: list[str],
+        tensors: NameToTensorList | None = None,
+        **kwargs: Any,
+    ) -> NameToTensorList:
+        """Validate a CustomVoice request and build Talker input tensors.
+
+        Qwen3-TTS expects an assistant ChatML turn rather than a generic user
+        turn. Speaker and language are separate codec-side conditioning IDs;
+        ``-1`` means automatic language selection.
+        """
+        del tensors
+        if not prompt:
+            raise ValueError("Qwen3-TTS requires a non-empty text prompt")
+        if set(input_modalities) != {"text"}:
+            raise ValueError(
+                "Qwen3-TTS CustomVoice currently supports text input only"
+            )
+        if set(output_modalities) != {"audio"}:
+            raise ValueError("Qwen3-TTS CustomVoice supports audio output only")
+        if kwargs.get("instruct"):
+            raise ValueError(
+                "Qwen3-TTS 0.6B CustomVoice does not support instructions"
+            )
+
+        speaker = str(
+            kwargs.get("speaker", kwargs.get("voice", self.config.default_speaker))
+        ).lower()
+        if speaker not in self.config.talker.spk_id:
+            supported = ", ".join(sorted(self.config.talker.spk_id))
+            raise ValueError(
+                f"Unsupported Qwen3-TTS speaker {speaker!r}; supported: {supported}"
+            )
+
+        language = str(kwargs.get("language", self.config.default_language)).lower()
+        if language != "auto" and language not in self.config.talker.codec_language_id:
+            supported = ", ".join(
+                ["auto", *sorted(self.config.talker.codec_language_id)]
+            )
+            raise ValueError(
+                f"Unsupported Qwen3-TTS language {language!r}; supported: {supported}"
+            )
+
+        dialect = self.config.talker.spk_is_dialect.get(speaker, False)
+        if dialect and language in {"auto", "chinese"}:
+            language = str(dialect)
+
+        # Match the official processor template exactly. `_build_prefill`
+        # relies on the fixed assistant suffix when separating prompt tokens
+        # into the initial prefill and per-frame text conditioning stream.
+        formatted = (
+            f"<|im_start|>assistant\n{prompt}<|im_end|>\n"
+            "<|im_start|>assistant\n"
+        )
+        encoded = self.tokenizer(
+            formatted,
+            return_tensors="pt",
+            padding=True,
+        )
+        text_inputs = encoded["input_ids"]
+        if text_inputs.ndim == 2:
+            text_inputs = text_inputs[0]
+
+        language_id = self.config.talker.codec_language_id.get(language, -1)
+        return {
+            "text_inputs": [text_inputs.to(dtype=torch.long)],
+            "speaker_id": [torch.tensor(
+                [self.config.talker.spk_id[speaker]], dtype=torch.long
+            )],
+            "language_id": [torch.tensor([language_id], dtype=torch.long)],
+        }
+
+    # -----------------------------------------------------------------------
+    # Conductor partition state machine
+    # -----------------------------------------------------------------------
+
+    def get_initial_forward_pass_args(
+        self,
+        partition_name: str,
+        input_modalities: list[str],
+        output_modalities: list[str],
+        input_signals: dict[str, list[TensorPointerInfo]],
+        model_kwargs: dict | None = None,
+    ) -> ForwardPassArgs:
+        """Create each partition's initial state.
+
+        Talker starts immediately from API tensors. Codec has no direct API
+        inputs and remains dormant until its incoming streaming connection has
+        enough frames to schedule ``codec_chunk``.
+        """
+        model_kwargs = model_kwargs or {}
+        if partition_name == "Talker":
+            metadata = CurrentForwardConductorMetadata(
+                input_modalities=input_modalities,
+                output_modalities=output_modalities,
+                graph_walk="talker_prefill",
+                is_prefill=True,
+                kwargs={
+                    "talker_max_tokens": self.get_max_output_tokens(**model_kwargs),
+                    "subtalker_sampling": self._get_subtalker_sampling(model_kwargs),
+                },
+            )
+            inputs = []
+            for name in ("text_inputs", "speaker_id", "language_id"):
+                edge = GraphEdge(next_node="Talker", name=name)
+                edge.tensor_info = input_signals.get(name, [])
+                inputs.append(edge)
+            return ForwardPassArgs(
+                full_metadata=metadata,
+                inputs=inputs,
+                unpersist_tensors=sum(
+                    [edge.tensor_info for edge in inputs], start=[]
+                ),
+                request_done="audio" not in output_modalities,
+                step_metadata=self._talker_step_metadata(metadata),
+            )
+
+        if partition_name == "Codec":
+            metadata = CurrentForwardConductorMetadata(
+                input_modalities=input_modalities,
+                output_modalities=output_modalities,
+                graph_walk="codec_chunk",
+                is_prefill=False,
+            )
+            return ForwardPassArgs(
+                full_metadata=metadata,
+                inputs=[],
+                unpersist_tensors=[],
+                request_done="audio" not in output_modalities,
+            )
+        raise ValueError(f"Unknown Qwen3-TTS partition: {partition_name!r}")
+
+    def get_partition_forward_pass_args(
+        self,
+        partition_name: str,
+        partition_metadata: CurrentForwardConductorMetadata,
+        persist_signals: dict[str, list[TensorPointerInfo]],
+        incoming_connections: list[StreamingConnectionState] | None = None,
+    ) -> ForwardPassArgs:
+        """Advance Talker prefill/decode and re-arm the streaming Codec.
+
+        Loop iterations are executed inside the ``talker_decode`` graph walk,
+        so the conductor sees that walk once after its loop stops. Codec is
+        rescheduled by connection readiness rather than an internal walk
+        transition.
+        """
+        del incoming_connections
+        if partition_name == "Talker":
+            if partition_metadata.graph_walk == "talker_prefill":
+                partition_metadata.graph_walk = "talker_decode"
+                partition_metadata.is_prefill = False
+                edge = GraphEdge(next_node="Talker", name="talker_input_embeds")
+                edge.tensor_info = persist_signals.get("talker_input_embeds", [])
+                return ForwardPassArgs(
+                    full_metadata=partition_metadata,
+                    inputs=[edge],
+                    unpersist_tensors=list(edge.tensor_info),
+                    step_metadata=self._talker_step_metadata(partition_metadata),
+                )
+            if partition_metadata.graph_walk == "talker_decode":
+                return ForwardPassArgs(
+                    full_metadata=partition_metadata,
+                    inputs=[],
+                    unpersist_tensors=[],
+                    request_done=True,
+                )
+            raise ValueError(
+                "Talker entered an unexpected graph walk: "
+                f"{partition_metadata.graph_walk!r}"
+            )
+
+        if partition_name == "Codec":
+            partition_metadata.graph_walk = "codec_chunk"
+            return ForwardPassArgs(
+                full_metadata=partition_metadata,
+                inputs=[],
+                unpersist_tensors=[],
+                step_metadata={
+                    "codec_chunk_frames": self.config.codec.chunk_frames,
+                    "codec_left_context_frames": (
+                        self.config.codec.left_context_frames
+                    ),
+                },
+            )
+        raise ValueError(f"Unknown Qwen3-TTS partition: {partition_name!r}")
+
+    # -----------------------------------------------------------------------
+    # Sampling and output encoding
+    # -----------------------------------------------------------------------
+
+    def get_sampling_config(
+        self,
+        node_name: str,
+        model_kwargs: dict | None = None,
+    ) -> SamplingConfig | None:
+        """Configure sampling for codec group 0 predicted by the Talker.
+
+        Residual groups 1-15 use the independent ``subtalker_*`` settings
+        carried in step metadata and consumed by ``TalkerSubmodule``.
+        """
+        if node_name != "Talker":
+            return None
+        model_kwargs = model_kwargs or {}
+        generation = self.config.generation
+        do_sample = model_kwargs.get("do_sample", generation.do_sample)
+        temperature = model_kwargs.get(
+            "temperature",
+            model_kwargs.get("talker_temperature", generation.temperature),
+        )
+        if not do_sample:
+            temperature = 0.0
+        return SamplingConfig(
+            vocab_size=self.config.talker.vocab_size,
+            temperature=temperature,
+            top_k=model_kwargs.get("top_k", generation.top_k),
+            top_p=model_kwargs.get("top_p", generation.top_p),
+            repetition_penalty=model_kwargs.get(
+                "repetition_penalty", generation.repetition_penalty
+            ),
+            ignore_eos=model_kwargs.get("ignore_eos", False),
+        )
+
+    def get_max_output_tokens(self, **model_kwargs: Any) -> int:
+        return model_kwargs.get(
+            "max_output_tokens",
+            model_kwargs.get("max_new_tokens", self.config.generation.max_new_tokens),
+        )
+
+    def get_output_sample_rate(self, modality: str = "audio") -> int:
+        return self.config.codec.output_sample_rate
+
+    def postprocess(
+        self,
+        output: torch.Tensor,
+        modality: str,
+        request_kwargs: dict | None = None,
+    ) -> bytes:
+        """Encode emitted waveform tensors as raw little-endian PCM16 bytes."""
+        del request_kwargs
+        if modality != "audio":
+            raise ValueError(f"Unsupported Qwen3-TTS output modality: {modality!r}")
+        if output.numel() == 0:
+            return b""
+        pcm = output.detach().cpu()
+        if pcm.is_floating_point():
+            pcm = (pcm.clamp(-1, 1) * 32767).to(torch.int16)
+        elif pcm.dtype != torch.int16:
+            pcm = pcm.to(torch.int16)
+        return pcm.contiguous().numpy().tobytes()
+
+    # -----------------------------------------------------------------------
+    # Lazy worker-side submodule and weight loading
+    # -----------------------------------------------------------------------
+
+    def get_submodule(
+        self,
+        node_name: str,
+        device: str = "cpu",
+        tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+        sp_group=None,
+    ) -> NodeSubmodule | None:
+        """Build only the node assigned to this worker and cache the wrapper."""
+        del sp_group
+        if node_name not in self.get_node_engine_types():
+            raise ValueError(f"Unknown Qwen3-TTS node: {node_name!r}")
+        if node_name in self._submodule_cache:
+            return self._submodule_cache[node_name]
+
+        self._ensure_full_snapshot()
+        if node_name == "Talker":
+            submodule = self._create_talker_submodule(
+                device=device,
+                tp_group=tp_group,
+                autocast_dtype=autocast_dtype,
+            )
+        else:
+            submodule = self._create_codec_submodule(device=device)
+        self._submodule_cache[node_name] = submodule
+        return submodule
+
+    @staticmethod
+    def _verify_loaded(
+        module: torch.nn.Module,
+        loaded: set[str],
+        component: str,
+    ) -> None:
+        """Fail startup if checkpoint filtering left any parameter uninitialized."""
+        expected = set(dict(module.named_parameters()))
+        missing = sorted(expected - loaded)
+        if missing:
+            preview = ", ".join(missing[:8])
+            raise RuntimeError(
+                f"{component} checkpoint did not initialize {len(missing)} "
+                f"parameters: {preview}"
+            )
+
+    def _create_talker_submodule(
+        self,
+        device: str,
+        tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+        ) -> NodeSubmodule:
+        from mstar.model.loader import LLAMA_STACKED_PARAMS, load_hf_weights
+        from mstar.model.loader.iterators import iter_safetensors_shards
+        from mstar.model.qwen3_tts.components.talker import (
+            Qwen3TTSCodePredictor,
+            Qwen3TTSTalkerModel,
+        )
+        from mstar.model.qwen3_tts.submodules import TalkerSubmodule
+
+        # Construct on meta first so worker startup never holds both a random
+        # initialization and checkpoint tensors in device memory.
+        with torch.device("meta"):
+            talker = Qwen3TTSTalkerModel(self.config, comm_group=tp_group)
+        if autocast_dtype is not None:
+            talker = talker.to(autocast_dtype)
+        talker.to_empty(device=device)
+
+        # The top-level checkpoint interleaves Talker and CodePredictor under
+        # ``talker.*``. Stream only the non-CodePredictor keys into this model.
+        def talker_weights():
+            for name, tensor in iter_safetensors_shards(
+                self.local_dir, device=device, prefix="talker."
+            ):
+                if not name.startswith("talker.code_predictor."):
+                    yield name.removeprefix("talker."), tensor
+
+        loaded = load_hf_weights(
+            talker,
+            talker_weights(),
+            stacked_params=LLAMA_STACKED_PARAMS,
+        )
+        self._verify_loaded(talker, loaded, "Qwen3-TTS Talker")
+        talker.eval()
+
+        # CodePredictor is small and depth-wise. It is loaded separately from
+        # ``talker.code_predictor.*`` and remains replicated under Talker TP.
+        with torch.device("meta"):
+            code_predictor = Qwen3TTSCodePredictor(self.config)
+        if autocast_dtype is not None:
+            code_predictor = code_predictor.to(autocast_dtype)
+        code_predictor.to_empty(device=device)
+        cp_prefix = "talker.code_predictor."
+        cp_weights = (
+            (name.removeprefix(cp_prefix), tensor)
+            for name, tensor in iter_safetensors_shards(
+                self.local_dir, device=device, prefix=cp_prefix
+            )
+        )
+        loaded = load_hf_weights(
+            code_predictor,
+            cp_weights,
+            stacked_params=LLAMA_STACKED_PARAMS,
+        )
+        self._verify_loaded(
+            code_predictor, loaded, "Qwen3-TTS CodePredictor"
+        )
+        # Piecewise CUDA Graph execution indexes all residual LM heads as one
+        # tensor; consolidate after the individual checkpoint heads are loaded.
+        code_predictor.consolidate_stacked_weights()
+        code_predictor.eval()
+        return TalkerSubmodule(talker, code_predictor, self.config)
+
+    def _create_codec_submodule(self, device: str) -> NodeSubmodule:
+        """Build the official speech-tokenizer decoder from its sub-checkpoint."""
+        try:
+            from qwen_tts.core.tokenizer_12hz.configuration_qwen3_tts_tokenizer_v2 import (
+                Qwen3TTSTokenizerV2DecoderConfig,
+            )
+            from qwen_tts.core.tokenizer_12hz.modeling_qwen3_tts_tokenizer_v2 import (
+                Qwen3TTSTokenizerV2Decoder,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "Qwen3-TTS Codec requires the 'qwen-tts' package; install "
+                "M* with the qwen3_tts optional dependency"
+            ) from exc
+
+        from mstar.model.loader import load_hf_weights
+        from mstar.model.loader.iterators import iter_safetensors_shards
+        from mstar.model.qwen3_tts.submodules import CodecSubmodule
+
+        # Reuse the official decoder implementation, but keep graph scheduling,
+        # chunk padding, overlap trimming, and output transport in M*.
+        decoder_config = Qwen3TTSTokenizerV2DecoderConfig(
+            **self.config.codec.decoder_kwargs()
+        )
+        with torch.device("meta"):
+            decoder = Qwen3TTSTokenizerV2Decoder(decoder_config)
+        decoder.to_empty(device=device)
+
+        codec_dir = Path(self.local_dir) / "speech_tokenizer"
+        prefix = "decoder."
+        weights = (
+            (name.removeprefix(prefix), tensor)
+            for name, tensor in iter_safetensors_shards(
+                codec_dir, device=device, prefix=prefix
+            )
+        )
+        loaded = load_hf_weights(decoder, weights)
+        self._verify_loaded(decoder, loaded, "Qwen3-TTS Codec")
+        decoder.eval()
+        return CodecSubmodule(decoder, self.config)
+
+    def _get_subtalker_sampling(self, model_kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Resolve sampling controls for residual codec groups 1 through 15."""
+        generation = self.config.generation
+        do_sample = model_kwargs.get(
+            "subtalker_dosample", generation.subtalker_dosample
+        )
+        return {
+            "do_sample": do_sample,
+            "temperature": (
+                model_kwargs.get(
+                    "subtalker_temperature", generation.subtalker_temperature
+                )
+                if do_sample
+                else 0.0
+            ),
+            "top_k": model_kwargs.get("subtalker_top_k", generation.subtalker_top_k),
+            "top_p": model_kwargs.get("subtalker_top_p", generation.subtalker_top_p),
+        }
+
+    @staticmethod
+    def _talker_step_metadata(
+        metadata: CurrentForwardConductorMetadata,
+    ) -> dict[str, Any]:
+        """Copy conductor-owned generation controls into worker step metadata."""
+        return {
+            "is_prefill": metadata.is_prefill,
+            "talker_max_tokens": metadata.kwargs["talker_max_tokens"],
+            "subtalker_sampling": metadata.kwargs["subtalker_sampling"],
+        }

--- a/mstar/model/qwen3_tts/qwen3_tts_model.py
+++ b/mstar/model/qwen3_tts/qwen3_tts_model.py
@@ -22,7 +22,12 @@ and partition declarations, state-machine transitions, sampling defaults, and
 lazy worker-side construction. Heavy weights are not loaded in ``__init__``.
 """
 
+import importlib
+import importlib.metadata
+import sys
+from importlib.machinery import ModuleSpec
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import torch
@@ -82,6 +87,57 @@ def _resolve_model_metadata(repo_id: str, cache_dir: str | None) -> str:
             "merges.txt",
             "speech_tokenizer/config.json",
         ],
+    )
+
+
+def _load_qwen3_tts_decoder_classes() -> tuple[type, type]:
+    """Load only qwen-tts' 12 Hz decoder modules.
+
+    ``qwen_tts.__init__`` eagerly imports its high-level inference package,
+    which in turn imports the unrelated 25 Hz tokenizer and pysox.  Pysox
+    probes for a system ``sox`` executable at import time and emits a warning
+    even though the 12 Hz decoder used here never calls it.  Registering the
+    installed package directories as namespace packages lets Python import the
+    two exact upstream modules without executing those broad ``__init__``
+    files.  If another caller already imported qwen_tts, preserve that module
+    and use normal imports.
+    """
+    if "qwen_tts" not in sys.modules:
+        try:
+            distribution = importlib.metadata.distribution("qwen-tts")
+        except importlib.metadata.PackageNotFoundError as exc:
+            raise ImportError(
+                "Qwen3-TTS Codec requires the 'qwen-tts' package; install "
+                "M* with the qwen3_tts optional dependency"
+            ) from exc
+
+        package_root = Path(distribution.locate_file("qwen_tts"))
+        package_paths = (
+            ("qwen_tts", package_root),
+            ("qwen_tts.core", package_root / "core"),
+            (
+                "qwen_tts.core.tokenizer_12hz",
+                package_root / "core" / "tokenizer_12hz",
+            ),
+        )
+        for name, path in package_paths:
+            module = ModuleType(name)
+            module.__package__ = name
+            module.__path__ = [str(path)]
+            spec = ModuleSpec(name, loader=None, is_package=True)
+            spec.submodule_search_locations = module.__path__
+            module.__spec__ = spec
+            sys.modules[name] = module
+
+    config_module = importlib.import_module(
+        "qwen_tts.core.tokenizer_12hz.configuration_qwen3_tts_tokenizer_v2"
+    )
+    model_module = importlib.import_module(
+        "qwen_tts.core.tokenizer_12hz.modeling_qwen3_tts_tokenizer_v2"
+    )
+    return (
+        config_module.Qwen3TTSTokenizerV2DecoderConfig,
+        model_module.Qwen3TTSTokenizerV2Decoder,
     )
 
 
@@ -660,12 +716,10 @@ class Qwen3TTSModel(Model):
     def _create_codec_submodule(self, device: str) -> NodeSubmodule:
         """Build the official speech-tokenizer decoder from its sub-checkpoint."""
         try:
-            from qwen_tts.core.tokenizer_12hz.configuration_qwen3_tts_tokenizer_v2 import (
+            (
                 Qwen3TTSTokenizerV2DecoderConfig,
-            )
-            from qwen_tts.core.tokenizer_12hz.modeling_qwen3_tts_tokenizer_v2 import (
                 Qwen3TTSTokenizerV2Decoder,
-            )
+            ) = _load_qwen3_tts_decoder_classes()
         except ImportError as exc:
             raise ImportError(
                 "Qwen3-TTS Codec requires the 'qwen-tts' package; install "

--- a/mstar/model/qwen3_tts/qwen3_tts_model.py
+++ b/mstar/model/qwen3_tts/qwen3_tts_model.py
@@ -22,12 +22,11 @@ and partition declarations, state-machine transitions, sampling defaults, and
 lazy worker-side construction. Heavy weights are not loaded in ``__init__``.
 """
 
-import importlib
 import importlib.metadata
+import importlib.util
 import sys
-from importlib.machinery import ModuleSpec
+from functools import lru_cache
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 
 import torch
@@ -90,51 +89,68 @@ def _resolve_model_metadata(repo_id: str, cache_dir: str | None) -> str:
     )
 
 
+@lru_cache(maxsize=1)
 def _load_qwen3_tts_decoder_classes() -> tuple[type, type]:
     """Load only qwen-tts' 12 Hz decoder modules.
 
     ``qwen_tts.__init__`` eagerly imports its high-level inference package,
     which in turn imports the unrelated 25 Hz tokenizer and pysox.  Pysox
     probes for a system ``sox`` executable at import time and emits a warning
-    even though the 12 Hz decoder used here never calls it.  Registering the
-    installed package directories as namespace packages lets Python import the
-    two exact upstream modules without executing those broad ``__init__``
-    files.  If another caller already imported qwen_tts, preserve that module
-    and use normal imports.
+    even though the 12 Hz decoder used here never calls it. Load the two exact
+    source files under an M*-private package name so their relative import
+    works without executing those broad ``__init__`` files or claiming the
+    public ``qwen_tts`` names in ``sys.modules``.
     """
-    if "qwen_tts" not in sys.modules:
-        try:
-            distribution = importlib.metadata.distribution("qwen-tts")
-        except importlib.metadata.PackageNotFoundError as exc:
-            raise ImportError(
-                "Qwen3-TTS Codec requires the 'qwen-tts' package; install "
-                "M* with the qwen3_tts optional dependency"
-            ) from exc
+    try:
+        distribution = importlib.metadata.distribution("qwen-tts")
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise ImportError(
+            "Qwen3-TTS Codec requires the 'qwen-tts' package; install "
+            "M* with the qwen3_tts optional dependency"
+        ) from exc
 
-        package_root = Path(distribution.locate_file("qwen_tts"))
-        package_paths = (
-            ("qwen_tts", package_root),
-            ("qwen_tts.core", package_root / "core"),
-            (
-                "qwen_tts.core.tokenizer_12hz",
-                package_root / "core" / "tokenizer_12hz",
-            ),
+    source_root = Path(distribution.locate_file(
+        "qwen_tts/core/tokenizer_12hz"
+    ))
+    private_package = "_mstar_qwen3_tts_tokenizer_12hz"
+    config_name = (
+        f"{private_package}.configuration_qwen3_tts_tokenizer_v2"
+    )
+    model_name = f"{private_package}.modeling_qwen3_tts_tokenizer_v2"
+    loaded_names = [private_package, config_name, model_name]
+
+    package_spec = importlib.util.spec_from_file_location(
+        private_package,
+        source_root / "__init__.py",
+        submodule_search_locations=[str(source_root)],
+    )
+    if package_spec is None:
+        raise ImportError(f"Cannot load qwen-tts package from {source_root}")
+    sys.modules[private_package] = importlib.util.module_from_spec(package_spec)
+
+    def load_private_module(name: str, path: Path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load qwen-tts module from {path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+
+    try:
+        config_module = load_private_module(
+            config_name,
+            source_root / "configuration_qwen3_tts_tokenizer_v2.py",
         )
-        for name, path in package_paths:
-            module = ModuleType(name)
-            module.__package__ = name
-            module.__path__ = [str(path)]
-            spec = ModuleSpec(name, loader=None, is_package=True)
-            spec.submodule_search_locations = module.__path__
-            module.__spec__ = spec
-            sys.modules[name] = module
+        model_module = load_private_module(
+            model_name,
+            source_root / "modeling_qwen3_tts_tokenizer_v2.py",
+        )
+    except Exception:
+        for name in loaded_names:
+            sys.modules.pop(name, None)
+        raise
 
-    config_module = importlib.import_module(
-        "qwen_tts.core.tokenizer_12hz.configuration_qwen3_tts_tokenizer_v2"
-    )
-    model_module = importlib.import_module(
-        "qwen_tts.core.tokenizer_12hz.modeling_qwen3_tts_tokenizer_v2"
-    )
     return (
         config_module.Qwen3TTSTokenizerV2DecoderConfig,
         model_module.Qwen3TTSTokenizerV2Decoder,
@@ -212,9 +228,9 @@ class Qwen3TTSModel(Model):
             max_seq_len=talker.max_position_embeddings,
             num_qo_heads=talker.num_attention_heads,
             nodes=["Talker"],
-            # FlashInfer 0.6.x auto-selects an FA3 JIT kernel on Hopper. The
-            # supported deployment toolchain uses the compatible FA2 kernel.
-            flashinfer_backend="fa2",
+            # Keep the model portable: deployment YAML may pin FA2 when its
+            # toolchain cannot build the Hopper FA3 JIT kernels.
+            flashinfer_backend="auto",
         )]
 
     def get_node_engine_types(self) -> dict[str, EngineType]:
@@ -384,6 +400,13 @@ class Qwen3TTSModel(Model):
             )
 
         language = str(kwargs.get("language", self.config.default_language)).lower()
+        dialect = self.config.talker.spk_is_dialect.get(speaker, False)
+        if dialect and language in {"auto", "chinese"}:
+            language = str(dialect).lower()
+
+        # Validate after applying the speaker's dialect. Otherwise a malformed
+        # dialect mapping falls through ``dict.get(..., -1)`` below and silently
+        # degrades to automatic language selection.
         if language != "auto" and language not in self.config.talker.codec_language_id:
             supported = ", ".join(
                 ["auto", *sorted(self.config.talker.codec_language_id)]
@@ -391,10 +414,6 @@ class Qwen3TTSModel(Model):
             raise ValueError(
                 f"Unsupported Qwen3-TTS language {language!r}; supported: {supported}"
             )
-
-        dialect = self.config.talker.spk_is_dialect.get(speaker, False)
-        if dialect and language in {"auto", "chinese"}:
-            language = str(dialect)
 
         # Match the official processor template exactly. `_build_prefill`
         # relies on the fixed assistant suffix when separating prompt tokens

--- a/mstar/model/qwen3_tts/submodules.py
+++ b/mstar/model/qwen3_tts/submodules.py
@@ -1,0 +1,1040 @@
+# ---------------------------------------------------------------------------
+# NodeSubmodule wrappers for Qwen3-TTS
+# ---------------------------------------------------------------------------
+#
+# Two submodules cover the complete text-to-speech streaming pipeline:
+#   1. TalkerSubmodule (KV_CACHE engine)
+#      - Builds the official text/voice prefill sequence.
+#      - Maintains the Talker paged KV cache across 12 Hz decode steps.
+#      - Predicts codec group 0 with the Talker and groups 1-15 with the
+#        depth-wise CodePredictor.
+#      - Supports continuous batching, whole-forward decode CUDA Graphs, and
+#        a piecewise CUDA Graph for the CodePredictor inner loop.
+#   2. CodecSubmodule (STATELESS engine)
+#      - Receives buffered codec frames from the Talker partition.
+#      - Pads variable final tails to fixed CUDA Graph capture shapes.
+#      - Runs the official speech-tokenizer decoder and trims overlap before
+#        emitting 24 kHz PCM.
+#
+# Engine-facing lifecycle:
+#   prepare_inputs -> preprocess -> forward/forward_batched
+#                  -> postprocess -> check_stop (Talker only)
+#
+# Streaming topology:
+#   Talker --[codec_tokens, LeftContextChunkPolicy(300, 25)]--> Codec
+# ---------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from mstar.communication.tensors import NameToTensorList
+from mstar.conductor.request_info import CurrentForwardPassInfo
+from mstar.engine.base import NodeBatch
+from mstar.engine.cuda_graph_config import (
+    BasicBatchedCudaGraphConfig,
+    PiecewiseBatchedConfig,
+    PiecewiseCaptureShape,
+    PiecewiseCudaGraphConfig,
+)
+from mstar.engine.kv_store import PositionInfo
+from mstar.model.qwen3_tts.components.talker import (
+    Qwen3TTSCodePredictor,
+    Qwen3TTSTalkerModel,
+)
+from mstar.model.qwen3_tts.config import Qwen3TTSModelConfig
+from mstar.model.submodule_base import (
+    ARNodeInputs,
+    ARNodeSubmodule,
+    ModelInputsFromEngine,
+    NodeInputs,
+)
+from mstar.utils.sampling import SeenTokenMask
+
+# ===========================================================================
+# 1. TalkerSubmodule - autoregressive 12 Hz codec-frame generation
+# ===========================================================================
+
+
+class TalkerSubmodule(ARNodeSubmodule):
+    """Run text/voice prefill and produce one 16-code frame per AR step.
+
+    Codec group 0 is sampled from the main Talker head. The residual
+    CodePredictor then walks groups 1-15 within the same frame. The sum of all
+    16 codec embeddings becomes the recurrent input for the next Talker step;
+    the complete code vector is streamed independently to ``CodecSubmodule``.
+    """
+
+    MAX_BATCH_SIZE = 32
+    DECODE_CAPTURE_BATCH_SIZES = [1, 2, 4, 8, 16, 32]
+
+    def __init__(
+        self,
+        talker_model: Qwen3TTSTalkerModel,
+        code_predictor: Qwen3TTSCodePredictor,
+        config: Qwen3TTSModelConfig,
+    ) -> None:
+        super().__init__()
+        self.model = talker_model
+        self.code_predictor = code_predictor
+        self.config = config
+        self.talker_config = config.talker
+        self.cp_config = config.talker.code_predictor
+        self.num_codes = config.talker.num_code_groups
+        self._suppress_mask: torch.Tensor | None = None
+        self._cp_kv_cache: torch.Tensor | None = None
+
+    def _get_suppress_mask(self) -> torch.Tensor:
+        """Cache the checkpoint's static invalid-token mask on the worker GPU."""
+        if self._suppress_mask is None:
+            vocab_size = self.talker_config.vocab_size
+            mask = torch.zeros(
+                vocab_size, dtype=torch.bool, device=self.get_device()
+            )
+            mask[max(0, vocab_size - 1024):] = True
+            eos = self.talker_config.codec_eos_token_id
+            if 0 <= eos < vocab_size:
+                mask[eos] = False
+            self._suppress_mask = mask
+        return self._suppress_mask
+
+    def _get_batch_suppress_mask(
+        self, request_ids: list[str]
+    ) -> torch.Tensor:
+        """Apply request-local minimum-length EOS suppression to the base mask."""
+        mask = self._get_suppress_mask().unsqueeze(0).expand(
+            len(request_ids), -1
+        ).clone()
+        eos = self.talker_config.codec_eos_token_id
+        if 0 <= eos < mask.shape[1]:
+            mask[:, eos] = torch.tensor(
+                [
+                    int(self.request_state(request_id).get("generated_frames", 0))
+                    < self.config.generation.min_new_tokens
+                    for request_id in request_ids
+                ],
+                dtype=torch.bool,
+                device=mask.device,
+            )
+        return mask
+
+    def _get_cp_kv_cache(self, batch_size: int) -> torch.Tensor:
+        """Return the fixed CodePredictor scratch cache for this micro-batch.
+
+        CodePredictor attention is local to one 16-group frame, so this cache
+        does not belong to the engine's cross-step paged KV cache. A maximum
+        batch allocation is reused and overwritten for every Talker step,
+        which also gives the piecewise CUDA Graph stable addresses.
+        """
+        expected = (
+            self.cp_config.num_hidden_layers,
+            self.MAX_BATCH_SIZE,
+            2,
+            self.num_codes,
+            self.cp_config.num_key_value_heads,
+            self.cp_config.head_dim,
+        )
+        if self._cp_kv_cache is None:
+            self._cp_kv_cache = torch.empty(
+                expected,
+                dtype=self.model.model.codec_embedding.weight.dtype,
+                device=self.get_device(),
+            )
+        return self._cp_kv_cache[:, :batch_size]
+
+    def _project_text(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """Map tokenizer embeddings into the Talker hidden width."""
+        text_hidden = self.model.model.text_embedding(token_ids)
+        projection_dtype = self.model.text_projection.linear_fc1.weight.dtype
+        return self.model.text_projection(text_hidden.to(projection_dtype))
+
+    def _special_text_embeds(
+        self, dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Project TTS BOS/EOS/PAD once for official sequence construction."""
+        token_ids = torch.tensor(
+            [[
+                self.config.tts_bos_token_id,
+                self.config.tts_eos_token_id,
+                self.config.tts_pad_token_id,
+            ]],
+            dtype=torch.long,
+            device=self.get_device(),
+        )
+        bos, eos, pad = self._project_text(token_ids).to(dtype).chunk(3, dim=1)
+        return bos, eos, pad
+
+    def _build_prefill(
+        self,
+        request_id: str,
+        text_ids: torch.Tensor,
+        speaker_id: int,
+        language_id: int,
+    ) -> torch.Tensor:
+        """Build the official mixed text/codec prefill embedding sequence.
+
+        The assistant-role prefix and codec conditioning tags enter the
+        one-shot prefill. Remaining prompt text is retained in per-request
+        state and added one token at a time to later recurrent codec embeds.
+        This aligns text progress with the 12 Hz acoustic generation steps.
+        """
+        text_ids = text_ids.to(device=self.get_device(), dtype=torch.long).view(1, -1)
+        if text_ids.shape[1] < 9:
+            raise ValueError(
+                "Qwen3-TTS formatted prompt is shorter than its fixed chat suffix"
+            )
+
+        codec = self.talker_config
+        codec_prefix = (
+            [codec.codec_nothink_id, codec.codec_think_bos_id, codec.codec_think_eos_id]
+            if language_id < 0
+            else [
+                codec.codec_think_id,
+                codec.codec_think_bos_id,
+                language_id,
+                codec.codec_think_eos_id,
+            ]
+        )
+        codec_ids = torch.tensor(
+            [[*codec_prefix, speaker_id, codec.codec_pad_id, codec.codec_bos_id]],
+            dtype=torch.long,
+            device=self.get_device(),
+        )
+        codec_embeds = self.model.model.codec_embedding(codec_ids)
+        bos_embed, eos_embed, pad_embed = self._special_text_embeds(
+            codec_embeds.dtype
+        )
+
+        # Prefix layout mirrors the official CustomVoice generation helper:
+        # assistant role, language/voice codec tags, then first text token.
+        role_embed = self._project_text(text_ids[:, :3]).to(codec_embeds.dtype)
+        tag_text = torch.cat([
+            pad_embed.expand(-1, codec_embeds.shape[1] - 2, -1),
+            bos_embed,
+        ], dim=1)
+        tag_embed = tag_text + codec_embeds[:, :-1]
+        first_text = (
+            self._project_text(text_ids[:, 3:4]).to(codec_embeds.dtype)
+            + codec_embeds[:, -1:]
+        )
+        prefill = torch.cat([role_embed, tag_embed, first_text], dim=1)
+
+        # The fixed five-token ChatML suffix is replaced by projected TTS EOS.
+        # Decode consumes this tensor by ``generation_step`` and uses PAD once
+        # the text condition has been exhausted.
+        trailing = torch.cat([
+            self._project_text(text_ids[:, 4:-5]).to(codec_embeds.dtype),
+            eos_embed,
+        ], dim=1)
+        self.request_state(request_id).add_all(
+            trailing_text_hidden=trailing.squeeze(0),
+            tts_pad_embed=pad_embed[0, 0],
+            generation_step=0,
+            generated_frames=0,
+        )
+        return prefill.squeeze(0)
+
+    def prepare_inputs(
+        self,
+        graph_walk: str,
+        fwd_info: CurrentForwardPassInfo,
+        inputs: NameToTensorList,
+        seen_token_mask: SeenTokenMask | None = None,
+        pos_info: dict[str, PositionInfo] = {},
+        **kwargs: Any,
+    ) -> ARNodeInputs:
+        """Convert routed request tensors into one Talker sequence fragment.
+
+        Prefill creates the mixed conditioning sequence. Decode combines the
+        previous frame's summed codec embedding with the next projected text
+        condition. This method performs no transformer compute; the engine can
+        therefore prepare requests before admitting them to a micro-batch.
+        """
+        del seen_token_mask, pos_info, kwargs
+        if graph_walk == "talker_prefill":
+            input_embeds = self._build_prefill(
+                fwd_info.request_id,
+                inputs["text_inputs"][0],
+                int(inputs["speaker_id"][0].item()),
+                int(inputs["language_id"][0].item()),
+            )
+        elif graph_walk == "talker_decode":
+            state = self.request_state(fwd_info.request_id)
+            step = int(state["generation_step"])
+            trailing = state["trailing_text_hidden"]
+            text_condition = (
+                trailing[step]
+                if step < trailing.shape[0]
+                else state["tts_pad_embed"]
+            )
+            # ``talker_input_embeds`` is the recurrent graph edge emitted by
+            # the previous frame, not a token ID that needs another lookup.
+            input_embeds = inputs["talker_input_embeds"][0].to(
+                device=self.get_device(),
+                dtype=text_condition.dtype,
+            ).reshape(1, -1)
+            input_embeds = input_embeds + text_condition
+            state.add("generation_step", step + 1)
+        else:
+            raise ValueError(f"Unknown Qwen3-TTS Talker walk: {graph_walk!r}")
+
+        return ARNodeInputs(
+            input_embeds=input_embeds,
+            input_seq_len=input_embeds.shape[0],
+        )
+
+    def preprocess(
+        self,
+        graph_walk: str,
+        engine_inputs: ModelInputsFromEngine,
+        inputs: list[ARNodeInputs],
+    ) -> dict[str, torch.Tensor | Any]:
+        """Pack a continuous batch and plan request-specific paged attention.
+
+        Prefill sequences may have different lengths, so embeddings are
+        concatenated into one packed tensor. ``last_token_indices`` maps each
+        request back to the hidden state used for codec-group-0 prediction.
+        FlashInfer receives separate sequence lengths and KV page tables.
+        """
+        del graph_walk
+        cache_manager = engine_inputs.cache_manager
+        assert cache_manager is not None
+        cache_manager.set_active_label("main")
+        seq_lens = [item.input_seq_len for item in inputs]
+        cache_manager.plan_attention(seq_lens=seq_lens, is_causal=True, label="main")
+        cache_manager.plan_rope(seq_lens=seq_lens, pos_ids=None, label="main")
+        return {
+            "input_embeds": torch.cat([
+                item.input_embeds for item in inputs if item.input_embeds is not None
+            ], dim=0),
+            "last_token_indices": (
+                torch.tensor(seq_lens, device=self.get_device()).cumsum(0) - 1
+            ),
+            "suppress_mask": self._get_batch_suppress_mask(
+                engine_inputs.request_ids
+            ),
+        }
+
+    @staticmethod
+    def _sample_code_predictor(
+        sampler,
+        logits: torch.Tensor,
+        sampling: dict[str, Any],
+    ) -> torch.Tensor:
+        """Eager fallback sampler for one residual codec group."""
+        temperature = float(sampling.get("temperature", 0.9))
+        if not sampling.get("do_sample", True) or temperature <= 0:
+            return sampler._broadcast_tokens(logits.argmax(dim=-1))
+        return sampler.sample_with_config(
+            logits=logits,
+            temperature=temperature,
+            top_k=int(sampling.get("top_k", 50)),
+            top_p=float(sampling.get("top_p", 1.0)),
+        )
+
+    @staticmethod
+    def _sample_from_uniform(
+        logits: torch.Tensor,
+        uniform: torch.Tensor,
+        temperature: torch.Tensor,
+        top_k: torch.Tensor,
+        top_p: torch.Tensor,
+        do_sample: torch.Tensor,
+    ) -> torch.Tensor:
+        """Graph-safe batched top-k/top-p sampling from supplied uniforms."""
+        vocab_size = logits.shape[-1]
+        greedy = logits.argmax(dim=-1)
+        safe_temperature = torch.where(
+            do_sample,
+            temperature.clamp_min(1e-5),
+            torch.ones_like(temperature),
+        ).unsqueeze(1)
+        sorted_logits, sorted_indices = torch.sort(
+            logits / safe_temperature, dim=-1, descending=True
+        )
+        positions = torch.arange(vocab_size, device=logits.device).unsqueeze(0)
+        effective_top_k = torch.where(
+            top_k > 0,
+            top_k.clamp_max(vocab_size),
+            torch.full_like(top_k, vocab_size),
+        )
+        sorted_logits = sorted_logits.masked_fill(
+            positions >= effective_top_k.unsqueeze(1), float("-inf")
+        )
+        probs = torch.softmax(sorted_logits, dim=-1)
+        cumulative = probs.cumsum(dim=-1)
+        remove = cumulative - probs > top_p.clamp_min(1e-6).unsqueeze(1)
+        probs = probs.masked_fill(remove, 0)
+        probs = probs / probs.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+        cdf = probs.cumsum(dim=-1)
+        sampled_rank = (cdf < uniform.unsqueeze(1)).sum(dim=-1)
+        sampled_rank = sampled_rank.clamp_max(vocab_size - 1)
+        sampled = sorted_indices.gather(1, sampled_rank.unsqueeze(1)).squeeze(1)
+        return torch.where(do_sample, sampled, greedy).to(torch.long)
+
+    def _run_code_predictor_tensor_loop(
+        self,
+        last_hidden: torch.Tensor,
+        layer0_codes: torch.Tensor,
+        uniforms: torch.Tensor,
+        temperature: torch.Tensor,
+        top_k: torch.Tensor,
+        top_p: torch.Tensor,
+        do_sample: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Predict residual groups 1-15 with graph-safe tensor operations.
+
+        Random uniforms and sampling parameters are inputs, rather than being
+        created in this function, so CUDA Graph replay changes samples without
+        recapturing the depth loop.
+        """
+        batch_size = layer0_codes.shape[0]
+        all_codes = torch.empty(
+            batch_size,
+            self.num_codes,
+            dtype=torch.long,
+            device=layer0_codes.device,
+        )
+        all_codes[:, 0] = layer0_codes
+        codec_embed = self.model.model.codec_embedding(layer0_codes)
+        codec_embed_sum = codec_embed.clone()
+        cp_cache = self._get_cp_kv_cache(batch_size)
+        pos = torch.zeros(
+            batch_size, 1, dtype=torch.long, device=layer0_codes.device
+        )
+        # Position 0 conditions the depth decoder on the Talker hidden state.
+        # Each following position consumes the previous group's embedding.
+        self.code_predictor.forward_depth_unrolled(
+            last_hidden.unsqueeze(1), pos, cp_cache, cache_pos=0
+        )
+        for group_idx in range(1, self.num_codes):
+            pos.fill_(group_idx)
+            cp_hidden = self.code_predictor.forward_depth_unrolled(
+                codec_embed.unsqueeze(1), pos, cp_cache, cache_pos=group_idx
+            ).squeeze(1)
+            cp_logits = torch.matmul(
+                cp_hidden,
+                self.code_predictor.lm_head_weight[group_idx - 1].t(),
+            )
+            codes = self._sample_from_uniform(
+                cp_logits,
+                uniforms[:, group_idx - 1],
+                temperature,
+                top_k,
+                top_p,
+                do_sample,
+            )
+            all_codes[:, group_idx] = codes
+            codec_embed = self.code_predictor.model.codec_embedding[
+                group_idx - 1
+            ](codes)
+            codec_embed_sum.add_(codec_embed)
+        return all_codes, codec_embed_sum
+
+    def _code_predictor_piecewise_capture(
+        self,
+        static_inputs: dict[str, torch.Tensor],
+        static_cm=None,
+    ) -> dict[str, torch.Tensor]:
+        """Piecewise capture entry point for the hot residual-code depth loop."""
+        del static_cm
+        all_codes, codec_embed_sum = self._run_code_predictor_tensor_loop(
+            last_hidden=static_inputs["last_hidden"],
+            layer0_codes=static_inputs["layer0_codes"],
+            uniforms=static_inputs["uniforms"],
+            temperature=static_inputs["temperature"],
+            top_k=static_inputs["top_k"],
+            top_p=static_inputs["top_p"],
+            do_sample=static_inputs["do_sample"],
+        )
+        return {
+            "all_codes": all_codes,
+            "codec_embed_sum": codec_embed_sum,
+        }
+
+    def _piecewise_sampling_inputs(
+        self,
+        engine_inputs: ModelInputsFromEngine,
+        sampling: dict[str, Any],
+    ) -> dict[str, torch.Tensor]:
+        """Generate per-request RNG and dynamic sampling tensors before replay.
+
+        A persistent generator preserves each request's random stream across
+        changing micro-batches. Distributed workers broadcast the uniforms so
+        replicated CodePredictors choose identical residual codes.
+        """
+        batch_size = len(engine_inputs.request_ids)
+        device = self.get_device()
+        uniforms = []
+        for request_id in engine_inputs.request_ids:
+            state = self.request_state(request_id)
+            generator = state.get("code_predictor_generator")
+            if generator is None:
+                generator = torch.Generator(device=device)
+                generator.manual_seed(
+                    int(engine_inputs.per_request_info[request_id].random_seed)
+                )
+                state.add("code_predictor_generator", generator)
+            uniforms.append(torch.rand(
+                self.num_codes - 1,
+                dtype=torch.float32,
+                device=device,
+                generator=generator,
+            ))
+        uniform_tensor = torch.stack(uniforms)
+        sampler = engine_inputs.sampler
+        assert sampler is not None
+        uniform_tensor = sampler._broadcast_tokens(uniform_tensor)
+        return {
+            "uniforms": uniform_tensor,
+            "temperature": torch.full(
+                (batch_size,),
+                float(sampling.get("temperature", 0.9)),
+                dtype=torch.float32,
+                device=device,
+            ),
+            "top_k": torch.full(
+                (batch_size,),
+                int(sampling.get("top_k", 50)),
+                dtype=torch.long,
+                device=device,
+            ),
+            "top_p": torch.full(
+                (batch_size,),
+                float(sampling.get("top_p", 1.0)),
+                dtype=torch.float32,
+                device=device,
+            ),
+            "do_sample": torch.full(
+                (batch_size,),
+                bool(sampling.get("do_sample", True)),
+                dtype=torch.bool,
+                device=device,
+            ),
+        }
+
+    def _run_code_predictor_piecewise(
+        self,
+        engine_inputs: ModelInputsFromEngine,
+        last_hidden: torch.Tensor,
+        layer0_codes: torch.Tensor,
+        sampling: dict[str, Any],
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        """Replay the captured depth loop, or signal the caller to use eager."""
+        runner = engine_inputs.piecewise_runners.get("code_predictor_loop")
+        batch_size = layer0_codes.shape[0]
+        if runner is None or not runner.can_run(batch_size=batch_size):
+            return None
+        static_inputs = self._piecewise_sampling_inputs(engine_inputs, sampling)
+        static_inputs.update({
+            "last_hidden": last_hidden,
+            "layer0_codes": layer0_codes,
+        })
+        output = runner.run(static_inputs=static_inputs, real_bs=batch_size)
+        sampler = engine_inputs.sampler
+        assert sampler is not None
+        all_codes = sampler._broadcast_tokens(output["all_codes"])
+        codec_embed_sum = sampler._broadcast_tokens(output["codec_embed_sum"])
+        return all_codes, codec_embed_sum
+
+    def _run_frame(
+        self,
+        engine_inputs: ModelInputsFromEngine,
+        input_embeds: torch.Tensor,
+        last_token_indices: torch.Tensor,
+        suppress_mask: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        """Produce one complete codec frame for every request in the batch.
+
+        The main Talker advances the engine-managed KV cache and predicts group
+        0. The CodePredictor fills residual groups through the piecewise graph
+        when available, with the identical eager loop as a fallback.
+        """
+        hidden = self.model(input_embeds, engine_inputs.cache_manager)
+        last_hidden = hidden.index_select(0, last_token_indices)
+        logits = self.model.codec_head(last_hidden)
+        logits = logits.masked_fill(suppress_mask, float("-inf"))
+        sampler = engine_inputs.sampler
+        assert sampler is not None
+        layer0_codes = sampler.sample(
+            engine_inputs.request_ids, logits, apply_penalty=True
+        )
+
+        sampling = engine_inputs.first_request_info.step_metadata.get(
+            "subtalker_sampling", {}
+        )
+        piecewise_result = self._run_code_predictor_piecewise(
+            engine_inputs=engine_inputs,
+            last_hidden=last_hidden,
+            layer0_codes=layer0_codes,
+            sampling=sampling,
+        )
+        if piecewise_result is not None:
+            all_codes, codec_embed_sum = piecewise_result
+            return {
+                "talker_input_embeds": codec_embed_sum,
+                "codec_tokens": all_codes,
+                "new_token": layer0_codes,
+            }
+
+        # Eager fallback mirrors `_run_code_predictor_tensor_loop`. It uses the
+        # engine sampler directly because this path is outside CUDA capture.
+        batch_size = layer0_codes.shape[0]
+        all_codes = torch.empty(
+            batch_size, self.num_codes, dtype=torch.long, device=logits.device
+        )
+        all_codes[:, 0] = layer0_codes
+        codec_embed = self.model.model.codec_embedding(layer0_codes)
+        codec_embed_sum = codec_embed.clone()
+
+        cp_cache = self._get_cp_kv_cache(batch_size)
+        pos = torch.zeros(batch_size, 1, dtype=torch.long, device=logits.device)
+        self.code_predictor.forward_depth_unrolled(
+            last_hidden.unsqueeze(1), pos, cp_cache, cache_pos=0
+        )
+        for group_idx in range(1, self.num_codes):
+            pos.fill_(group_idx)
+            cp_hidden = self.code_predictor.forward_depth_unrolled(
+                codec_embed.unsqueeze(1), pos, cp_cache, cache_pos=group_idx
+            ).squeeze(1)
+            cp_logits = torch.matmul(
+                cp_hidden,
+                self.code_predictor.lm_head_weight[group_idx - 1].t(),
+            )
+            codes = self._sample_code_predictor(sampler, cp_logits, sampling)
+            all_codes[:, group_idx] = codes
+            codec_embed = self.code_predictor.model.codec_embedding[
+                group_idx - 1
+            ](codes)
+            codec_embed_sum.add_(codec_embed)
+
+        return {
+            "talker_input_embeds": codec_embed_sum,
+            "codec_tokens": all_codes,
+            "new_token": layer0_codes,
+        }
+
+    def forward(
+        self,
+        graph_walk: str,
+        engine_inputs: ModelInputsFromEngine,
+        input_embeds: torch.Tensor,
+        last_token_indices: torch.Tensor,
+        suppress_mask: torch.Tensor,
+        **kwargs: Any,
+    ) -> NameToTensorList:
+        del graph_walk, kwargs
+        output = self._run_frame(
+            engine_inputs, input_embeds, last_token_indices, suppress_mask
+        )
+        return {name: [tensor] for name, tensor in output.items()}
+
+    def forward_batched(
+        self,
+        graph_walk: str,
+        engine_inputs: ModelInputsFromEngine,
+        input_embeds: torch.Tensor,
+        last_token_indices: torch.Tensor,
+        suppress_mask: torch.Tensor,
+        **kwargs: Any,
+    ) -> dict[str, NameToTensorList]:
+        del graph_walk, kwargs
+        output = self._run_frame(
+            engine_inputs, input_embeds, last_token_indices, suppress_mask
+        )
+        return {
+            request_id: {
+                "talker_input_embeds": [output["talker_input_embeds"][i:i + 1]],
+                "codec_tokens": [output["codec_tokens"][i]],
+                "new_token": [output["new_token"][i]],
+            }
+            for i, request_id in enumerate(engine_inputs.request_ids)
+        }
+
+    def postprocess(
+        self,
+        request_id: str,
+        request_info: CurrentForwardPassInfo,
+        outputs: dict[str, list[torch.Tensor]],
+        **kwargs: Any,
+    ) -> None:
+        """Rename the stop token output and advance metadata without GPU sync."""
+        del request_info, kwargs
+        if "new_token" in outputs:
+            outputs["layer0_codes"] = outputs.pop("new_token")
+            state = self.request_state(request_id)
+            state.add(
+                "generated_frames", int(state.get("generated_frames", 0)) + 1
+            )
+
+    def check_stop(
+        self,
+        request_id: str,
+        request_info: CurrentForwardPassInfo,
+        outputs: dict[str, list[torch.Tensor]],
+    ) -> set[str]:
+        """Stop the graph loop on codec EOS or the request frame limit.
+
+        This callback runs off the GPU execution thread, so reading the sampled
+        token with ``item`` is allowed here rather than in ``postprocess``.
+        """
+        if "layer0_codes" not in outputs:
+            return set()
+        token = int(outputs["layer0_codes"][0].item())
+        generated = int(
+            self.request_state(request_id).get("generated_frames", 0)
+        )
+        max_tokens = request_info.step_metadata.get(
+            "talker_max_tokens", request_info.max_tokens
+        )
+        if token == self.talker_config.codec_eos_token_id or generated >= max_tokens:
+            return {"talker_decode_loop"}
+        return set()
+
+    def can_batch(self, batch: NodeBatch, model_inputs: list[NodeInputs]) -> bool:
+        """Admit compatible prefill/decode requests to continuous batching.
+
+        Residual sampling settings must match because the eager path reads one
+        batch-level configuration. Main Talker sampling remains request-local
+        through the engine sampler.
+        """
+        if (
+            batch.graph_walk not in {"talker_prefill", "talker_decode"}
+            or not model_inputs
+            or len(model_inputs) > self.MAX_BATCH_SIZE
+        ):
+            return False
+        sampling = {
+            repr(info.step_metadata.get("subtalker_sampling", {}))
+            for info in batch.per_request_info.values()
+        }
+        return len(sampling) <= 1
+
+    def max_batch_size(self, graph_walk: str) -> int:
+        del graph_walk
+        return self.MAX_BATCH_SIZE
+
+    def get_cuda_graph_configs(
+        self, device: torch.device, tp_world_size: int = 1
+    ) -> list[BasicBatchedCudaGraphConfig]:
+        """Capture fixed one-token Talker decode batches, including sampling."""
+        del tp_world_size
+        dtype = self.model.model.codec_embedding.weight.dtype
+        return [BasicBatchedCudaGraphConfig(
+            capture_graph_walk="talker_decode",
+            labels=["main"],
+            requires_cfg=False,
+            single_request_inputs=ARNodeInputs(
+                input_embeds=torch.zeros(
+                    1,
+                    self.talker_config.hidden_size,
+                    dtype=dtype,
+                    device=device,
+                ),
+                input_seq_len=1,
+            ),
+            capture_batch_sizes=self.DECODE_CAPTURE_BATCH_SIZES,
+            compile=True,
+        )]
+
+    def get_piecewise_cuda_graph_configs(
+        self,
+        device: torch.device,
+        autocast_dtype: torch.dtype,
+        tp_world_size: int = 1,
+    ) -> dict[str, PiecewiseCudaGraphConfig]:
+        """Capture CodePredictor's 15-step depth loop as an inner CUDA Graph.
+
+        This runner is also useful when the whole Talker graph is ineligible,
+        for example after a request overrides ``subtalker_*`` sampling values.
+        It has no engine KV cache: its small frame-local cache is a static
+        tensor owned by this submodule.
+        """
+        del tp_world_size
+        hidden_size = self.talker_config.hidden_size
+        capture_dtype = autocast_dtype or self.model.model.codec_embedding.weight.dtype
+
+        def make_static_inputs(
+            shape: PiecewiseCaptureShape,
+        ) -> dict[str, torch.Tensor]:
+            return {
+                "last_hidden": torch.zeros(
+                    shape.bs,
+                    hidden_size,
+                    dtype=capture_dtype,
+                    device=device,
+                ),
+                "layer0_codes": torch.zeros(
+                    shape.bs, dtype=torch.long, device=device
+                ),
+                "uniforms": torch.zeros(
+                    shape.bs,
+                    self.num_codes - 1,
+                    dtype=torch.float32,
+                    device=device,
+                ),
+                "temperature": torch.full(
+                    (shape.bs,),
+                    self.config.generation.subtalker_temperature,
+                    dtype=torch.float32,
+                    device=device,
+                ),
+                "top_k": torch.full(
+                    (shape.bs,),
+                    self.config.generation.subtalker_top_k,
+                    dtype=torch.long,
+                    device=device,
+                ),
+                "top_p": torch.full(
+                    (shape.bs,),
+                    self.config.generation.subtalker_top_p,
+                    dtype=torch.float32,
+                    device=device,
+                ),
+                "do_sample": torch.full(
+                    (shape.bs,),
+                    self.config.generation.subtalker_dosample,
+                    dtype=torch.bool,
+                    device=device,
+                ),
+            }
+
+        return {
+            "code_predictor_loop": PiecewiseBatchedConfig(
+                capture_fn=self._code_predictor_piecewise_capture,
+                make_static_inputs=make_static_inputs,
+                seq_len=1,
+                uses_kv_cache=False,
+                capture_batch_sizes=self.DECODE_CAPTURE_BATCH_SIZES,
+                compile=False,
+            )
+        }
+
+    def can_use_cuda_graphs(
+        self, batch: NodeBatch, model_inputs: list[NodeInputs]
+    ) -> bool:
+        """Use the whole decode graph only for its captured sampling constants."""
+        if batch.graph_walk != "talker_decode" or not self.can_batch(
+            batch, model_inputs
+        ):
+            return False
+        expected = {
+            "do_sample": self.config.generation.subtalker_dosample,
+            "temperature": self.config.generation.subtalker_temperature,
+            "top_k": self.config.generation.subtalker_top_k,
+            "top_p": self.config.generation.subtalker_top_p,
+        }
+        for info in batch.per_request_info.values():
+            if info.step_metadata.get("subtalker_sampling", expected) != expected:
+                return False
+        return super().can_use_cuda_graphs(batch, model_inputs)
+
+    def get_needed_cache_labels(
+        self,
+        graph_walk: str,
+        per_request_info: dict[str, CurrentForwardPassInfo],
+    ) -> list[str]:
+        del graph_walk, per_request_info
+        return ["main"]
+
+
+# ===========================================================================
+# 2. CodecSubmodule - fixed-shape streaming waveform decode
+# ===========================================================================
+
+
+class CodecSubmodule(ARNodeSubmodule):
+    """Convert streamed 16-code frames into overlap-trimmed PCM chunks.
+
+    The node runs on a stateless engine, but ``ARNodeInputs`` is reused as the
+    typed container for fixed-length codec tensors. Per-request state stores
+    only how many non-padding frames arrived and whether a prior chunk was
+    emitted; the neural decoder itself has no cross-call state.
+    """
+
+    disable_torch_compile = True
+    MAX_BATCH_SIZE = 16
+    CAPTURE_BATCH_SIZES = [1, 2, 4, 8, 16]
+
+    def __init__(self, decoder: torch.nn.Module, config: Qwen3TTSModelConfig):
+        super().__init__()
+        self.decoder = decoder
+        self.config = config
+        self.full_seq_len = (
+            config.codec.chunk_frames + config.codec.left_context_frames
+        )
+        self.total_upsample = 1
+        for factor in (
+            *config.codec.upsample_rates,
+            *config.codec.upsampling_ratios,
+        ):
+            self.total_upsample *= factor
+
+    def get_stateless_flavor(self) -> str:
+        return "audio_codec"
+
+    def prepare_inputs(
+        self,
+        graph_walk: str,
+        fwd_info: CurrentForwardPassInfo,
+        inputs: NameToTensorList,
+        seen_token_mask: SeenTokenMask | None = None,
+        pos_info: dict[str, PositionInfo] = {},
+        **kwargs: Any,
+    ) -> ARNodeInputs:
+        """Remove EOS frames and pad one stream chunk to its capture shape.
+
+        Input arrives as ``[frames, code_groups]``. The official decoder wants
+        ``[quantizers, frames]``; every request is padded to ``chunk + context``
+        so differently sized final tails can reuse the same CUDA Graph.
+        """
+        del graph_walk, seen_token_mask, pos_info, kwargs
+        codes = inputs["codec_tokens"][0].to(
+            device=self.get_device(), dtype=torch.long
+        )
+        if codes.ndim == 1:
+            codes = codes.view(-1, self.config.num_code_groups)
+        if codes.ndim != 2:
+            raise ValueError(
+                f"Expected codec tokens with shape (frames, groups), got {codes.shape}"
+            )
+        # EOS belongs to Talker loop control and is not a valid codec codebook
+        # index for waveform reconstruction.
+        codes = codes[
+            codes[:, 0] != self.config.talker.codec_eos_token_id,
+            :self.config.codec.num_quantizers,
+        ]
+        original_frames = codes.shape[0]
+        if original_frames > self.full_seq_len:
+            raise ValueError(
+                f"Codec chunk has {original_frames} frames, maximum is "
+                f"{self.full_seq_len}"
+            )
+        if original_frames < self.full_seq_len:
+            codes = torch.nn.functional.pad(
+                codes,
+                (0, 0, 0, self.full_seq_len - original_frames),
+            )
+        self.request_state(fwd_info.request_id).add(
+            "latest_codec_frames", original_frames
+        )
+        return ARNodeInputs(
+            tensor_inputs={"codec_tokens": codes.t().contiguous()},
+        )
+
+    def preprocess(
+        self,
+        graph_walk: str,
+        engine_inputs: ModelInputsFromEngine,
+        inputs: list[ARNodeInputs],
+    ) -> dict[str, torch.Tensor]:
+        """Stack equal fixed-shape codec chunks into one continuous batch."""
+        del graph_walk, engine_inputs
+        return {
+            "codec_tokens": torch.stack([
+                item.tensor_inputs["codec_tokens"] for item in inputs
+            ])
+        }
+
+    def _decode(self, codec_tokens: torch.Tensor) -> torch.Tensor:
+        """Run the official decoder and convert normalized audio to PCM16."""
+        wav = self.decoder(codec_tokens)
+        return (wav.clamp(-1, 1) * 32767).to(torch.int16).squeeze(1)
+
+    def forward(
+        self,
+        graph_walk: str,
+        engine_inputs: ModelInputsFromEngine,
+        codec_tokens: torch.Tensor,
+        **kwargs: Any,
+    ) -> NameToTensorList:
+        del graph_walk, engine_inputs, kwargs
+        return {"audio_chunk": [self._decode(codec_tokens)]}
+
+    def forward_batched(
+        self,
+        graph_walk: str,
+        engine_inputs: ModelInputsFromEngine,
+        codec_tokens: torch.Tensor,
+        **kwargs: Any,
+    ) -> dict[str, NameToTensorList]:
+        del graph_walk, kwargs
+        wavs = self._decode(codec_tokens)
+        return {
+            request_id: {"audio_chunk": [wavs[i]]}
+            for i, request_id in enumerate(engine_inputs.request_ids)
+        }
+
+    def postprocess(
+        self,
+        request_id: str,
+        request_info: CurrentForwardPassInfo,
+        outputs: dict[str, list[torch.Tensor]],
+        **kwargs: Any,
+    ) -> None:
+        """Remove padded tail and duplicated left-context PCM before emission."""
+        del request_info, kwargs
+        if "audio_chunk" not in outputs:
+            return
+        state = self.request_state(request_id)
+        frames = int(state.get("latest_codec_frames", 0))
+        emitted = bool(state.get("codec_chunk_emitted", False))
+        # The first chunk has no overlap. Later stream chunks include old codec
+        # frames at the front, whose decoded samples must not be emitted twice.
+        left_context = self.config.codec.left_context_frames if emitted else 0
+        start = left_context * self.total_upsample
+        end = frames * self.total_upsample
+        outputs["audio_chunk"][0] = outputs["audio_chunk"][0][start:end]
+        state.add("codec_chunk_emitted", True)
+
+    def can_batch(self, batch: NodeBatch, model_inputs: list[NodeInputs]) -> bool:
+        """Batch codec requests only when their decoder input shapes match."""
+        del batch
+        return 0 < len(model_inputs) <= self.MAX_BATCH_SIZE and len({
+            item.tensor_inputs["codec_tokens"].shape for item in model_inputs
+        }) == 1
+
+    def max_batch_size(self, graph_walk: str) -> int:
+        del graph_walk
+        return self.MAX_BATCH_SIZE
+
+    def get_cuda_graph_configs(
+        self, device: torch.device, tp_world_size: int = 1
+    ) -> list[BasicBatchedCudaGraphConfig]:
+        """Capture fixed-length Codec batches for all scheduler buckets."""
+        del tp_world_size
+        return [BasicBatchedCudaGraphConfig(
+            capture_graph_walk="codec_chunk",
+            single_request_inputs=ARNodeInputs(
+                input_seq_len=self.full_seq_len,
+                tensor_inputs={
+                    "codec_tokens": torch.zeros(
+                        self.config.codec.num_quantizers,
+                        self.full_seq_len,
+                        dtype=torch.long,
+                        device=device,
+                    )
+                },
+            ),
+            capture_batch_sizes=self.CAPTURE_BATCH_SIZES,
+            compile=False,
+        )]
+
+    def can_use_cuda_graphs(
+        self, batch: NodeBatch, model_inputs: list[NodeInputs]
+    ) -> bool:
+        return (
+            batch.graph_walk == "codec_chunk"
+            and self.can_batch(batch, model_inputs)
+            and all(
+                item.tensor_inputs["codec_tokens"].shape
+                == (
+                    self.config.codec.num_quantizers,
+                    self.full_seq_len,
+                )
+                for item in model_inputs
+            )
+            and super().can_use_cuda_graphs(batch, model_inputs)
+        )

--- a/mstar/model/qwen3_tts/submodules.py
+++ b/mstar/model/qwen3_tts/submodules.py
@@ -75,6 +75,8 @@ class TalkerSubmodule(ARNodeSubmodule):
     disable_torch_compile = True
     MAX_BATCH_SIZE = 32
     DECODE_CAPTURE_BATCH_SIZES = [1, 2, 4, 8, 16, 32]
+    CHATML_ASSISTANT_PREFIX_TOKEN_IDS = (151644, 77091, 198)
+    CHATML_ASSISTANT_SUFFIX_TOKEN_IDS = (151645, 198, 151644, 77091, 198)
 
     def __init__(
         self,
@@ -107,23 +109,23 @@ class TalkerSubmodule(ARNodeSubmodule):
         return self._suppress_mask
 
     def _get_batch_suppress_mask(
-        self, request_ids: list[str]
+        self, inputs: list[ARNodeInputs]
     ) -> torch.Tensor:
-        """Apply request-local minimum-length EOS suppression to the base mask."""
+        """Apply input-carried minimum-length EOS suppression to the base mask.
+
+        CUDA Graph replay calls ``preprocess`` with capture-slot dummy request
+        ids, so looking up request state here would permanently observe a new
+        request at frame zero. ``prepare_inputs`` runs with the real request and
+        carries the dynamic flag as a tensor instead.
+        """
         mask = self._get_suppress_mask().unsqueeze(0).expand(
-            len(request_ids), -1
+            len(inputs), -1
         ).clone()
         eos = self.talker_config.codec_eos_token_id
         if 0 <= eos < mask.shape[1]:
-            mask[:, eos] = torch.tensor(
-                [
-                    int(self.request_state(request_id).get("generated_frames", 0))
-                    < self.config.generation.min_new_tokens
-                    for request_id in request_ids
-                ],
-                dtype=torch.bool,
-                device=mask.device,
-            )
+            mask[:, eos] = torch.cat([
+                item.tensor_inputs["suppress_eos"] for item in inputs
+            ]).to(device=mask.device, dtype=torch.bool)
         return mask
 
     def _get_cp_kv_cache(self, batch_size: int) -> torch.Tensor:
@@ -187,9 +189,30 @@ class TalkerSubmodule(ARNodeSubmodule):
         This aligns text progress with the 12 Hz acoustic generation steps.
         """
         text_ids = text_ids.to(device=self.get_device(), dtype=torch.long).view(1, -1)
-        if text_ids.shape[1] < 9:
+        expected_prefix = text_ids.new_tensor(
+            self.CHATML_ASSISTANT_PREFIX_TOKEN_IDS
+        )
+        expected_suffix = text_ids.new_tensor(
+            self.CHATML_ASSISTANT_SUFFIX_TOKEN_IDS
+        )
+        prefix_len = expected_prefix.numel()
+        suffix_len = expected_suffix.numel()
+        if text_ids.shape[1] < prefix_len + 1 + suffix_len:
             raise ValueError(
-                "Qwen3-TTS formatted prompt is shorter than its fixed chat suffix"
+                "Qwen3-TTS formatted prompt is shorter than its fixed ChatML "
+                "prefix, text token, and suffix"
+            )
+        if not torch.equal(text_ids[0, :prefix_len], expected_prefix):
+            raise ValueError(
+                "Qwen3-TTS ChatML assistant prefix changed; expected token IDs "
+                f"{expected_prefix.tolist()}, got "
+                f"{text_ids[0, :prefix_len].tolist()}"
+            )
+        if not torch.equal(text_ids[0, -suffix_len:], expected_suffix):
+            raise ValueError(
+                "Qwen3-TTS ChatML assistant suffix changed; expected token IDs "
+                f"{expected_suffix.tolist()}, got "
+                f"{text_ids[0, -suffix_len:].tolist()}"
             )
 
         codec = self.talker_config
@@ -215,14 +238,18 @@ class TalkerSubmodule(ARNodeSubmodule):
 
         # Prefix layout mirrors the official CustomVoice generation helper:
         # assistant role, language/voice codec tags, then first text token.
-        role_embed = self._project_text(text_ids[:, :3]).to(codec_embeds.dtype)
+        role_embed = self._project_text(
+            text_ids[:, :prefix_len]
+        ).to(codec_embeds.dtype)
         tag_text = torch.cat([
             pad_embed.expand(-1, codec_embeds.shape[1] - 2, -1),
             bos_embed,
         ], dim=1)
         tag_embed = tag_text + codec_embeds[:, :-1]
         first_text = (
-            self._project_text(text_ids[:, 3:4]).to(codec_embeds.dtype)
+            self._project_text(
+                text_ids[:, prefix_len:prefix_len + 1]
+            ).to(codec_embeds.dtype)
             + codec_embeds[:, -1:]
         )
         prefill = torch.cat([role_embed, tag_embed, first_text], dim=1)
@@ -231,7 +258,9 @@ class TalkerSubmodule(ARNodeSubmodule):
         # Decode consumes this tensor by ``generation_step`` and uses PAD once
         # the text condition has been exhausted.
         trailing = torch.cat([
-            self._project_text(text_ids[:, 4:-5]).to(codec_embeds.dtype),
+            self._project_text(
+                text_ids[:, prefix_len + 1:-suffix_len]
+            ).to(codec_embeds.dtype),
             eos_embed,
         ], dim=1)
         self.request_state(request_id).add_all(
@@ -266,6 +295,7 @@ class TalkerSubmodule(ARNodeSubmodule):
                 int(inputs["speaker_id"][0].item()),
                 int(inputs["language_id"][0].item()),
             )
+            state = self.request_state(fwd_info.request_id)
         elif graph_walk == "talker_decode":
             state = self.request_state(fwd_info.request_id)
             step = int(state["generation_step"])
@@ -286,9 +316,18 @@ class TalkerSubmodule(ARNodeSubmodule):
         else:
             raise ValueError(f"Unknown Qwen3-TTS Talker walk: {graph_walk!r}")
 
+        suppress_eos = (
+            int(state.get("generated_frames", 0))
+            < self.config.generation.min_new_tokens
+        )
         return ARNodeInputs(
             input_embeds=input_embeds,
             input_seq_len=input_embeds.shape[0],
+            tensor_inputs={
+                "suppress_eos": torch.tensor(
+                    [suppress_eos], dtype=torch.bool, device=self.get_device()
+                )
+            },
         )
 
     def preprocess(
@@ -318,9 +357,7 @@ class TalkerSubmodule(ARNodeSubmodule):
             "last_token_indices": (
                 torch.tensor(seq_lens, device=self.get_device()).cumsum(0) - 1
             ),
-            "suppress_mask": self._get_batch_suppress_mask(
-                engine_inputs.request_ids
-            ),
+            "suppress_mask": self._get_batch_suppress_mask(inputs),
         }
 
     @staticmethod
@@ -746,22 +783,38 @@ class TalkerSubmodule(ARNodeSubmodule):
     def get_cuda_graph_configs(
         self, device: torch.device, tp_world_size: int = 1
     ) -> list[BasicBatchedCudaGraphConfig]:
-        """Keep the recurrent Talker path outside a whole CUDA Graph.
+        """Capture fixed one-token Talker decode batches, including sampling.
 
-        A whole-walk capture also captures the main sampler, the mutable
-        15-position CodePredictor cache, and the recurrent codec-embedding
-        output. Real-checkpoint tests showed that this combined graph can
-        replay stale residual state after the text condition is exhausted: it
-        then emits silent frames until ``max_output_tokens`` instead of codec
-        EOS. The hot CodePredictor depth loop is still captured independently
-        by :meth:`get_piecewise_cuda_graph_configs`; the outer Talker
-        transformer and its request state remain eager.
-
-        Prefill also stays eager because it is variable-length, runs only once
-        per request, and is not on the 12 Hz recurrent hot path.
+        Dynamic EOS suppression is carried by ``ARNodeInputs`` and packed into
+        a graph input, so replay never consults capture-slot dummy request state.
+        Prefill remains eager because it is variable-length and runs once per
+        request.
         """
-        del device, tp_world_size
-        return []
+        del tp_world_size
+        dtype = self.model.model.codec_embedding.weight.dtype
+        return [BasicBatchedCudaGraphConfig(
+            capture_graph_walk="talker_decode",
+            labels=["main"],
+            requires_cfg=False,
+            single_request_inputs=ARNodeInputs(
+                input_embeds=torch.zeros(
+                    1,
+                    self.talker_config.hidden_size,
+                    dtype=dtype,
+                    device=device,
+                ),
+                input_seq_len=1,
+                # Padding slots clone this template, so every replay input must
+                # declare the same dynamic key as a real prepared request.
+                tensor_inputs={
+                    "suppress_eos": torch.ones(
+                        1, dtype=torch.bool, device=device
+                    )
+                },
+            ),
+            capture_batch_sizes=self.DECODE_CAPTURE_BATCH_SIZES,
+            compile=True,
+        )]
 
     def get_piecewise_cuda_graph_configs(
         self,
@@ -771,9 +824,10 @@ class TalkerSubmodule(ARNodeSubmodule):
     ) -> dict[str, PiecewiseCudaGraphConfig]:
         """Capture CodePredictor's 15-step depth loop as an inner CUDA Graph.
 
-        The outer Talker walk intentionally remains eager so EOS and recurrent
-        state stay request-owned. This inner graph has no engine KV cache: its
-        small frame-local cache is a static tensor owned by this submodule.
+        This runner is also useful when the whole Talker graph is ineligible,
+        for example after a request overrides ``subtalker_*`` sampling values.
+        It has no engine KV cache: its small frame-local cache is a static
+        tensor owned by this submodule.
         """
         del tp_world_size
         hidden_size = self.talker_config.hidden_size
@@ -838,9 +892,21 @@ class TalkerSubmodule(ARNodeSubmodule):
     def can_use_cuda_graphs(
         self, batch: NodeBatch, model_inputs: list[NodeInputs]
     ) -> bool:
-        """Reject whole-walk capture; only the inner CodePredictor is graphed."""
-        del batch, model_inputs
-        return False
+        """Use the whole decode graph only for its captured sampling constants."""
+        if batch.graph_walk != "talker_decode" or not self.can_batch(
+            batch, model_inputs
+        ):
+            return False
+        expected = {
+            "do_sample": self.config.generation.subtalker_dosample,
+            "temperature": self.config.generation.subtalker_temperature,
+            "top_k": self.config.generation.subtalker_top_k,
+            "top_p": self.config.generation.subtalker_top_p,
+        }
+        for info in batch.per_request_info.values():
+            if info.step_metadata.get("subtalker_sampling", expected) != expected:
+                return False
+        return super().can_use_cuda_graphs(batch, model_inputs)
 
     def get_needed_cache_labels(
         self,

--- a/mstar/model/qwen3_tts/submodules.py
+++ b/mstar/model/qwen3_tts/submodules.py
@@ -67,6 +67,12 @@ class TalkerSubmodule(ARNodeSubmodule):
     the complete code vector is streamed independently to ``CodecSubmodule``.
     """
 
+    # Compiling the entire engine-facing forward traces request sampling,
+    # residual-code control flow, and recurrent routing in addition to the
+    # transformer. It introduces graph breaks and showed no steady-state win
+    # for this path. The CodePredictor hot loop remains CUDA-graph captured
+    # independently below.
+    disable_torch_compile = True
     MAX_BATCH_SIZE = 32
     DECODE_CAPTURE_BATCH_SIZES = [1, 2, 4, 8, 16, 32]
 
@@ -343,7 +349,11 @@ class TalkerSubmodule(ARNodeSubmodule):
         top_p: torch.Tensor,
         do_sample: torch.Tensor,
     ) -> torch.Tensor:
-        """Graph-safe batched top-k/top-p sampling from supplied uniforms."""
+        """Graph-safe batched top-k/top-p sampling from supplied uniforms.
+
+        TODO(#199): replace this model-local path with the engine's auxiliary
+        sampler once it supports independent per-request CUDA-graph buffers.
+        """
         vocab_size = logits.shape[-1]
         greedy = logits.argmax(dim=-1)
         safe_temperature = torch.where(
@@ -660,10 +670,20 @@ class TalkerSubmodule(ARNodeSubmodule):
         outputs: dict[str, list[torch.Tensor]],
         **kwargs: Any,
     ) -> None:
-        """Rename the stop token output and advance metadata without GPU sync."""
+        """Expose the stop token and advance metadata without a GPU sync.
+
+        Whole-graph replay and eager execution normally retain ``new_token``.
+        ``codec_tokens`` is the routed output, though, so use its first codebook
+        as a fallback.  This keeps EOS detection correct even if an execution
+        path filters the sampler-only output before slow-path ``check_stop``.
+        """
         del request_info, kwargs
         if "new_token" in outputs:
             outputs["layer0_codes"] = outputs.pop("new_token")
+        elif "layer0_codes" not in outputs and "codec_tokens" in outputs:
+            codec_tokens = outputs["codec_tokens"][0]
+            outputs["layer0_codes"] = [codec_tokens.reshape(-1)[0]]
+        if "layer0_codes" in outputs:
             state = self.request_state(request_id)
             state.add(
                 "generated_frames", int(state.get("generated_frames", 0)) + 1
@@ -689,7 +709,14 @@ class TalkerSubmodule(ARNodeSubmodule):
         max_tokens = request_info.step_metadata.get(
             "talker_max_tokens", request_info.max_tokens
         )
-        if token == self.talker_config.codec_eos_token_id or generated >= max_tokens:
+        sampling_config = getattr(request_info, "sampling_config", {}).get(
+            "Talker"
+        )
+        ignore_eos = bool(getattr(sampling_config, "ignore_eos", False))
+        reached_eos = (
+            not ignore_eos and token == self.talker_config.codec_eos_token_id
+        )
+        if reached_eos or generated >= max_tokens:
             return {"talker_decode_loop"}
         return set()
 
@@ -719,25 +746,22 @@ class TalkerSubmodule(ARNodeSubmodule):
     def get_cuda_graph_configs(
         self, device: torch.device, tp_world_size: int = 1
     ) -> list[BasicBatchedCudaGraphConfig]:
-        """Capture fixed one-token Talker decode batches, including sampling."""
-        del tp_world_size
-        dtype = self.model.model.codec_embedding.weight.dtype
-        return [BasicBatchedCudaGraphConfig(
-            capture_graph_walk="talker_decode",
-            labels=["main"],
-            requires_cfg=False,
-            single_request_inputs=ARNodeInputs(
-                input_embeds=torch.zeros(
-                    1,
-                    self.talker_config.hidden_size,
-                    dtype=dtype,
-                    device=device,
-                ),
-                input_seq_len=1,
-            ),
-            capture_batch_sizes=self.DECODE_CAPTURE_BATCH_SIZES,
-            compile=True,
-        )]
+        """Keep the recurrent Talker path outside a whole CUDA Graph.
+
+        A whole-walk capture also captures the main sampler, the mutable
+        15-position CodePredictor cache, and the recurrent codec-embedding
+        output. Real-checkpoint tests showed that this combined graph can
+        replay stale residual state after the text condition is exhausted: it
+        then emits silent frames until ``max_output_tokens`` instead of codec
+        EOS. The hot CodePredictor depth loop is still captured independently
+        by :meth:`get_piecewise_cuda_graph_configs`; the outer Talker
+        transformer and its request state remain eager.
+
+        Prefill also stays eager because it is variable-length, runs only once
+        per request, and is not on the 12 Hz recurrent hot path.
+        """
+        del device, tp_world_size
+        return []
 
     def get_piecewise_cuda_graph_configs(
         self,
@@ -747,10 +771,9 @@ class TalkerSubmodule(ARNodeSubmodule):
     ) -> dict[str, PiecewiseCudaGraphConfig]:
         """Capture CodePredictor's 15-step depth loop as an inner CUDA Graph.
 
-        This runner is also useful when the whole Talker graph is ineligible,
-        for example after a request overrides ``subtalker_*`` sampling values.
-        It has no engine KV cache: its small frame-local cache is a static
-        tensor owned by this submodule.
+        The outer Talker walk intentionally remains eager so EOS and recurrent
+        state stay request-owned. This inner graph has no engine KV cache: its
+        small frame-local cache is a static tensor owned by this submodule.
         """
         del tp_world_size
         hidden_size = self.talker_config.hidden_size
@@ -815,21 +838,9 @@ class TalkerSubmodule(ARNodeSubmodule):
     def can_use_cuda_graphs(
         self, batch: NodeBatch, model_inputs: list[NodeInputs]
     ) -> bool:
-        """Use the whole decode graph only for its captured sampling constants."""
-        if batch.graph_walk != "talker_decode" or not self.can_batch(
-            batch, model_inputs
-        ):
-            return False
-        expected = {
-            "do_sample": self.config.generation.subtalker_dosample,
-            "temperature": self.config.generation.subtalker_temperature,
-            "top_k": self.config.generation.subtalker_top_k,
-            "top_p": self.config.generation.subtalker_top_p,
-        }
-        for info in batch.per_request_info.values():
-            if info.step_metadata.get("subtalker_sampling", expected) != expected:
-                return False
-        return super().can_use_cuda_graphs(batch, model_inputs)
+        """Reject whole-walk capture; only the inner CodePredictor is graphed."""
+        del batch, model_inputs
+        return False
 
     def get_needed_cache_labels(
         self,
@@ -855,8 +866,13 @@ class CodecSubmodule(ARNodeSubmodule):
     """
 
     disable_torch_compile = True
-    MAX_BATCH_SIZE = 16
-    CAPTURE_BATCH_SIZES = [1, 2, 4, 8, 16]
+    # The official 114M-parameter decoder materializes large fixed-shape
+    # activations while CUDA graphs are captured.  Capturing bs=16 exhausts an
+    # H100 once Talker weights and the CodePredictor graphs are resident, so
+    # keep the safe ceiling at 8 until the decoder is ported to M*'s
+    # lighter-weight codec components.
+    MAX_BATCH_SIZE = 8
+    CAPTURE_BATCH_SIZES = [1, 2, 4, 8]
 
     def __init__(self, decoder: torch.nn.Module, config: Qwen3TTSModelConfig):
         super().__init__()

--- a/mstar/model/registry.py
+++ b/mstar/model/registry.py
@@ -5,6 +5,7 @@ from mstar.model.higgs_audio.higgs_audio_model import HiggsAudioModel
 from mstar.model.orpheus.orpheus_model import OrpheusModel
 from mstar.model.pi05.pi05_model import Pi05Model
 from mstar.model.qwen3_omni.qwen3_omni_model import Qwen3OmniModel
+from mstar.model.qwen3_tts.qwen3_tts_model import Qwen3TTSModel
 from mstar.model.vjepa2.vjepa2_model import VJepa2ACModel, VJepa2Model
 from mstar.model.whisper.whisper_model import WhisperModel
 
@@ -16,6 +17,7 @@ MODEL_REGISTRY: dict[str, type[Model]] = {
     "orpheus": OrpheusModel,
     "pi05": Pi05Model,
     "qwen3_omni": Qwen3OmniModel,
+    "qwen3_tts": Qwen3TTSModel,
     "vjepa2": VJepa2Model,
     "vjepa2_ac": VJepa2ACModel,
     "whisper_large": WhisperModel,
@@ -38,6 +40,7 @@ HF_MODELS: dict[str, dict] = {
     # state-dict remap inside Pi05Model.get_submodule().
     "pi05": {"model_path_hf": "lerobot/pi05_base"},
     "qwen3_omni": {"model_path_hf": "Qwen/Qwen3-Omni-30B-A3B-Instruct"},
+    "qwen3_tts": {"model_path_hf": "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"},
     # V-JEPA 2 standard (encoder + masked predictor).  Default is ViT-L @ 256
     # (~300M); the same class loads vitl/h/g at 256 or 384 by reading
     # config.json.

--- a/mstar/utils/flashinfer_utils.py
+++ b/mstar/utils/flashinfer_utils.py
@@ -33,7 +33,7 @@ def run_rms_norm(
     if rms_norm_dtype is not None:
         input = input.to(rms_norm_dtype)
     elif torch.is_autocast_enabled():
-        dtype = torch.get_autocast_gpu_dtype()
+        dtype = torch.get_autocast_dtype("cuda")
         input = input.to(dtype)
     elif input.dtype == torch.float32:
         # Unsupported dtype; must recast
@@ -100,6 +100,7 @@ class FlashInferPrefillWrapper:
         device: torch.device = torch.device("cuda"),
         use_cuda_graph: bool = False,
         enable_nvtx: bool = False,
+        backend: str = "auto",
     ):
         self.device = device
         self.use_cuda_graph = use_cuda_graph
@@ -141,6 +142,7 @@ class FlashInferPrefillWrapper:
                 paged_kv_indptr_buf=self._paged_kv_indptr_buf,
                 paged_kv_indices_buf=self._paged_kv_indices_buf,
                 paged_kv_last_page_len_buf=self._paged_kv_last_page_len_buf,
+                backend=backend,
             )
 
             # Static buffers for vectorized KV cache writes
@@ -152,7 +154,7 @@ class FlashInferPrefillWrapper:
             )
         else:
             self.attn_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-                workspace_buffer, "NHD"
+                workspace_buffer, "NHD", backend=backend
             )
             self.token_to_page = None
             self.token_to_cache = None
@@ -318,6 +320,7 @@ class FlashInferDecodeWrapper:
         device: torch.device = torch.device("cuda"),
         use_cuda_graph: bool = False,
         enable_nvtx: bool = False,
+        backend: str = "auto",
     ):
         self.device = device
         self.use_cuda_graph = use_cuda_graph
@@ -353,6 +356,7 @@ class FlashInferDecodeWrapper:
                 paged_kv_indptr_buffer=self._paged_kv_indptr_buf,
                 paged_kv_indices_buffer=self._paged_kv_indices_buf,
                 paged_kv_last_page_len_buffer=self._paged_kv_last_page_len_buf,
+                backend=backend,
             )
 
             # Static buffer for KV write locations: [batch_size, 2] = (page_idx, pos_idx)
@@ -363,6 +367,7 @@ class FlashInferDecodeWrapper:
             self.attn_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
                 workspace_buffer, "NHD",
                 use_tensor_cores=True,
+                backend=backend,
             )
             self.kv_cache_locations = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,16 @@ qwen3_omni = [
     "ninja",  # speeds up the first-use JIT build of the vendored MoE align kernel
 ]
 
+qwen3_tts = [
+    "einops",
+    "flashinfer-python>=0.6.4",
+    "huggingface-hub",
+    "mooncake-transfer-engine",
+    "qwen-tts==0.1.1",
+    "safetensors",
+    "transformers>=4.57.3",
+]
+
 orpheus = [
     "einops",
     "flashinfer-python>=0.6.4",
@@ -162,6 +172,7 @@ all = [
     "safetensors",
     "triton",
     "qwen-omni-utils",
+    "qwen-tts==0.1.1",
     "numba>=0.61",
     "ninja",  # speeds up the first-use JIT build of the vendored MoE align kernel
     # flash-attn is intentionally omitted (Qwen3-Omni needs it) — install it

--- a/test/integration/test_qwen3_tts_real_weights.py
+++ b/test/integration/test_qwen3_tts_real_weights.py
@@ -1,0 +1,162 @@
+"""Real-weight integration tests for the Qwen3-TTS M* port.
+
+The module never downloads weights. It skips unless the 0.6B CustomVoice
+checkpoint is already present in a standard Hugging Face cache and CUDA is
+available.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from mstar.engine.cuda_graph_runner import PiecewiseCudaGraphRunner
+from mstar.model.qwen3_tts.qwen3_tts_model import Qwen3TTSModel
+
+HF_REPO = "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"
+
+
+def _find_cached_snapshot() -> Path | None:
+    repo_dir = f"models--{HF_REPO.replace('/', '--')}"
+    roots = []
+    if os.environ.get("HF_HUB_CACHE"):
+        roots.append(Path(os.environ["HF_HUB_CACHE"]))
+    if os.environ.get("HF_HOME"):
+        roots.append(Path(os.environ["HF_HOME"]) / "hub")
+    roots.append(Path.home() / ".cache" / "huggingface" / "hub")
+
+    for root in roots:
+        snapshots = root / repo_dir / "snapshots"
+        if not snapshots.is_dir():
+            continue
+        for snapshot in snapshots.iterdir():
+            if (
+                (snapshot / "model.safetensors").is_file()
+                and (snapshot / "speech_tokenizer" / "model.safetensors").is_file()
+            ):
+                return snapshot
+    return None
+
+
+SNAPSHOT = _find_cached_snapshot()
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA"),
+    pytest.mark.skipif(
+        SNAPSHOT is None,
+        reason=f"{HF_REPO} is not present in the local Hugging Face cache",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def model() -> Qwen3TTSModel:
+    assert SNAPSHOT is not None
+    return Qwen3TTSModel(model_path_hf=str(SNAPSHOT))
+
+
+@pytest.fixture(scope="module")
+def talker(model):
+    submodule = model.get_submodule(
+        "Talker",
+        device="cuda:0",
+        autocast_dtype=torch.bfloat16,
+    )
+    assert submodule is not None
+    return submodule
+
+
+@pytest.fixture(scope="module")
+def codec(model):
+    submodule = model.get_submodule("Codec", device="cuda:0")
+    assert submodule is not None
+    return submodule
+
+
+def test_real_checkpoint_loads_all_components(model, talker, codec):
+    assert model.get_submodule("Talker", device="cuda:0") is talker
+    assert model.get_submodule("Codec", device="cuda:0") is codec
+    assert sum(p.numel() for p in talker.model.parameters()) == 764_218_368
+    assert sum(p.numel() for p in talker.code_predictor.parameters()) == 141_570_304
+    assert sum(p.numel() for p in codec.decoder.parameters()) == 114_323_137
+    assert next(talker.model.parameters()).dtype == torch.bfloat16
+    assert next(codec.decoder.parameters()).dtype == torch.float32
+
+
+def test_real_tokenizer_and_prefill_build_expected_hidden_width(model, talker):
+    tensors = model.process_prompt(
+        "Testing Qwen three TTS.",
+        input_modalities=["text"],
+        output_modalities=["audio"],
+        voice="Vivian",
+        language="English",
+    )
+    prepared = talker.prepare_inputs(
+        "talker_prefill",
+        SimpleNamespace(request_id="integration-prefill"),
+        tensors,
+    )
+
+    assert prepared.input_embeds.ndim == 2
+    assert prepared.input_embeds.shape[1] == model.config.talker.hidden_size
+    assert prepared.input_seq_len == prepared.input_embeds.shape[0]
+
+
+def test_real_code_predictor_piecewise_graph_matches_eager(talker):
+    device = torch.device("cuda:0")
+    config = talker.get_piecewise_cuda_graph_configs(
+        device=device,
+        autocast_dtype=torch.bfloat16,
+    )["code_predictor_loop"]
+    config.capture_batch_sizes = [1]
+    runner = PiecewiseCudaGraphRunner(
+        config=config,
+        device=device,
+        autocast_dtype=torch.bfloat16,
+    )
+    runner.warmup_and_capture()
+    assert sorted(runner.graphs) == [(1, 1)]
+
+    shape = config.get_capture_shapes([1])[0]
+    inputs = config.make_static_inputs(shape)
+    generator = torch.Generator(device=device).manual_seed(1234)
+    inputs["last_hidden"].normal_(generator=generator)
+    inputs["layer0_codes"].fill_(1)
+    inputs["uniforms"].uniform_(generator=generator)
+
+    eager_codes, eager_embeds = talker._run_code_predictor_tensor_loop(
+        last_hidden=inputs["last_hidden"],
+        layer0_codes=inputs["layer0_codes"],
+        uniforms=inputs["uniforms"],
+        temperature=inputs["temperature"],
+        top_k=inputs["top_k"],
+        top_p=inputs["top_p"],
+        do_sample=inputs["do_sample"],
+    )
+    graph_output = runner.run(static_inputs=inputs, real_bs=1)
+    graph_codes = graph_output["all_codes"]
+    graph_embeds = graph_output["codec_embed_sum"]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(graph_codes, eager_codes, rtol=0, atol=0)
+    torch.testing.assert_close(graph_embeds, eager_embeds, rtol=0, atol=0)
+
+
+def test_real_codec_decodes_expected_number_of_pcm_samples(codec, model):
+    frames = 2
+    codes = torch.zeros(
+        1,
+        model.config.codec.num_quantizers,
+        frames,
+        dtype=torch.long,
+        device="cuda:0",
+    )
+    pcm = codec._decode(codes)
+    torch.cuda.synchronize()
+
+    assert pcm.shape == (1, frames * model.config.codec.decode_upsample_rate)
+    assert pcm.dtype == torch.int16
+

--- a/test/integration/test_qwen3_tts_real_weights.py
+++ b/test/integration/test_qwen3_tts_real_weights.py
@@ -159,4 +159,3 @@ def test_real_codec_decodes_expected_number_of_pcm_samples(codec, model):
 
     assert pcm.shape == (1, frames * model.config.codec.decode_upsample_rate)
     assert pcm.dtype == torch.int16
-

--- a/test/modular/test_qwen3_tts_model.py
+++ b/test/modular/test_qwen3_tts_model.py
@@ -1,0 +1,693 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from mstar.conductor.request_info import CurrentForwardConductorMetadata
+from mstar.engine.base import EngineType, NodeBatch
+from mstar.model.qwen3_tts.components.talker import (
+    Qwen3TTSCodePredictor,
+    Qwen3TTSTalkerModel,
+)
+from mstar.model.qwen3_tts.config import (
+    Qwen3TTSCodecConfig,
+    Qwen3TTSCodePredictorConfig,
+    Qwen3TTSModelConfig,
+    Qwen3TTSTalkerConfig,
+)
+from mstar.model.qwen3_tts.qwen3_tts_model import Qwen3TTSModel
+from mstar.model.qwen3_tts.submodules import CodecSubmodule, TalkerSubmodule
+from mstar.model.registry import HF_MODELS, MODEL_REGISTRY
+from mstar.model.submodule_base import ARNodeInputs, ModelInputsFromEngine
+from mstar.streaming.chunk_policy import LeftContextChunkPolicy
+from mstar.streaming.stream_buffer import StreamBuffer
+from mstar.utils.flashinfer_utils import (
+    FlashInferDecodeWrapper,
+    FlashInferPrefillWrapper,
+)
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "qwen3tts.yaml"
+
+
+class _TokenizerStub:
+    def __init__(self):
+        self.last_text = None
+
+    def __call__(self, text, **kwargs):
+        self.last_text = text
+        assert kwargs == {"return_tensors": "pt", "padding": True}
+        return {"input_ids": torch.tensor([[1, 2, 3]])}
+
+
+def _make_model() -> Qwen3TTSModel:
+    model = object.__new__(Qwen3TTSModel)
+    model.config = Qwen3TTSModelConfig()
+    model.tokenizer = _TokenizerStub()
+    model._submodule_cache = {}
+    return model
+
+
+def test_qwen3_tts_config_reads_checkpoint_json(tmp_path):
+    (tmp_path / "speech_tokenizer").mkdir()
+    (tmp_path / "config.json").write_text(json.dumps({
+        "tts_model_type": "custom_voice",
+        "talker_config": {
+            "num_hidden_layers": 30,
+            "num_code_groups": 16,
+            "spk_id": {"test_voice": 42},
+            "code_predictor_config": {"num_hidden_layers": 6},
+        },
+    }))
+    (tmp_path / "generation_config.json").write_text(json.dumps({
+        "temperature": 0.7,
+        "max_new_tokens": 123,
+    }))
+    (tmp_path / "speech_tokenizer" / "config.json").write_text(json.dumps({
+        "output_sample_rate": 22050,
+        "decoder_config": {"num_quantizers": 16, "codebook_size": 1024},
+    }))
+
+    config = Qwen3TTSModelConfig.from_pretrained(tmp_path)
+
+    assert config.talker.num_hidden_layers == 30
+    assert config.talker.code_predictor.num_hidden_layers == 6
+    assert config.talker.spk_id == {"test_voice": 42}
+    assert config.generation.temperature == 0.7
+    assert config.generation.min_new_tokens == 2
+    assert config.generation.max_new_tokens == 123
+    assert config.codec.output_sample_rate == 22050
+    assert config.codec.codebook_size == 1024
+
+
+def test_qwen3_tts_model_loads_tokenizer_with_correct_regex(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "speech_tokenizer").mkdir()
+    (tmp_path / "config.json").write_text(json.dumps({
+        "tts_model_type": "custom_voice",
+        "talker_config": {},
+    }))
+    (tmp_path / "generation_config.json").write_text("{}")
+    (tmp_path / "speech_tokenizer" / "config.json").write_text("{}")
+    captured = {}
+
+    def from_pretrained(path, **kwargs):
+        captured["path"] = path
+        captured.update(kwargs)
+        return _TokenizerStub()
+
+    monkeypatch.setattr(
+        "mstar.model.qwen3_tts.qwen3_tts_model.AutoTokenizer.from_pretrained",
+        from_pretrained,
+    )
+    Qwen3TTSModel(model_path_hf=str(tmp_path))
+
+    assert captured["path"] == str(tmp_path)
+    assert captured["fix_mistral_regex"] is True
+
+
+def test_qwen3_tts_declares_talker_and_codec_graphs():
+    model = _make_model()
+
+    assert set(model.get_graph_walk_graphs()) == {
+        "talker_prefill",
+        "talker_decode",
+        "codec_chunk",
+    }
+    assert [part.name for part in model.get_partitions()] == ["Talker", "Codec"]
+    topology = model.get_partition_topology()
+    assert topology.partitions == ["Talker", "Codec"]
+    assert len(topology.connections) == 1
+    assert topology.connections[0].edge_name == "codec_tokens"
+
+
+def test_qwen3_tts_registry_engines_cache_and_yaml_are_consistent():
+    model = _make_model()
+
+    assert MODEL_REGISTRY["qwen3_tts"] is Qwen3TTSModel
+    assert HF_MODELS["qwen3_tts"] == {
+        "model_path_hf": "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"
+    }
+    assert model.get_node_engine_types() == {
+        "Talker": EngineType.KV_CACHE,
+        "Codec": EngineType.STATELESS,
+    }
+    kv_configs = model.get_kv_cache_config()
+    assert len(kv_configs) == 1
+    kv = kv_configs[0]
+    assert kv.nodes == ["Talker"]
+    assert kv.num_layers == model.config.talker.num_hidden_layers
+    assert kv.num_kv_heads == model.config.talker.num_key_value_heads
+    assert kv.num_qo_heads == model.config.talker.num_attention_heads
+    assert kv.head_dim == model.config.talker.head_dim
+    assert kv.flashinfer_backend == "fa2"
+
+    worker_graphs = model.get_worker_graphs(str(CONFIG_PATH))
+    by_walk = {
+        next(iter(worker_graph.graph_walks)): worker_graph
+        for worker_graph in worker_graphs
+    }
+    assert set(by_walk) == {
+        "talker_prefill",
+        "talker_decode",
+        "codec_chunk",
+    }
+    assert all(worker_graph.ranks == [0] for worker_graph in worker_graphs)
+    assert by_walk["codec_chunk"].consumes_stream is True
+
+
+def test_flashinfer_wrappers_forward_explicit_kernel_backend(monkeypatch):
+    captured = {}
+
+    class _PrefillWrapper:
+        def __init__(self, *args, **kwargs):
+            captured["prefill"] = kwargs["backend"]
+
+    class _DecodeWrapper:
+        def __init__(self, *args, **kwargs):
+            captured["decode"] = kwargs["backend"]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "flashinfer",
+        SimpleNamespace(
+            BatchPrefillWithPagedKVCacheWrapper=_PrefillWrapper,
+            BatchDecodeWithPagedKVCacheWrapper=_DecodeWrapper,
+        ),
+    )
+    common = {
+        "workspace_buffer": torch.empty(1),
+        "num_qo_heads": 2,
+        "num_kv_heads": 1,
+        "head_dim": 8,
+        "page_size": 16,
+        "device": torch.device("cpu"),
+        "backend": "fa2",
+    }
+
+    FlashInferPrefillWrapper(**common)
+    FlashInferDecodeWrapper(**common)
+
+    assert captured == {"prefill": "fa2", "decode": "fa2"}
+
+
+def test_qwen3_tts_process_prompt_matches_official_template():
+    model = _make_model()
+
+    tensors = model.process_prompt(
+        "你好",
+        input_modalities=["text"],
+        output_modalities=["audio"],
+        voice="Vivian",
+        language="Chinese",
+    )
+
+    assert model.tokenizer.last_text == (
+        "<|im_start|>assistant\n你好<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    assert tensors["text_inputs"][0].tolist() == [1, 2, 3]
+    assert tensors["speaker_id"][0].item() == 3065
+    assert tensors["language_id"][0].item() == 2055
+
+
+@pytest.mark.parametrize(
+    ("prompt", "inputs", "outputs", "kwargs", "message"),
+    [
+        ("", ["text"], ["audio"], {}, "non-empty"),
+        ("hello", ["audio"], ["audio"], {}, "text input only"),
+        ("hello", ["text"], ["text"], {}, "audio output only"),
+        ("hello", ["text"], ["audio", "text"], {}, "audio output only"),
+        ("hello", ["text"], ["audio"], {"voice": "unknown"}, "speaker"),
+        (
+            "hello",
+            ["text"],
+            ["audio"],
+            {"language": "unknown"},
+            "language",
+        ),
+        (
+            "hello",
+            ["text"],
+            ["audio"],
+            {"instruct": "speak slowly"},
+            "does not support instructions",
+        ),
+    ],
+)
+def test_qwen3_tts_rejects_unsupported_requests(
+    prompt, inputs, outputs, kwargs, message
+):
+    with pytest.raises(ValueError, match=message):
+        _make_model().process_prompt(
+            prompt,
+            input_modalities=inputs,
+            output_modalities=outputs,
+            **kwargs,
+        )
+
+
+def test_qwen3_tts_initial_partition_args_route_expected_inputs():
+    model = _make_model()
+    pointers = {
+        name: [SimpleNamespace(name=name)]
+        for name in ("text_inputs", "speaker_id", "language_id")
+    }
+
+    talker = model.get_initial_forward_pass_args(
+        "Talker",
+        input_modalities=["text"],
+        output_modalities=["audio"],
+        input_signals=pointers,
+        model_kwargs={"max_new_tokens": 12, "subtalker_top_k": 7},
+    )
+    assert talker.full_metadata.graph_walk == "talker_prefill"
+    assert [edge.name for edge in talker.inputs] == list(pointers)
+    assert talker.full_metadata.kwargs["talker_max_tokens"] == 12
+    assert talker.step_metadata["subtalker_sampling"]["top_k"] == 7
+
+    codec = model.get_initial_forward_pass_args(
+        "Codec",
+        input_modalities=["text"],
+        output_modalities=["audio"],
+        input_signals=pointers,
+    )
+    assert codec.full_metadata.graph_walk == "codec_chunk"
+    assert codec.inputs == []
+    assert codec.request_done is False
+
+
+def test_qwen3_tts_talker_prefill_transitions_to_decode():
+    model = _make_model()
+    metadata = CurrentForwardConductorMetadata(
+        input_modalities=["text"],
+        output_modalities=["audio"],
+        graph_walk="talker_prefill",
+        is_prefill=True,
+        kwargs={
+            "talker_max_tokens": 100,
+            "subtalker_sampling": {},
+        },
+    )
+
+    result = model.get_partition_forward_pass_args(
+        partition_name="Talker",
+        partition_metadata=metadata,
+        persist_signals={"talker_input_embeds": []},
+    )
+
+    assert result.full_metadata.graph_walk == "talker_decode"
+    assert result.full_metadata.is_prefill is False
+    assert result.inputs[0].name == "talker_input_embeds"
+    assert result.request_done is False
+
+
+def test_qwen3_tts_talker_decode_marks_partition_done():
+    model = _make_model()
+    metadata = CurrentForwardConductorMetadata(
+        input_modalities=["text"],
+        output_modalities=["audio"],
+        graph_walk="talker_decode",
+        is_prefill=False,
+    )
+
+    result = model.get_partition_forward_pass_args(
+        partition_name="Talker",
+        partition_metadata=metadata,
+        persist_signals={},
+    )
+
+    assert result.request_done is True
+
+
+def test_qwen3_tts_postprocess_encodes_pcm16():
+    model = _make_model()
+
+    output = model.postprocess(
+        torch.tensor([-1.0, 0.0, 1.0]),
+        modality="audio",
+    )
+
+    expected = torch.tensor([-32767, 0, 32767], dtype=torch.int16)
+    assert output == expected.numpy().tobytes()
+
+
+def _tiny_model_config() -> Qwen3TTSModelConfig:
+    code_predictor = Qwen3TTSCodePredictorConfig(
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        hidden_size=16,
+        intermediate_size=32,
+        head_dim=8,
+        vocab_size=32,
+        num_code_groups=4,
+    )
+    talker = Qwen3TTSTalkerConfig(
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        hidden_size=16,
+        intermediate_size=32,
+        head_dim=8,
+        vocab_size=64,
+        text_hidden_size=16,
+        text_vocab_size=128,
+        num_code_groups=4,
+        codec_pad_id=33,
+        codec_bos_id=34,
+        codec_eos_token_id=35,
+        codec_think_id=36,
+        codec_nothink_id=37,
+        codec_think_bos_id=38,
+        codec_think_eos_id=39,
+        code_predictor=code_predictor,
+    )
+    return Qwen3TTSModelConfig(
+        tts_pad_token_id=120,
+        tts_bos_token_id=121,
+        tts_eos_token_id=122,
+        talker=talker,
+        codec=Qwen3TTSCodecConfig(
+            num_quantizers=4,
+            chunk_frames=3,
+            left_context_frames=2,
+            upsample_rates=(2,),
+            upsampling_ratios=(2,),
+            decode_upsample_rate=4,
+        ),
+    )
+
+
+def test_qwen3_tts_talker_builds_official_streaming_prefill():
+    config = _tiny_model_config()
+    talker = Qwen3TTSTalkerModel(config)
+    predictor = Qwen3TTSCodePredictor(config)
+    submodule = TalkerSubmodule(talker, predictor, config)
+
+    embeds = submodule._build_prefill(
+        request_id="request",
+        text_ids=torch.arange(1, 13),
+        speaker_id=40,
+        language_id=-1,
+    )
+
+    assert embeds.shape == (9, 16)
+    state = submodule.request_state("request")
+    assert state["trailing_text_hidden"].shape == (4, 16)
+    assert state["tts_pad_embed"].shape == (16,)
+    assert state["generation_step"] == 0
+
+
+def test_qwen3_tts_prefill_frame_counts_toward_generation_limit():
+    config = _tiny_model_config()
+    submodule = TalkerSubmodule(
+        Qwen3TTSTalkerModel(config),
+        Qwen3TTSCodePredictor(config),
+        config,
+    )
+    submodule.request_state("request").add("generated_frames", 0)
+    outputs = {"new_token": [torch.tensor(1)]}
+    request_info = SimpleNamespace(
+        step_metadata={"talker_max_tokens": 1},
+        max_tokens=8192,
+    )
+
+    submodule.postprocess("request", request_info, outputs)
+
+    assert submodule.check_stop("request", request_info, outputs) == {
+        "talker_decode_loop"
+    }
+
+
+def test_qwen3_tts_suppresses_eos_for_official_minimum_frames():
+    config = _tiny_model_config()
+    submodule = TalkerSubmodule(
+        Qwen3TTSTalkerModel(config),
+        Qwen3TTSCodePredictor(config),
+        config,
+    )
+    submodule.request_state("new").add("generated_frames", 0)
+    submodule.request_state("ready").add(
+        "generated_frames", config.generation.min_new_tokens
+    )
+
+    mask = submodule._get_batch_suppress_mask(["new", "ready"])
+    eos = config.talker.codec_eos_token_id
+
+    assert mask.shape == (2, config.talker.vocab_size)
+    assert mask[0, eos].item() is True
+    assert mask[1, eos].item() is False
+
+
+def test_qwen3_tts_talker_batches_and_captures_decode():
+    config = _tiny_model_config()
+    submodule = TalkerSubmodule(
+        Qwen3TTSTalkerModel(config),
+        Qwen3TTSCodePredictor(config),
+        config,
+    )
+    expected_sampling = {
+        "do_sample": config.generation.subtalker_dosample,
+        "temperature": config.generation.subtalker_temperature,
+        "top_k": config.generation.subtalker_top_k,
+        "top_p": config.generation.subtalker_top_p,
+    }
+    info = {
+        request_id: SimpleNamespace(
+            step_metadata={"subtalker_sampling": expected_sampling.copy()}
+        )
+        for request_id in ("a", "b")
+    }
+    batch = NodeBatch(
+        node_name="Talker",
+        graph_walk="talker_decode",
+        request_ids=["a", "b"],
+        per_request_input_tensors={},
+        per_request_info=info,
+    )
+    model_inputs = [
+        ARNodeInputs(input_embeds=torch.zeros(1, 16), input_seq_len=1)
+        for _ in range(2)
+    ]
+
+    assert submodule.can_batch(batch, model_inputs)
+    assert submodule.can_use_cuda_graphs(batch, model_inputs)
+    cache_manager = SimpleNamespace(
+        set_active_label=lambda label: None,
+        plan_attention=lambda **kwargs: None,
+        plan_rope=lambda **kwargs: None,
+    )
+    packed = submodule.preprocess(
+        "talker_decode",
+        ModelInputsFromEngine(
+            request_ids=["a", "b"],
+            per_request_info=info,
+            cache_manager=cache_manager,
+        ),
+        model_inputs,
+    )
+    assert packed["input_embeds"].shape == (2, 16)
+    assert packed["last_token_indices"].tolist() == [0, 1]
+    graph_config = submodule.get_cuda_graph_configs(torch.device("cpu"))[0]
+    assert graph_config.capture_graph_walk == "talker_decode"
+    assert graph_config.capture_batch_sizes == [1, 2, 4, 8, 16, 32]
+    piecewise = submodule.get_piecewise_cuda_graph_configs(
+        torch.device("cpu"), torch.float32
+    )["code_predictor_loop"]
+    assert piecewise.seq_len == 1
+    assert piecewise.uses_kv_cache is False
+    assert piecewise.capture_batch_sizes == [1, 2, 4, 8, 16, 32]
+    capture_shape = piecewise.get_capture_shapes([2])[0]
+    static_inputs = piecewise.make_static_inputs(capture_shape)
+    assert static_inputs["last_hidden"].shape == (2, 16)
+    assert static_inputs["uniforms"].shape == (2, 3)
+
+    info["b"].step_metadata["subtalker_sampling"]["temperature"] = 0.7
+    assert not submodule.can_batch(batch, model_inputs)
+    assert not submodule.can_use_cuda_graphs(batch, model_inputs)
+
+
+def test_qwen3_tts_piecewise_sampling_is_tensor_only():
+    logits = torch.tensor([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]])
+    tokens = TalkerSubmodule._sample_from_uniform(
+        logits=logits,
+        uniform=torch.tensor([0.3, 0.7]),
+        temperature=torch.ones(2),
+        top_k=torch.tensor([1, 1]),
+        top_p=torch.ones(2),
+        do_sample=torch.tensor([True, False]),
+    )
+    assert tokens.tolist() == [2, 0]
+
+
+def test_qwen3_tts_uses_piecewise_runner_when_available():
+    config = _tiny_model_config()
+    submodule = TalkerSubmodule(
+        Qwen3TTSTalkerModel(config),
+        Qwen3TTSCodePredictor(config),
+        config,
+    )
+
+    class _Sampler:
+        @staticmethod
+        def _broadcast_tokens(tensor):
+            return tensor
+
+    class _Runner:
+        called = False
+
+        @staticmethod
+        def can_run(batch_size):
+            return batch_size == 1
+
+        def run(self, static_inputs, real_bs):
+            self.called = True
+            assert real_bs == 1
+            assert static_inputs["uniforms"].shape == (1, 3)
+            return {
+                "all_codes": torch.tensor([[1, 2, 3, 4]]),
+                "codec_embed_sum": torch.zeros(1, 16),
+            }
+
+    runner = _Runner()
+    result = submodule._run_code_predictor_piecewise(
+        engine_inputs=ModelInputsFromEngine(
+            request_ids=["request"],
+            per_request_info={
+                "request": SimpleNamespace(random_seed=123)
+            },
+            sampler=_Sampler(),
+            piecewise_runners={"code_predictor_loop": runner},
+        ),
+        last_hidden=torch.zeros(1, 16),
+        layer0_codes=torch.tensor([1]),
+        sampling={
+            "do_sample": True,
+            "temperature": 0.9,
+            "top_k": 10,
+            "top_p": 0.8,
+        },
+    )
+
+    assert runner.called
+    assert result is not None
+    assert result[0].tolist() == [[1, 2, 3, 4]]
+    assert result[1].shape == (1, 16)
+
+
+class _FakeCodecDecoder(torch.nn.Module):
+    def __init__(self, upsample: int):
+        super().__init__()
+        self.anchor = torch.nn.Parameter(torch.zeros(()))
+        self.upsample = upsample
+
+    def forward(self, codes):
+        length = codes.shape[-1] * self.upsample
+        return torch.zeros(codes.shape[0], 1, length, dtype=torch.float32)
+
+
+def test_qwen3_tts_codec_trims_overlap_after_first_chunk():
+    config = _tiny_model_config()
+    submodule = CodecSubmodule(_FakeCodecDecoder(4), config)
+    state = submodule.request_state("request")
+    state.add("latest_codec_frames", 5)
+
+    first = {"audio_chunk": [torch.arange(20)]}
+    submodule.postprocess("request", None, first)
+    assert first["audio_chunk"][0].tolist() == list(range(20))
+
+    second = {"audio_chunk": [torch.arange(20)]}
+    submodule.postprocess("request", None, second)
+    assert second["audio_chunk"][0].tolist() == list(range(8, 20))
+
+
+def test_qwen3_tts_codec_filters_eos_and_pads_to_capture_shape():
+    config = _tiny_model_config()
+    submodule = CodecSubmodule(_FakeCodecDecoder(4), config)
+    eos = config.talker.codec_eos_token_id
+    codes = torch.tensor([
+        [1, 2, 3, 4],
+        [eos, 0, 0, 0],
+        [5, 6, 7, 8],
+    ])
+
+    prepared = submodule.prepare_inputs(
+        "codec_chunk",
+        SimpleNamespace(request_id="request"),
+        {"codec_tokens": [codes]},
+    )
+
+    packed = prepared.tensor_inputs["codec_tokens"]
+    assert packed.shape == (4, 5)
+    assert packed[:, :2].t().tolist() == [[1, 2, 3, 4], [5, 6, 7, 8]]
+    assert packed[:, 2:].count_nonzero().item() == 0
+    assert submodule.request_state("request")["latest_codec_frames"] == 2
+
+
+def test_qwen3_tts_streaming_policy_flushes_only_new_tail_audio():
+    config = _tiny_model_config()
+    stream = StreamBuffer(
+        request_id="request",
+        edge_name="codec_tokens",
+        from_partition="Talker",
+        policy=LeftContextChunkPolicy(
+            chunk=config.codec.chunk_frames,
+            left_context=config.codec.left_context_frames,
+        ),
+    )
+    for i in range(5):
+        tensor_id = str(i)
+        stream.pre_read_register(tensor_id)
+        stream.put(tensor_id, torch.tensor([i]))
+        if i == 2:
+            first = stream.pop_chunk()
+            assert first.data["data"].flatten().tolist() == [0, 1, 2]
+
+    stream.signal_done()
+    assert stream.has_chunk_ready()
+    tail = stream.pop_chunk()
+    assert tail.data["data"].flatten().tolist() == [1, 2, 3, 4]
+    assert tail.is_final is True
+
+    codec = CodecSubmodule(_FakeCodecDecoder(4), config)
+    state = codec.request_state("request")
+    state.add_all(latest_codec_frames=4, codec_chunk_emitted=True)
+    outputs = {"audio_chunk": [torch.arange(16)]}
+    codec.postprocess("request", None, outputs)
+    assert outputs["audio_chunk"][0].tolist() == list(range(8, 16))
+
+
+def test_qwen3_tts_codec_batches_and_declares_cuda_graphs():
+    config = _tiny_model_config()
+    submodule = CodecSubmodule(_FakeCodecDecoder(4), config)
+    model_inputs = [
+        ARNodeInputs(tensor_inputs={
+            "codec_tokens": torch.zeros(4, 5, dtype=torch.long)
+        })
+        for _ in range(2)
+    ]
+    batch = NodeBatch(
+        node_name="Codec",
+        graph_walk="codec_chunk",
+        request_ids=["a", "b"],
+        per_request_input_tensors={},
+    )
+
+    assert submodule.can_batch(batch, model_inputs)
+    assert submodule.can_use_cuda_graphs(batch, model_inputs)
+    packed = submodule.preprocess(
+        "codec_chunk",
+        ModelInputsFromEngine(request_ids=["a", "b"], per_request_info={}),
+        model_inputs,
+    )
+    assert packed["codec_tokens"].shape == (2, 4, 5)
+    graph_config = submodule.get_cuda_graph_configs(torch.device("cpu"))[0]
+    assert graph_config.capture_graph_walk == "codec_chunk"
+    assert graph_config.capture_batch_sizes == [1, 2, 4, 8, 16]
+    assert graph_config.single_request_inputs.tensor_inputs[
+        "codec_tokens"
+    ].shape == (4, 5)

--- a/test/modular/test_qwen3_tts_model.py
+++ b/test/modular/test_qwen3_tts_model.py
@@ -1,4 +1,6 @@
+import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -157,6 +159,46 @@ def test_qwen3_tts_registry_engines_cache_and_yaml_are_consistent():
     }
     assert all(worker_graph.ranks == [0] for worker_graph in worker_graphs)
     assert by_walk["codec_chunk"].consumes_stream is True
+
+
+def test_qwen3_tts_cli_and_benchmark_entries_are_registered():
+    repo_root = str(Path(__file__).resolve().parents[2])
+    sys.path.insert(0, repo_root)
+    from benchmark.base import ModelType, Qwen3TTS, RequestType
+    from mstar.cli.main import DEFAULT_CONFIGS, _next_steps
+
+    assert DEFAULT_CONFIGS["qwen3_tts"] == "qwen3tts.yaml"
+    benchmark_model = ModelType.QWEN3TTS.inst()
+    assert isinstance(benchmark_model, Qwen3TTS)
+    assert benchmark_model.get_hf_url() == (
+        "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"
+    )
+    assert benchmark_model.get_supported_modalities() == {RequestType.T2S}
+    assert 'voice="Vivian"' in _next_steps("qwen3_tts", "0.0.0.0", 8000)
+    sys.path.remove(repo_root)
+
+
+def test_qwen3_tts_decoder_import_does_not_probe_sox():
+    if importlib.util.find_spec("qwen_tts") is None:
+        pytest.skip("qwen-tts optional dependency is not installed")
+    script = """
+import sys
+from mstar.model.qwen3_tts.qwen3_tts_model import _load_qwen3_tts_decoder_classes
+config_cls, decoder_cls = _load_qwen3_tts_decoder_classes()
+print(config_cls.__name__, decoder_cls.__name__)
+print('sox_loaded=' + str('sox' in sys.modules))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "Qwen3TTSTokenizerV2DecoderConfig Qwen3TTSTokenizerV2Decoder" in (
+        result.stdout
+    )
+    assert "sox_loaded=False" in result.stdout
+    assert "SoX could not be found" not in result.stderr
 
 
 def test_flashinfer_wrappers_forward_explicit_kernel_backend(monkeypatch):
@@ -423,6 +465,57 @@ def test_qwen3_tts_prefill_frame_counts_toward_generation_limit():
     }
 
 
+def test_qwen3_tts_stops_on_eos_from_routed_codec_tokens():
+    config = _tiny_model_config()
+    submodule = TalkerSubmodule(
+        Qwen3TTSTalkerModel(config),
+        Qwen3TTSCodePredictor(config),
+        config,
+    )
+    submodule.request_state("request").add("generated_frames", 0)
+    outputs = {"codec_tokens": [torch.tensor([
+        config.talker.codec_eos_token_id, 1, 2, 3
+    ])]}
+    request_info = SimpleNamespace(
+        step_metadata={"talker_max_tokens": 100},
+        sampling_config={
+            "Talker": SimpleNamespace(ignore_eos=False),
+        },
+        max_tokens=8192,
+    )
+
+    submodule.postprocess("request", request_info, outputs)
+
+    assert outputs["layer0_codes"][0].item() == config.talker.codec_eos_token_id
+    assert submodule.check_stop("request", request_info, outputs) == {
+        "talker_decode_loop"
+    }
+
+
+def test_qwen3_tts_honors_ignore_eos_for_fixed_length_benchmarks():
+    config = _tiny_model_config()
+    submodule = TalkerSubmodule(
+        Qwen3TTSTalkerModel(config),
+        Qwen3TTSCodePredictor(config),
+        config,
+    )
+    submodule.request_state("request").add("generated_frames", 0)
+    outputs = {"new_token": [torch.tensor(
+        config.talker.codec_eos_token_id
+    )]}
+    request_info = SimpleNamespace(
+        step_metadata={"talker_max_tokens": 100},
+        sampling_config={
+            "Talker": SimpleNamespace(ignore_eos=True),
+        },
+        max_tokens=8192,
+    )
+
+    submodule.postprocess("request", request_info, outputs)
+
+    assert submodule.check_stop("request", request_info, outputs) == set()
+
+
 def test_qwen3_tts_suppresses_eos_for_official_minimum_frames():
     config = _tiny_model_config()
     submodule = TalkerSubmodule(
@@ -443,7 +536,7 @@ def test_qwen3_tts_suppresses_eos_for_official_minimum_frames():
     assert mask[1, eos].item() is False
 
 
-def test_qwen3_tts_talker_batches_and_captures_decode():
+def test_qwen3_tts_talker_batches_and_keeps_recurrent_decode_eager():
     config = _tiny_model_config()
     submodule = TalkerSubmodule(
         Qwen3TTSTalkerModel(config),
@@ -474,8 +567,9 @@ def test_qwen3_tts_talker_batches_and_captures_decode():
         for _ in range(2)
     ]
 
+    assert submodule.disable_torch_compile is True
     assert submodule.can_batch(batch, model_inputs)
-    assert submodule.can_use_cuda_graphs(batch, model_inputs)
+    assert not submodule.can_use_cuda_graphs(batch, model_inputs)
     cache_manager = SimpleNamespace(
         set_active_label=lambda label: None,
         plan_attention=lambda **kwargs: None,
@@ -492,9 +586,7 @@ def test_qwen3_tts_talker_batches_and_captures_decode():
     )
     assert packed["input_embeds"].shape == (2, 16)
     assert packed["last_token_indices"].tolist() == [0, 1]
-    graph_config = submodule.get_cuda_graph_configs(torch.device("cpu"))[0]
-    assert graph_config.capture_graph_walk == "talker_decode"
-    assert graph_config.capture_batch_sizes == [1, 2, 4, 8, 16, 32]
+    assert submodule.get_cuda_graph_configs(torch.device("cpu")) == []
     piecewise = submodule.get_piecewise_cuda_graph_configs(
         torch.device("cpu"), torch.float32
     )["code_predictor_loop"]
@@ -687,7 +779,12 @@ def test_qwen3_tts_codec_batches_and_declares_cuda_graphs():
     assert packed["codec_tokens"].shape == (2, 4, 5)
     graph_config = submodule.get_cuda_graph_configs(torch.device("cpu"))[0]
     assert graph_config.capture_graph_walk == "codec_chunk"
-    assert graph_config.capture_batch_sizes == [1, 2, 4, 8, 16]
+    assert submodule.max_batch_size("codec_chunk") == 8
+    assert graph_config.capture_batch_sizes == [1, 2, 4, 8]
     assert graph_config.single_request_inputs.tensor_inputs[
         "codec_tokens"
     ].shape == (4, 5)
+
+    oversized = model_inputs * 5
+    assert len(oversized) == 10
+    assert not submodule.can_batch(batch, oversized)

--- a/test/modular/test_qwen3_tts_model.py
+++ b/test/modular/test_qwen3_tts_model.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+import yaml
 
 from mstar.conductor.request_info import CurrentForwardConductorMetadata
 from mstar.engine.base import EngineType, NodeBatch
@@ -145,7 +146,9 @@ def test_qwen3_tts_registry_engines_cache_and_yaml_are_consistent():
     assert kv.num_kv_heads == model.config.talker.num_key_value_heads
     assert kv.num_qo_heads == model.config.talker.num_attention_heads
     assert kv.head_dim == model.config.talker.head_dim
-    assert kv.flashinfer_backend == "fa2"
+    assert kv.flashinfer_backend == "auto"
+    serving_config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    assert serving_config["kv_cache"]["flashinfer_backend"] == "fa2"
 
     worker_graphs = model.get_worker_graphs(str(CONFIG_PATH))
     by_walk = {
@@ -183,10 +186,16 @@ def test_qwen3_tts_decoder_import_does_not_probe_sox():
         pytest.skip("qwen-tts optional dependency is not installed")
     script = """
 import sys
+import importlib.util
 from mstar.model.qwen3_tts.qwen3_tts_model import _load_qwen3_tts_decoder_classes
 config_cls, decoder_cls = _load_qwen3_tts_decoder_classes()
 print(config_cls.__name__, decoder_cls.__name__)
 print('sox_loaded=' + str('sox' in sys.modules))
+print('public_qwen_tts_loaded=' + str(any(
+    name == 'qwen_tts' or name.startswith('qwen_tts.') for name in sys.modules
+)))
+public_spec = importlib.util.find_spec('qwen_tts')
+print('public_qwen_tts_origin=' + str(public_spec.origin))
 """
     result = subprocess.run(
         [sys.executable, "-c", script],
@@ -198,6 +207,8 @@ print('sox_loaded=' + str('sox' in sys.modules))
         result.stdout
     )
     assert "sox_loaded=False" in result.stdout
+    assert "public_qwen_tts_loaded=False" in result.stdout
+    assert "qwen_tts/__init__.py" in result.stdout
     assert "SoX could not be found" not in result.stderr
 
 
@@ -254,6 +265,29 @@ def test_qwen3_tts_process_prompt_matches_official_template():
     assert tensors["text_inputs"][0].tolist() == [1, 2, 3]
     assert tensors["speaker_id"][0].item() == 3065
     assert tensors["language_id"][0].item() == 2055
+
+
+def test_qwen3_tts_validates_speaker_dialect_after_language_override():
+    model = _make_model()
+
+    tensors = model.process_prompt(
+        "你好",
+        input_modalities=["text"],
+        output_modalities=["audio"],
+        voice="Eric",
+        language="auto",
+    )
+    assert tensors["language_id"][0].item() == 2062
+
+    model.config.talker.spk_is_dialect["vivian"] = "missing_dialect"
+    with pytest.raises(ValueError, match="missing_dialect"):
+        model.process_prompt(
+            "你好",
+            input_modalities=["text"],
+            output_modalities=["audio"],
+            voice="Vivian",
+            language="auto",
+        )
 
 
 @pytest.mark.parametrize(
@@ -429,6 +463,8 @@ def test_qwen3_tts_talker_builds_official_streaming_prefill():
     talker = Qwen3TTSTalkerModel(config)
     predictor = Qwen3TTSCodePredictor(config)
     submodule = TalkerSubmodule(talker, predictor, config)
+    submodule.CHATML_ASSISTANT_PREFIX_TOKEN_IDS = (1, 2, 3)
+    submodule.CHATML_ASSISTANT_SUFFIX_TOKEN_IDS = (8, 9, 10, 11, 12)
 
     embeds = submodule._build_prefill(
         request_id="request",
@@ -442,6 +478,27 @@ def test_qwen3_tts_talker_builds_official_streaming_prefill():
     assert state["trailing_text_hidden"].shape == (4, 16)
     assert state["tts_pad_embed"].shape == (16,)
     assert state["generation_step"] == 0
+
+
+def test_qwen3_tts_talker_rejects_changed_chatml_layout():
+    config = _tiny_model_config()
+    submodule = TalkerSubmodule(
+        Qwen3TTSTalkerModel(config),
+        Qwen3TTSCodePredictor(config),
+        config,
+    )
+    submodule.CHATML_ASSISTANT_PREFIX_TOKEN_IDS = (1, 2, 3)
+    submodule.CHATML_ASSISTANT_SUFFIX_TOKEN_IDS = (8, 9, 10, 11, 12)
+    text_ids = torch.arange(1, 13)
+    text_ids[-1] = 7
+
+    with pytest.raises(ValueError, match="ChatML assistant suffix changed"):
+        submodule._build_prefill(
+            request_id="request",
+            text_ids=text_ids,
+            speaker_id=40,
+            language_id=-1,
+        )
 
 
 def test_qwen3_tts_prefill_frame_counts_toward_generation_limit():
@@ -523,12 +580,15 @@ def test_qwen3_tts_suppresses_eos_for_official_minimum_frames():
         Qwen3TTSCodePredictor(config),
         config,
     )
-    submodule.request_state("new").add("generated_frames", 0)
-    submodule.request_state("ready").add(
-        "generated_frames", config.generation.min_new_tokens
-    )
-
-    mask = submodule._get_batch_suppress_mask(["new", "ready"])
+    inputs = [
+        ARNodeInputs(tensor_inputs={
+            "suppress_eos": torch.tensor([True]),
+        }),
+        ARNodeInputs(tensor_inputs={
+            "suppress_eos": torch.tensor([False]),
+        }),
+    ]
+    mask = submodule._get_batch_suppress_mask(inputs)
     eos = config.talker.codec_eos_token_id
 
     assert mask.shape == (2, config.talker.vocab_size)
@@ -536,7 +596,48 @@ def test_qwen3_tts_suppresses_eos_for_official_minimum_frames():
     assert mask[1, eos].item() is False
 
 
-def test_qwen3_tts_talker_batches_and_keeps_recurrent_decode_eager():
+def test_qwen3_tts_eos_suppression_ignores_graph_dummy_request_ids():
+    config = _tiny_model_config()
+    submodule = TalkerSubmodule(
+        Qwen3TTSTalkerModel(config),
+        Qwen3TTSCodePredictor(config),
+        config,
+    )
+    real_state = submodule.request_state("real")
+    real_state.add_all(
+        generation_step=0,
+        generated_frames=config.generation.min_new_tokens,
+        trailing_text_hidden=torch.zeros(1, config.talker.hidden_size),
+        tts_pad_embed=torch.zeros(config.talker.hidden_size),
+    )
+    prepared = submodule.prepare_inputs(
+        "talker_decode",
+        SimpleNamespace(request_id="real"),
+        {"talker_input_embeds": [torch.zeros(1, config.talker.hidden_size)]},
+    )
+    cache_manager = SimpleNamespace(
+        set_active_label=lambda label: None,
+        plan_attention=lambda **kwargs: None,
+        plan_rope=lambda **kwargs: None,
+    )
+
+    packed = submodule.preprocess(
+        "talker_decode",
+        ModelInputsFromEngine(
+            request_ids=["__graph_dummy__"],
+            per_request_info={},
+            cache_manager=cache_manager,
+        ),
+        [prepared],
+    )
+
+    eos = config.talker.codec_eos_token_id
+    assert prepared.tensor_inputs["suppress_eos"].item() is False
+    assert packed["suppress_mask"][0, eos].item() is False
+    assert "__graph_dummy__" not in submodule.request_states
+
+
+def test_qwen3_tts_talker_batches_and_captures_decode():
     config = _tiny_model_config()
     submodule = TalkerSubmodule(
         Qwen3TTSTalkerModel(config),
@@ -563,13 +664,17 @@ def test_qwen3_tts_talker_batches_and_keeps_recurrent_decode_eager():
         per_request_info=info,
     )
     model_inputs = [
-        ARNodeInputs(input_embeds=torch.zeros(1, 16), input_seq_len=1)
+        ARNodeInputs(
+            input_embeds=torch.zeros(1, 16),
+            input_seq_len=1,
+            tensor_inputs={"suppress_eos": torch.tensor([True])},
+        )
         for _ in range(2)
     ]
 
     assert submodule.disable_torch_compile is True
     assert submodule.can_batch(batch, model_inputs)
-    assert not submodule.can_use_cuda_graphs(batch, model_inputs)
+    assert submodule.can_use_cuda_graphs(batch, model_inputs)
     cache_manager = SimpleNamespace(
         set_active_label=lambda label: None,
         plan_attention=lambda **kwargs: None,
@@ -586,7 +691,12 @@ def test_qwen3_tts_talker_batches_and_keeps_recurrent_decode_eager():
     )
     assert packed["input_embeds"].shape == (2, 16)
     assert packed["last_token_indices"].tolist() == [0, 1]
-    assert submodule.get_cuda_graph_configs(torch.device("cpu")) == []
+    graph_config = submodule.get_cuda_graph_configs(torch.device("cpu"))[0]
+    assert graph_config.capture_graph_walk == "talker_decode"
+    assert graph_config.capture_batch_sizes == [1, 2, 4, 8, 16, 32]
+    assert graph_config.single_request_inputs.tensor_inputs[
+        "suppress_eos"
+    ].item() is True
     piecewise = submodule.get_piecewise_cuda_graph_configs(
         torch.device("cpu"), torch.float32
     )["code_predictor_loop"]
@@ -601,6 +711,51 @@ def test_qwen3_tts_talker_batches_and_keeps_recurrent_decode_eager():
     info["b"].step_metadata["subtalker_sampling"]["temperature"] = 0.7
     assert not submodule.can_batch(batch, model_inputs)
     assert not submodule.can_use_cuda_graphs(batch, model_inputs)
+
+
+def test_qwen3_tts_code_predictor_uses_native_gqa(monkeypatch):
+    config = _tiny_model_config()
+    predictor = Qwen3TTSCodePredictor(config)
+    # This CPU-only contract test targets the SDPA call. FlashInfer RMSNorm is
+    # CUDA-only, so replace normalization without changing attention geometry.
+    for layer in predictor.model.layers:
+        layer.input_layernorm = torch.nn.Identity()
+        layer.post_attention_layernorm = torch.nn.Identity()
+        layer.self_attn.q_norm = torch.nn.Identity()
+        layer.self_attn.k_norm = torch.nn.Identity()
+    predictor.model.norm = torch.nn.Identity()
+    original_sdpa = torch.nn.functional.scaled_dot_product_attention
+    calls = []
+
+    def capture_sdpa(query, key, value, **kwargs):
+        calls.append((query.shape, key.shape, value.shape, kwargs))
+        return original_sdpa(query, key, value, **kwargs)
+
+    monkeypatch.setattr(
+        torch.nn.functional,
+        "scaled_dot_product_attention",
+        capture_sdpa,
+    )
+    output = predictor.forward_depth_unrolled(
+        inputs_embeds=torch.randn(1, 1, config.talker.hidden_size),
+        position_ids=torch.zeros(1, 1, dtype=torch.long),
+        kv_cache=torch.empty(
+            config.talker.code_predictor.num_hidden_layers,
+            1,
+            2,
+            config.talker.num_code_groups,
+            config.talker.code_predictor.num_key_value_heads,
+            config.talker.code_predictor.head_dim,
+        ),
+        cache_pos=0,
+    )
+
+    query_shape, key_shape, value_shape, kwargs = calls[0]
+    assert output.shape == (1, 1, config.talker.hidden_size)
+    assert query_shape[1] == config.talker.code_predictor.num_attention_heads
+    assert key_shape[1] == config.talker.code_predictor.num_key_value_heads
+    assert value_shape[1] == config.talker.code_predictor.num_key_value_heads
+    assert kwargs["enable_gqa"] is True
 
 
 def test_qwen3_tts_piecewise_sampling_is_tensor_only():


### PR DESCRIPTION
## What does this PR do?

Adds initial serving support for `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice`.

- Registers the `qwen3_tts` model and adds its serving YAML and dependencies.
- Implements checkpoint configuration parsing, weight loading, request preprocessing, and PCM audio postprocessing.
- Declares the Talker and Codec partitions and their graph walks.
- Supports continuous batching and streaming codec output.
- Adds CUDA Graph support for batched decode and piecewise capture of inner loops.
- Adds configurable FlashInfer attention backends so Qwen3-TTS can use the compatible FA2 kernels.
- Adds unit tests and CUDA real-checkpoint integration tests covering graph transitions, batching, CUDA Graph execution, tokenizer/prefill behavior, and codec output.

### Partition and graph-walk layout

Qwen3-TTS is split into two independently scheduled partitions:

- **Talker** uses the KV-cache engine and owns `talker_prefill` and `talker_decode`. Prefill consumes the text, speaker, and language inputs, then transitions to the autoregressive decode loop. Each decode iteration predicts one complete 16-group codec frame and feeds its embedding back into the next iteration.
- **Codec** is a stateless consumer partition with the `codec_chunk` walk. Codec tokens are streamed from Talker and buffered with left context. Once enough new frames are available, the conductor schedules `codec_chunk`, emits the resulting PCM audio to the client, and re-arms the partition for the next chunk.

This separation allows waveform decoding and audio streaming to overlap with subsequent Talker decode iterations instead of waiting for the full token sequence.

## How was it tested?

- `.venv/bin/ruff check .`
- `FLASHINFER_WORKSPACE_BASE=/tmp/mstar-flashinfer .venv/bin/pytest -q test/modular/test_qwen3_tts_model.py`
  - `27 passed`

Real-weight CUDA integration tests are included in `test/integration/test_qwen3_tts_real_weights.py` for GPU environments with the Qwen3-TTS checkpoint available.

## Checklist

- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
