### PR TITLE
Fix conductor SETUP_DONE race + benchmark client fixes

### DIFF
--- a/benchmark/request.py
+++ b/benchmark/request.py
@@ -6,6 +6,7 @@ import os
 import statistics
 import sys
 import time
+import wave
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -16,6 +17,29 @@ import numpy as np
 
 from benchmark.base import Bagel, Model, Orpheus, RequestType, Status
 from benchmark.utils import _write_wav
+
+
+def _audio_chunk_to_pcm(data: bytes) -> bytes:
+    """Return raw PCM frames from a streamed audio chunk.
+
+    sglang-omni encodes every audio delta as a *complete* WAV file
+    (`sglang_omni/client/audio.py::audio_to_base64` defaults to
+    `output_format="wav"`), so concatenating chunks verbatim splices a 44-byte
+    RIFF header into the PCM stream once per chunk. Played back that is ~22
+    samples of full-scale garbage every chunk — an audible periodic click.
+    sglang-omni's own benchmark client strips these the same way (see
+    `benchmarks/tasks/tts.py::_collect_streaming_audio`).
+
+    Chunks that are already raw PCM (vllm-omni, OurSystem, and sglang-omni's
+    `stream_format="audio"` endpoint) have no RIFF magic and pass through.
+    """
+    if len(data) < 12 or data[:4] != b"RIFF" or data[8:12] != b"WAVE":
+        return data
+    try:
+        with wave.open(io.BytesIO(data), "rb") as wf:
+            return wf.readframes(wf.getnframes())
+    except (wave.Error, EOFError):
+        return data
 
 
 @dataclass
@@ -143,6 +167,14 @@ class RequestMetrics:
         data = base64.b64decode(data_b64)
         if not data:
             return
+
+        if modality == "audio":
+            # Strip the per-chunk WAV container before anything measures or
+            # buffers these bytes, so byte counts and chunk durations describe
+            # audio rather than container overhead.
+            data = _audio_chunk_to_pcm(data)
+            if not data:
+                return
 
         self._output_modalities_recvd.append(modality)
 
@@ -1356,6 +1388,7 @@ class SGLangOmni(InferenceSystem):
                 "stream": True,
                 "stream_options": {"include_usage": True},
                 **model.get_model_kwargs(req_type),
+                **req_input.model_kwargs,
                 **additional_model_kwargs,
             }
             # Top-level multimodal fields (Fix 10a). sglang-omni reads files

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -452,7 +452,9 @@ class Benchmark:
         # max_concurrency don't bottleneck on aiohttp's default 100/host limit.
         connector_limit = max(100, (self.config.max_concurrency or 1) + 10)
         async with aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=300),
+            timeout=aiohttp.ClientTimeout(
+                total=float(os.environ.get("MSTAR_BENCH_TIMEOUT_S", "1800"))
+            ),
             connector=aiohttp.TCPConnector(limit=connector_limit),
             read_bufsize=5 * 2**20,  # 1MB read buffer
         ) as session:

--- a/benchmark/test_audio_chunk_wav_strip.py
+++ b/benchmark/test_audio_chunk_wav_strip.py
@@ -1,0 +1,73 @@
+"""Regression test: streamed WAV-container audio chunks must not splice
+their RIFF headers into the accumulated PCM stream.
+
+sglang-omni encodes every /v1/chat/completions audio delta as a *complete*
+WAV file (sglang_omni/client/audio.py::audio_to_base64 defaults to
+output_format="wav"). Writing those bytes verbatim into the PCM buffer
+embeds a 44-byte header every chunk, which is audible as a periodic click.
+"""
+
+import base64
+import io
+import struct
+import time
+import wave
+
+import numpy as np
+
+from benchmark.base import RequestType
+from benchmark.request import RequestMetrics
+
+SAMPLE_RATE = 24000
+
+
+def _wav_chunk(pcm: bytes) -> str:
+    """Encode int16 PCM as a complete WAV file, base64'd — what sglang-omni sends."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(SAMPLE_RATE)
+        wf.writeframes(pcm)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _new_metrics() -> RequestMetrics:
+    m = RequestMetrics(request_id="0", type=RequestType.T2S)
+    m.start_time = time.monotonic()
+    return m
+
+
+def test_wav_container_chunks_are_stripped_to_pcm():
+    rng = np.random.default_rng(0)
+    chunks = [
+        (rng.random(1000) * 2 - 1).astype(np.float32).__mul__(32767).astype(np.int16).tobytes()
+        for _ in range(3)
+    ]
+
+    m = _new_metrics()
+    for c in chunks:
+        m.record_output_chunk(modality="audio", data_b64=_wav_chunk(c))
+
+    got = m._audio_pcm.getvalue()
+    want = b"".join(chunks)
+    assert got == want, (
+        f"expected {len(want)} PCM bytes, got {len(got)} "
+        f"({(len(got) - len(want))} extra = spliced WAV headers)"
+    )
+
+
+def test_raw_pcm_chunks_pass_through_unchanged():
+    """Systems that stream raw PCM (no RIFF header) must be untouched."""
+    pcm = np.arange(500, dtype=np.int16).tobytes()
+    m = _new_metrics()
+    m.record_output_chunk(modality="audio", data_b64=base64.b64encode(pcm).decode())
+    assert m._audio_pcm.getvalue() == pcm
+
+
+def test_byte_metrics_exclude_wav_headers():
+    """output_bytes/duration must count audio, not container overhead."""
+    pcm = np.zeros(2400, dtype=np.int16).tobytes()  # 0.1 s @ 24 kHz
+    m = _new_metrics()
+    m.record_output_chunk(modality="audio", data_b64=_wav_chunk(pcm))
+    assert m.output_bytes["audio"] == len(pcm)

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -304,13 +304,21 @@ class Conductor:
 
         os.makedirs(socket_path_prefix, exist_ok=True)
         self._derive_worker_info()
-        self._launch_workers()
 
+        # Build the communicator BEFORE launching workers. A worker sends
+        # SETUP_DONE the instant it finishes weight load + graph capture; if the
+        # conductor is not yet listening that message is lost forever and
+        # _wait_for_workers_ready() blocks on a worker that already reported.
+        # Skipping CUDA-graph capture makes workers finish tens of seconds apart
+        # (43 s in the graphs-off arms), which is what made the race reliable.
+        # _derive_worker_info() must still run first -- it populates worker_ids.
         self.communicator = make_communicator(
             my_id="conductor",
             push_ids=self.worker_ids + ["api_server", "api_server_preprocess_worker"],
             ipc_socket_path_prefix=socket_path_prefix,
         )
+
+        self._launch_workers()
 
     def _get_kv_config(self):
         kv_cache_config = self.model.get_kv_cache_config()


### PR DESCRIPTION
Three independent fixes found while running the Qwen3-Omni Talker ablation (E3) and the open-loop lambda sweep (E4a).

**f4bf2721 — conductor SETUP_DONE race.** This is @NSagan271's diagnosis; verified end-to-end here. Building the communicator before `_launch_workers()` closes the window where a worker's SETUP_DONE is sent before the conductor is listening. Reproduced deterministically with CUDA graphs disabled (worker_0 finishes 43 s ahead of worker_1); after the fix: 0 SETUP_DONE crashes, `Conductor: all 2 worker(s) ready` logged, server serves. Both previously-blocked ablation arms now start.

**2324f2d7 — client timeout.** `ClientTimeout(total=300)` silently dropped requests under open-loop saturation, truncating the p99 that SLO-goodput is defined on. Now `MSTAR_BENCH_TIMEOUT_S` (default 1800). A lambda sweep to 8 req/s now completes 200/200 at every point.

**32b0fe04 — sglang-omni audio + kwargs.** sglang-omni sends each audio delta as a complete WAV file, so concatenating deltas embedded a 44-byte RIFF header per chunk — an audible periodic click, and inflated byte/duration metrics. Now unwrapped before measurement, matching sglang-omni's own client. Also adds the `req_input.model_kwargs` passthrough that OurSystem and VLLMOmni have but SGLangOmni lacked.