### PR TITLE
Conductor SETUP_DONE race + benchmark client fixes

### DIFF
--- a/benchmark/request.py
+++ b/benchmark/request.py
@@ -833,7 +833,7 @@ class VoxServe(InferenceSystem):
             async with session.post(
                 f"{base_url}/generate",
                 data=form,
-                timeout=aiohttp.ClientTimeout(total=None, sock_read=30),
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
             ) as resp:
                 resp.raise_for_status()
 
@@ -1101,7 +1101,7 @@ class VLLMOmni(InferenceSystem):
                 json=payload,
                 headers=headers,
                 read_bufsize=2**24,
-                timeout=aiohttp.ClientTimeout(total=None, sock_read=120),
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
             ) as resp:
                 if resp.status != 200:
                     raise Exception(f"HTTP {resp.status}: {await resp.text()}")
@@ -1258,7 +1258,7 @@ class VLLMOmni(InferenceSystem):
                 read_bufsize=2**24,
                 timeout=aiohttp.ClientTimeout(
                     total=None,
-                    sock_read=300,
+                    sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600")),
                 ),
             ) as resp:
                 if resp.status != 200:
@@ -1410,7 +1410,7 @@ class SGLangOmni(InferenceSystem):
                 f"{base_url}/v1/chat/completions",
                 json=payload,
                 read_bufsize=2**24,
-                timeout=aiohttp.ClientTimeout(total=None, sock_read=120),
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
             ) as resp:
                 if resp.status != 200:
                     raise Exception(f"HTTP {resp.status}: {await resp.text()}")
@@ -1571,7 +1571,7 @@ class OursOpenAI(VLLMOmni):
                     data=form,
                     headers={"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'EMPTY')}"},
                     read_bufsize=2**24,
-                    timeout=aiohttp.ClientTimeout(total=None, sock_read=300),
+                    timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
                 ) as resp:
                     if resp.status != 200:
                         raise Exception(f"HTTP {resp.status}: {await resp.text()}")
@@ -1594,7 +1594,7 @@ class OursOpenAI(VLLMOmni):
                         "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'EMPTY')}",
                     },
                     read_bufsize=2**24,
-                    timeout=aiohttp.ClientTimeout(total=None, sock_read=300),
+                    timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
                 ) as resp:
                     if resp.status != 200:
                         raise Exception(f"HTTP {resp.status}: {await resp.text()}")
@@ -1655,7 +1655,7 @@ class OursOpenAI(VLLMOmni):
                 json=payload,
                 headers={"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'EMPTY')}"},
                 read_bufsize=2**24,
-                timeout=aiohttp.ClientTimeout(total=None, sock_read=120),
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
             ) as resp:
                 if resp.status != 200:
                     raise Exception(f"HTTP {resp.status}: {await resp.text()}")

--- a/benchmark/request.py
+++ b/benchmark/request.py
@@ -6,6 +6,7 @@ import os
 import statistics
 import sys
 import time
+import wave
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -16,6 +17,29 @@ import numpy as np
 
 from benchmark.base import Bagel, Model, Orpheus, RequestType, Status
 from benchmark.utils import _write_wav
+
+
+def _audio_chunk_to_pcm(data: bytes) -> bytes:
+    """Return raw PCM frames from a streamed audio chunk.
+
+    sglang-omni encodes every audio delta as a *complete* WAV file
+    (`sglang_omni/client/audio.py::audio_to_base64` defaults to
+    `output_format="wav"`), so concatenating chunks verbatim splices a 44-byte
+    RIFF header into the PCM stream once per chunk. Played back that is ~22
+    samples of full-scale garbage every chunk — an audible periodic click.
+    sglang-omni's own benchmark client strips these the same way (see
+    `benchmarks/tasks/tts.py::_collect_streaming_audio`).
+
+    Chunks that are already raw PCM (vllm-omni, OurSystem, and sglang-omni's
+    `stream_format="audio"` endpoint) have no RIFF magic and pass through.
+    """
+    if len(data) < 12 or data[:4] != b"RIFF" or data[8:12] != b"WAVE":
+        return data
+    try:
+        with wave.open(io.BytesIO(data), "rb") as wf:
+            return wf.readframes(wf.getnframes())
+    except (wave.Error, EOFError):
+        return data
 
 
 @dataclass
@@ -143,6 +167,14 @@ class RequestMetrics:
         data = base64.b64decode(data_b64)
         if not data:
             return
+
+        if modality == "audio":
+            # Strip the per-chunk WAV container before anything measures or
+            # buffers these bytes, so byte counts and chunk durations describe
+            # audio rather than container overhead.
+            data = _audio_chunk_to_pcm(data)
+            if not data:
+                return
 
         self._output_modalities_recvd.append(modality)
 
@@ -1356,6 +1388,7 @@ class SGLangOmni(InferenceSystem):
                 "stream": True,
                 "stream_options": {"include_usage": True},
                 **model.get_model_kwargs(req_type),
+                **req_input.model_kwargs,
                 **additional_model_kwargs,
             }
             # Top-level multimodal fields (Fix 10a). sglang-omni reads files

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -452,7 +452,9 @@ class Benchmark:
         # max_concurrency don't bottleneck on aiohttp's default 100/host limit.
         connector_limit = max(100, (self.config.max_concurrency or 1) + 10)
         async with aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=300),
+            timeout=aiohttp.ClientTimeout(
+                total=float(os.environ.get("MSTAR_BENCH_TIMEOUT_S", "1800"))
+            ),
             connector=aiohttp.TCPConnector(limit=connector_limit),
             read_bufsize=5 * 2**20,  # 1MB read buffer
         ) as session:

--- a/benchmark/test_audio_chunk_wav_strip.py
+++ b/benchmark/test_audio_chunk_wav_strip.py
@@ -1,0 +1,73 @@
+"""Regression test: streamed WAV-container audio chunks must not splice
+their RIFF headers into the accumulated PCM stream.
+
+sglang-omni encodes every /v1/chat/completions audio delta as a *complete*
+WAV file (sglang_omni/client/audio.py::audio_to_base64 defaults to
+output_format="wav"). Writing those bytes verbatim into the PCM buffer
+embeds a 44-byte header every chunk, which is audible as a periodic click.
+"""
+
+import base64
+import io
+import struct
+import time
+import wave
+
+import numpy as np
+
+from benchmark.base import RequestType
+from benchmark.request import RequestMetrics
+
+SAMPLE_RATE = 24000
+
+
+def _wav_chunk(pcm: bytes) -> str:
+    """Encode int16 PCM as a complete WAV file, base64'd — what sglang-omni sends."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(SAMPLE_RATE)
+        wf.writeframes(pcm)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _new_metrics() -> RequestMetrics:
+    m = RequestMetrics(request_id="0", type=RequestType.T2S)
+    m.start_time = time.monotonic()
+    return m
+
+
+def test_wav_container_chunks_are_stripped_to_pcm():
+    rng = np.random.default_rng(0)
+    chunks = [
+        (rng.random(1000) * 2 - 1).astype(np.float32).__mul__(32767).astype(np.int16).tobytes()
+        for _ in range(3)
+    ]
+
+    m = _new_metrics()
+    for c in chunks:
+        m.record_output_chunk(modality="audio", data_b64=_wav_chunk(c))
+
+    got = m._audio_pcm.getvalue()
+    want = b"".join(chunks)
+    assert got == want, (
+        f"expected {len(want)} PCM bytes, got {len(got)} "
+        f"({(len(got) - len(want))} extra = spliced WAV headers)"
+    )
+
+
+def test_raw_pcm_chunks_pass_through_unchanged():
+    """Systems that stream raw PCM (no RIFF header) must be untouched."""
+    pcm = np.arange(500, dtype=np.int16).tobytes()
+    m = _new_metrics()
+    m.record_output_chunk(modality="audio", data_b64=base64.b64encode(pcm).decode())
+    assert m._audio_pcm.getvalue() == pcm
+
+
+def test_byte_metrics_exclude_wav_headers():
+    """output_bytes/duration must count audio, not container overhead."""
+    pcm = np.zeros(2400, dtype=np.int16).tobytes()  # 0.1 s @ 24 kHz
+    m = _new_metrics()
+    m.record_output_chunk(modality="audio", data_b64=_wav_chunk(pcm))
+    assert m.output_bytes["audio"] == len(pcm)

--- a/mstar/cli/main.py
+++ b/mstar/cli/main.py
@@ -137,6 +137,8 @@ def _serve(args: argparse.Namespace) -> None:
     ]
     if args.cache_dir:
         argv += ["--cache-dir", args.cache_dir]
+    if args.timeout is not None:
+        argv += ["--timeout", str(args.timeout)]
     if args.log_stats:
         argv += ["--log-stats"]
     if args.log_stats_file:
@@ -158,6 +160,12 @@ def build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--host", default="0.0.0.0")
     serve.add_argument("--port", type=int, default=8000)
     serve.add_argument("--gpus", default=None, help="CUDA_VISIBLE_DEVICES, e.g. '0' or '0,1,2'")
+    # Per-request server-side timeout. The API server defaults to 600 s; that is
+    # far too short when generation is slowed down deliberately (e.g. running a
+    # node eagerly via MSTAR_DISABLE_CUDA_GRAPH), where a single request can take
+    # many minutes and would otherwise abort mid-stream with a 500.
+    serve.add_argument("--timeout", type=float, default=None,
+                       help="Per-request timeout in seconds (server default: 600)")
     serve.add_argument("--config", default=None, help="override the default config (path to YAML)")
     serve.add_argument("--cache-dir", default=None, help="HuggingFace weight cache directory")
     serve.add_argument("--socket-path-prefix", default=None, help="ZMQ IPC socket prefix")

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -304,13 +304,21 @@ class Conductor:
 
         os.makedirs(socket_path_prefix, exist_ok=True)
         self._derive_worker_info()
-        self._launch_workers()
 
+        # Build the communicator BEFORE launching workers. A worker sends
+        # SETUP_DONE the instant it finishes weight load + graph capture; if the
+        # conductor is not yet listening that message is lost forever and
+        # _wait_for_workers_ready() blocks on a worker that already reported.
+        # Skipping CUDA-graph capture makes workers finish tens of seconds apart
+        # (43 s in the graphs-off arms), which is what made the race reliable.
+        # _derive_worker_info() must still run first -- it populates worker_ids.
         self.communicator = make_communicator(
             my_id="conductor",
             push_ids=self.worker_ids + ["api_server", "api_server_preprocess_worker"],
             ipc_socket_path_prefix=socket_path_prefix,
         )
+
+        self._launch_workers()
 
     def _get_kv_config(self):
         kv_cache_config = self.model.get_kv_cache_config()


### PR DESCRIPTION
Five independent fixes from running E3 (Talker ablation) and E4a (open-loop lambda sweep). Each separately cherry-pickable.

**f4bf2721 — conductor SETUP_DONE race.** @NSagan271's diagnosis, verified end-to-end. Building the communicator before `_launch_workers()` closes the window where a worker's SETUP_DONE is sent before the conductor listens. Reproduced deterministically with CUDA graphs disabled (worker_0 finishes ~43 s ahead of worker_1). After: 0 crashes, `all 2 worker(s) ready` logged, 5/5 ablation cells completed. **Caveat:** still intermittent — roughly one launch in three instead hangs on dispatch (conductor spinning, workers idle). Retry works; may need push-channel setup deferred until workers are up.

**2324f2d7 — client total timeout.** `ClientTimeout(total=300)` silently dropped requests under saturation, truncating the p99 that SLO-goodput is defined on. Now `MSTAR_BENCH_TIMEOUT_S` (default 1800).

**32b0fe04 — sglang-omni audio + kwargs.** Each audio delta arrives as a complete WAV file; concatenating deltas embedded a 44-byte RIFF header per chunk — audible clicking plus inflated byte/duration metrics. Now unwrapped before measurement. Also adds the `req_input.model_kwargs` passthrough SGLangOmni lacked. **Correction to that commit message:** it claims vllm-omni sends raw PCM and passes through untouched — wrong. Verified 8/8 vllm-omni files contain spliced headers too. Inflation: vllm-omni 0.049%, sglang-omni 0.119%, M* 0%.

**5b0d4e17 — `mstar serve --timeout` passthrough.** The API server had the flag; the CLI never forwarded it, so the 600 s per-request cap aborted every graphs-off request mid-stream.

**1d1e0654 — unify sock_read.** Adapters hardcoded 30 s (M*) vs 120/300 s (others) — a per-system client policy inside a cross-system comparison. Now `MSTAR_BENCH_SOCK_READ_S` (default 600). Under overload sglang-omni went from 194/109/88/102 of 200 to **200/200 at every rate**; the failures were client patience, not server collapse, and excluding them had understated its tail.