### PR TITLE
Unify client sock_read + forward --timeout from mstar serve

### DIFF
--- a/benchmark/request.py
+++ b/benchmark/request.py
@@ -833,7 +833,7 @@ class VoxServe(InferenceSystem):
             async with session.post(
                 f"{base_url}/generate",
                 data=form,
-                timeout=aiohttp.ClientTimeout(total=None, sock_read=30),
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
             ) as resp:
                 resp.raise_for_status()
 
@@ -1101,7 +1101,7 @@ class VLLMOmni(InferenceSystem):
                 json=payload,
                 headers=headers,
                 read_bufsize=2**24,
-                timeout=aiohttp.ClientTimeout(total=None, sock_read=120),
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
             ) as resp:
                 if resp.status != 200:
                     raise Exception(f"HTTP {resp.status}: {await resp.text()}")
@@ -1258,7 +1258,7 @@ class VLLMOmni(InferenceSystem):
                 read_bufsize=2**24,
                 timeout=aiohttp.ClientTimeout(
                     total=None,
-                    sock_read=300,
+                    sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600")),
                 ),
             ) as resp:
                 if resp.status != 200:
@@ -1410,7 +1410,7 @@ class SGLangOmni(InferenceSystem):
                 f"{base_url}/v1/chat/completions",
                 json=payload,
                 read_bufsize=2**24,
-                timeout=aiohttp.ClientTimeout(total=None, sock_read=120),
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
             ) as resp:
                 if resp.status != 200:
                     raise Exception(f"HTTP {resp.status}: {await resp.text()}")
@@ -1571,7 +1571,7 @@ class OursOpenAI(VLLMOmni):
                     data=form,
                     headers={"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'EMPTY')}"},
                     read_bufsize=2**24,
-                    timeout=aiohttp.ClientTimeout(total=None, sock_read=300),
+                    timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
                 ) as resp:
                     if resp.status != 200:
                         raise Exception(f"HTTP {resp.status}: {await resp.text()}")
@@ -1594,7 +1594,7 @@ class OursOpenAI(VLLMOmni):
                         "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'EMPTY')}",
                     },
                     read_bufsize=2**24,
-                    timeout=aiohttp.ClientTimeout(total=None, sock_read=300),
+                    timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
                 ) as resp:
                     if resp.status != 200:
                         raise Exception(f"HTTP {resp.status}: {await resp.text()}")
@@ -1655,7 +1655,7 @@ class OursOpenAI(VLLMOmni):
                 json=payload,
                 headers={"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'EMPTY')}"},
                 read_bufsize=2**24,
-                timeout=aiohttp.ClientTimeout(total=None, sock_read=120),
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=float(os.environ.get("MSTAR_BENCH_SOCK_READ_S", "600"))),
             ) as resp:
                 if resp.status != 200:
                     raise Exception(f"HTTP {resp.status}: {await resp.text()}")

--- a/mstar/cli/main.py
+++ b/mstar/cli/main.py
@@ -138,6 +138,8 @@ def _serve(args: argparse.Namespace) -> None:
     ]
     if args.cache_dir:
         argv += ["--cache-dir", args.cache_dir]
+    if args.timeout is not None:
+        argv += ["--timeout", str(args.timeout)]
     if args.log_stats:
         argv += ["--log-stats"]
     if args.log_stats_file:
@@ -159,6 +161,12 @@ def build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--host", default="0.0.0.0")
     serve.add_argument("--port", type=int, default=8000)
     serve.add_argument("--gpus", default=None, help="CUDA_VISIBLE_DEVICES, e.g. '0' or '0,1,2'")
+    # Per-request server-side timeout. The API server defaults to 600 s; that is
+    # far too short when generation is slowed down deliberately (e.g. running a
+    # node eagerly via MSTAR_DISABLE_CUDA_GRAPH), where a single request can take
+    # many minutes and would otherwise abort mid-stream with a 500.
+    serve.add_argument("--timeout", type=float, default=None,
+                       help="Per-request timeout in seconds (server default: 600)")
     serve.add_argument("--config", default=None, help="override the default config (path to YAML)")
     serve.add_argument("--cache-dir", default=None, help="HuggingFace weight cache directory")
     serve.add_argument("--socket-path-prefix", default=None, help="ZMQ IPC socket prefix")


### PR DESCRIPTION
Two remaining fixes after #191; rebased onto ablation-flags so the already-merged conductor/timeout/WAV-strip commits are dropped.

**5015aeeb — `mstar serve --timeout` passthrough.** The API server accepts `--timeout` (per-request, default 600 s) but the CLI built its argv explicitly and never forwarded it, so the cap was unreachable. Too short whenever generation is deliberately slowed: running the Talker eagerly pushes E2E p99 to 174 s at concurrency 1 and past 700 s at 32, so requests aborted mid-stream with `HTTPException(500, 'Request timed out')` followed by starlette's `response already started`.

**454477f5 — unify `sock_read`.** Adapters hardcoded their own silence-patience: OurSystem 30 s, VLLMOmni and SGLangOmni 120/300 s — a per-system client policy inside a cross-system comparison. Now `MSTAR_BENCH_SOCK_READ_S` (default 600; not 1800 so a wedged server still surfaces within ten minutes). It did not bias results measured so far — M* had the tightest value and still completed 200/200 everywhere — but it censors asymmetrically under load. For sglang-omni at lambda = 1/2/4/8 the old 120 s gave 194/109/88/102 of 200, every failure `Timeout on reading data from socket`, none server-side; at 600 s all four complete 200/200. Excluding those slow requests had understated the tail: lambda=2 RTF p50 2.256 -> 3.027, TTFA p50 71 s -> 106 s.