### PR TITLE
Qwen3-Omni Audio Understanding Bug Fixes

### DIFF
--- a/mstar/model/qwen3_omni/components/rope.py
+++ b/mstar/model/qwen3_omni/components/rope.py
@@ -253,12 +253,16 @@ def get_rope_index_audio(
 ) -> torch.Tensor:
     """Build 3D MRoPE position IDs for an audio-only span.
 
-    For audio the temporal component advances per audio frame and the
-    height/width components are set to ``start_pos`` (i.e. the same
-    base as the temporal component's first position), which matches the
-    HF convention for single-modality audio where h/w track the text
-    position.  The temporal component is time-based via the Qwen3-Omni
-    ``position_id_per_seconds`` constant (default 25 positions/sec).
+    All three components advance together, one per audio token — audio
+    tokens are positioned exactly like text.  Without vision inputs, HF's
+    ``get_rope_index`` takes its non-spatial branch and returns
+    ``(cumsum(attention_mask) - 1).expand(3, -1, -1)``; checked against the
+    real implementation, an audio span comes back as t == h == w ==
+    2, 3, 4, ….
+
+    Pinning h/w to a constant instead (what this did before) leaves the
+    ``mrope_section`` bands that read those components with no positional
+    progression across the span, which degrades long audio the most.
 
     Parameters
     ----------
@@ -269,10 +273,9 @@ def get_rope_index_audio(
     device : torch.device, optional
         Device for the returned tensor.
     position_id_per_seconds : int
-        Unused here -- kept for API symmetry with the HF implementation
-        where audio timestamps map to integer position IDs.  The audio
-        encoder already outputs one token per quantized frame, so the
-        temporal component simply increments by one per token.
+        Unused here -- kept for API symmetry.  It applies to HF's spatial
+        branch (vision present), where audio position IDs come from
+        timestamps rather than token index.
 
     Returns
     -------
@@ -280,16 +283,10 @@ def get_rope_index_audio(
         Shape ``(3, num_audio_tokens)``.  ``dtype=torch.float``.
     """
     del position_id_per_seconds  # kept for API compatibility
-    temporal = torch.arange(
+    positions = torch.arange(
         num_audio_tokens, dtype=torch.float, device=device
     ) + float(start_pos)
-    height = torch.full(
-        (num_audio_tokens,), float(start_pos), dtype=torch.float, device=device
-    )
-    width = torch.full(
-        (num_audio_tokens,), float(start_pos), dtype=torch.float, device=device
-    )
-    return torch.stack([temporal, height, width], dim=0)
+    return positions.unsqueeze(0).expand(3, -1).contiguous()
 
 
 def get_rope_index_vision(

--- a/mstar/model/qwen3_omni/config.py
+++ b/mstar/model/qwen3_omni/config.py
@@ -75,16 +75,17 @@ class ThinkerTextConfig:
 
 @dataclass
 class ThinkerConfig:
-    audio_token_id: int = 151646
+    # Defaults match Qwen3-Omni's tokenizer; ``thinker_config`` in the HF
+    # config supplies all three, so these only apply to a checkpoint that
+    # omits them.  They are NOT the Qwen2.5-Omni ids — 151646/151647/151648
+    # are ``<|object_ref_start|>`` / ``<|object_ref_end|>`` / ``<|box_start|>``
+    # in this vocab, so inheriting those silently wraps audio spans in the
+    # wrong sentinels.
+    audio_token_id: int = 151675
     image_token_id: int = 151655
     video_token_id: int = 151656
-    audio_start_token_id: int = 151647
-    # NOTE: Qwen3-Omni's HF config explicitly omits ``audio_end_token_id``
-    # (it is marked as ``AttributeError()`` in the modular file), but the
-    # tokenizer still defines ``<|audio_eos|>`` which has the same id as
-    # in Qwen2.5-Omni (151648).  We track it here so we can wrap audio
-    # spans in their sentinel BOS/EOS tokens during prefill.
-    audio_end_token_id: int = 151648
+    audio_start_token_id: int = 151669
+    audio_end_token_id: int = 151670
     vision_start_token_id: int = 151652
     # NOTE: Qwen3-Omni's HF config exposes ``vision_start_token_id`` but
     # not ``vision_end_token_id``; we use the same value as Qwen3-VL /

--- a/mstar/model/qwen3_omni/qwen3_omni_model.py
+++ b/mstar/model/qwen3_omni/qwen3_omni_model.py
@@ -54,6 +54,10 @@ from mstar.utils.sampling import SamplingConfig
 
 logger = logging.getLogger(__name__)
 
+# Marks where modality content belongs inside the templated user turn.
+# Split out before tokenization, so it never reaches the tokenizer.
+_MM_SPLIT_SENTINEL = "<<<mstar_modality_split>>>"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -541,7 +545,13 @@ class Qwen3OmniModel(Model):
                 kwargs={
                     "audio_output": audio_output,
                     "talker_prefill_done": False,
-                    "num_thinker_prefill_steps": len(input_modalities),
+                    # Derived from the schedule, not len(input_modalities):
+                    # a modality request splits its text into two walks.
+                    "num_thinker_prefill_steps": len(
+                        self._build_thinker_prefill_schedule(
+                            input_modalities, input_signals,
+                        )
+                    ),
                     "prefill_chunks_processed": 0,
                     "voice": model_kwargs.get("voice", "Ethan"),
                     "talker_max_tokens": self.get_max_talker_output_tokens(**model_kwargs),
@@ -634,7 +644,12 @@ class Qwen3OmniModel(Model):
     ) -> list[tuple[str, dict[str, TensorPointerInfo]]]:
         """Build the sequential prefill schedule for the Thinker.
 
-        Order: [prefill_text] + [prefill_audio if audio inputs] + [prefill_vision if vision inputs]
+        Order: [text before the modality content] + [modality walks, in
+        request order] + [text after it].  ``process_prompt`` splits the
+        templated prompt into those two text segments so the Thinker sees
+        HF's layout, where modality content sits inside the user turn ahead
+        of the prompt text.  Text-only requests have a single segment and no
+        modality walks.
 
         Each schedule entry is ``(walk_name, {input_name: tensor_info})``,
         capturing all tensors needed by that step's first node.  For audio
@@ -644,7 +659,7 @@ class Qwen3OmniModel(Model):
         """
         schedule: list[tuple[str, dict[str, TensorPointerInfo]]] = []
 
-        texts = input_signals.get("text_inputs", [])
+        texts = list(input_signals.get("text_inputs", []))
         audio_features = input_signals.get("audio_features", [])
         audio_seqlens = input_signals.get("audio_seqlens", [])
         pixel_values = input_signals.get("pixel_values", [])
@@ -654,15 +669,19 @@ class Qwen3OmniModel(Model):
         video_grid_thws = input_signals.get("video_grid_thw", [])
         video_second_per_grid = input_signals.get("video_second_per_grid", [])
 
-        text_idx = audio_idx = vision_idx = video_idx = 0
+        # Every modality input goes between the two text segments, in
+        # request order, so image+audio prefills as
+        # ``…<|im_start|>user\n`` → vision → audio → ``{prompt}<|im_end|>…``.
+        # Text interleaved BETWEEN modality blocks isn't representable, but
+        # it never reaches here either: ``flatten_messages`` collapses each
+        # request to (files…, text), dropping their relative order.
+        if texts:
+            schedule.append(("prefill_text", {"text_inputs": texts.pop(0)}))
+
+        audio_idx = vision_idx = video_idx = 0
         for mod in input_modalities:
             if mod == "text":
-                if text_idx < len(texts):
-                    schedule.append((
-                        "prefill_text",
-                        {"text_inputs": texts[text_idx]},
-                    ))
-                    text_idx += 1
+                continue
             elif mod == "audio":
                 if audio_idx < len(audio_features):
                     entry: dict[str, TensorPointerInfo] = {
@@ -691,6 +710,9 @@ class Qwen3OmniModel(Model):
                         entry["video_second_per_grid"] = video_second_per_grid[video_idx]
                     schedule.append(("prefill_vision", entry))
                     video_idx += 1
+
+        for text_info in texts:
+            schedule.append(("prefill_text", {"text_inputs": text_info}))
 
         return schedule
 
@@ -773,7 +795,7 @@ class Qwen3OmniModel(Model):
     ) -> ForwardPassArgs:
         """Thinker partition state machine.
 
-        1. Build prefill schedule: [prefill_text] + [prefill_audio] + [prefill_vision]
+        1. Build prefill schedule: [prefill_text] + [modality walks] + [prefill_text]
         2. Pop walks from schedule until done
         3. Transition to thinker_decode
         4. Each decode step: check new_token for EOS (im_end_token_id)
@@ -1027,32 +1049,16 @@ class Qwen3OmniModel(Model):
         for waveform in raw_audio_inputs:
             np_audios.append(waveform.cpu().numpy())
 
-        # ----- Preferred path: text-only chat template + separate modality processors -----
+        # HF puts modality content INSIDE the user turn, ahead of the prompt:
         #
-        # We deliberately DO NOT include image/audio/video content blocks in
-        # the messages list passed to apply_chat_template.  HF's chat template
-        # would otherwise insert ``<|vision_start|><|image_pad|>...<|vision_end|>``
-        # placeholders into text_inputs, which we don't want because:
+        #   <|im_start|>user\n<|audio_start|><|audio_pad|><|audio_end|>{prompt}<|im_end|>
         #
-        #   1. Our prefill_vision / prefill_audio walks already wrap the
-        #      modality content in their own start/end tokens before pushing
-        #      it into the Thinker's KV cache.  Having the same wrapping in
-        #      text_inputs would make the model see each modality twice
-        #      (once as actual encoder embeddings via the modality walks,
-        #      once as generic token embeddings via prefill_text), which is
-        #      noise.
-        #
-        #   2. Unlike HF's single-shot prefill (which masked-scatter's the
-        #      vision embeds INTO the placeholder positions in input_embeds),
-        #      our multi-walk prefill builds up the same final KV cache via
-        #      sequential walks.  The modality placeholders in text_inputs
-        #      would never be replaced by real content in our flow.
-        #
-        # Functionally, both approaches end up with the same set of
-        # embeddings in the KV cache (text + modality content).  Stripping
-        # the placeholders avoids noise from the unfilled embeddings.
-        # if self._processor is not None:
-            # try:
+        # We reproduce that layout with sequential walks, so the templated
+        # prompt is split at the sentinel below into the text before the
+        # modality content and the text after it.  The placeholders stay out
+        # of both halves: the modality walks re-emit the start/end sentinels
+        # themselves (``ThinkerSubmodule._wrap_audio_input``) and the encoder
+        # embeddings take the place of the pad tokens.
         messages = [
             {
                 "role": "system",
@@ -1064,24 +1070,37 @@ class Qwen3OmniModel(Model):
                 ),
             },
         ]
-        if prompt is not None:
-            messages.append(
-                {"role": "user", "content": prompt},
-            )
+        num_mm_inputs = len(pil_images) + len(np_audios) + len(raw_video_inputs)
+        if prompt is not None or num_mm_inputs:
+            messages.append({
+                "role": "user",
+                "content": (
+                    (_MM_SPLIT_SENTINEL if num_mm_inputs else "") + (prompt or "")
+                ),
+            })
 
-        # apply_chat_template with TEXT-ONLY content -> no modality
-        # placeholders are inserted.  add_generation_prompt=True
-        # appends the trailing ``<|im_start|>assistant\n`` so the
-        # model knows to start the assistant response.
         text = self._processor.apply_chat_template(
             messages,
             tokenize=False,
             add_generation_prompt=True,
         )
-        input_ids = self.tokenizer(
-            text, return_tensors="pt"
-        )["input_ids"][0]
-        result["text_inputs"] = [input_ids]
+
+        if num_mm_inputs:
+            head_text, sep, tail_text = text.partition(_MM_SPLIT_SENTINEL)
+            assert sep and _MM_SPLIT_SENTINEL not in tail_text, (
+                "chat template did not render exactly one modality-split "
+                f"sentinel; got {text!r}"
+            )
+            segments = [head_text, tail_text]
+        else:
+            segments = [text]
+
+        # Empty segments are dropped — a zero-length prefill walk has nothing
+        # to embed.  Neither half is empty under Qwen3-Omni's template.
+        result["text_inputs"] = [
+            self.tokenizer(seg, return_tensors="pt")["input_ids"][0]
+            for seg in segments if seg
+        ]
 
         result["pixel_values"] = []
         result["image_grid_thw"] = []


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

Fixes two bugs that made Qwen3-Omni audio-input requests (A2T/A2S) produce fluent but wrong output.

**1. Modality content was prefilled outside the chat template.** `input_modalities` arrives as `["audio", "text"]` (`flatten_messages` appends `"text"` last), and the prefill schedule walked it in that order, while `text_inputs` held the fully templated prompt with the modality placeholders stripped. `process_prompt` now splits the templated prompt at the modality-content boundary, and the schedule is `[text head] + [modality walks] + [text tail]`, reproducing HF's layout where modality content sits inside the user turn ahead of the prompt text. Text-only requests are unsplit and unchanged. `num_thinker_prefill_steps` (which the Talker uses to detect the final Thinker prefill chunk) is now derived from the schedule rather than `len(input_modalities)`, since a modality request now has one more walk than it has modalities.

**2. Audio MRoPE height/width were pinned to a constant.** `get_rope_index_audio` advanced only the temporal component across an audio span and held h/w at `start_pos`. HF does not do this: with no vision input, `get_rope_index` takes its non-spatial branch and returns all three components identical and sequential. The frozen bands carried no positional information across the audio at all, so the model could not order what it heard — hence transcriptions that skip the start and then loop, degrading with audio length. Vision was unaffected because it goes through HF's spatial branch with real grid positions, which is why I2T always looked fine.

Also updates the `audio_token_id` / `audio_start_token_id` / `audio_end_token_id` defaults in `ThinkerConfig` from the Qwen2.5-Omni values (which decode to `<|object_ref_start|>` / `<|object_ref_end|>` / `<|box_start|>` in this vocab) to Qwen3-Omni's. No runtime effect — HF's `thinker_config` supplies all three — purely a guard against a checkpoint that omits them.

## How was it tested?

Ran 120-second LibriSpeech A2T requests and verified transcription quality, plus benchmarks across all other modalities to confirm nothing else regressed. Note that I2T output changes: it had the same prompt-layout defect (the main bug was the MRoPE IDs so I2T seemed qualitatively fine, but this is still a parity issue).

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
