### PR TITLE
pin ruff + ignore Too many positional arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ mstar-serve = "mstar.api_server.entrypoint:main"
 
 [project.optional-dependencies]
 dev = [
-    "ruff",
+    "ruff<=0.16",
     "pytest",
 ]
 
@@ -205,6 +205,7 @@ ignore = [
     "PLR2004", # Magic value used in comparison
     "PLW0603", # Using the global statement
     "PLW2901", # Loop variable overwritten by assignment target
+    "PLR0917", # Too many positional arguments
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

Fixes  the repo-wide red `ruff check` CI: the latest `ruff` (0.16.0) now fails on `PLR0917 Too many positional arguments` in `benchmark/dataset.py` and `benchmark/request.py`.

This PR adds `PLR0917` to the ignore list on `pyproject.toml` and pins `ruff <= 0.16.0` to avoid this issue in the future.

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->
```
uv pip install --upgrade ruff
ruff check
```

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
