### PR TITLE
Cosmos3 droid

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ uv pip install \
   "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu13torch2.9cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
 ```
 
-Other models: `mstar serve cosmos3` · `mstar serve qwen3_omni` · `mstar serve orpheus` · `mstar serve pi05` · `mstar serve vjepa2`
+Other models: `mstar serve cosmos3` · `mstar serve cosmos3_droid` · `mstar serve qwen3_omni` · `mstar serve orpheus` · `mstar serve pi05` · `mstar serve vjepa2`
 
 **Python SDK** — works for every model (text, image, audio, video):
 
@@ -117,6 +117,7 @@ _Note_: The **first request(s) on a fresh environment can be slow** — often te
 | [Qwen3-Omni](https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct) | Omni | text, image, audio, video → text, speech | `/v1/chat/completions` |
 | [Orpheus](https://huggingface.co/canopylabs/orpheus-3b-0.1-ft) | Speech LM | text → speech | `/v1/audio/speech` |
 | [Cosmos3 Nano / Super](https://huggingface.co/nvidia/Cosmos3-Nano) | World model | text, image, video → image, video (+ sound), robot actions | `/v1/images/generations`, `/v1/videos/generations` |
+| [Cosmos3 Policy DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID) | Robot policy | text, image, video → robot actions, video | `/generate` |
 | [Pi0.5](https://huggingface.co/lerobot/pi05_base) | Vision-language-action | text, image, state → robot actions | `/generate` |
 | [V-JEPA 2 / 2-AC](https://huggingface.co/facebook/vjepa2-vitl-fpc64-256) | World model | video (+ actions) → latents, rollouts | `/generate` |
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ _Note_: The **first request(s) on a fresh environment can be slow** — often te
 | [Qwen3-Omni](https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct) | Omni | text, image, audio, video → text, speech | `/v1/chat/completions` |
 | [Orpheus](https://huggingface.co/canopylabs/orpheus-3b-0.1-ft) | Speech LM | text → speech | `/v1/audio/speech` |
 | [Cosmos3 Nano / Super](https://huggingface.co/nvidia/Cosmos3-Nano) | World model | text, image, video → image, video (+ sound), robot actions | `/v1/images/generations`, `/v1/videos/generations` |
-| [Cosmos3 Policy DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID) | Robot policy | text, image, video → robot actions, video | `/generate` |
+| [Cosmos3 Policy DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID) | Robot policy | text, image, video → robot actions, video | `/generate`, `/v1/images/generations`, `/v1/videos/generations` |
 | [Pi0.5](https://huggingface.co/lerobot/pi05_base) | Vision-language-action | text, image, state → robot actions | `/generate` |
 | [V-JEPA 2 / 2-AC](https://huggingface.co/facebook/vjepa2-vitl-fpc64-256) | World model | video (+ actions) → latents, rollouts | `/generate` |
 

--- a/configs/cosmos3_droid.yaml
+++ b/configs/cosmos3_droid.yaml
@@ -1,0 +1,30 @@
+model: "cosmos3_droid"
+# Sequence-length hint for the scheduler. The conductor only asserts its
+# presence; the real per-request capacity is the KV pool below.
+max_seq_len: 8192
+# KV pool sizing, matching the Nano config: the checkpoint is Nano-sized and
+# still serves the full video paths (forward dynamics decodes a rollout
+# video), so it keeps the pool that covers single-request video at every tier.
+kv_cache:
+  max_num_pages: 1024
+# Denoise CUDA-graph capture knobs (serving). cuda_graph=false serves eager;
+# graph_max_latent_area caps which resolutions are captured (latent H*W). The
+# COSMOS3_DISABLE_CUDA_GRAPH / COSMOS3_GRAPH_MAX_LATENT_AREA env vars override.
+model_kwargs:
+  cuda_graph: true
+  graph_max_latent_area: 2000
+  # The checkpoint ships no sound pathway (sound_gen false, no
+  # sound_tokenizer/); stated here so the yaml documents the served surface.
+  enable_sound: false
+  # Sampling defaults for action requests, matching the released DROID
+  # RoboLab policy serving parameters (4-step denoise, guidance 3.0). The
+  # flow shift stays at the action default (5.0, the 480p training shift).
+  num_inference_steps_action: 4
+  guidance_scale_action: 3.0
+node_groups:
+  - node_names: ["dit"]
+    ranks: [0]
+  # No audio_decoder: the checkpoint has no sound pathway, so the sound walk
+  # (the only consumer of that node) is never built.
+  - node_names: ["vae_encoder", "vae_decoder"]
+    ranks: [0]

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -20,6 +20,11 @@ Registry keys live in ``mstar/model/registry.py`` (``MODEL_REGISTRY`` / ``HF_MOD
    * - ``cosmos3``
      - ``nvidia/Cosmos3-Nano``
      - Cosmos3 world model: t2i/t2v/i2v/v2v diffusion, robot-action modes, opt-in sound.
+   * - ``cosmos3_droid``
+     - ``nvidia/Cosmos3-Nano-Policy-DROID``
+     - Cosmos3 action-policy fine-tune for the DROID platform (``domain_name``
+       ``droid_lerobot``, 10-dim raw actions); no sound pathway. The config
+       serves the released policy sampling defaults (4 steps, guidance 3.0).
    * - ``cosmos3_super``
      - ``nvidia/Cosmos3-Super``
      - Cosmos3-Super (64B) variant of the above; TP/SP for multi-GPU serving.

--- a/mstar/api_server/openai/adapters.py
+++ b/mstar/api_server/openai/adapters.py
@@ -380,6 +380,7 @@ ADAPTER_REGISTRY: dict[str, OpenAIAdapter] = {
     "qwen3_omni": Qwen3OmniAdapter(),
     "orpheus": OrpheusAdapter(),
     "cosmos3": Cosmos3Adapter(),
+    "cosmos3_droid": Cosmos3Adapter(),
     "cosmos3_super": Cosmos3Adapter(),
 }
 

--- a/mstar/cli/main.py
+++ b/mstar/cli/main.py
@@ -26,6 +26,7 @@ DEFAULT_CONFIGS: dict[str, str] = {
     "bagel": "bagel_single_gpu.yaml",
     "bagel_cfg_parallel": "bagel_cfg_parallel.yaml",
     "cosmos3": "cosmos3_nano.yaml",
+    "cosmos3_droid": "cosmos3_droid.yaml",
     "cosmos3_super": "cosmos3_super_tp2.yaml",
     "orpheus": "orpheus_colocated.yaml",
     "qwen3_omni": "qwen3omni_2gpu.yaml",
@@ -85,6 +86,11 @@ def _next_steps(model: str, host: str, port: int) -> str:
     if model in ("cosmos3", "cosmos3_super"):
         lines.append("    open(\"out.png\",\"wb\").write(client.generate_image(\"a red cube on a wooden table\"))")
         lines.append("    res = client.generate(text=\"a robot arm cleaning a plate\", output_modalities=(\"video\",))")
+    if model == "cosmos3_droid":
+        lines.append("    res = client.generate(text=\"pick up the banana and place it in the bowl\",")
+        lines.append("                           images=[\"frame.jpg\"], output_modalities=(\"action\",),")
+        lines.append("                           action_mode=\"policy\", domain_name=\"droid_lerobot\",")
+        lines.append("                           raw_action_dim=10, action_chunk_size=16)")
     if model == "qwen3_omni":
         lines.append("    client.chat(\"Say hi\", output_modalities=(\"text\",\"audio\")).save_audio(\"out.wav\")")
     if model in ("orpheus", "qwen3_omni"):

--- a/mstar/model/cosmos3/components/packing.py
+++ b/mstar/model/cosmos3/components/packing.py
@@ -188,6 +188,54 @@ def action_start_frame_offset(action_length: int, video_length: int) -> int:
     )
 
 
+# The published Cosmos3 embodiment-domain table: requests may name their
+# embodiment instead of sending the numeric domain id. droid_lerobot and
+# robomind-franka share a domain (both are a Franka arm with a Robotiq
+# gripper); the agibot names are aliases of one domain likewise.
+EMBODIMENT_TO_DOMAIN_ID: dict[str, int] = {
+    "no_action": 0,
+    "av": 1,
+    "camera_pose": 2,
+    "hand_pose": 3,
+    "pusht": 4,
+    "libero": 5,
+    "umi": 6,
+    "bridge_orig_lerobot": 7,
+    "droid_lerobot": 8,
+    "robomind-franka": 8,
+    "galbot": 9,
+    "robomind-franka-dual": 12,
+    "robomind-ur": 13,
+    "agibotworld": 15,
+    "agibot_gear_gripper": 15,
+    "agibot_gear_gripper_ext": 15,
+    "fractal": 20,
+}
+
+
+def resolve_action_domain_id(domain_id, domain_name) -> int:
+    """Resolve an action request's embodiment domain. A numeric ``domain_id``
+    wins; otherwise ``domain_name`` looks up the published table. One of the
+    two is required — the domain conditions the action pathway, and a silent
+    default would predict actions for the wrong embodiment."""
+    if domain_id is not None:
+        resolved = int(domain_id)
+        if resolved < 0:
+            raise ValueError(f"Cosmos3 domain_id must be non-negative, got {resolved}.")
+        return resolved
+    if domain_name is None or not str(domain_name).strip():
+        raise ValueError(
+            "Cosmos3 action requests require 'domain_id' or a non-empty 'domain_name'."
+        )
+    key = str(domain_name).strip().lower()
+    if key not in EMBODIMENT_TO_DOMAIN_ID:
+        raise ValueError(
+            f"Unknown Cosmos3 action domain_name={domain_name!r}; expected one of "
+            f"{sorted(EMBODIMENT_TO_DOMAIN_ID)} or a numeric domain_id."
+        )
+    return EMBODIMENT_TO_DOMAIN_ID[key]
+
+
 # ---------------------------------------------------------------------------
 # Prompt tokenization — ported from pipeline.tokenize_prompt. Image mode
 # (num_frames == 1) and video mode differ only in the system prompt and the

--- a/mstar/model/cosmos3/config.py
+++ b/mstar/model/cosmos3/config.py
@@ -153,6 +153,13 @@ class Cosmos3Config:
     # Default frame count for a video request that doesn't specify ``num_frames``
     # (the Wan VAE downsamples time by 4, so latent frames = 1 + (n - 1) // 4).
     num_frames_video: int = 17
+    # Action-request sampling defaults (all three action modes), following the
+    # reference action serving recipe: 30-step denoise, guidance 1.0, flow
+    # shift 5.0 (the 480p training shift). Checkpoint yamls override — the
+    # released DROID policy serves 4 steps at guidance 3.0.
+    num_inference_steps_action: int = 30
+    guidance_scale_action: float = 1.0
+    flow_shift_action: float = 5.0
 
     # ----- denoise CUDA-graph capture (serving knobs) -----
     # Capture the fixed-shape denoise step as a CUDA graph (the launch-bound-tier

--- a/mstar/model/cosmos3/cosmos3_model.py
+++ b/mstar/model/cosmos3/cosmos3_model.py
@@ -52,6 +52,7 @@ from mstar.graph.base import (
 from mstar.graph.special_destinations import EMIT_TO_CLIENT, EMPTY_DESTINATION
 from mstar.model.base import ForwardPassArgs, Model
 from mstar.model.cosmos3 import constants
+from mstar.model.cosmos3.components.packing import ACTION_MODES, resolve_action_domain_id
 from mstar.model.cosmos3.config import Cosmos3Config
 from mstar.model.cosmos3.submodules import (
     ACTION_GEN_LOOP,
@@ -626,28 +627,76 @@ class Cosmos3Model(Model):
             except ValueError:
                 pass
 
-        # A video request without an explicit frame count gets the video default
-        # (>1); image requests stay single-frame.
-        default_frames = (
-            self.config.num_frames_video if "video" in (output_modalities or []) else 1
-        )
-        num_frames = int(mk.get("num_frames", default_frames))
-        # The image and video cookbook step counts differ (image 50, video 35);
-        # default by mode and let the request override. The denoise loop runs this
-        # many steps and stops early (Cosmos3DiTSubmodule.check_stop), so the value
+        # Action requests resolve their mode up front: it switches the frame,
+        # step, guidance and flow-shift defaulting below to the action recipe.
+        action_mode = mk.get("action_mode")
+        if action_mode is not None:
+            action_mode = str(action_mode).strip().lower()
+            if action_mode not in ACTION_MODES:
+                raise ValueError(
+                    f"Unsupported Cosmos3 action_mode={mk.get('action_mode')!r}; "
+                    f"expected one of {sorted(ACTION_MODES)}."
+                )
+
+        if action_mode is not None:
+            # An action request predicts one action token per frame, so the
+            # frame count and the chunk length are coupled (num_frames = chunk
+            # or chunk + 1) and default off each other; chunk 16 when neither
+            # is sent (the reference action default).
+            raw_chunk = mk.get("action_chunk_size")
+            raw_frames = mk.get("num_frames")
+            if raw_chunk is not None:
+                action_chunk = int(raw_chunk)
+            elif raw_frames is not None:
+                action_chunk = int(raw_frames) - 1
+            else:
+                action_chunk = 16
+            if action_chunk <= 0:
+                raise ValueError(
+                    f"Cosmos3 action_chunk_size must be positive, got {action_chunk}."
+                )
+            num_frames = int(raw_frames) if raw_frames is not None else action_chunk + 1
+            if num_frames not in (action_chunk, action_chunk + 1):
+                raise ValueError(
+                    "Cosmos3 action requests require num_frames to equal "
+                    "action_chunk_size or action_chunk_size + 1; got "
+                    f"num_frames={num_frames}, action_chunk_size={action_chunk}."
+                )
+            # A bare action request runs the 480p tier (832x480) — the released
+            # policy serving resolution, and the tier whose training shift the
+            # action flow-shift default (5.0) matches.
+            if "size" not in mk and "width" not in mk and "height" not in mk:
+                width, height = 832, 480
+        else:
+            action_chunk = None
+            # A video request without an explicit frame count gets the video
+            # default (>1); image requests stay single-frame.
+            default_frames = (
+                self.config.num_frames_video if "video" in (output_modalities or []) else 1
+            )
+            num_frames = int(mk.get("num_frames", default_frames))
+        # The cookbook step counts differ per mode (image 50, video 35, action
+        # 30 — configs override the action count per checkpoint); default by
+        # mode and let the request override. The denoise loop runs this many
+        # steps and stops early (Cosmos3DiTSubmodule.check_stop), so the value
         # is only bounded above by the loop's static max_iters.
-        default_steps = (
-            self.config.num_inference_steps_video if num_frames > 1
-            else self.config.num_inference_steps
-        )
+        if action_mode is not None:
+            default_steps = self.config.num_inference_steps_action
+        elif num_frames > 1:
+            default_steps = self.config.num_inference_steps_video
+        else:
+            default_steps = self.config.num_inference_steps
         steps = int(mk.get("num_inference_steps", default_steps))
         steps = max(1, min(steps, self.config.max_inference_steps))
+        default_guidance = (
+            self.config.guidance_scale_action if action_mode is not None else 6.0
+        )
         params = {
             "width": int(mk.get("width", width)),
             "height": int(mk.get("height", height)),
             "num_frames": num_frames,
             "fps": float(mk.get("fps", self.config.fps)),
-            "guidance_scale": float(mk.get("guidance_scale", 6.0)),
+            "guidance_scale": float(mk.get("guidance_scale", default_guidance)),
             "num_inference_steps": steps,
             "has_image_condition": "image" in (input_modalities or []),
             "use_karras_sigma": mk.get("use_karras_sigmas"),
@@ -661,7 +710,7 @@ class Cosmos3Model(Model):
         # latent frames taken from the request video (reference recipe defaults:
         # indexes (0, 1), keep "first", flow_shift 10.0). Validated here so a
         # malformed request fails at submission rather than mid-denoise.
-        has_video_condition = "video" in (input_modalities or []) and "action_mode" not in mk
+        has_video_condition = "video" in (input_modalities or []) and action_mode is None
         if has_video_condition:
             from mstar.model.cosmos3.components.packing import normalize_condition_frame_indexes
 
@@ -687,11 +736,13 @@ class Cosmos3Model(Model):
         # reference Cosmos3 t2i recipe: classifier-free guidance only on the
         # timestep interval [400, 1000] (outside it the denoise step runs the
         # conditional branch alone) and flow_shift 3.0. Request kwargs override;
-        # video-to-video defaults to the reference V2V flow_shift; other
-        # image-conditioned / video paths keep their own defaults (full CFG,
-        # scheduler-config flow_shift).
-        is_t2i = num_frames == 1 and not params["has_image_condition"]
+        # action modes default to the action flow shift, video-to-video to the
+        # reference V2V flow shift; other image-conditioned / video paths keep
+        # their own defaults (full CFG, scheduler-config flow_shift).
+        is_t2i = num_frames == 1 and not params["has_image_condition"] and action_mode is None
         fs = mk.get("flow_shift")
+        if fs is None and action_mode is not None:
+            fs = self.config.flow_shift_action
         if fs is None and is_t2i:
             fs = 3.0
         if fs is None and has_video_condition:
@@ -703,16 +754,44 @@ class Cosmos3Model(Model):
             gi = (400.0, 1000.0)
         if gi is not None:
             params["guidance_interval"] = (float(gi[0]), float(gi[1]))
-        # Action requests carry a few extra keys straight through (``action`` is
-        # the clean conditioning action chunk for forward-dynamics).
-        for k in ("action_mode", "action_chunk_size", "raw_action_dim", "domain_id",
-                  "action_fps", "action"):
-            if k in mk:
-                params[k] = mk[k]
+        # Action requests must name their embodiment explicitly — the domain
+        # conditions the action pathway, and a silent default would predict
+        # actions for the wrong robot. ``domain_name`` resolves through the
+        # published embodiment table; a numeric ``domain_id`` wins. The raw
+        # action width is likewise required (forward-dynamics can infer it
+        # from its conditioning ``action`` array) and bounded by the model's
+        # padded action dim.
+        if action_mode is not None:
+            params["action_mode"] = action_mode
+            params["action_chunk_size"] = action_chunk
+            params["domain_id"] = resolve_action_domain_id(
+                mk.get("domain_id"), mk.get("domain_name")
+            )
+            raw_dim = mk.get("raw_action_dim")
+            if raw_dim is None and action_mode == "forward_dynamics" and mk.get("action") is not None:
+                try:
+                    raw_dim = int(torch.as_tensor(mk["action"]).shape[-1])
+                except (TypeError, ValueError, RuntimeError):
+                    raw_dim = None
+            if raw_dim is None:
+                raise ValueError(
+                    "Cosmos3 action requests require 'raw_action_dim' "
+                    "(forward_dynamics may omit it when the 'action' array carries the width)."
+                )
+            raw_dim = int(raw_dim)
+            if not 1 <= raw_dim <= self.config.max_action_dim:
+                raise ValueError(
+                    f"Cosmos3 raw_action_dim must be in [1, {self.config.max_action_dim}], "
+                    f"got {raw_dim}."
+                )
+            params["raw_action_dim"] = raw_dim
+            for k in ("action_fps", "action"):
+                if k in mk:
+                    params[k] = mk[k]
         # Opt-in sound generation: video-only (image and action requests carry
         # no sound band), and only when the served checkpoint/config enable it.
         if mk.get("generate_sound") or mk.get("sound_gen"):
-            if num_frames <= 1 or "action_mode" in params:
+            if num_frames <= 1 or action_mode is not None:
                 raise ValueError(
                     "Cosmos3 sound generation is supported only for video requests "
                     "(num_frames > 1, no action mode)."

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1795,12 +1795,15 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
         # epilogues (~20-30% off the 189-frame video decode, neutral for
         # images) at the cost of one trace per new shape. fullgraph=False
         # breaks around the VAE's causal-conv feature cache.
-        # COSMOS3_COMPILE_VAE=0 disables (eager is identical bar fp rounding).
+        # COSMOS3_COMPILE_VAE=0 disables.
         self._decode = vae.decode if vae is not None else None
+        self._decode_compiled = False
+        self._warmed_decode_shapes: set[tuple[int, ...]] = set()
         if vae is not None and os.environ.get("COSMOS3_COMPILE_VAE", "1").lower() not in (
             "0", "false", "no", "off",
         ):
             self._decode = torch.compile(vae.decode, fullgraph=False, dynamic=False)
+            self._decode_compiled = True
             logger.info("Cosmos3 VAE decode torch.compile enabled")
         # Resolve + log the decode dtype now (a cheap cuDNN-version read) so the
         # choice is fixed at startup, not on the first request.
@@ -1842,6 +1845,20 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
         # on the fp32-decode path.
         z = (latents.to(vae_dtype) / inv_std + mean).to(vae_dtype)
         with torch.autocast(device_type="cuda", enabled=False):
+            if (
+                self._decode_compiled
+                and vae_dtype == torch.bfloat16
+                and tuple(z.shape) not in self._warmed_decode_shapes
+            ):
+                # A process's first execution of the compiled bf16 decode
+                # returns corrupted frames on some torch/cuDNN stacks — even
+                # when the kernels come from a warm on-disk inductor cache —
+                # while every later call of the same graphs is correct. Decode
+                # once per new latent shape and discard, so served frames
+                # always come from warmed graphs. The fp32 decode does not
+                # exhibit this and skips the warm-up.
+                self._decode(z)
+                self._warmed_decode_shapes.add(tuple(z.shape))
             decoded = self._decode(z).sample  # [1, 3, T, H, W] in [-1, 1]
         # Quantize to 8-bit here (the output is an 8-bit image/mp4 either way) so
         # only the uint8 frames cross the SHM edge to the data worker, not a 4x

--- a/mstar/model/cosmos3/tests/test_droid.py
+++ b/mstar/model/cosmos3/tests/test_droid.py
@@ -1,0 +1,158 @@
+"""CPU-only checks for serving Cosmos3-Nano-Policy-DROID.
+
+The registry/config wiring checks always run. The checkpoint-structure checks
+parse the DROID checkpoint's JSON files and build the backbone on the ``meta``
+device (shapes only, zero storage) — point ``COSMOS3_DROID_DIR`` at a
+Cosmos3-Nano-Policy-DROID directory to run them (skipped otherwise).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+from mstar.model.cosmos3.components.transformer import Cosmos3OmniTransformer
+from mstar.model.cosmos3.config import Cosmos3Config
+from mstar.model.cosmos3.cosmos3_model import Cosmos3Model
+from mstar.model.cosmos3.loader import (
+    DROP_KEYS,
+    cosmos3_name_remapper,
+    read_transformer_weight_keys,
+    read_transformer_weight_shapes,
+)
+
+DROID_DIR = Path(os.environ.get("COSMOS3_DROID_DIR", "/nonexistent-cosmos3-droid"))
+
+needs_droid = pytest.mark.skipif(
+    not DROID_DIR.exists(), reason="set COSMOS3_DROID_DIR to a Cosmos3-Nano-Policy-DROID dir"
+)
+
+
+def test_droid_registry_and_config_wiring() -> None:
+    from mstar.cli.main import DEFAULT_CONFIGS
+    from mstar.model.registry import HF_MODELS, MODEL_REGISTRY
+
+    assert MODEL_REGISTRY["cosmos3_droid"] is Cosmos3Model
+    assert HF_MODELS["cosmos3_droid"]["model_path_hf"] == "nvidia/Cosmos3-Nano-Policy-DROID"
+
+    import mstar
+
+    yaml_path = Path(mstar.__file__).resolve().parent.parent / "configs" / DEFAULT_CONFIGS["cosmos3_droid"]
+    assert yaml_path.exists(), yaml_path
+
+    import yaml
+
+    cfg = yaml.safe_load(yaml_path.read_text())
+    assert cfg["model"] == "cosmos3_droid"
+    mk = cfg["model_kwargs"]
+    # The released DROID policy sampling defaults, and the explicit statement
+    # that this checkpoint serves no sound.
+    assert mk["enable_sound"] is False
+    assert mk["num_inference_steps_action"] == 4
+    assert mk["guidance_scale_action"] == 3.0
+    node_names = {n for g in cfg["node_groups"] for n in g["node_names"]}
+    assert "audio_decoder" not in node_names
+    assert {"dit", "vae_encoder", "vae_decoder"} <= node_names
+
+
+@needs_droid
+def test_droid_config_roundtrip() -> None:
+    cfg = Cosmos3Config.from_pretrained(DROID_DIR)
+
+    # Nano-identical transformer dimensions.
+    assert cfg.num_hidden_layers == 36
+    assert cfg.hidden_size == 4096
+    assert cfg.num_attention_heads == 32
+    assert cfg.num_key_value_heads == 8
+    assert cfg.head_dim == 128
+    assert cfg.intermediate_size == 12288
+
+    # Capability flags: the action pathway stays, the sound pathway is gone.
+    assert cfg.action_gen is True
+    assert cfg.max_action_dim == 64 and cfg.num_embodiment_domains == 32
+    assert cfg.sound_gen is False
+    assert cfg.sound_dim is None
+
+    # VAE + scheduler match the Nano components.
+    assert cfg.vae.z_dim == 48
+    assert cfg.vae.scale_factor_spatial == 16 and cfg.vae.scale_factor_temporal == 4
+    assert len(cfg.vae.latents_mean) == 48 and len(cfg.vae.latents_std) == 48
+    assert cfg.scheduler.scheduler_type == "unipc"
+    assert cfg.scheduler.flow_shift == 1.0
+
+
+@needs_droid
+def test_droid_loader_key_coverage() -> None:
+    cfg = Cosmos3Config.from_pretrained(DROID_DIR)
+    with torch.device("meta"):
+        model = Cosmos3OmniTransformer(cfg)
+
+    model_keys = set(model.state_dict().keys())
+    index_keys = read_transformer_weight_keys(DROID_DIR)
+
+    # No audio projections in this checkpoint or in the built backbone.
+    assert not any("audio" in k for k in index_keys)
+    assert not any("audio" in k for k in model_keys)
+
+    dropped = {k for k in index_keys if cosmos3_name_remapper(k) is None}
+    assert dropped == set(DROP_KEYS), dropped
+
+    mapped = {cosmos3_name_remapper(k) for k in index_keys}
+    mapped.discard(None)
+    missing = model_keys - mapped
+    unexpected = mapped - model_keys
+    assert not missing, f"backbone params not covered by checkpoint: {sorted(missing)[:20]}"
+    assert not unexpected, f"checkpoint keys with no backbone param: {sorted(unexpected)[:20]}"
+
+    # Nano's counts minus the five audio keys (modality embed + proj_in/out
+    # weight and bias): 814 - 5 == 809 in the index, 813 - 5 == 808 built.
+    assert len(index_keys) == 809, len(index_keys)
+    assert len(model_keys) == 808, len(model_keys)
+
+
+@needs_droid
+def test_droid_loader_shape_coverage() -> None:
+    cfg = Cosmos3Config.from_pretrained(DROID_DIR)
+    with torch.device("meta"):
+        model = Cosmos3OmniTransformer(cfg)
+
+    try:
+        ckpt_shapes = read_transformer_weight_shapes(DROID_DIR)
+    except Exception as exc:  # noqa: BLE001 — LFS pointer / missing shards
+        pytest.skip(f"transformer shards unreadable: {exc}")
+
+    model_shapes = {k: tuple(v.shape) for k, v in model.state_dict().items()}
+    mismatched = {
+        k: {"model": s, "ckpt": ckpt_shapes.get(k)}
+        for k, s in model_shapes.items()
+        if s != ckpt_shapes.get(k)
+    }
+    assert not mismatched, mismatched
+
+
+@needs_droid
+def test_droid_sound_pathway_disabled() -> None:
+    from mstar.engine.base import EngineType
+    from mstar.model.cosmos3 import constants
+
+    model = Cosmos3Model(model_path_hf=str(DROID_DIR))
+    assert model.config.sound_gen is False
+    assert model._sound_serving_enabled() is False
+
+    # The sound walk and the audio_decoder node are not declared, so a config
+    # without them serves every remaining walk.
+    walks = model.get_graph_walk_graphs()
+    assert constants.VIDEO_SOUND_GEN_WALK not in walks
+    assert constants.ACTION_GEN_WALK in walks and constants.ACTION_VIDEO_GEN_WALK in walks
+    types = model.get_node_engine_types()
+    assert "audio_decoder" not in types
+    assert types["dit"] is EngineType.KV_CACHE
+
+    # A sound-requesting video request is rejected up front.
+    with pytest.raises(ValueError, match="sound"):
+        model._resolve_gen_params(
+            {"num_frames": 17, "generate_sound": True}, ["text"], ["video"]
+        )

--- a/mstar/model/cosmos3/tests/test_droid.py
+++ b/mstar/model/cosmos3/tests/test_droid.py
@@ -32,11 +32,15 @@ needs_droid = pytest.mark.skipif(
 
 
 def test_droid_registry_and_config_wiring() -> None:
+    from mstar.api_server.openai.adapters import get_adapter
     from mstar.cli.main import DEFAULT_CONFIGS
     from mstar.model.registry import HF_MODELS, MODEL_REGISTRY
 
     assert MODEL_REGISTRY["cosmos3_droid"] is Cosmos3Model
     assert HF_MODELS["cosmos3_droid"]["model_path_hf"] == "nvidia/Cosmos3-Nano-Policy-DROID"
+
+    adapter = get_adapter("cosmos3_droid")
+    assert adapter is not None and adapter.supports_images and adapter.supports_videos
 
     import mstar
 

--- a/mstar/model/cosmos3/tests/test_serving.py
+++ b/mstar/model/cosmos3/tests/test_serving.py
@@ -388,6 +388,63 @@ def test_gen_params_action_defaults() -> None:
     assert p["flow_shift"] == 5.0
 
 
+def test_vae_decode_bf16_warmup(monkeypatch) -> None:
+    """The compiled bf16 decode warms each new latent shape with a discarded
+    call (a process's first compiled-bf16 execution returns corrupted frames
+    on some stacks); fp32 and uncompiled decodes run exactly once."""
+    from types import SimpleNamespace
+
+    import torch
+
+    from mstar.model.cosmos3.config import Cosmos3Config
+    from mstar.model.cosmos3.submodules import Cosmos3VAEDecoderSubmodule
+
+    class _StubVAE(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(1, dtype=torch.bfloat16))
+            self.config = SimpleNamespace(latents_mean=[0.0] * 4, latents_std=[1.0] * 4)
+            self.calls = 0
+
+        def decode(self, z):
+            self.calls += 1
+            t = 1 + (z.shape[2] - 1) * 4
+            return SimpleNamespace(sample=torch.zeros(1, 3, t, 8, 8, dtype=torch.bfloat16))
+
+    monkeypatch.setenv("COSMOS3_COMPILE_VAE", "0")  # keep _decode the raw stub
+    vae = _StubVAE()
+    sub = Cosmos3VAEDecoderSubmodule(vae, Cosmos3Config())
+    sub._decode_compiled = True
+    sub._decode_dtype_cached = torch.bfloat16
+
+    z1 = torch.zeros(1, 4, 3, 8, 8, dtype=torch.bfloat16)
+    out = sub.forward("image_gen", None, z1)
+    assert vae.calls == 2  # warm-up + served decode
+    assert out["image_output"][0].dtype == torch.uint8
+
+    sub.forward("image_gen", None, z1)
+    assert vae.calls == 3  # shape already warmed
+
+    z2 = torch.zeros(1, 4, 5, 8, 8, dtype=torch.bfloat16)
+    sub.forward("image_gen", None, z2)
+    assert vae.calls == 5  # new shape warms again
+
+    # fp32 decode never warms.
+    sub._decode_dtype_cached = torch.float32
+    vae.float()
+    z3 = torch.zeros(1, 4, 7, 8, 8, dtype=torch.float32)
+    sub.forward("image_gen", None, z3)
+    assert vae.calls == 6
+
+    # Uncompiled bf16 decode never warms.
+    sub._decode_dtype_cached = torch.bfloat16
+    sub._decode_compiled = False
+    vae.to(torch.bfloat16)
+    z4 = torch.zeros(1, 4, 9, 8, 8, dtype=torch.bfloat16)
+    sub.forward("image_gen", None, z4)
+    assert vae.calls == 7
+
+
 def test_gen_params_max_sequence_length() -> None:
     model = Cosmos3Model(model_path_hf="unused", skip_weight_loading=True)
     assert model._resolve_gen_params({}, ["text"], ["image"])["max_sequence_length"] == 4096

--- a/mstar/model/cosmos3/tests/test_serving.py
+++ b/mstar/model/cosmos3/tests/test_serving.py
@@ -262,10 +262,130 @@ def test_gen_params_v2v() -> None:
 
     # Action requests own their video input; no V2V params are attached.
     p = model._resolve_gen_params(
-        {"action_mode": "inverse_dynamics", "action_chunk_size": 8, "raw_action_dim": 7},
+        {"action_mode": "inverse_dynamics", "action_chunk_size": 8, "raw_action_dim": 7,
+         "domain_id": 1},
         ["video", "text"], ["action"],
     )
     assert "has_video_condition" not in p
+
+
+def test_gen_params_action_defaults() -> None:
+    model = Cosmos3Model(model_path_hf="unused", skip_weight_loading=True)
+
+    # A bare policy request gets the reference action serving defaults: 30
+    # steps, guidance 1.0, flow shift 5.0, chunk 16 (so 17 frames), 480p tier.
+    p = model._resolve_gen_params(
+        {"action_mode": "policy", "domain_name": "droid_lerobot", "raw_action_dim": 10},
+        ["image", "text"], ["action"],
+    )
+    assert p["action_mode"] == "policy"
+    assert p["num_inference_steps"] == 30
+    assert p["guidance_scale"] == 1.0
+    assert p["flow_shift"] == 5.0
+    assert p["action_chunk_size"] == 16 and p["num_frames"] == 17
+    assert (p["width"], p["height"]) == (832, 480)
+    assert p["domain_id"] == 8
+    assert p["raw_action_dim"] == 10
+    # 1-frame-equivalent action requests never pick up the t2i CFG interval.
+    assert "guidance_interval" not in p
+
+    # Explicit values win over every action default.
+    p = model._resolve_gen_params(
+        {"action_mode": "policy", "domain_id": 3, "raw_action_dim": 9,
+         "num_inference_steps": 8, "guidance_scale": 2.0, "flow_shift": 10.0,
+         "size": "320x192", "action_chunk_size": 60, "num_frames": 61},
+        ["image", "text"], ["action"],
+    )
+    assert p["num_inference_steps"] == 8
+    assert p["guidance_scale"] == 2.0
+    assert p["flow_shift"] == 10.0
+    assert (p["width"], p["height"]) == (320, 192)
+    assert p["domain_id"] == 3  # numeric id wins; no name sent
+    assert p["action_chunk_size"] == 60 and p["num_frames"] == 61
+
+    # The chunk and the frame count default off each other.
+    p = model._resolve_gen_params(
+        {"action_mode": "inverse_dynamics", "num_frames": 33, "domain_id": 1,
+         "raw_action_dim": 9},
+        ["video", "text"], ["action"],
+    )
+    assert p["action_chunk_size"] == 32 and p["num_frames"] == 33
+    p = model._resolve_gen_params(
+        {"action_mode": "policy", "action_chunk_size": 32, "domain_id": 8,
+         "raw_action_dim": 10},
+        ["image", "text"], ["action"],
+    )
+    assert p["num_frames"] == 33
+    with pytest.raises(ValueError, match="num_frames to equal"):
+        model._resolve_gen_params(
+            {"action_mode": "policy", "action_chunk_size": 16, "num_frames": 20,
+             "domain_id": 8, "raw_action_dim": 10},
+            ["image", "text"], ["action"],
+        )
+    with pytest.raises(ValueError, match="must be positive"):
+        model._resolve_gen_params(
+            {"action_mode": "policy", "action_chunk_size": 0, "domain_id": 8,
+             "raw_action_dim": 10},
+            ["image", "text"], ["action"],
+        )
+
+    # The embodiment domain is required and resolves by name or id; numeric
+    # id wins when both are sent.
+    with pytest.raises(ValueError, match="domain_id"):
+        model._resolve_gen_params(
+            {"action_mode": "policy", "raw_action_dim": 10},
+            ["image", "text"], ["action"],
+        )
+    with pytest.raises(ValueError, match="domain_name"):
+        model._resolve_gen_params(
+            {"action_mode": "policy", "domain_name": "not_a_robot", "raw_action_dim": 10},
+            ["image", "text"], ["action"],
+        )
+    p = model._resolve_gen_params(
+        {"action_mode": "policy", "domain_id": 2, "domain_name": "droid_lerobot",
+         "raw_action_dim": 10},
+        ["image", "text"], ["action"],
+    )
+    assert p["domain_id"] == 2
+
+    # raw_action_dim is required (policy/inverse) and bounded by the padded
+    # action dim; forward_dynamics infers it from its conditioning array.
+    with pytest.raises(ValueError, match="raw_action_dim"):
+        model._resolve_gen_params(
+            {"action_mode": "policy", "domain_id": 8}, ["image", "text"], ["action"],
+        )
+    with pytest.raises(ValueError, match=r"\[1, 64\]"):
+        model._resolve_gen_params(
+            {"action_mode": "policy", "domain_id": 8, "raw_action_dim": 65},
+            ["image", "text"], ["action"],
+        )
+    p = model._resolve_gen_params(
+        {"action_mode": "forward_dynamics", "domain_id": 1,
+         "action_chunk_size": 2, "action": [[0.0] * 9, [0.1] * 9]},
+        ["image", "text"], ["video"],
+    )
+    assert p["raw_action_dim"] == 9
+
+    # Unknown modes fail at submission.
+    with pytest.raises(ValueError, match="action_mode"):
+        model._resolve_gen_params(
+            {"action_mode": "teleport", "domain_id": 1, "raw_action_dim": 9},
+            ["image", "text"], ["action"],
+        )
+
+    # Checkpoint yamls override the action sampling defaults (the DROID policy
+    # config serves 4 steps at guidance 3.0).
+    droid_like = Cosmos3Model(
+        model_path_hf="unused", skip_weight_loading=True,
+        num_inference_steps_action=4, guidance_scale_action=3.0,
+    )
+    p = droid_like._resolve_gen_params(
+        {"action_mode": "policy", "domain_name": "droid_lerobot", "raw_action_dim": 10},
+        ["image", "text"], ["action"],
+    )
+    assert p["num_inference_steps"] == 4
+    assert p["guidance_scale"] == 3.0
+    assert p["flow_shift"] == 5.0
 
 
 def test_gen_params_max_sequence_length() -> None:

--- a/mstar/model/registry.py
+++ b/mstar/model/registry.py
@@ -11,6 +11,7 @@ from mstar.model.whisper.whisper_model import WhisperModel
 MODEL_REGISTRY: dict[str, type[Model]] = {
     "bagel": BagelModel,
     "cosmos3": Cosmos3Model,
+    "cosmos3_droid": Cosmos3Model,
     "cosmos3_super": Cosmos3Model,
     "higgs_audio": HiggsAudioModel,
     "orpheus": OrpheusModel,
@@ -25,6 +26,11 @@ HF_MODELS: dict[str, dict] = {
     "bagel": {"model_path_hf": "ByteDance-Seed/BAGEL-7B-MoT"},
     # NVIDIA Cosmos3-Nano generator (diffusers transformer/ + Wan VAE + UniPC).
     "cosmos3": {"model_path_hf": "nvidia/Cosmos3-Nano"},
+    # Cosmos3-Nano-Policy-DROID — Nano-sized action-policy fine-tune for the
+    # DROID robot platform (domain droid_lerobot, 10-dim raw actions). Same
+    # class; the checkpoint's config disables the sound pathway (sound_gen
+    # false, no sound_tokenizer/), so the model self-serves without audio.
+    "cosmos3_droid": {"model_path_hf": "nvidia/Cosmos3-Nano-Policy-DROID"},
     # Cosmos3-Super (64B) — same architecture + class; dims (64 layers / 5120
     # hidden / 25600 intermediate) load from the checkpoint's config.json, so it
     # needs tensor parallelism (it does not fit on one GPU).


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

- New registry family `cosmos3_droid` -> `nvidia/Cosmos3-Nano-Policy-DROID` (same `Cosmos3Model`; dims + capability flags load from the checkpoint, which differs from Nano only in `sound_gen:false` - the audio heads are already construction-gated on that flag, and the sound walk self-disables).
- `configs/cosmos3_droid.yaml` (Nano-shaped; no audio_decoder node; `num_inference_steps_action: 4`, `guidance_scale_action: 3.0` i.e.the released DROID RoboLab policy-server sampling params), `mstar serve cosmos3_droid`, OpenAI image/video adapter registration, README + docs rows.
- Action-request serving defaults aligned with the reference action recipe for every cosmos3 checkpoint (previously they fell to the generic image/video defaults):
  - steps 30 / guidance 1.0 / flow_shift 5.0 / 832x480, config-overridable (`num_inference_steps_action`, `guidance_scale_action`, `flow_shift_action`).
  - `action_chunk_size` <-> `num_frames` default off each other (chunk 16 when neither is sent; `num_frames ∈ {chunk, chunk+1}` validated at submission. Previously an action request without `num_frames` failed mid-denoise).
  - The embodiment domain is now required and `domain_name` strings resolve through the published table (droid_lerobot=8); previously a missing  `domain_id` silently became 0 (= the no_action domain).
  - `raw_action_dim` required + bounded by the model's padded action dim (forward_dynamics infers it from the conditioning `action` array).

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->

- CPU: cosmos3 serving/loader/droid tests 27 passed (new: an action-defaults battery in test_serving.py; test_droid.py
- GPU suite (both checkpoint dirs): 8F/50P — failure set identical to the documented coriander bf16-SDPA set; +6 new tests pass.
- Serving (coriander H200, tp1): policy (bare-defaults + pinned fixed-seed byte-determinism), inverse_dynamics (video obs -> action), forward_dynamics (image + action -> rollout video, visually inspected), t2v/i2v (eyeballed), `/v1/videos` with `model=cosmos3_droid`.
- Compiled bf16 VAE decode: a process's first execution of the compiled bf16 decode returns corrupted frames on some torch/cuDNN stacks (found on torch 2.11/cu130/cuDNN 9.19; deterministic, inductor-side, bf16-only, unaffected by autotune/layout/naming options, present even with a warm on-disk cache; fp32 is clean and aot_eager is bit-exact). The decoder now warms each new latent shape with one discarded decode before serving (test_vae_decode_bf16_warmup); first served outputs then match eager to <=5/255 on a fresh cache, and the fp32 path is byte-unchanged (nano t2i bit cells == mint on the fix commit).

## Checklist
- [ ] `ruff check .` passes
- [ ] Added or updated tests / docs where relevant
