### PR TITLE
fix(client): decode streamed lines when Content-Type has no charset

### DIFF
--- a/mstar/client/client.py
+++ b/mstar/client/client.py
@@ -185,6 +185,12 @@ class MStarClient:
             url, data=data, files=files or None, stream=True, timeout=self.timeout
         ) as resp:
             resp.raise_for_status()
+            # ``decode_unicode=True`` only yields ``str`` when ``resp.encoding``
+            # is set, and that is derived from the Content-Type charset. The
+            # server streams ``application/x-ndjson`` without one, so default to
+            # UTF-8 (the NDJSON encoding) instead of dropping every line.
+            if resp.encoding is None:
+                resp.encoding = "utf-8"
             for line in resp.iter_lines(decode_unicode=True):
                 if not isinstance(line, str):
                     continue

--- a/test/modular/test_client_sdk.py
+++ b/test/modular/test_client_sdk.py
@@ -1,7 +1,9 @@
 """Unit tests for the mstar Python SDK parsing/encoding (no live server)."""
 
 import base64
+import io
 import json
+from unittest import mock
 
 import pytest
 
@@ -53,6 +55,25 @@ def test_coerce_and_build_files():
     c = MStarClient("http://x")
     assert c._coerce_file("images", 0, b"\x89PNG") == ("image_0.png", b"\x89PNG")
     assert c._build_files(None, b"\x00\x01", None) == [("files", ("audio_0.wav", b"\x00\x01"))]
+
+
+def test_stream_without_content_type_charset():
+    """Content-Type without a charset must still yield events (issue #163)."""
+    requests = pytest.importorskip("requests")
+    line = json.dumps({"modality": "text", "data": base64.b64encode(b"hi").decode(), "metadata": {}})
+
+    resp = requests.Response()
+    resp.status_code = 200
+    resp.headers["Content-Type"] = "application/x-ndjson"  # no charset
+    resp.raw = io.BytesIO((line + "\n").encode())
+    assert resp.encoding is None
+
+    c = MStarClient("http://x")
+    ctx = mock.MagicMock()
+    ctx.__enter__.return_value = resp
+    with mock.patch.object(c._session, "post", return_value=ctx):
+        events = list(c._stream("http://x/generate", {}, None))
+    assert [e.text for e in events] == ["hi"]
 
 
 def test_audiobuffer_wav_bytes():


### PR DESCRIPTION
## What does this PR do?

Closes #163.

`MStarClient.stream()` returned zero events when the server sent a `Content-Type` without a charset (e.g. `application/x-ndjson`). `requests` only honours `decode_unicode=True` when `resp.encoding` is set, and that is derived from the charset — so `iter_lines()` yielded `bytes` and `_stream()` dropped every line via its `isinstance(line, str)` guard. Non-streaming was unaffected because `resp.json()` ignores the charset. `resp.encoding` now defaults to utf-8 (the NDJSON encoding) when unset.

## How was it tested?

New `test_client_sdk.py::test_stream_without_content_type_charset` feeds a charset-less NDJSON response through `_stream`; it fails on `main` (0 events) and passes with the fix. `test/modular/test_client_sdk.py` passes (6/6), `ruff check` clean on both changed files.

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
