### PR TITLE
Pluggable routers

### DIFF
--- a/mstar/model/components/moe.py
+++ b/mstar/model/components/moe.py
@@ -51,6 +51,15 @@ except Exception as e:  # pragma: no cover -- exercised only when triton missing
 class TopKRouter(nn.Module):
     """Softmax top-k router shared by all MoE blocks.
 
+    Implements the router contract expected by the MoE blocks::
+
+        router(hidden_states, router_states=None)
+            -> (routing_weights, selected_experts, router_states_next)
+
+    This router is stateless: ``router_states`` is ignored and
+    ``router_states_next`` is always ``None``. Stateful routers (e.g. the
+    ZONOS2 EDA router) can be injected into a block in its place.
+
     Args:
         hidden_size: input hidden dimension.
         num_experts: total number of routed experts.
@@ -74,14 +83,21 @@ class TopKRouter(nn.Module):
         self.weight = nn.Parameter(torch.zeros(num_experts, hidden_size))
 
     def forward(
-        self, hidden_states: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        self,
+        hidden_states: torch.Tensor,
+        router_states: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, None]:
         """
+        Args:
+            hidden_states: ``(tokens, hidden_size)`` router input.
+            router_states: unused (stateless router); accepted for
+                interface compatibility with stateful routers.
+
         Returns:
-            router_logits: ``(tokens, num_experts)`` softmax distribution.
             routing_weights: ``(tokens, top_k)`` top-k probabilities
                 (optionally renormalized).
             selected_experts: ``(tokens, top_k)`` int64 indices.
+            router_states_next: always ``None`` (stateless).
         """
         hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
         router_logits = F.linear(hidden_states, self.weight)
@@ -92,7 +108,7 @@ class TopKRouter(nn.Module):
             router_top_value = router_top_value / router_top_value.sum(dim=-1, keepdim=True)
 
         routing_weights = router_top_value.to(router_logits.dtype)
-        return router_logits, routing_weights, router_indices
+        return routing_weights, router_indices, None
 
 
 def dispatch_experts_fused(
@@ -175,6 +191,7 @@ class SparseMoeBlock(nn.Module):
         num_experts_per_tok: int,
         moe_intermediate_size: int,
         norm_topk_prob: bool = True,
+        router: nn.Module | None = None,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -182,7 +199,7 @@ class SparseMoeBlock(nn.Module):
         self.num_experts_per_tok = num_experts_per_tok
         self.moe_intermediate_size = moe_intermediate_size
 
-        self.gate = TopKRouter(
+        self.gate = router if router is not None else TopKRouter(
             hidden_size=hidden_size,
             num_experts=num_experts,
             num_experts_per_tok=num_experts_per_tok,
@@ -196,16 +213,23 @@ class SparseMoeBlock(nn.Module):
             torch.empty(num_experts, hidden_size, moe_intermediate_size)
         )
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_states: torch.Tensor | None = None,
+        *,
+        return_router_states: bool = False,
+    ):
         input_shape = hidden_states.shape
         hidden_dim = hidden_states.shape[-1]
         flat = hidden_states.view(-1, hidden_dim).contiguous()
-        _, routing_weights, selected_experts = self.gate(flat)
+        routing_weights, selected_experts, router_states_next = self.gate(flat, router_states)
         out = _dispatch(
             flat, self.experts.gate_up_proj, self.experts.down_proj,
             self.num_experts, selected_experts, routing_weights,
         )
-        return out.view(input_shape)
+        out = out.view(input_shape)
+        return (out, router_states_next) if return_router_states else out
 
 
 class SparseMoeBlockWithSharedExpert(nn.Module):
@@ -228,6 +252,7 @@ class SparseMoeBlockWithSharedExpert(nn.Module):
         moe_intermediate_size: int,
         shared_expert: nn.Module,
         norm_topk_prob: bool = False,
+        router: nn.Module | None = None,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -235,7 +260,7 @@ class SparseMoeBlockWithSharedExpert(nn.Module):
         self.num_experts_per_tok = num_experts_per_tok
         self.moe_intermediate_size = moe_intermediate_size
 
-        self.gate = TopKRouter(
+        self.gate = router if router is not None else TopKRouter(
             hidden_size=hidden_size,
             num_experts=num_experts,
             num_experts_per_tok=num_experts_per_tok,
@@ -251,20 +276,27 @@ class SparseMoeBlockWithSharedExpert(nn.Module):
         self.shared_expert = shared_expert
         self.shared_expert_gate = nn.Linear(hidden_size, 1, bias=False)
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_states: torch.Tensor | None = None,
+        *,
+        return_router_states: bool = False,
+    ):
         input_shape = hidden_states.shape
         hidden_dim = hidden_states.shape[-1]
         flat = hidden_states.view(-1, hidden_dim).contiguous()
 
         shared = self.shared_expert(flat)
 
-        _, routing_weights, selected_experts = self.gate(flat)
+        routing_weights, selected_experts, router_states_next = self.gate(flat, router_states)
         routed = _dispatch(
             flat, self.experts.gate_up_proj, self.experts.down_proj,
             self.num_experts, selected_experts, routing_weights,
         )
         shared_gate = torch.sigmoid(self.shared_expert_gate(flat))
-        return (routed + shared_gate * shared).view(input_shape)
+        out = (routed + shared_gate * shared).view(input_shape)
+        return (out, router_states_next) if return_router_states else out
 
 
 # ---------------------------------------------------------------------------
@@ -331,6 +363,7 @@ class ParallelSparseMoeBlock(nn.Module):
         num_experts_per_tok: int,
         moe_intermediate_size: int,
         norm_topk_prob: bool = True,
+        router: nn.Module | None = None,
         comm_group: CommGroup | None = None,
     ) -> None:
         super().__init__()
@@ -345,7 +378,7 @@ class ParallelSparseMoeBlock(nn.Module):
         self.num_experts_per_tok = num_experts_per_tok
         self.moe_intermediate_size = moe_intermediate_size
 
-        self.gate = TopKRouter(
+        self.gate = router if router is not None else TopKRouter(
             hidden_size=hidden_size,
             num_experts=num_experts,
             num_experts_per_tok=num_experts_per_tok,
@@ -380,11 +413,17 @@ class ParallelSparseMoeBlock(nn.Module):
         )
         return result
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_states: torch.Tensor | None = None,
+        *,
+        return_router_states: bool = False,
+    ):
         input_shape = hidden_states.shape
         hidden_dim = hidden_states.shape[-1]
         flat = hidden_states.view(-1, hidden_dim).contiguous()
-        _, routing_weights, selected_experts = self.gate(flat)
+        routing_weights, selected_experts, router_states_next = self.gate(flat, router_states)
 
         if self.comm_group.world_size == 1:
             out = _dispatch(
@@ -393,7 +432,8 @@ class ParallelSparseMoeBlock(nn.Module):
             )
         else:
             out = self._dispatch_tp(flat, routing_weights, selected_experts)
-        return out.view(input_shape)
+        out = out.view(input_shape)
+        return (out, router_states_next) if return_router_states else out
 
     def _dispatch_tp(
         self, flat: torch.Tensor,
@@ -428,6 +468,7 @@ class ParallelSparseMoeBlockWithSharedExpert(nn.Module):
         moe_intermediate_size: int,
         shared_expert: nn.Module,
         norm_topk_prob: bool = False,
+        router: nn.Module | None = None,
         comm_group: CommGroup | None = None,
     ) -> None:
         super().__init__()
@@ -442,7 +483,7 @@ class ParallelSparseMoeBlockWithSharedExpert(nn.Module):
         self.num_experts_per_tok = num_experts_per_tok
         self.moe_intermediate_size = moe_intermediate_size
 
-        self.gate = TopKRouter(
+        self.gate = router if router is not None else TopKRouter(
             hidden_size=hidden_size,
             num_experts=num_experts,
             num_experts_per_tok=num_experts_per_tok,
@@ -479,14 +520,20 @@ class ParallelSparseMoeBlockWithSharedExpert(nn.Module):
         )
         return result
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_states: torch.Tensor | None = None,
+        *,
+        return_router_states: bool = False,
+    ):
         input_shape = hidden_states.shape
         hidden_dim = hidden_states.shape[-1]
         flat = hidden_states.view(-1, hidden_dim).contiguous()
 
         shared = self.shared_expert(flat)
 
-        _, routing_weights, selected_experts = self.gate(flat)
+        routing_weights, selected_experts, router_states_next = self.gate(flat, router_states)
         if self.comm_group.world_size == 1:
             routed = _dispatch(
                 flat, self.experts.gate_up_proj, self.experts.down_proj,
@@ -495,7 +542,8 @@ class ParallelSparseMoeBlockWithSharedExpert(nn.Module):
         else:
             routed = self._dispatch_tp(flat, routing_weights, selected_experts)
         shared_gate = torch.sigmoid(self.shared_expert_gate(flat))
-        return (routed + shared_gate * shared).view(input_shape)
+        out = (routed + shared_gate * shared).view(input_shape)
+        return (out, router_states_next) if return_router_states else out
 
     def _dispatch_tp(
         self, flat: torch.Tensor,

--- a/mstar/model/components/moe.py
+++ b/mstar/model/components/moe.py
@@ -19,6 +19,40 @@ Parallel (TP-aware) variants:
 When triton is installed and inputs are on CUDA, dispatch goes through
 the Triton fused-MoE kernel in :mod:`mstar.utils.fused_moe`; otherwise it
 falls back to the naive per-expert loop in :func:`dispatch_experts_fused`.
+
+Router contract
+---------------
+
+Each block computes its expert assignment with a router. The block keeps
+the router in ``self.gate``. The default router is :class:`TopKRouter`.
+
+A router is an ``nn.Module``. A router does not extend a base class. The
+``forward`` method of the router must obey this contract::
+
+    router(hidden_states, router_states=None)
+        -> (routing_weights, selected_experts, router_states_next)
+
+The router reads these inputs:
+
+* ``hidden_states`` is the input tensor. The shape is ``(tokens, hidden_size)``.
+* ``router_states`` is the state from the previous call. A stateless router
+  ignores this input.
+
+The router returns these outputs:
+
+* ``routing_weights`` is the tensor of expert weights. The shape is
+  ``(tokens, top_k)``.
+* ``selected_experts`` is the tensor of expert indices. The shape is
+  ``(tokens, top_k)``. The type is int64.
+* ``router_states_next`` is the state for the next call. A stateless router
+  returns ``None``.
+
+A stateless router ignores ``router_states``. A stateless router returns
+``None`` for ``router_states_next``.
+
+A stateful router reads ``router_states``. A stateful router returns a new
+state. To thread the state through a block, set the ``return_router_states``
+flag on the block.
 """
 from __future__ import annotations
 
@@ -49,16 +83,11 @@ except Exception as e:  # pragma: no cover -- exercised only when triton missing
 
 
 class TopKRouter(nn.Module):
-    """Softmax top-k router shared by all MoE blocks.
+    """Softmax top-k router. This is the default router for all MoE blocks.
 
-    Implements the router contract expected by the MoE blocks::
-
-        router(hidden_states, router_states=None)
-            -> (routing_weights, selected_experts, router_states_next)
-
-    This router is stateless: ``router_states`` is ignored and
-    ``router_states_next`` is always ``None``. Stateful routers (e.g. the
-    ZONOS2 EDA router) can be injected into a block in its place.
+    See the module docstring for the router contract. This router is
+    stateless. It ignores ``router_states``. It returns ``None`` for
+    ``router_states_next``.
 
     Args:
         hidden_size: input hidden dimension.

--- a/test/modular/test_moe_router_injection.py
+++ b/test/modular/test_moe_router_injection.py
@@ -1,0 +1,111 @@
+"""Tests for the injectable / state-aware MoE router interface.
+
+These exercise the CPU naive-dispatch path (no CUDA required), covering:
+
+* the stateless :class:`TopKRouter` 3-tuple contract,
+* injecting a custom *stateful* router into a block,
+* the opt-in ``return_router_states`` flag threading state in and out,
+* the default bare-tensor return staying backward compatible.
+"""
+
+from __future__ import annotations
+
+import sys
+
+sys.path.insert(0, ".")
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from mstar.model.components import SparseMoeBlock, TopKRouter
+
+
+class _StatefulRouter(nn.Module):
+    """Minimal stateful router matching the block router contract.
+
+    ``router(x, router_states=None) -> (weights, experts, states_next)``.
+    The next state is the running sum of the inputs it has seen, so a
+    caller threading state across calls sees it accumulate.
+    """
+
+    def __init__(self, hidden_size: int, num_experts: int, top_k: int) -> None:
+        super().__init__()
+        self.top_k = top_k
+        self.num_experts = num_experts
+        self.weight = nn.Parameter(torch.randn(num_experts, hidden_size) * 0.02)
+        self.calls = 0
+
+    def forward(self, hidden_states, router_states=None):
+        self.calls += 1
+        logits = F.linear(hidden_states, self.weight)
+        probs = F.softmax(logits.float(), dim=-1)
+        weights, experts = torch.topk(probs, self.top_k, dim=-1)
+        weights = weights / weights.sum(dim=-1, keepdim=True)
+        base = router_states if router_states is not None else torch.zeros_like(hidden_states)
+        router_states_next = base + hidden_states
+        return weights.to(hidden_states.dtype), experts.to(torch.int64), router_states_next
+
+
+def _make_block(router=None):
+    return SparseMoeBlock(
+        hidden_size=32,
+        num_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=16,
+        norm_topk_prob=True,
+        router=router,
+    )
+
+
+def test_topk_router_contract():
+    """Stateless router returns (weights, experts, None), ignoring state."""
+    router = TopKRouter(hidden_size=32, num_experts=8, num_experts_per_tok=2)
+    x = torch.randn(5, 32)
+    weights, experts, states_next = router(x)
+    assert weights.shape == (5, 2)
+    assert experts.shape == (5, 2)
+    assert states_next is None
+    # router_states is accepted and ignored.
+    _, _, states_next2 = router(x, router_states=torch.randn(5, 32))
+    assert states_next2 is None
+
+
+def test_default_router_is_topk():
+    block = _make_block()
+    assert isinstance(block.gate, TopKRouter)
+
+
+def test_injected_router_is_used():
+    router = _StatefulRouter(hidden_size=32, num_experts=8, top_k=2)
+    block = _make_block(router=router)
+    assert block.gate is router
+    x = torch.randn(4, 32)
+    block(x)
+    assert router.calls == 1
+
+
+def test_return_router_states_threads_state():
+    router = _StatefulRouter(hidden_size=32, num_experts=8, top_k=2)
+    block = _make_block(router=router)
+    x = torch.randn(4, 32)
+
+    out, state = block(x, return_router_states=True)
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == x.shape
+    # First call: incoming state is None -> next state is x.
+    torch.testing.assert_close(state, x)
+
+    # Thread the state back in: next state accumulates to 2x.
+    out2, state2 = block(x, router_states=state, return_router_states=True)
+    assert out2.shape == x.shape
+    torch.testing.assert_close(state2, 2 * x)
+
+
+def test_default_return_is_bare_tensor():
+    """Without the flag, forward returns a plain tensor (backward compat)."""
+    block = _make_block(router=_StatefulRouter(32, 8, 2))
+    x = torch.randn(4, 32)
+    out = block(x)
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == x.shape


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

Adds the passing of custom `nn.Module`s in place of the standard `TopKRouter` to the various `MoeBlock`s. Adds handling custom routers that are stateful e.g. `router(hidden_states, router_states) -> (routing_weights, selected_experts, router_states_next)` inside the `MoeBlock`s. 

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->
Closes #182 

## How was it tested?
This PR has passed `test_qwen3_omni_fused_moe.py`. I am running into problems when I try to run Qwen3, which is the only model that currently uses the `MoeBlock`s, so no smoketest has been run. 

<!-- Commands you ran, or why tests aren't applicable. -->

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
