### PR TITLE
Fix KeyError in eager batched execution for packed-output submodules

### DIFF
--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -558,15 +558,31 @@ class KVCacheEngine(BaseEngine):
         # fast path in cuda_graph_runner.sample_and_remap).
         batched_logits = batched_output.pop("__batched_logits__", None)
 
+        real_seq_lens = [inp.input_seq_len for inp in inputs]
+        unpacked = submodule.unpack_packed_outputs(
+            static_output=batched_output,
+            request_ids=batch.request_ids,
+            real_seq_lens=real_seq_lens,
+            inputs=inputs,
+            per_request_info=batch.per_request_info,
+        )
+        if unpacked:
+            batched_output = unpacked
+
         if self.enable_nvtx:
             range_push("ar.batched.sample", synchronize=False)
         if batched_logits is not None:
             sampler = self.submodule_management[batch.node_name].sampler
             sampled = sampler.sample(batch.request_ids, batched_logits)
             for rid, view in zip(batch.request_ids, sampled.split(1), strict=True):
-                rid_out = batched_output[rid]
+                if rid not in batched_output:
+                    logger.warning((
+                        f"{rid} not found in output of forward_batched for walk {batch.graph_walk}. "
+                        f"batched_output keys={list(batched_output.keys())}"
+                    ))
+                rid_out = batched_output.get(rid, {})
                 rid_out["new_token"] = [view]
-                del rid_out["logits"]
+                rid_out.pop("logits", None)
             output = NodeOutput(per_request_output_tensors=batched_output)
         else:
             output = NodeOutput(per_request_output_tensors=batched_output)

--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -161,6 +161,10 @@ class KVCacheEngine(BaseEngine):
         # warnings — each unique miss shape is logged at most once.
         self._logged_graph_misses: set[tuple] = set()
 
+        # Dedup set for "forward_batched emitted no entry for this request"
+        # warnings — logged at most once per (node, graph walk).
+        self._logged_missing_rid_outputs: set[tuple[str, str]] = set()
+
     capabilities = EngineCapabilities(
         requires_kv_cache=True,
         supports_cpu_offload=True,
@@ -558,6 +562,12 @@ class KVCacheEngine(BaseEngine):
         # fast path in cuda_graph_runner.sample_and_remap).
         batched_logits = batched_output.pop("__batched_logits__", None)
 
+        # Prefill-style submodules emit batch-wide packed sentinels instead of
+        # per-rid entries, because per-request slice ends depend on the real
+        # seq_lens a fixed-shape captured region can't honor. Slice them here,
+        # merging key-by-key (and dropping the now-consumed sentinels) so this
+        # path matches CudaGraphRunner._merge_unpacked. No-op for decode-style
+        # submodules, whose hook returns {}.
         real_seq_lens = [inp.input_seq_len for inp in inputs]
         unpacked = submodule.unpack_packed_outputs(
             static_output=batched_output,
@@ -566,8 +576,15 @@ class KVCacheEngine(BaseEngine):
             inputs=inputs,
             per_request_info=batch.per_request_info,
         )
-        if unpacked:
-            batched_output = unpacked
+        # Remaining ``__``-prefixed keys are batch-wide sentinels, never request
+        # ids, so drop them unconditionally — otherwise they reach
+        # NodeOutput.per_request_output_tensors as phantom requests (e.g.
+        # talker_prefill's __batched_talker_prefill_hidden__, which the graph
+        # runner also discards).
+        for key in [k for k in batched_output if k.startswith("__")]:
+            del batched_output[key]
+        for rid, rid_out in unpacked.items():
+            batched_output.setdefault(rid, {}).update(rid_out)
 
         if self.enable_nvtx:
             range_push("ar.batched.sample", synchronize=False)
@@ -576,11 +593,19 @@ class KVCacheEngine(BaseEngine):
             sampled = sampler.sample(batch.request_ids, batched_logits)
             for rid, view in zip(batch.request_ids, sampled.split(1), strict=True):
                 if rid not in batched_output:
-                    logger.warning((
-                        f"{rid} not found in output of forward_batched for walk {batch.graph_walk}. "
-                        f"batched_output keys={list(batched_output.keys())}"
-                    ))
-                rid_out = batched_output.get(rid, {})
+                    # Expected when a submodule gates its per-rid emission
+                    # (e.g. Qwen3-Omni skips thinker_states for text-only
+                    # requests); the request still needs its sampled token,
+                    # so start it from an empty dict rather than dropping it.
+                    log_key = (batch.node_name, batch.graph_walk)
+                    if log_key not in self._logged_missing_rid_outputs:
+                        self._logged_missing_rid_outputs.add(log_key)
+                        logger.warning(
+                            "forward_batched emitted no per-request output for %s "
+                            "on walk %s; keys=%s. Emitting sampled token only.",
+                            rid, batch.graph_walk, sorted(batched_output),
+                        )
+                rid_out = batched_output.setdefault(rid, {})
                 rid_out["new_token"] = [view]
                 rid_out.pop("logits", None)
             output = NodeOutput(per_request_output_tensors=batched_output)


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

### Problem

`KVCacheEngine._execute_batched` (the eager, non-CUDA-graph batched path) never invoked `submodule.unpack_packed_outputs`. Prefill-style submodules pack their outputs into batch-wide sentinel tensors instead of per-request entries, because per-request slice boundaries depend on real `seq_len`s and can't be honored inside a fixed-shape captured region. Qwen3-Omni's Thinker prefill walks (`prefill_text` / `prefill_audio` / `prefill_vision`) return exactly this:

```python
return {
    "__batched_logits__": logits,
    "__batched_thinker_states__": thinker_states,
}
```
After popping `__batched_logits__`, `_execute_batched` indexed `batched_output[rid]` to attach the sampled token, but no per-rid keys existed, so it raised `KeyError`.

The leftover `__batched_thinker_states__` sentinel would also have flowed into `NodeOutput.per_request_output_tensors` as if it were a request id.

CudaGraphRunner already did the right thing here via `_merge_unpacked`; only the eager path was missing the hook.

### Fix
Call `submodule.unpack_packed_outputs` in `_execute_batched` after the forward and before sampling, so the packed sentinels are sliced into per-request outputs on both execution paths.

## How was it tested?

Ran the mixed-modality (A2T and TTS) workload with PD diaggregation that triggered the KeyError, verified all requests completed.

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
