### PR TITLE
Sliding Window Attention (AR video gen) + KV cache lifecycle management

### DIFF
--- a/configs/cosmos3_nano_ar.yaml
+++ b/configs/cosmos3_nano_ar.yaml
@@ -1,0 +1,20 @@
+model: "cosmos3"
+# Sequence-length hint for the scheduler. The conductor only asserts its
+# presence; the real per-request capacity is the KV pool below.
+max_seq_len: 8192
+kv_cache:
+  max_num_pages: 1024
+# Windowed-AR serving config: same nano deployment as cosmos3_nano.yaml plus
+# the opt-in windowed video walk (enable_windowed_video adds the
+# vae_decoder_ar node and its streaming decoder partition; requests opt in
+# per call via window_mode). Windowed requests run the eager denoise path, so
+# capture stays enabled only for the t2i tiers it already covers.
+model_kwargs:
+  cuda_graph: true
+  graph_max_latent_area: 2000
+  enable_windowed_video: true
+node_groups:
+  - node_names: ["dit"]
+    ranks: [0]
+  - node_names: ["vae_encoder", "vae_decoder", "vae_decoder_ar", "audio_decoder"]
+    ranks: [0]

--- a/configs/cosmos3_nano_ar_sp2.yaml
+++ b/configs/cosmos3_nano_ar_sp2.yaml
@@ -1,0 +1,18 @@
+model: "cosmos3"
+# Sequence-length hint for the scheduler (see cosmos3_nano.yaml).
+max_seq_len: 8192
+# Per-rank KV pool (see cosmos3_nano_sp2.yaml).
+kv_cache:
+  max_num_pages: 1024
+# cosmos3_nano_sp2.yaml plus the opt-in windowed video walk: the DiT (and its
+# windowed commit pass) runs Ulysses sequence-parallel across two ranks; the
+# streaming window decoder is small and runs un-sharded on rank 0, consuming
+# the window-latents stream the multi-rank producer dedups to rank 0.
+model_kwargs:
+  enable_windowed_video: true
+node_groups:
+  - node_names: ["dit"]
+    ranks: [0, 1]
+    sp_size: 2
+  - node_names: ["vae_encoder", "vae_decoder", "vae_decoder_ar", "audio_decoder"]
+    ranks: [0]

--- a/configs/cosmos3_nano_ar_tp2.yaml
+++ b/configs/cosmos3_nano_ar_tp2.yaml
@@ -1,0 +1,18 @@
+model: "cosmos3"
+# Sequence-length hint for the scheduler (see cosmos3_nano.yaml).
+max_seq_len: 8192
+# Per-rank KV pool (see cosmos3_nano_tp2.yaml).
+kv_cache:
+  max_num_pages: 1024
+# cosmos3_nano_tp2.yaml plus the opt-in windowed video walk: the DiT (and its
+# windowed commit pass) runs tensor-parallel across two ranks; the streaming
+# window decoder is small and runs un-sharded on rank 0, consuming the
+# window-latents stream the multi-rank producer dedups to rank 0.
+model_kwargs:
+  enable_windowed_video: true
+node_groups:
+  - node_names: ["dit"]
+    ranks: [0, 1]
+    tp_size: 2
+  - node_names: ["vae_encoder", "vae_decoder", "vae_decoder_ar", "audio_decoder"]
+    ranks: [0]

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -486,6 +486,7 @@ class APIServer:
         """
         start = time.time()
         finished = False
+        error_delivered = False
         try:
             while True:
                 if time.time() - start > self.timeout_seconds:
@@ -505,6 +506,7 @@ class APIServer:
                         done = True
 
                 for chunk in new_chunks:
+                    error_delivered |= chunk.modality == "error"
                     yield chunk
 
                 if done:
@@ -522,12 +524,20 @@ class APIServer:
                     if finished_req is not None:
                         self._finalize_profile(finished_req)
                     for chunk in remaining:
+                        error_delivered |= chunk.modality == "error"
                         yield chunk
                     # A request can fail after the stream is already open
                     # (preprocess error, result-delivery timeout); the HTTP
                     # status is committed by then, so the error must travel
-                    # in-band as the final chunk.
-                    if finished_req is not None and finished_req.error is not None:
+                    # in-band as the final chunk. A preprocess failure is
+                    # already delivered as an in-band error chunk above — only
+                    # synthesize one for errors that never produced a chunk
+                    # (e.g. result-delivery timeout), not a duplicate.
+                    if (
+                        finished_req is not None
+                        and finished_req.error is not None
+                        and not error_delivered
+                    ):
                         yield ResultChunk(
                             request_id=request_id,
                             modality="error",

--- a/mstar/api_server/openai/router.py
+++ b/mstar/api_server/openai/router.py
@@ -129,6 +129,10 @@ async def videos_generations(request: VideoGenerationRequest):
     except Exception as e:  # noqa: BLE001
         default_status = 400 if isinstance(e, (ValueError, TypeError)) else 500
         return _error(getattr(e, "status_code", default_status), str(getattr(e, "detail", e)), "server_error")
+    if (request.model_extra or {}).get("stream_video"):
+        return StreamingResponse(
+            result, media_type="application/x-ndjson", headers={"Cache-Control": "no-cache"}
+        )
     return JSONResponse(result)
 
 

--- a/mstar/api_server/openai/serving_videos.py
+++ b/mstar/api_server/openai/serving_videos.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import logging
 
 from mstar.api_server import media_io
@@ -15,15 +16,18 @@ async def create_videos(api, model_name, adapter, req):  # noqa: ARG001
     args = adapter.video_to_request(req, api.upload_dir)
     request_id = rid("vid")
 
+    stream = bool(args.model_kwargs.get("stream_video"))
     api.submit_request(
         text=args.text,
         file_paths=args.file_paths,
         input_modalities=args.input_modalities,
         output_modalities=["video"],
         model_kwargs=args.model_kwargs,
-        streaming=False,
+        streaming=stream,
         request_id=request_id,
     )
+    if stream:
+        return _stream_ndjson(api, request_id)
 
     chunks = await api.collect_results(request_id)
     # Each video chunk is an mp4 (H.264); return it base64-encoded, mirroring the
@@ -52,3 +56,33 @@ async def create_videos(api, model_name, adapter, req):  # noqa: ARG001
                 logger.exception("Muxing generated audio into the mp4 failed; returning video only")
         data.append({"b64_json": base64.b64encode(video).decode("ascii"), "url": None})
     return {"created": now(), "data": data}
+
+
+async def _stream_ndjson(api, request_id):
+    """Yield one NDJSON line per result chunk for a ``stream_video`` request.
+
+    A windowed request emits each window's mp4 as its own ``video`` chunk;
+    the lines use the ``/generate`` wire shape (modality / base64 data /
+    metadata) with a running ``index``, and the stream is closed by a ``done``
+    line carrying the chunk count. Failures after the stream is open travel
+    in-band as a terminal ``error`` line (the HTTP status is committed), in
+    which case no ``done`` line follows.
+    """
+    index = 0
+    failed = False
+    async for chunk in api.iter_result_chunks(request_id):
+        metadata = dict(chunk.metadata or {})
+        if chunk.modality == "error":
+            failed = True
+        else:
+            metadata["index"] = index
+            index += 1
+        yield json.dumps({
+            "modality": chunk.modality,
+            "data": base64.b64encode(chunk.data).decode("ascii"),
+            "metadata": metadata,
+        }) + "\n"
+    if not failed:
+        yield json.dumps(
+            {"modality": "done", "data": "", "metadata": {"chunks": index}}
+        ) + "\n"

--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -548,6 +548,10 @@ class BatchedCacheManager(ABC):
         for rid in self.request_ids:
             state = self._get_state(rid)
             state.seq_len += n
+            if n:
+                # Committed content grew — signal caches of prefix-derived
+                # views (see KVRequestState.prefix_epoch).
+                state.prefix_epoch += 1
             state.position_id_start += (pos_id_n if pos_id_n is not None else n)
 
     @torch.compiler.disable
@@ -601,6 +605,8 @@ class BatchedCacheManager(ABC):
                     n = seq_lens[i]
                     state = self._get_state(rid, label=label)
                     state.seq_len += n
+                    if n:
+                        state.prefix_epoch += 1
                     if pos_id_ns is None:
                         state.position_id_start += n
                     elif isinstance(pos_id_ns, int):
@@ -614,6 +620,8 @@ class BatchedCacheManager(ABC):
                 n = ps.seq_lens[i]
                 state = self._get_state(rid, label=label)
                 state.seq_len += n
+                if n:
+                    state.prefix_epoch += 1
                 if pos_id_ns is None:
                     if ps.custom_pos_advance is not None:
                         state.position_id_start += ps.custom_pos_advance[i]
@@ -627,6 +635,26 @@ class BatchedCacheManager(ABC):
         # bleed into a subsequent walk.
         for ps in self._plan_states.values():
             ps.custom_pos_advance = None
+
+    @torch.compiler.disable
+    def protect_prefix(
+        self, request_id: str, num_tokens: int, label: str | None = None,
+    ) -> None:
+        """Mark the first ``num_tokens`` of the request's stream (active label
+        unless given) as never releasable. See
+        ``PagedAllocationManager.protect_prefix``."""
+        label = label or self.active_labels.get(request_id, "main")
+        self.alloc_manager.protect_prefix(request_id, label, num_tokens)
+
+    @torch.compiler.disable
+    def release_oldest(
+        self, request_id: str, num_tokens: int, label: str | None = None,
+    ) -> int:
+        """Free the oldest unprotected tokens of a live request, whole pages
+        only; returns tokens actually freed. See
+        ``PagedAllocationManager.release_oldest``."""
+        label = label or self.active_labels.get(request_id, "main")
+        return self.alloc_manager.release_oldest(request_id, label, num_tokens)
 
     @torch.compiler.disable
     def snapshot_all(

--- a/mstar/engine/cache_manager.py
+++ b/mstar/engine/cache_manager.py
@@ -1488,14 +1488,22 @@ class DenseGenCacheManager(FlashInferCacheManager):
         offset = 0
         for idx, prefix_len, gen_len, state in dg["segs"]:
             prefix_cache = state.dense_prefix_kv
-            if prefix_cache is None:
-                prefix_cache = state.dense_prefix_kv = {}
-            cached = prefix_cache.get(layer_idx)
+            if prefix_cache is None or prefix_cache.get("epoch") != state.prefix_epoch:
+                # First gather, or the committed content mutated since the
+                # last one (windowed generation appends/evicts per window —
+                # prefix_epoch moves with every such mutation): drop the stale
+                # clones and re-gather from the live pages. Static-prefix
+                # requests keep the single-gather behavior (their epoch never
+                # moves after prefill).
+                prefix_cache = state.dense_prefix_kv = {
+                    "epoch": state.prefix_epoch, "layers": {},
+                }
+            cached = prefix_cache["layers"].get(layer_idx)
             if cached is None:
                 sub = kv_layer[idx]  # [n_pages, 2, page_size, num_kv_heads, head_dim]
                 k_pref = sub[:, 0].reshape(-1, num_kv_heads, head_dim)[:prefix_len].clone()
                 v_pref = sub[:, 1].reshape(-1, num_kv_heads, head_dim)[:prefix_len].clone()
-                prefix_cache[layer_idx] = (k_pref, v_pref)
+                prefix_cache["layers"][layer_idx] = (k_pref, v_pref)
             else:
                 k_pref, v_pref = cached
             k_parts.append(k_pref)

--- a/mstar/engine/cpu_page_pool.py
+++ b/mstar/engine/cpu_page_pool.py
@@ -16,10 +16,19 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class OffloadedState:
-    """Tracks a single (request, label) that has been offloaded to CPU."""
+    """Tracks a single (request, label) that has been offloaded to CPU.
+
+    Carries the full stream bookkeeping (not just seq_len/position) so a
+    reload restores a windowed label's protection/release state exactly,
+    rather than relying on the live KVRequestState object surviving the
+    offload untouched.
+    """
     cpu_page_indices: list[int]
     seq_len: int
     position_id_start: int
+    protected_prefix_tokens: int = 0
+    released_tokens: int = 0
+    prefix_epoch: int = 0
 
 
 class CPUPagePool:
@@ -68,6 +77,9 @@ class CPUPagePool:
         gpu_page_indices: list[int],
         seq_len: int,
         position_id_start: int,
+        protected_prefix_tokens: int = 0,
+        released_tokens: int = 0,
+        prefix_epoch: int = 0,
     ) -> None:
         """Copy GPU pages → CPU pages (async on dedicated stream)."""
         n_pages = len(gpu_page_indices)
@@ -94,6 +106,9 @@ class CPUPagePool:
             cpu_page_indices=cpu_pages,
             seq_len=seq_len,
             position_id_start=position_id_start,
+            protected_prefix_tokens=protected_prefix_tokens,
+            released_tokens=released_tokens,
+            prefix_epoch=prefix_epoch,
         )
 
     def reload_pages(
@@ -102,10 +117,11 @@ class CPUPagePool:
         label: str,
         gpu_kv_cache: torch.Tensor,
         gpu_page_indices: list[int],
-    ) -> tuple[int, int]:
+    ) -> OffloadedState:
         """Copy CPU pages → GPU pages (async), free CPU pages.
 
-        Returns (seq_len, position_id_start) that were saved during offload.
+        Returns the ``OffloadedState`` saved during offload (its
+        ``cpu_page_indices`` are freed and no longer meaningful).
         """
         state = self.offloaded[request_id][label]
 
@@ -117,11 +133,10 @@ class CPUPagePool:
                 )
 
         self.page_allocator.free(state.cpu_page_indices)
-        seq_len, pos_id = state.seq_len, state.position_id_start
         del self.offloaded[request_id][label]
         if not self.offloaded[request_id]:
             del self.offloaded[request_id]
-        return seq_len, pos_id
+        return state
 
     def sync(self) -> None:
         """Wait for all pending GPU↔CPU copies to complete."""

--- a/mstar/engine/kv_store.py
+++ b/mstar/engine/kv_store.py
@@ -164,16 +164,16 @@ class KVRequestState:
     # sequence length of the in-distributed-store KV cache
     is_paused: bool = False
 
-    # Lazily-filled {layer_idx: (k_pref, v_pref)} contiguous copies of the frozen
-    # text-prefix K/V, used by the dense generation-attention path. The prefix is
-    # written once at prefill and immutable through denoise (text tokens get no
-    # timestep embedding; the dense path never writes generation K/V to pages), so
-    # it is gathered once and reused across steps rather than re-gathered from the
-    # paged cache every step. Reset to None by _new_state()
-    # (add_request/reset_label/remove_request) — exactly when the prefix pages are
-    # (re)allocated — so it needs no manual invalidation. Labels whose committed
-    # content mutates mid-request (windowed generation) additionally reset it in
-    # release_oldest and carry prefix_epoch for consumers to detect growth.
+    # Lazily-filled {"epoch": int, "layers": {layer_idx: (k_pref, v_pref)}}
+    # contiguous copies of the committed-prefix K/V, used by the dense
+    # generation-attention path. For a static prefix (text written once at
+    # prefill, immutable through denoise) it is gathered once and reused
+    # across steps; when the committed content mutates mid-request (windowed
+    # generation appends/evicts per window) the recorded epoch falls behind
+    # prefix_epoch and the dense path re-gathers from the live pages — once
+    # per mutation, amortized over the steps between them. Reset to None by
+    # _new_state() (add_request/reset_label/remove_request) and by
+    # release_oldest (freed pages may be reused before the next gather).
     dense_prefix_kv: dict | None = None
 
     # Windowed-generation bookkeeping (PagedAllocationManager.protect_prefix /

--- a/mstar/engine/kv_store.py
+++ b/mstar/engine/kv_store.py
@@ -171,8 +171,20 @@ class KVRequestState:
     # it is gathered once and reused across steps rather than re-gathered from the
     # paged cache every step. Reset to None by _new_state()
     # (add_request/reset_label/remove_request) — exactly when the prefix pages are
-    # (re)allocated — so it needs no manual invalidation.
+    # (re)allocated — so it needs no manual invalidation. Labels whose committed
+    # content mutates mid-request (windowed generation) additionally reset it in
+    # release_oldest and carry prefix_epoch for consumers to detect growth.
     dense_prefix_kv: dict | None = None
+
+    # Windowed-generation bookkeeping (PagedAllocationManager.protect_prefix /
+    # release_oldest): the first protected_prefix_tokens of the stream are never
+    # releasable; released_tokens counts tokens compacted out of the front so
+    # far; prefix_epoch increments on every committed-content mutation (append
+    # via advance_seq_len(s), partial release) so caches of prefix-derived
+    # views can detect staleness instead of assuming a write-once prefix.
+    protected_prefix_tokens: int = 0
+    released_tokens: int = 0
+    prefix_epoch: int = 0
 
     def get_pos_info(self):
         return PositionInfo(
@@ -660,6 +672,64 @@ class PagedAllocationManager:
                 self.page_allocator.free(state.page_indices)
             self.request_states[request_id][label] = self._new_state()
 
+    def protect_prefix(self, request_id: str, label: str, num_tokens: int) -> None:
+        """Mark the first ``num_tokens`` of the label's stream as never
+        releasable (e.g. a text prefix that must survive while older
+        generated context is evicted). Set once, after the prefix commits;
+        idempotent at the same value."""
+        with self._lock:
+            state = self.request_states[request_id][label]
+            if num_tokens < 0 or num_tokens > state.seq_len:
+                raise ValueError(
+                    f"protect_prefix({num_tokens}) outside committed seq_len "
+                    f"{state.seq_len} for request {request_id!r} label {label!r}"
+                )
+            if state.released_tokens:
+                raise ValueError(
+                    f"protect_prefix must precede any release_oldest for "
+                    f"request {request_id!r} label {label!r}"
+                )
+            if state.protected_prefix_tokens not in (0, num_tokens):
+                raise ValueError(
+                    f"protected prefix already {state.protected_prefix_tokens} "
+                    f"tokens for request {request_id!r} label {label!r}, "
+                    f"got {num_tokens}"
+                )
+            state.protected_prefix_tokens = num_tokens
+
+    def release_oldest(self, request_id: str, label: str, num_tokens: int) -> int:
+        """Free the oldest unprotected tokens of a live request, whole pages
+        only, compacting the page list so the remaining stream stays
+        contiguous in page-list order.
+
+        The freed span starts at the first page fully past the protected
+        prefix; a page straddling the protection boundary and the partially
+        written tail page are never freed, so the realized release can fall
+        short of ``num_tokens`` by up to a page — callers re-offer the
+        shortfall on their next call. ``seq_len`` drops by exactly the freed
+        token count; ``position_id_start`` is untouched (it describes token
+        0, which is protected and never moves). Returns tokens freed.
+        """
+        self.wait_for_retrieves(request_id, label)
+        with self._lock:
+            state = self.request_states[request_id][label]
+            page_size = self.config.page_size
+            first = (state.protected_prefix_tokens + page_size - 1) // page_size
+            releasable = state.seq_len // page_size - first
+            k = min(num_tokens // page_size, releasable)
+            if k <= 0:
+                return 0
+            freed = state.page_indices[first : first + k]
+            del state.page_indices[first : first + k]
+            state.seq_len -= k * page_size
+            state.released_tokens += k * page_size
+            state.prefix_epoch += 1
+            # The dense fast path's cached prefix clone may include freed
+            # tokens; drop it so the next gather rebuilds from live pages.
+            state.dense_prefix_kv = None
+            self.page_allocator.free(freed)
+            return k * page_size
+
     def cleanup(self):
         self._kv_transfer_engine.shutdown()
 
@@ -705,6 +775,9 @@ class PagedAllocationManager:
             cpu_pool.offload_pages(
                 request_id, label, self.kv_cache,
                 state.page_indices, state.seq_len, state.position_id_start,
+                protected_prefix_tokens=state.protected_prefix_tokens,
+                released_tokens=state.released_tokens,
+                prefix_epoch=state.prefix_epoch,
             )
             with self._lock:
                 freed += len(state.page_indices)
@@ -722,10 +795,13 @@ class PagedAllocationManager:
                 gpu_pages = self.page_allocator.allocate(n_pages)
                 state = self.get_state(request_id, label)
                 state.page_indices = gpu_pages
-                seq_len, pos_id = cpu_pool.reload_pages(
+                restored = cpu_pool.reload_pages(
                     request_id, label, self.kv_cache, gpu_pages,
                 )
-                state.seq_len = seq_len
-                state.position_id_start = pos_id
+                state.seq_len = restored.seq_len
+                state.position_id_start = restored.position_id_start
+                state.protected_prefix_tokens = restored.protected_prefix_tokens
+                state.released_tokens = restored.released_tokens
+                state.prefix_epoch = restored.prefix_epoch
         cpu_pool.sync()
 

--- a/mstar/engine/windowing.py
+++ b/mstar/engine/windowing.py
@@ -1,0 +1,165 @@
+"""Windowed (sliding-window) autoregressive generation support.
+
+``WindowSchedule`` is pure window arithmetic over abstract sequence units
+(latent frames for video models). ``WindowedKVSession`` turns schedule events
+into KV-cache lifecycle calls — protect the immutable prefix once, release
+aged-out context after each window commit — so a model drives windowed
+generation without hand-rolling page/token bookkeeping. Models own their
+walk, conditioning math, and attention plans; this module owns the schedule
+and the lifecycle sequencing.
+"""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WindowPlan:
+    """One window's slice of a windowed generation.
+
+    Unit indices are absolute within the full sequence. The leading
+    ``cond_units`` of the window re-pin the tail of the previous window as
+    clean conditioning (the chained-mode overlap; 0 when there is no
+    overlap). ``commit_start:commit_end`` is the span this window newly
+    generates — the span a kv-mode commit pass appends to the cache
+    (overlap units were already committed by the previous window).
+    """
+    index: int
+    start: int
+    end: int
+    cond_units: int
+
+    @property
+    def units(self) -> int:
+        return self.end - self.start
+
+    @property
+    def commit_start(self) -> int:
+        return self.start + self.cond_units
+
+    @property
+    def commit_end(self) -> int:
+        return self.end
+
+
+class WindowSchedule:
+    """Window arithmetic for one request.
+
+    ``total_units`` are generated in windows of ``window_units`` advancing by
+    ``window_units - overlap_units``; the final window may be short, and every
+    unit is generated exactly once (commit spans partition ``[0, total)``).
+    ``context_units`` bounds the committed history retained in the cache
+    after each commit; 0 means retain everything (no release).
+    """
+
+    def __init__(
+        self,
+        total_units: int,
+        window_units: int,
+        context_units: int = 0,
+        overlap_units: int = 0,
+    ):
+        if total_units < 1:
+            raise ValueError(f"total_units must be >= 1, got {total_units}")
+        if window_units < 1:
+            raise ValueError(f"window_units must be >= 1, got {window_units}")
+        if not 0 <= overlap_units < window_units:
+            raise ValueError(
+                f"overlap_units must be in [0, window_units), got "
+                f"{overlap_units} with window_units={window_units}"
+            )
+        if context_units < 0:
+            raise ValueError(f"context_units must be >= 0, got {context_units}")
+        self.total_units = total_units
+        self.window_units = window_units
+        self.context_units = context_units
+        self.overlap_units = overlap_units
+        self.stride = window_units - overlap_units
+        if total_units <= window_units:
+            self.num_windows = 1
+        else:
+            self.num_windows = 1 + -(-(total_units - window_units) // self.stride)
+
+    def window(self, index: int) -> WindowPlan:
+        if not 0 <= index < self.num_windows:
+            raise IndexError(
+                f"window {index} out of range [0, {self.num_windows})"
+            )
+        start = index * self.stride
+        end = min(start + self.window_units, self.total_units)
+        cond = self.overlap_units if index > 0 else 0
+        return WindowPlan(index=index, start=start, end=end, cond_units=cond)
+
+    def windows(self):
+        return (self.window(k) for k in range(self.num_windows))
+
+    def released_end(self, index: int) -> int:
+        """Units released from the front of the committed stream once window
+        ``index`` has committed: everything older than ``context_units``
+        behind the commit frontier. 0 when context is unbounded."""
+        if self.context_units == 0:
+            return 0
+        return max(0, self.window(index).commit_end - self.context_units)
+
+
+class WindowedKVSession:
+    """KV lifecycle driver for one (request, label) under a ``WindowSchedule``.
+
+    ``handle`` provides ``protect_prefix(request_id, num_tokens, label=...)``
+    and ``release_oldest(request_id, num_tokens, label=...) -> int`` (the
+    ``BatchedCacheManager`` passthrough surface). Units convert to cache
+    tokens via ``tokens_per_unit``. Releases are page-floored by the
+    allocator; the session re-offers the shortfall on the next call, so the
+    realized context tracks the nominal one within a page.
+    """
+
+    def __init__(
+        self,
+        handle,
+        request_id: str,
+        label: str,
+        schedule: WindowSchedule,
+        tokens_per_unit: int,
+    ):
+        if tokens_per_unit < 1:
+            raise ValueError(
+                f"tokens_per_unit must be >= 1, got {tokens_per_unit}"
+            )
+        self._handle = handle
+        self._request_id = request_id
+        self._label = label
+        self._schedule = schedule
+        self._tokens_per_unit = tokens_per_unit
+        self._prefix_protected = False
+        self._released_tokens = 0
+
+    @property
+    def released_tokens(self) -> int:
+        return self._released_tokens
+
+    def protect_prefix(self, prefix_tokens: int) -> None:
+        """Protect the immutable stream head (e.g. the text prefix). Call
+        once, after the prefix has committed and before any release."""
+        if self._prefix_protected:
+            raise RuntimeError(
+                f"prefix already protected for request "
+                f"{self._request_id!r} label {self._label!r}"
+            )
+        self._handle.protect_prefix(
+            self._request_id, prefix_tokens, label=self._label
+        )
+        self._prefix_protected = True
+
+    def after_commit(self, window_index: int) -> int:
+        """Release context that aged out once ``window_index`` committed.
+        Returns tokens actually freed (0 when nothing aged out yet, or the
+        accumulated shortfall is still under a page)."""
+        target = (
+            self._schedule.released_end(window_index) * self._tokens_per_unit
+        )
+        ask = target - self._released_tokens
+        if ask <= 0:
+            return 0
+        freed = self._handle.release_oldest(
+            self._request_id, ask, label=self._label
+        )
+        self._released_tokens += freed
+        return freed

--- a/mstar/model/cosmos3/components/packing.py
+++ b/mstar/model/cosmos3/components/packing.py
@@ -355,6 +355,7 @@ def build_vision_segment(
     vae_scale_factor_temporal: int,
     device,
     noisy_frames: list[int] | None = None,
+    start_frame_offset: int = 0,
 ) -> dict[str, Any]:
     """``latent_shape`` is the vision latent tensor shape ``[B, C, T, H, W]``.
 
@@ -362,7 +363,10 @@ def build_vision_segment(
     are clean conditioning context. When ``None`` it defaults to frame 0 clean
     if ``has_image_condition`` else all frames noisy — i.e. the t2i/t2v/i2v
     layouts. Action modes pass an explicit list (e.g. ``[]`` for
-    inverse-dynamics, where the whole video is conditioning)."""
+    inverse-dynamics, where the whole video is conditioning).
+    ``start_frame_offset`` shifts the temporal mRoPE axis so the segment's
+    frames sit at absolute frame indices ``start_frame_offset ..`` — a window
+    of a longer video positions itself exactly where the full clip would."""
     p = config.latent_patch_size
     _, _, latent_t, latent_h, latent_w = latent_shape
     patch_h = math.ceil(latent_h / p)
@@ -392,6 +396,7 @@ def build_vision_segment(
         fps=effective_fps,
         base_fps=float(config.base_fps),
         temporal_compression_factor=vae_scale_factor_temporal,
+        start_frame_offset=start_frame_offset,
     )
 
     return {
@@ -449,6 +454,7 @@ def build_static_inputs(
     has_image_condition: bool = False,
     sound_latent_frames: int | None = None,
     noisy_frames: list[int] | None = None,
+    start_frame_offset: int = 0,
 ) -> dict[str, Any]:
     """Assemble the per-prompt static transformer inputs for image/video
     generation. ``latent_shape`` is ``[B, C, T, H, W]`` (``T == 1`` for images;
@@ -472,6 +478,7 @@ def build_static_inputs(
         vae_scale_factor_temporal=vae_scale_factor_temporal,
         device=device,
         noisy_frames=noisy_frames,
+        start_frame_offset=start_frame_offset,
     )
     parts = [text["text_mrope_ids"], vision["vision_mrope_ids"]]
     static = {**text, **vision}

--- a/mstar/model/cosmos3/components/transformer.py
+++ b/mstar/model/cosmos3/components/transformer.py
@@ -828,6 +828,33 @@ class Cosmos3OmniTransformer(nn.Module):
             und_seq = layer.forward_und(und_seq, cos, sin, cache_handle)
         cache_handle.advance_seq_lens()
 
+    def commit_window(
+        self, latents: torch.Tensor, position_ids_per_branch: list[torch.Tensor],
+        cache_handle,
+    ) -> None:
+        """Run the generation tower over a finished window's clean latents and
+        append their K/V to the planned label(s) — the frame-token analogue of
+        ``prefill_und``. Clean conditioning frames receive no timestep
+        embedding, so the committed K/V is denoise-step independent, exactly
+        like i2v/v2v clean frames. ``position_ids_per_branch`` carries one
+        [3, N] mRoPE block per guidance branch (the branches share content but
+        their positions differ with the prompt length); the sequence packs
+        [cond | uncond] to match the batched plan's label order. No velocity
+        is decoded — the pass exists for its cache writes."""
+        packed, _ = self._patchify_and_pack_latents([latents])
+        gen_seq = self.proj_in(packed)
+        if len(position_ids_per_branch) > 1:
+            gen_seq = torch.cat([gen_seq] * len(position_ids_per_branch), dim=0)
+        cos_parts, sin_parts = [], []
+        for pos in position_ids_per_branch:
+            c, s = self._rotary(pos, gen_seq.device, gen_seq.dtype)
+            cos_parts.append(c)
+            sin_parts.append(s)
+        cos = torch.cat(cos_parts, dim=0) if len(cos_parts) > 1 else cos_parts[0]
+        sin = torch.cat(sin_parts, dim=0) if len(sin_parts) > 1 else sin_parts[0]
+        self._sp_run_gen_layers(gen_seq, cos, sin, cache_handle)
+        cache_handle.advance_seq_lens()
+
     def _sp_run_gen_layers(self, gen_seq, cos, sin, cache_handle, prefer_all_gather=False):
         """Run the generation layer stack, sequence-parallel-sharded across the
         SP group when active. ``gen_seq``/``cos``/``sin`` are the FULL sequence

--- a/mstar/model/cosmos3/config.py
+++ b/mstar/model/cosmos3/config.py
@@ -148,6 +148,10 @@ class Cosmos3Config:
     # one-frame conditioning visibly degrades the continuation.
     window_frames_default: int = 29
     overlap_frames_default: int = 8
+    # kv-mode committed-context horizon (61 px = 16 latent frames): frames
+    # older than this behind the commit frontier are evicted from the cache.
+    # A request may pass context_frames=0 to retain everything.
+    context_frames_default: int = 61
     # Latent frames of already-generated context re-decoded ahead of each
     # window so the causal VAE's conv stack is warm at the kept frames; the
     # context-derived pixels are trimmed. Raise if window boundaries seam.

--- a/mstar/model/cosmos3/config.py
+++ b/mstar/model/cosmos3/config.py
@@ -133,6 +133,25 @@ class Cosmos3Config:
     # audio_decoder node with its ~1.9 GB AVAE). Requires the checkpoint to ship
     # sound_tokenizer/; set False to serve video-only and skip loading it.
     enable_sound: bool = True
+    # Serve opt-in windowed autoregressive video generation (the video_gen_ar
+    # walk plus the vae_decoder_ar node and its streaming decoder partition).
+    # Off by default: the served node set, walks and partitions are unchanged
+    # unless a deployment enables it, and requests only run windowed when they
+    # ask for a window_mode.
+    enable_windowed_video: bool = False
+    # Cap on how many windows one request may span (bounds the AR loop's
+    # static iteration count together with max_inference_steps).
+    max_windows: int = 64
+    # Windowed-request defaults, in pixel frames (quantized to latent frames
+    # server-side; the Wan VAE downsamples time by scale_factor_temporal).
+    # The overlap default matches the V2V recipe's two pinned latent frames —
+    # one-frame conditioning visibly degrades the continuation.
+    window_frames_default: int = 29
+    overlap_frames_default: int = 8
+    # Latent frames of already-generated context re-decoded ahead of each
+    # window so the causal VAE's conv stack is warm at the kept frames; the
+    # context-derived pixels are trimmed. Raise if window boundaries seam.
+    windowed_decode_context_latents: int = 8
     video_temporal_causal: bool = False
     freeze_und: bool = False
 

--- a/mstar/model/cosmos3/constants.py
+++ b/mstar/model/cosmos3/constants.py
@@ -24,6 +24,13 @@ PREFILL_COND_VIDEO_WALK = "prefill_cond_video"
 IMAGE_GEN_WALK = "image_gen"
 VIDEO_GEN_WALK = "video_gen"
 VIDEO_SOUND_GEN_WALK = "video_sound_gen"
+# Windowed autoregressive video generation (opt-in via
+# ``enable_windowed_video``): the denoise loop produces the video
+# window-by-window and streams each finished window's latents to a dedicated
+# decoder partition, which decodes incrementally and assembles the video.
+VIDEO_GEN_AR_WALK = "video_gen_ar"
+VIDEO_DECODE_AR_WALK = "video_decode_ar"
+WINDOW_DECODER_PARTITION = "window_decoder"
 ACTION_GEN_WALK = "action_gen"
 # Forward-dynamics runs the same joint video+action denoise but emits the
 # predicted video (VAE-decoded) instead of the action, so it has its own walk.

--- a/mstar/model/cosmos3/cosmos3_model.py
+++ b/mstar/model/cosmos3/cosmos3_model.py
@@ -1005,11 +1005,18 @@ class Cosmos3Model(Model):
             params["context_latent_units"] = context_units
             params["total_latent_units"] = total_units
             params["num_windows"] = schedule.num_windows
+            params["stream_video"] = bool(mk.get("stream_video"))
             # Every window after the first is conditioned generation, which
             # the reference recipe runs at the V2V flow shift; one shift for
             # all windows keeps the per-window schedules consistent. Request
             # flow_shift overrides.
             params.setdefault("flow_shift", constants.V2V_DEFAULT_FLOW_SHIFT)
+        elif mk.get("stream_video"):
+            # The non-windowed walks emit one video at the very end; there is
+            # nothing to deliver incrementally.
+            raise ValueError(
+                "Cosmos3 stream_video requires a windowed request (set window_mode)."
+            )
         return params
 
     def _step_metadata(self, metadata: CurrentForwardConductorMetadata) -> dict:

--- a/mstar/model/cosmos3/cosmos3_model.py
+++ b/mstar/model/cosmos3/cosmos3_model.py
@@ -901,18 +901,21 @@ class Cosmos3Model(Model):
             params["generate_sound"] = True
             if mk.get("sound_duration") is not None:
                 params["sound_duration"] = float(mk["sound_duration"])
-        # Opt-in windowed AR video: the clip is generated window by window
-        # (chained mode: each window is a full bidirectional denoise
-        # conditioned on the previous window's tail). Frame-count knobs are
-        # quantized to latent frames here so the whole pipeline agrees on the
-        # schedule; validation up front so malformed requests fail at
+        # Opt-in windowed AR video: the clip is generated window by window.
+        # ``chained`` conditions each window on the previous window's tail
+        # (full bidirectional denoise per window); ``kv`` runs block-causal
+        # cross-window attention through committed K/V, with frames older
+        # than the context horizon evicted from the cache. Frame-count knobs
+        # are quantized to latent frames here so the whole pipeline agrees on
+        # the schedule; validation up front so malformed requests fail at
         # submission.
         window_mode = mk.get("window_mode")
         if window_mode is not None:
             window_mode = str(window_mode).strip().lower()
-            if window_mode != "chained":
+            if window_mode not in ("chained", "kv"):
                 raise ValueError(
-                    f"Cosmos3 window_mode must be 'chained', got {mk.get('window_mode')!r}."
+                    f"Cosmos3 window_mode must be 'chained' or 'kv', got "
+                    f"{mk.get('window_mode')!r}."
                 )
             if not self._windowed_serving_enabled():
                 raise ValueError(
@@ -931,6 +934,11 @@ class Cosmos3Model(Model):
                 raise ValueError(
                     "Cosmos3 windowed generation does not support video conditioning."
                 )
+            is_kv = window_mode == "kv"
+            if not is_kv and mk.get("context_frames") is not None:
+                raise ValueError(
+                    "Cosmos3 context_frames applies to window_mode='kv' only."
+                )
             tf = self.config.vae.scale_factor_temporal
             window_frames = int(mk.get("window_frames", self.config.window_frames_default))
             if window_frames < 1 + tf:
@@ -938,7 +946,17 @@ class Cosmos3Model(Model):
                     f"Cosmos3 window_frames must be at least {1 + tf}, got {window_frames}."
                 )
             window_units = 1 + (window_frames - 1) // tf
-            overlap_frames = int(mk.get("overlap_frames", self.config.overlap_frames_default))
+            # kv windows advance without re-pinned overlap — cross-window
+            # conditioning flows through the committed K/V, and a zero overlap
+            # keeps each commit exactly covering the pages its denoise steps
+            # wrote (the cache stream stays page-exact).
+            default_overlap = 0 if is_kv else self.config.overlap_frames_default
+            overlap_frames = int(mk.get("overlap_frames", default_overlap))
+            if is_kv and overlap_frames:
+                raise ValueError(
+                    "Cosmos3 window_mode='kv' does not support overlap_frames; "
+                    "cross-window conditioning comes from the committed context."
+                )
             overlap_units = min(max(round(overlap_frames / tf), 0), window_units - 1)
             if overlap_units:
                 # Two clean latent frames are the conditioning floor (the V2V
@@ -951,6 +969,18 @@ class Cosmos3Model(Model):
                     f"for its overlap (window {window_units} vs overlap "
                     f"{overlap_units} latent frames)."
                 )
+            context_units = 0
+            if is_kv:
+                context_frames = int(
+                    mk.get("context_frames", self.config.context_frames_default)
+                )
+                if context_frames < 0:
+                    raise ValueError(
+                        f"Cosmos3 context_frames must be >= 0, got {context_frames}."
+                    )
+                # 0 retains all committed frames (no eviction).
+                if context_frames:
+                    context_units = 1 + (context_frames - 1) // tf
             total_units = 1 + (num_frames - 1) // tf
             # Pad the schedule up to whole windows: a short final window can
             # regenerate just a frame or two off almost pure conditioning,
@@ -961,7 +991,8 @@ class Cosmos3Model(Model):
                 rem = (total_units - window_units) % stride
                 total_units += (stride - rem) % stride
             schedule = WindowSchedule(
-                total_units, window_units, overlap_units=overlap_units
+                total_units, window_units,
+                context_units=context_units, overlap_units=overlap_units,
             )
             if schedule.num_windows > self.config.max_windows:
                 raise ValueError(
@@ -971,12 +1002,13 @@ class Cosmos3Model(Model):
             params["window_mode"] = window_mode
             params["window_latent_units"] = window_units
             params["overlap_latent_units"] = overlap_units
+            params["context_latent_units"] = context_units
             params["total_latent_units"] = total_units
             params["num_windows"] = schedule.num_windows
-            # Every window after the first is conditioned generation (the
-            # previous tail pinned clean), which the reference recipe runs at
-            # the V2V flow shift; one shift for all windows keeps the
-            # per-window schedules consistent. Request flow_shift overrides.
+            # Every window after the first is conditioned generation, which
+            # the reference recipe runs at the V2V flow shift; one shift for
+            # all windows keeps the per-window schedules consistent. Request
+            # flow_shift overrides.
             params.setdefault("flow_shift", constants.V2V_DEFAULT_FLOW_SHIFT)
         return params
 

--- a/mstar/model/cosmos3/cosmos3_model.py
+++ b/mstar/model/cosmos3/cosmos3_model.py
@@ -35,11 +35,13 @@ import torch
 from mstar.communication.tensors import NameToTensorList
 from mstar.conductor.request_info import (
     CurrentForwardConductorMetadata,
+    PartitionDefinition,
     StreamingConnectionState,
 )
 from mstar.distributed.base import ShardingConfig
 from mstar.engine.base import EngineType
 from mstar.engine.kv_store import KVCacheConfig
+from mstar.engine.windowing import WindowSchedule
 from mstar.graph.base import (
     GraphEdge,
     GraphNode,
@@ -58,13 +60,17 @@ from mstar.model.cosmos3.submodules import (
     ACTION_GEN_LOOP,
     ACTION_VIDEO_GEN_LOOP,
     IMAGE_GEN_LOOP,
+    VIDEO_GEN_AR_LOOP,
     VIDEO_GEN_LOOP,
     VIDEO_SOUND_GEN_LOOP,
     Cosmos3AudioDecoderSubmodule,
     Cosmos3DiTSubmodule,
+    Cosmos3VAEDecoderARSubmodule,
     Cosmos3VAEDecoderSubmodule,
     Cosmos3VAEEncoderSubmodule,
 )
+from mstar.streaming.chunk_policy import FixedChunkPolicy
+from mstar.streaming.topology import Connection, PartitionTopology, StreamingGraphEdge
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +78,7 @@ DIT_NODE = "dit"
 VAE_ENCODER_NODE = "vae_encoder"
 VAE_DECODER_NODE = "vae_decoder"
 AUDIO_DECODER_NODE = "audio_decoder"
+VAE_DECODER_AR_NODE = "vae_decoder_ar"
 
 
 class Cosmos3Model(Model):
@@ -82,6 +89,8 @@ class Cosmos3Model(Model):
     PREFILL_COND_VIDEO_WALK = constants.PREFILL_COND_VIDEO_WALK
     IMAGE_GEN_WALK = constants.IMAGE_GEN_WALK
     VIDEO_GEN_WALK = constants.VIDEO_GEN_WALK
+    VIDEO_GEN_AR_WALK = constants.VIDEO_GEN_AR_WALK
+    VIDEO_DECODE_AR_WALK = constants.VIDEO_DECODE_AR_WALK
     VIDEO_SOUND_GEN_WALK = constants.VIDEO_SOUND_GEN_WALK
     ACTION_GEN_WALK = constants.ACTION_GEN_WALK
     ACTION_VIDEO_GEN_WALK = constants.ACTION_VIDEO_GEN_WALK
@@ -196,6 +205,11 @@ class Cosmos3Model(Model):
             return True
         return (self._ensure_repo() / "sound_tokenizer" / "config.json").exists()
 
+    def _windowed_serving_enabled(self) -> bool:
+        """Whether the opt-in windowed-AR video walk (and its vae_decoder_ar
+        node + streaming decoder partition) is served."""
+        return bool(self.config.enable_windowed_video)
+
     def get_node_engine_types(self) -> dict[str, EngineType]:
         types = {
             DIT_NODE: EngineType.KV_CACHE,
@@ -204,6 +218,8 @@ class Cosmos3Model(Model):
         }
         if self._sound_serving_enabled():
             types[AUDIO_DECODER_NODE] = EngineType.STATELESS
+        if self._windowed_serving_enabled():
+            types[VAE_DECODER_AR_NODE] = EngineType.STATELESS
         return types
 
     def get_default_sharding_config(self) -> ShardingConfig:
@@ -451,7 +467,88 @@ class Cosmos3Model(Model):
         # (and only needs a node_groups entry) when sound serving is enabled.
         if self._sound_serving_enabled():
             walks[self.VIDEO_SOUND_GEN_WALK] = video_sound_gen
+
+        # Windowed AR video (opt-in): the same denoise loop, run window by
+        # window. On each window's last step the DiT emits the finished
+        # window's latents on a streaming edge; the vae_decoder_ar node — its
+        # own partition, so it decodes window k while the loop denoises
+        # window k+1 — consumes them per chunk and emits the assembled video.
+        if self._windowed_serving_enabled():
+            walks[self.VIDEO_GEN_AR_WALK] = Sequential(
+                [
+                    Loop(
+                        name=VIDEO_GEN_AR_LOOP,
+                        section=GraphNode(
+                            name=DIT_NODE,
+                            input_names=["latents", "time_index", "cond_latents"],
+                            outputs=[
+                                GraphEdge(next_node=DIT_NODE, name="latents"),
+                                GraphEdge(next_node=DIT_NODE, name="time_index"),
+                                StreamingGraphEdge(
+                                    next_node=VAE_DECODER_AR_NODE,
+                                    name="window_latents",
+                                    target_partition=constants.WINDOW_DECODER_PARTITION,
+                                ),
+                            ],
+                            enable_async_scheduling=True,
+                        ),
+                        max_iters=self.config.max_windows
+                        * (self.config.max_inference_steps + 1),
+                        outputs=[],
+                    ),
+                ]
+            )
+            # The decoder partition's walk must be the bare consumer node (the
+            # streaming consumer lookup resolves the edge's node from a
+            # top-level GraphNode section).
+            walks[self.VIDEO_DECODE_AR_WALK] = GraphNode(
+                name=VAE_DECODER_AR_NODE,
+                input_names=["window_latents"],
+                outputs=[
+                    GraphEdge(
+                        next_node=EMIT_TO_CLIENT,
+                        name="video_output",
+                        output_modality="video",
+                    ),
+                ],
+            )
         return walks
+
+    def get_partitions(self):
+        if not self._windowed_serving_enabled():
+            return super().get_partitions()
+        walks = set(self.get_graph_walk_graphs().keys())
+        return [
+            PartitionDefinition(
+                name="default",
+                graph_walks=walks - {self.VIDEO_DECODE_AR_WALK},
+                initial_walk=None,
+                producer_partitions=[],
+            ),
+            PartitionDefinition(
+                name=constants.WINDOW_DECODER_PARTITION,
+                graph_walks={self.VIDEO_DECODE_AR_WALK},
+                initial_walk=self.VIDEO_DECODE_AR_WALK,
+                producer_partitions=["default"],
+            ),
+        ]
+
+    def get_partition_topology(self):
+        if not self._windowed_serving_enabled():
+            return super().get_partition_topology()
+        return PartitionTopology(
+            partitions=["default", constants.WINDOW_DECODER_PARTITION],
+            connections=[
+                Connection(
+                    from_partition="default",
+                    to_partition=constants.WINDOW_DECODER_PARTITION,
+                    edge_name="window_latents",
+                    # One committed window per chunk; the decoder manages its
+                    # own left context from the latents it has already seen.
+                    chunk_policy_factory=lambda: FixedChunkPolicy(chunk_size=1),
+                ),
+            ],
+        )
 
     # ------------------------------------------------------------------
     # Model ABC: I/O
@@ -804,6 +901,83 @@ class Cosmos3Model(Model):
             params["generate_sound"] = True
             if mk.get("sound_duration") is not None:
                 params["sound_duration"] = float(mk["sound_duration"])
+        # Opt-in windowed AR video: the clip is generated window by window
+        # (chained mode: each window is a full bidirectional denoise
+        # conditioned on the previous window's tail). Frame-count knobs are
+        # quantized to latent frames here so the whole pipeline agrees on the
+        # schedule; validation up front so malformed requests fail at
+        # submission.
+        window_mode = mk.get("window_mode")
+        if window_mode is not None:
+            window_mode = str(window_mode).strip().lower()
+            if window_mode != "chained":
+                raise ValueError(
+                    f"Cosmos3 window_mode must be 'chained', got {mk.get('window_mode')!r}."
+                )
+            if not self._windowed_serving_enabled():
+                raise ValueError(
+                    "Cosmos3 windowed video generation is disabled for this deployment."
+                )
+            if num_frames <= 1 or action_mode is not None:
+                raise ValueError(
+                    "Cosmos3 windowed generation requires a video request "
+                    "(num_frames > 1, no action mode)."
+                )
+            if params.get("generate_sound"):
+                raise ValueError(
+                    "Cosmos3 windowed generation does not support sound generation."
+                )
+            if params.get("has_video_condition"):
+                raise ValueError(
+                    "Cosmos3 windowed generation does not support video conditioning."
+                )
+            tf = self.config.vae.scale_factor_temporal
+            window_frames = int(mk.get("window_frames", self.config.window_frames_default))
+            if window_frames < 1 + tf:
+                raise ValueError(
+                    f"Cosmos3 window_frames must be at least {1 + tf}, got {window_frames}."
+                )
+            window_units = 1 + (window_frames - 1) // tf
+            overlap_frames = int(mk.get("overlap_frames", self.config.overlap_frames_default))
+            overlap_units = min(max(round(overlap_frames / tf), 0), window_units - 1)
+            if overlap_units:
+                # Two clean latent frames are the conditioning floor (the V2V
+                # recipe's pin count); a single frame visibly degrades the
+                # next window.
+                overlap_units = max(overlap_units, 2)
+            if overlap_units >= window_units:
+                raise ValueError(
+                    f"Cosmos3 windowed request needs window_frames large enough "
+                    f"for its overlap (window {window_units} vs overlap "
+                    f"{overlap_units} latent frames)."
+                )
+            total_units = 1 + (num_frames - 1) // tf
+            # Pad the schedule up to whole windows: a short final window can
+            # regenerate just a frame or two off almost pure conditioning,
+            # which comes out degraded. The decoder trims the assembled video
+            # back to the requested frame count.
+            stride = window_units - overlap_units
+            if total_units > window_units:
+                rem = (total_units - window_units) % stride
+                total_units += (stride - rem) % stride
+            schedule = WindowSchedule(
+                total_units, window_units, overlap_units=overlap_units
+            )
+            if schedule.num_windows > self.config.max_windows:
+                raise ValueError(
+                    f"Cosmos3 windowed request spans {schedule.num_windows} windows, "
+                    f"over the served limit of {self.config.max_windows}."
+                )
+            params["window_mode"] = window_mode
+            params["window_latent_units"] = window_units
+            params["overlap_latent_units"] = overlap_units
+            params["total_latent_units"] = total_units
+            params["num_windows"] = schedule.num_windows
+            # Every window after the first is conditioned generation (the
+            # previous tail pinned clean), which the reference recipe runs at
+            # the V2V flow shift; one shift for all windows keeps the
+            # per-window schedules consistent. Request flow_shift overrides.
+            params.setdefault("flow_shift", constants.V2V_DEFAULT_FLOW_SHIFT)
         return params
 
     def _step_metadata(self, metadata: CurrentForwardConductorMetadata) -> dict:
@@ -820,6 +994,24 @@ class Cosmos3Model(Model):
         model_kwargs: dict | None = None,
     ) -> ForwardPassArgs:
         params = self._resolve_gen_params(model_kwargs, input_modalities, output_modalities)
+        # The windowed decoder partition starts idle on its decode walk; the
+        # window stream self-triggers its passes, and the resolved params ride
+        # along for its per-request window bookkeeping. Non-windowed requests
+        # leave it idle until the stream's terminal flush, which it skips.
+        if partition_name == constants.WINDOW_DECODER_PARTITION:
+            md = CurrentForwardConductorMetadata(
+                input_modalities=input_modalities,
+                output_modalities=output_modalities,
+                graph_walk=self.VIDEO_DECODE_AR_WALK,
+                is_prefill=False,
+                kwargs=params,
+            )
+            return ForwardPassArgs(
+                full_metadata=md,
+                inputs=[],
+                unpersist_tensors=[],
+                step_metadata=self._step_metadata(md),
+            )
         # Visual conditioning routes through a conditioned prefill that also feeds
         # the DiT the input to VAE-encode: a video (action inverse-dynamics) or an
         # image (image-to-video, action policy/forward-dynamics). Fall back to the
@@ -870,6 +1062,18 @@ class Cosmos3Model(Model):
         request_done = False
         inputs: list[GraphEdge] = []
 
+        # The windowed decoder partition is self-triggered by its stream
+        # buffer; the conductor only keeps its walk pinned. Its completion is
+        # the stream's final chunk, not a conductor decision.
+        if partition_name == constants.WINDOW_DECODER_PARTITION:
+            metadata.graph_walk = self.VIDEO_DECODE_AR_WALK
+            return ForwardPassArgs(
+                full_metadata=metadata,
+                inputs=[],
+                unpersist_tensors=[],
+                step_metadata=self._step_metadata(metadata),
+            )
+
         # Forward-dynamics conditions on a clean action chunk and emits the
         # predicted video; inverse-dynamics / policy emit the action.
         is_fd = metadata.kwargs.get("action_mode") == "forward_dynamics"
@@ -888,6 +1092,8 @@ class Cosmos3Model(Model):
                 metadata.graph_walk = self.ACTION_VIDEO_GEN_WALK
             elif is_action:
                 metadata.graph_walk = self.ACTION_GEN_WALK
+            elif is_video and metadata.kwargs.get("window_mode"):
+                metadata.graph_walk = self.VIDEO_GEN_AR_WALK
             elif is_video and metadata.kwargs.get("generate_sound"):
                 metadata.graph_walk = self.VIDEO_SOUND_GEN_WALK
             elif is_video:
@@ -912,8 +1118,8 @@ class Cosmos3Model(Model):
             cond_edge.tensor_info = persist_signals.get("cond_latents", [])
             inputs.append(cond_edge)
         elif metadata.graph_walk in (
-            self.IMAGE_GEN_WALK, self.VIDEO_GEN_WALK, self.VIDEO_SOUND_GEN_WALK,
-            self.ACTION_GEN_WALK, self.ACTION_VIDEO_GEN_WALK,
+            self.IMAGE_GEN_WALK, self.VIDEO_GEN_WALK, self.VIDEO_GEN_AR_WALK,
+            self.VIDEO_SOUND_GEN_WALK, self.ACTION_GEN_WALK, self.ACTION_VIDEO_GEN_WALK,
         ):
             request_done = True
 
@@ -961,6 +1167,12 @@ class Cosmos3Model(Model):
             )
         if node_name == VAE_DECODER_NODE:
             return Cosmos3VAEDecoderSubmodule(
+                vae=self._build_vae(device), config=self.config
+            )
+        if node_name == VAE_DECODER_AR_NODE:
+            # Shares the decoder VAE weights; only the streaming chunk state
+            # and compile wrapper are per-node.
+            return Cosmos3VAEDecoderARSubmodule(
                 vae=self._build_vae(device), config=self.config
             )
         if node_name == AUDIO_DECODER_NODE:

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -2257,17 +2257,17 @@ class Cosmos3VAEDecoderARSubmodule(Cosmos3VAEDecoderSubmodule):
         overlap = st["ar_overlap"] if index > 0 else 0
         new = latents[:, :, overlap:] if overlap else latents
         tail = st.get("ar_tail")
-        if tail is None:
-            pixels = self._decode_pixels(new)
-        else:
-            ctx = tail[:, :, -st["ar_ctx"]:]
-            pixels = self._decode_pixels(torch.cat([ctx, new.to(ctx.dtype)], dim=2))
+        # The retained tail is already capped at ar_ctx latents, so appending
+        # the window's new latents yields the [context | window] decode input
+        # and the next tail in one tensor.
+        stream_tail = new if tail is None else torch.cat([tail, new.to(tail.dtype)], dim=2)
+        pixels = self._decode_pixels(stream_tail)
+        if tail is not None:
             # A mid-stream latent decodes to scale_factor_temporal frames; the
             # leading context (and the clip-start special frame, which falls
             # inside it) is exactly the part being trimmed.
             keep = new.shape[2] * self.config.vae.scale_factor_temporal
             pixels = pixels[:, :, -keep:]
-        stream_tail = new if tail is None else torch.cat([tail, new.to(tail.dtype)], dim=2)
         st.add("ar_tail", stream_tail[:, :, -st["ar_ctx"]:])
         st.add("ar_chunks", index + 1)
         if st["ar_stream"]:

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -2243,6 +2243,8 @@ class Cosmos3VAEDecoderARSubmodule(Cosmos3VAEDecoderSubmodule):
                 # The schedule may be padded up to whole windows; the request's
                 # frame count is what the assembled video is trimmed to.
                 ar_out_frames=int(md["num_frames"]),
+                ar_stream=bool(md.get("stream_video")),
+                ar_emitted=0,
                 ar_pixels=[],
             )
         index = st["ar_chunks"]
@@ -2259,10 +2261,17 @@ class Cosmos3VAEDecoderARSubmodule(Cosmos3VAEDecoderSubmodule):
             # inside it) is exactly the part being trimmed.
             keep = new.shape[2] * self.config.vae.scale_factor_temporal
             pixels = pixels[:, :, -keep:]
-        st["ar_pixels"].append(pixels)
         stream_tail = new if tail is None else torch.cat([tail, new.to(tail.dtype)], dim=2)
         st.add("ar_tail", stream_tail[:, :, -st["ar_ctx"]:])
         st.add("ar_chunks", index + 1)
+        if st["ar_stream"]:
+            # Deliver each window as its own chunk, capped at the frames still
+            # owed (the padded final window can outrun the requested count);
+            # nothing is retained across windows.
+            chunk = pixels[:, :, : st["ar_out_frames"] - st["ar_emitted"]]
+            st.add("ar_emitted", st["ar_emitted"] + chunk.shape[2])
+            return {"video_output": [chunk]} if chunk.shape[2] else {}
+        st["ar_pixels"].append(pixels)
         if index + 1 < st["ar_windows"]:
             return {}
         video = torch.cat(st["ar_pixels"], dim=2)[:, :, : st["ar_out_frames"]]

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -734,35 +734,33 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
     # preprocess: plan paged attention for the labels this walk touches.
     # ------------------------------------------------------------------
 
-    def _plan_gen(
-        self, cm, st, num_gen: int, cfg_active: bool = True, dense_gen: bool = True,
-    ) -> None:
+    def _plan_gen(self, cm, st, num_gen: int, cfg_active: bool = True) -> None:
         """Plan a denoise step's non-causal attention: one batched plan covering
         both guidance branches when they run together, else a plan per label.
         ``cfg_active`` False (a guidance_interval out-of-interval step, or
         gs==1) plans the conditional branch alone — matching the cond-only
         forward — so an interval step costs no wasted uncond/batched plan.
-        ``dense_gen`` False keeps the label on the paged path — kv-windowed
-        requests mutate their committed prefix per window (commit + release),
-        which breaks the dense fast path's frozen-prefix gather."""
+        kv-windowed requests stay dense-eligible: their committed prefix
+        mutates per window, which the dense path detects via prefix_epoch and
+        answers with a per-window re-gather."""
         if st["uncond"] is None or not cfg_active:
             cm.plan_attention(
                 seq_lens=[num_gen], is_causal=False, label=COND_LABEL,
-                write_store=False, dense_gen=dense_gen,
+                write_store=False, dense_gen=True,
             )
         elif self.batched_cfg:
             cm.plan_attention_batched_cfg(
                 labels=[COND_LABEL, UNCOND_LABEL], seq_lens=[num_gen],
-                is_causal=False, write_store=False, dense_gen=dense_gen,
+                is_causal=False, write_store=False, dense_gen=True,
             )
         else:
             cm.plan_attention(
                 seq_lens=[num_gen], is_causal=False, label=COND_LABEL,
-                write_store=False, dense_gen=dense_gen,
+                write_store=False, dense_gen=True,
             )
             cm.plan_attention(
                 seq_lens=[num_gen], is_causal=False, label=UNCOND_LABEL,
-                write_store=False, dense_gen=dense_gen,
+                write_store=False, dense_gen=True,
             )
 
     def _plan_commit(self, cm, st, window_index: int) -> None:
@@ -879,7 +877,6 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                 }
             ti = inputs[0].tensor_inputs["time_index"]
             step_index = int(ti.reshape(-1)[0].item())
-            dense_gen = True
             if "ar_schedule" in st:
                 # Windowed: the loop counter is global; guidance is decided on
                 # the within-window step, matching the forward. In kv mode the
@@ -894,10 +891,9 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                         "time_index": ti,
                     }
                 step_index = local
-                dense_gen = not st.get("ar_kv_mode")
             self._plan_gen(
                 cm, st, st["cond"]["num_vision_tokens"],
-                cfg_active=self._cfg_active(st, step_index), dense_gen=dense_gen,
+                cfg_active=self._cfg_active(st, step_index),
             )
             return {
                 "latents": inputs[0].tensor_inputs["latents"],
@@ -1429,12 +1425,21 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             # Image/video batch only in the two-branch guidance regime, so one
             # batched-CFG plan covers them. (Batches are per graph walk, so
             # sound requests only ever batch with sound requests.) Windowed
-            # requests keep the single-request path: their window boundaries
-            # swap per-request statics/scheduler mid-walk, which the packed
-            # batched forward doesn't model.
-            return all(
-                st["uncond"] is not None and "ar_schedule" not in st for st in sts
-            )
+            # requests join denoise batches — the batched forward maps their
+            # loop counter to the within-window step and handles chained
+            # window boundaries — but a kv commit iteration is a different
+            # computation (an append pass) and drops the batch to the
+            # sequential path.
+            if not all(st["uncond"] is not None for st in sts):
+                return False
+            for st, inp in zip(sts, model_inputs, strict=True):
+                if "ar_schedule" not in st:
+                    continue
+                ti = inp.tensor_inputs["time_index"]
+                local = int(ti.reshape(-1)[0].item()) % st["ar_iters_per_window"]
+                if local == st["ar_steps"]:
+                    return False
+            return True
         if batch.graph_walk in ACTION_WALKS:
             # Action batches when all requests share the guidance regime (all
             # single-branch -- guidance-scale-1 inverse/forward-dynamics and base
@@ -1479,6 +1484,10 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             st = states[rid]
             lat, ti = latents[rid], time_index[rid]
             step_index = int(ti.reshape(-1)[0].item())
+            if "ar_schedule" in st:
+                # Windowed: the loop counter is global; the schedule index is
+                # the within-window step (commit iterations never batch).
+                step_index %= st["ar_iters_per_window"]
             n_steps = len(st["scheduler"].timesteps)
             # A request may be one step past its denoise count (a discarded extra
             # step) while others in the batch are still running; clamp its
@@ -1494,12 +1503,12 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                 "vision_noisy_frame_indexes": st["cond"]["vision_noisy_frame_indexes"],
                 "vision_mse_loss_indexes": st["cond"]["mse_gen_indexes"],
             })
-            meta.append((rid, st, lat, ti, t))
+            meta.append((rid, st, lat, ti, t, step_index))
 
         results = self.transformer.denoise_step_batched(reqs, cm)
 
         out = {}
-        for (rid, st, lat, ti, t), (cond_v, uncond_v) in zip(meta, results, strict=True):
+        for (rid, st, lat, ti, t, local), (cond_v, uncond_v) in zip(meta, results, strict=True):
             velocity = uncond_v + st["gs"] * (cond_v - uncond_v)
             new_latents = st["scheduler"].step(
                 velocity.unsqueeze(0), t, lat.unsqueeze(0), return_dict=False
@@ -1508,7 +1517,17 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                 # Video-to-video: re-inject the clean conditioning frames, as in
                 # the single-request path.
                 new_latents = (1.0 - st["vmask"]) * new_latents + st["vmask"] * st["cond_video_latents"]
-            out[rid] = {"latents": [new_latents], "time_index": [ti + 1]}
+            if (
+                "ar_schedule" in st
+                and local + 1 == st["ar_steps"]
+                and not st.get("ar_kv_mode")
+            ):
+                # Chained window boundary inside a batch: emit + stage, as in
+                # the single-request path.
+                window_index = int(ti.reshape(-1)[0].item()) // st["ar_iters_per_window"]
+                out[rid] = self._finish_window(st, new_latents, ti, window_index)
+            else:
+                out[rid] = {"latents": [new_latents], "time_index": [ti + 1]}
         return out
 
     def _forward_batched_sound(self, engine_inputs, latents, sound_latents, time_index):

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -37,6 +37,7 @@ from mstar.engine.cuda_graph_config import (
     BasicBatchedCudaGraphConfig,
     FlashInferPackedCudaGraphConfig,
 )
+from mstar.engine.windowing import WindowSchedule
 from mstar.model.cosmos3.components.packing import (
     action_start_frame_offset,
     build_action_static_inputs,
@@ -50,6 +51,7 @@ from mstar.model.cosmos3.constants import (
     PREFILL_COND_VIDEO_WALK,
     PREFILL_COND_WALK,
     PREFILL_WALK,
+    VIDEO_GEN_AR_WALK,
     VIDEO_GEN_WALK,
     VIDEO_SOUND_GEN_WALK,
 )
@@ -66,8 +68,10 @@ logger = logging.getLogger(__name__)
 # image_gen and video_gen run the identical denoise step (the DiT loop is
 # shape-general over the frame count); they differ only in the emitted output
 # modality (a single image frame vs an encoded video), which the graph fixes per
-# walk, so the submodule treats them the same.
-GEN_WALKS = (IMAGE_GEN_WALK, VIDEO_GEN_WALK)
+# walk, so the submodule treats them the same. video_gen_ar runs the same step
+# too, over one window's latents at a time, with per-window state swaps at
+# window boundaries.
+GEN_WALKS = (IMAGE_GEN_WALK, VIDEO_GEN_WALK, VIDEO_GEN_AR_WALK)
 
 # All prefill variants run the same understanding-tower prefill; the conditioned
 # ones additionally VAE-encode an image (prefill_cond) or video
@@ -80,6 +84,7 @@ PREFILL_WALKS = (PREFILL_WALK, PREFILL_COND_WALK, PREFILL_COND_VIDEO_WALK)
 # step count.
 IMAGE_GEN_LOOP = "image_gen_loop"
 VIDEO_GEN_LOOP = "video_gen_loop"
+VIDEO_GEN_AR_LOOP = "video_gen_ar_loop"
 VIDEO_SOUND_GEN_LOOP = "video_sound_gen_loop"
 ACTION_GEN_LOOP = "action_gen_loop"
 ACTION_VIDEO_GEN_LOOP = "action_video_gen_loop"
@@ -300,6 +305,15 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             t_lat = self._latent_shape(height, width, num_frames)[2]
             noisy_frames = [f for f in range(t_lat) if f not in set(condition_indexes)]
 
+        # Windowed AR video: statics, scheduler and noise are built per window
+        # at the window's own latent shape (window boundaries swap them); the
+        # text prefill below is identical either way — its K/V is written once
+        # and read by every window's steps.
+        if md.get("window_mode") is not None:
+            return self._prepare_windowed_prefill(
+                fwd_info, md, cond_ids, uncond_ids, height, width, fps, gs, steps, device,
+            )
+
         # Opt-in sound: append a jointly denoised AVAE-latent band to the
         # generation block. Video-only (single-frame image and action requests
         # are rejected at request resolution).
@@ -348,6 +362,94 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             st.add("vmask", vmask)
 
         return node_inputs
+
+    def _window_latent_shape(self, height, width, units):
+        s = self.config.vae.scale_factor_spatial
+        return (1, self.config.latent_channel, units, height // s, width // s)
+
+    def _build_window_statics(
+        self, cond_ids, uncond_ids, height, width, units, fps,
+        has_image_condition, cond_units, device,
+    ):
+        """Packed statics for one window of ``units`` latent frames. The
+        leading ``cond_units`` frames are clean overlap conditioning (the
+        previous window's tail); the image anchor applies only to the first
+        window (``cond_units == 0``). A window packs exactly like a clip of
+        the same latent length — per-window positions start at frame 0, so
+        each window is in-distribution for the clip-trained checkpoint."""
+        tf = self.config.vae.scale_factor_temporal
+        num_frames = 1 + (units - 1) * tf
+        noisy = list(range(cond_units, units)) if cond_units else None
+        anchored = has_image_condition and cond_units == 0
+        cond = self._build_static(
+            cond_ids, height, width, num_frames, fps, anchored, device,
+            noisy_frames=noisy,
+        )
+        uncond = None
+        if uncond_ids is not None:
+            uncond = self._build_static(
+                uncond_ids, height, width, num_frames, fps, anchored, device,
+                noisy_frames=noisy,
+            )
+        return cond, uncond
+
+    def _prepare_windowed_prefill(
+        self, fwd_info, md, cond_ids, uncond_ids, height, width, fps, gs, steps, device,
+    ) -> ARNodeInputs:
+        schedule = WindowSchedule(
+            total_units=int(md["total_latent_units"]),
+            window_units=int(md["window_latent_units"]),
+            overlap_units=int(md["overlap_latent_units"]),
+        )
+        w0 = schedule.window(0)
+        has_image_condition = bool(md.get("has_image_condition", False))
+        cond, uncond = self._build_window_statics(
+            cond_ids, uncond_ids, height, width, w0.units, fps,
+            has_image_condition=has_image_condition, cond_units=0, device=device,
+        )
+        node_inputs = self._get_prefill_node_inputs(cond, uncond)
+        self._slim_statics(cond, uncond)
+        st = self.request_state(fwd_info.request_id)
+        st.add_all(
+            cond=cond,
+            uncond=uncond,
+            gs=gs,
+            guidance_interval=md.get("guidance_interval"),
+            scheduler=self._new_scheduler(
+                steps, device, flow_shift=md.get("flow_shift"),
+                use_karras_sigma=md.get("use_karras_sigma"),
+            ),
+            latent_shape=self._window_latent_shape(height, width, w0.units),
+            num_sound=None,
+            ar_schedule=schedule,
+            ar_steps=steps,
+            ar_total_iters=schedule.num_windows * steps,
+            ar_cond_ids=list(cond_ids),
+            ar_uncond_ids=list(uncond_ids) if uncond_ids is not None else None,
+            ar_has_image_condition=has_image_condition,
+            ar_flow_shift=md.get("flow_shift"),
+            ar_karras=md.get("use_karras_sigma"),
+            ar_size=(int(height), int(width)),
+            ar_fps=fps,
+            # (units, cond_units) -> slimmed (cond, uncond); steady and short
+            # final windows reuse their entry across boundaries.
+            ar_statics={},
+        )
+        return node_inputs
+
+    def _window_statics_for(self, st, units, cond_units, device):
+        cached = st["ar_statics"].get((units, cond_units))
+        if cached is not None:
+            return cached
+        height, width = st["ar_size"]
+        cond, uncond = self._build_window_statics(
+            st["ar_cond_ids"], st["ar_uncond_ids"], height, width, units,
+            st["ar_fps"], has_image_condition=st["ar_has_image_condition"],
+            cond_units=cond_units, device=device,
+        )
+        self._slim_statics(cond, uncond)
+        st["ar_statics"][(units, cond_units)] = (cond, uncond)
+        return cond, uncond
 
     @staticmethod
     def _slim_statics(cond: dict, uncond: dict | None) -> None:
@@ -478,9 +580,14 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
 
     def _prepare_image_gen(self, fwd_info, inputs, device) -> ARNodeInputs:
         st = self.request_states[fwd_info.request_id]
+        windowed = "ar_schedule" in st
         if "latents" not in inputs or len(inputs["latents"]) == 0:
             self._ingest_cond_latents(st, inputs, device)
             gen = torch.Generator(device=device).manual_seed(fwd_info.random_seed)
+            if windowed:
+                # Later windows draw their noise from the same generator, so a
+                # seeded windowed request is deterministic end to end.
+                st.add("ar_generator", gen)
             latents = torch.randn(
                 st["latent_shape"], generator=gen, device=device, dtype=self.transformer.proj_in.weight.dtype
             )
@@ -502,15 +609,18 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
 
         scheduler = st["scheduler"]
         step_index = int(time_index.reshape(-1)[0].item())
-        if step_index >= len(scheduler.timesteps):
+        if windowed:
+            if step_index >= st["ar_total_iters"]:
+                return None
+        elif step_index >= len(scheduler.timesteps):
             return None
         tensors = {"latents": latents, "time_index": time_index}
         # The CUDA-graph capture reads the timestep and rotary positions as static
         # buffers (it can't reach the per-request scheduler at replay), so
         # materialize them here. The eager path ignores these and recomputes from
         # per-request state. Only built in the two-branch guidance regime — the
-        # one the graph captures.
-        if st["uncond"] is not None:
+        # one the graph captures. Windowed requests run eager only.
+        if st["uncond"] is not None and not windowed:
             # The denoise loop may dispatch one extra (discarded) step past this
             # request's step count; clamp so materializing the static timestep
             # buffer can't index past the schedule.
@@ -719,6 +829,10 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                 }
             ti = inputs[0].tensor_inputs["time_index"]
             step_index = int(ti.reshape(-1)[0].item())
+            if "ar_schedule" in st:
+                # Windowed: the loop counter is global; guidance is decided on
+                # the within-window step, matching the forward.
+                step_index %= st["ar_steps"]
             self._plan_gen(
                 cm, st, st["cond"]["num_vision_tokens"], cfg_active=self._cfg_active(st, step_index)
             )
@@ -872,7 +986,15 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
     def _forward_image_gen(self, cm, st, latents, time_index, **kwargs) -> dict:
         scheduler = st["scheduler"]
         step_index = int(time_index.reshape(-1)[0].item())
-        if step_index >= len(scheduler.timesteps):
+        windowed = "ar_schedule" in st
+        if windowed:
+            # The loop counter is global; each window runs its own fresh
+            # scheduler over ar_steps steps.
+            if step_index >= st["ar_total_iters"]:
+                return {"latents": [latents], "time_index": [time_index]}
+            global_index = step_index
+            step_index = global_index % st["ar_steps"]
+        elif step_index >= len(scheduler.timesteps):
             # The loop may dispatch one step past this request's own count
             # before its stop signal lands; that step is a no-op.
             return {"latents": [latents], "time_index": [time_index]}
@@ -916,7 +1038,53 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             # scheduler step (the reference pipeline does the same) so scheduler
             # rounding can't drift the pinned latents.
             new_latents = (1.0 - st["vmask"]) * new_latents + st["vmask"] * st["cond_video_latents"]
+        if windowed and (global_index + 1) % st["ar_steps"] == 0:
+            return self._finish_window(st, new_latents, time_index, global_index)
         return {"latents": [new_latents], "time_index": [time_index + 1]}
+
+    def _finish_window(self, st, window_latents, time_index, global_index) -> dict:
+        """Last denoise step of a window: emit the window's clean latents on
+        the streaming edge and stage the next window — fresh scheduler, fresh
+        noise, and the finished tail re-pinned as clean overlap conditioning
+        through the same vmask machinery video-to-video uses."""
+        schedule = st["ar_schedule"]
+        window_index = global_index // st["ar_steps"]
+        outputs = {
+            "latents": [window_latents],
+            "time_index": [time_index + 1],
+            "window_latents": [window_latents],
+        }
+        if window_index + 1 >= schedule.num_windows:
+            return outputs
+        plan = schedule.window(window_index + 1)
+        device = window_latents.device
+        dtype = self.transformer.proj_in.weight.dtype
+        cond, uncond = self._window_statics_for(st, plan.units, plan.cond_units, device)
+        st.add("cond", cond)
+        st.add("uncond", uncond)
+        st.add("scheduler", self._new_scheduler(
+            st["ar_steps"], device, flow_shift=st.get("ar_flow_shift"),
+            use_karras_sigma=st.get("ar_karras"),
+        ))
+        height, width = st["ar_size"]
+        shape = self._window_latent_shape(height, width, plan.units)
+        st.add("latent_shape", shape)
+        next_latents = torch.randn(
+            shape, generator=st["ar_generator"], device=device, dtype=dtype
+        )
+        if plan.cond_units > 0:
+            tail = window_latents[:, :, -plan.cond_units:].to(dtype)
+            vmask = torch.zeros((1, 1, plan.units, 1, 1), device=device, dtype=dtype)
+            vmask[:, :, :plan.cond_units] = 1.0
+            cond_video = torch.zeros(shape, device=device, dtype=dtype)
+            cond_video[:, :, :plan.cond_units] = tail
+            st.add("vmask", vmask)
+            st.add("cond_video_latents", cond_video)
+            next_latents = vmask * cond_video + (1.0 - vmask) * next_latents
+        else:
+            st.remove(["vmask", "cond_video_latents"])
+        outputs["latents"] = [next_latents]
+        return outputs
 
     def _sound_kwargs(self, static, sound_latents, sound_ts) -> dict:
         return dict(
@@ -1131,8 +1299,13 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         ):
             # Image/video batch only in the two-branch guidance regime, so one
             # batched-CFG plan covers them. (Batches are per graph walk, so
-            # sound requests only ever batch with sound requests.)
-            return all(st["uncond"] is not None for st in sts)
+            # sound requests only ever batch with sound requests.) Windowed
+            # requests keep the single-request path: their window boundaries
+            # swap per-request statics/scheduler mid-walk, which the packed
+            # batched forward doesn't model.
+            return all(
+                st["uncond"] is not None and "ar_schedule" not in st for st in sts
+            )
         if batch.graph_walk in ACTION_WALKS:
             # Action batches when all requests share the guidance regime (all
             # single-branch -- guidance-scale-1 inverse/forward-dynamics and base
@@ -1592,10 +1765,17 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             ACTION_GEN_WALK: ACTION_GEN_LOOP,
             ACTION_VIDEO_GEN_WALK: ACTION_VIDEO_GEN_LOOP,
             VIDEO_GEN_WALK: VIDEO_GEN_LOOP,
+            VIDEO_GEN_AR_WALK: VIDEO_GEN_AR_LOOP,
             VIDEO_SOUND_GEN_WALK: VIDEO_SOUND_GEN_LOOP,
         }.get(request_info.graph_walk, IMAGE_GEN_LOOP)
         iter_idx = request_info.dynamic_loop_iter_counts.get(loop, 0)
-        if iter_idx + 1 >= len(st["scheduler"].timesteps):
+        # Windowed requests run every window's steps in one loop; others stop
+        # at their scheduler's step count.
+        total = (
+            st["ar_total_iters"] if "ar_schedule" in st
+            else len(st["scheduler"].timesteps)
+        )
+        if iter_idx + 1 >= total:
             return {loop}
         return set()
 
@@ -1830,7 +2010,8 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
                     self._decode_dtype_cached, torch.backends.cudnn.version())
         return self._decode_dtype_cached
 
-    def forward(self, graph_walk, engine_inputs: ModelInputsFromEngine, latents, **kwargs):
+    def _decode_pixels(self, latents: torch.Tensor) -> torch.Tensor:
+        """Latents -> uint8 pixel frames [1, 3, T, H, W]."""
         vae = self.vae
         vae_dtype = self._decode_dtype()
         if next(vae.parameters()).dtype != vae_dtype:
@@ -1864,7 +2045,10 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
         # only the uint8 frames cross the SHM edge to the data worker, not a 4x
         # larger fp32 tensor — the decoded video transfer dominates the fixed cost
         # at higher resolutions.
-        image = (decoded / 2 + 0.5).clamp(0, 1).mul(255).to(torch.uint8)
+        return (decoded / 2 + 0.5).clamp(0, 1).mul(255).to(torch.uint8)
+
+    def forward(self, graph_walk, engine_inputs: ModelInputsFromEngine, latents, **kwargs):
+        image = self._decode_pixels(latents)
         # Route the decoded tensor to the active walk's emit edge: image_gen
         # emits "image_output" (one frame); the video walks (plain, sound,
         # forward-dynamics) emit "video_output".
@@ -1874,3 +2058,64 @@ class Cosmos3VAEDecoderSubmodule(NodeSubmodule):
             else "image_output"
         )
         return {out_name: [image]}
+
+
+class Cosmos3VAEDecoderARSubmodule(Cosmos3VAEDecoderSubmodule):
+    """Streaming Wan VAE decode for windowed AR video.
+
+    Consumes one committed window's latents per stream chunk. Each window is
+    decoded behind a re-decoded left context (the last few latents of the
+    stream so far) so the causal conv stack is warm at the kept frames; the
+    context- and overlap-derived pixels are trimmed, and the assembled video
+    is emitted once the last window lands. Chunk count is the completion
+    signal — it is known per request up front — so the stream's terminal
+    flush (an empty pass, and the only pass a non-windowed request's idle
+    stream ever delivers) runs as a no-op forward: the pass must complete
+    normally for the partition to report done, so it is not vetoed.
+    """
+
+    def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs) -> NodeInputs:
+        chunks = (inputs or {}).get("window_latents") or []
+        if not chunks:
+            return NodeInputs(tensor_inputs={"latents": torch.empty(0)})
+        return NodeInputs(tensor_inputs={"latents": chunks[0]})
+
+    def forward(self, graph_walk, engine_inputs: ModelInputsFromEngine, latents, **kwargs):
+        if latents.numel() == 0:
+            return {}
+        rid = engine_inputs.request_ids[0]
+        st = self.request_state(rid)
+        if "ar_chunks" not in st:
+            md = engine_inputs.per_request_info[rid].step_metadata
+            st.add_all(
+                ar_chunks=0,
+                ar_windows=int(md["num_windows"]),
+                ar_overlap=int(md["overlap_latent_units"]),
+                ar_ctx=max(1, int(self.config.windowed_decode_context_latents)),
+                # The schedule may be padded up to whole windows; the request's
+                # frame count is what the assembled video is trimmed to.
+                ar_out_frames=int(md["num_frames"]),
+                ar_pixels=[],
+            )
+        index = st["ar_chunks"]
+        overlap = st["ar_overlap"] if index > 0 else 0
+        new = latents[:, :, overlap:] if overlap else latents
+        tail = st.get("ar_tail")
+        if tail is None:
+            pixels = self._decode_pixels(new)
+        else:
+            ctx = tail[:, :, -st["ar_ctx"]:]
+            pixels = self._decode_pixels(torch.cat([ctx, new.to(ctx.dtype)], dim=2))
+            # A mid-stream latent decodes to scale_factor_temporal frames; the
+            # leading context (and the clip-start special frame, which falls
+            # inside it) is exactly the part being trimmed.
+            keep = new.shape[2] * self.config.vae.scale_factor_temporal
+            pixels = pixels[:, :, -keep:]
+        st["ar_pixels"].append(pixels)
+        stream_tail = new if tail is None else torch.cat([tail, new.to(tail.dtype)], dim=2)
+        st.add("ar_tail", stream_tail[:, :, -st["ar_ctx"]:])
+        st.add("ar_chunks", index + 1)
+        if index + 1 < st["ar_windows"]:
+            return {}
+        video = torch.cat(st["ar_pixels"], dim=2)[:, :, : st["ar_out_frames"]]
+        return {"video_output": [video]}

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -1432,6 +1432,12 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             # sequential path.
             if not all(st["uncond"] is not None for st in sts):
                 return False
+            if batch.graph_walk not in GEN_WALKS:
+                # Windowed requests join only generation-loop batches; their
+                # prefill stays sequential (these passes carry no time_index,
+                # and the committed kv text prefix must not depend on which
+                # requests happened to arrive together).
+                return all("ar_schedule" not in st for st in sts)
             for st, inp in zip(sts, model_inputs, strict=True):
                 if "ar_schedule" not in st:
                     continue

--- a/mstar/model/cosmos3/submodules.py
+++ b/mstar/model/cosmos3/submodules.py
@@ -37,7 +37,7 @@ from mstar.engine.cuda_graph_config import (
     BasicBatchedCudaGraphConfig,
     FlashInferPackedCudaGraphConfig,
 )
-from mstar.engine.windowing import WindowSchedule
+from mstar.engine.windowing import WindowedKVSession, WindowSchedule
 from mstar.model.cosmos3.components.packing import (
     action_start_frame_offset,
     build_action_static_inputs,
@@ -195,6 +195,7 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         fps: float, has_image_condition: bool, device,
         sound_latent_frames: int | None = None,
         noisy_frames: list[int] | None = None,
+        start_frame_offset: int = 0,
     ) -> dict:
         static = build_static_inputs(
             list(ids), self._latent_shape(height, width, num_frames), self.config,
@@ -202,6 +203,7 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             has_image_condition=has_image_condition,
             sound_latent_frames=sound_latent_frames,
             noisy_frames=noisy_frames,
+            start_frame_offset=start_frame_offset,
         )
         # proj_out runs on the generation token block, so shift the joint-sequence
         # mse indexes to be relative to the generation tokens.
@@ -370,35 +372,44 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
     def _build_window_statics(
         self, cond_ids, uncond_ids, height, width, units, fps,
         has_image_condition, cond_units, device,
+        first_window=True, start_unit=0,
     ):
         """Packed statics for one window of ``units`` latent frames. The
         leading ``cond_units`` frames are clean overlap conditioning (the
         previous window's tail); the image anchor applies only to the first
-        window (``cond_units == 0``). A window packs exactly like a clip of
-        the same latent length — per-window positions start at frame 0, so
-        each window is in-distribution for the clip-trained checkpoint."""
+        window. A window packs exactly like a clip of the same latent length.
+        Chained windows position from frame 0 (each window in-distribution
+        for the clip-trained checkpoint); kv windows pass their absolute
+        first frame as ``start_unit`` so relative distances to the committed
+        context K/V — rotated at absolute positions — stay right."""
         tf = self.config.vae.scale_factor_temporal
         num_frames = 1 + (units - 1) * tf
         noisy = list(range(cond_units, units)) if cond_units else None
-        anchored = has_image_condition and cond_units == 0
+        anchored = has_image_condition and first_window
         cond = self._build_static(
             cond_ids, height, width, num_frames, fps, anchored, device,
-            noisy_frames=noisy,
+            noisy_frames=noisy, start_frame_offset=start_unit,
         )
         uncond = None
         if uncond_ids is not None:
             uncond = self._build_static(
                 uncond_ids, height, width, num_frames, fps, anchored, device,
-                noisy_frames=noisy,
+                noisy_frames=noisy, start_frame_offset=start_unit,
             )
         return cond, uncond
 
     def _prepare_windowed_prefill(
         self, fwd_info, md, cond_ids, uncond_ids, height, width, fps, gs, steps, device,
     ) -> ARNodeInputs:
+        # kv mode appends each window's clean K/V to the cache (one commit
+        # iteration per window, hence steps + 1 loop iterations) and evicts
+        # context beyond the horizon; chained re-pins the previous tail as
+        # clean conditioning instead and never touches committed state.
+        is_kv = md.get("window_mode") == "kv"
         schedule = WindowSchedule(
             total_units=int(md["total_latent_units"]),
             window_units=int(md["window_latent_units"]),
+            context_units=int(md.get("context_latent_units", 0)) if is_kv else 0,
             overlap_units=int(md["overlap_latent_units"]),
         )
         w0 = schedule.window(0)
@@ -408,7 +419,9 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             has_image_condition=has_image_condition, cond_units=0, device=device,
         )
         node_inputs = self._get_prefill_node_inputs(cond, uncond)
+        tokens_per_unit = cond["num_vision_tokens"] // w0.units
         self._slim_statics(cond, uncond)
+        iters_per_window = steps + 1 if is_kv else steps
         st = self.request_state(fwd_info.request_id)
         st.add_all(
             cond=cond,
@@ -423,7 +436,11 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             num_sound=None,
             ar_schedule=schedule,
             ar_steps=steps,
-            ar_total_iters=schedule.num_windows * steps,
+            ar_iters_per_window=iters_per_window,
+            ar_total_iters=schedule.num_windows * iters_per_window,
+            ar_kv_mode=is_kv,
+            ar_rid=fwd_info.request_id,
+            ar_tokens_per_unit=tokens_per_unit,
             ar_cond_ids=list(cond_ids),
             ar_uncond_ids=list(uncond_ids) if uncond_ids is not None else None,
             ar_has_image_condition=has_image_condition,
@@ -431,24 +448,28 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             ar_karras=md.get("use_karras_sigma"),
             ar_size=(int(height), int(width)),
             ar_fps=fps,
-            # (units, cond_units) -> slimmed (cond, uncond); steady and short
-            # final windows reuse their entry across boundaries.
+            # WindowPlan-keyed slimmed (cond, uncond) cache; chained windows
+            # share entries across boundaries (their positions restart at 0),
+            # kv windows are position-distinct and each get their own.
             ar_statics={},
         )
         return node_inputs
 
-    def _window_statics_for(self, st, units, cond_units, device):
-        cached = st["ar_statics"].get((units, cond_units))
+    def _window_statics_for(self, st, plan, device):
+        start_unit = plan.start if st.get("ar_kv_mode") else 0
+        key = (plan.units, plan.cond_units, start_unit, plan.index == 0)
+        cached = st["ar_statics"].get(key)
         if cached is not None:
             return cached
         height, width = st["ar_size"]
         cond, uncond = self._build_window_statics(
-            st["ar_cond_ids"], st["ar_uncond_ids"], height, width, units,
+            st["ar_cond_ids"], st["ar_uncond_ids"], height, width, plan.units,
             st["ar_fps"], has_image_condition=st["ar_has_image_condition"],
-            cond_units=cond_units, device=device,
+            cond_units=plan.cond_units, device=device,
+            first_window=plan.index == 0, start_unit=start_unit,
         )
         self._slim_statics(cond, uncond)
-        st["ar_statics"][(units, cond_units)] = (cond, uncond)
+        st["ar_statics"][key] = (cond, uncond)
         return cond, uncond
 
     @staticmethod
@@ -713,31 +734,60 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
     # preprocess: plan paged attention for the labels this walk touches.
     # ------------------------------------------------------------------
 
-    def _plan_gen(self, cm, st, num_gen: int, cfg_active: bool = True) -> None:
+    def _plan_gen(
+        self, cm, st, num_gen: int, cfg_active: bool = True, dense_gen: bool = True,
+    ) -> None:
         """Plan a denoise step's non-causal attention: one batched plan covering
         both guidance branches when they run together, else a plan per label.
         ``cfg_active`` False (a guidance_interval out-of-interval step, or
         gs==1) plans the conditional branch alone — matching the cond-only
-        forward — so an interval step costs no wasted uncond/batched plan."""
+        forward — so an interval step costs no wasted uncond/batched plan.
+        ``dense_gen`` False keeps the label on the paged path — kv-windowed
+        requests mutate their committed prefix per window (commit + release),
+        which breaks the dense fast path's frozen-prefix gather."""
         if st["uncond"] is None or not cfg_active:
             cm.plan_attention(
                 seq_lens=[num_gen], is_causal=False, label=COND_LABEL,
-                write_store=False, dense_gen=True,
+                write_store=False, dense_gen=dense_gen,
             )
         elif self.batched_cfg:
             cm.plan_attention_batched_cfg(
                 labels=[COND_LABEL, UNCOND_LABEL], seq_lens=[num_gen],
-                is_causal=False, write_store=False, dense_gen=True,
+                is_causal=False, write_store=False, dense_gen=dense_gen,
             )
         else:
             cm.plan_attention(
                 seq_lens=[num_gen], is_causal=False, label=COND_LABEL,
-                write_store=False, dense_gen=True,
+                write_store=False, dense_gen=dense_gen,
             )
             cm.plan_attention(
                 seq_lens=[num_gen], is_causal=False, label=UNCOND_LABEL,
-                write_store=False, dense_gen=True,
+                write_store=False, dense_gen=dense_gen,
             )
+
+    def _plan_commit(self, cm, st, window_index: int) -> None:
+        """Plan a kv-mode commit pass: a packed append of the window's newly
+        generated units under both guidance branches (each branch's future
+        windows read its own context, so both are written regardless of any
+        guidance interval). Non-causal like every gen plan; the fresh K/V
+        lands on the label's tail pages and ``advance_seq_lens`` inside the
+        commit forward makes it permanent."""
+        plan = st["ar_schedule"].window(window_index)
+        n = (plan.commit_end - plan.commit_start) * st["ar_tokens_per_unit"]
+        if st["uncond"] is not None and self.batched_cfg:
+            cm.plan_attention_batched_cfg(
+                labels=[COND_LABEL, UNCOND_LABEL], seq_lens=[n],
+                is_causal=False, write_store=False,
+            )
+        else:
+            cm.plan_attention(
+                seq_lens=[n], is_causal=False, label=COND_LABEL, write_store=False,
+            )
+            if st["uncond"] is not None:
+                cm.plan_attention(
+                    seq_lens=[n], is_causal=False, label=UNCOND_LABEL,
+                    write_store=False,
+                )
 
     def _preprocess_image_gen_captured(self, cm, inputs) -> dict:
         """Plan a denoise step for the CUDA-graph path.
@@ -829,12 +879,25 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
                 }
             ti = inputs[0].tensor_inputs["time_index"]
             step_index = int(ti.reshape(-1)[0].item())
+            dense_gen = True
             if "ar_schedule" in st:
                 # Windowed: the loop counter is global; guidance is decided on
-                # the within-window step, matching the forward.
-                step_index %= st["ar_steps"]
+                # the within-window step, matching the forward. In kv mode the
+                # extra per-window iteration is the commit pass, which gets an
+                # append plan instead of a denoise plan.
+                per = st["ar_iters_per_window"]
+                local = step_index % per
+                if local == st["ar_steps"]:
+                    self._plan_commit(cm, st, step_index // per)
+                    return {
+                        "latents": inputs[0].tensor_inputs["latents"],
+                        "time_index": ti,
+                    }
+                step_index = local
+                dense_gen = not st.get("ar_kv_mode")
             self._plan_gen(
-                cm, st, st["cond"]["num_vision_tokens"], cfg_active=self._cfg_active(st, step_index)
+                cm, st, st["cond"]["num_vision_tokens"],
+                cfg_active=self._cfg_active(st, step_index), dense_gen=dense_gen,
             )
             return {
                 "latents": inputs[0].tensor_inputs["latents"],
@@ -989,11 +1052,18 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         windowed = "ar_schedule" in st
         if windowed:
             # The loop counter is global; each window runs its own fresh
-            # scheduler over ar_steps steps.
+            # scheduler over ar_steps steps, and in kv mode the extra
+            # per-window iteration commits the finished window's K/V.
             if step_index >= st["ar_total_iters"]:
                 return {"latents": [latents], "time_index": [time_index]}
             global_index = step_index
-            step_index = global_index % st["ar_steps"]
+            per = st["ar_iters_per_window"]
+            local = global_index % per
+            if local == st["ar_steps"]:
+                return self._commit_window(
+                    cm, st, latents, time_index, global_index // per
+                )
+            step_index = local
         elif step_index >= len(scheduler.timesteps):
             # The loop may dispatch one step past this request's own count
             # before its stop signal lands; that step is a no-op.
@@ -1038,17 +1108,76 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
             # scheduler step (the reference pipeline does the same) so scheduler
             # rounding can't drift the pinned latents.
             new_latents = (1.0 - st["vmask"]) * new_latents + st["vmask"] * st["cond_video_latents"]
-        if windowed and (global_index + 1) % st["ar_steps"] == 0:
-            return self._finish_window(st, new_latents, time_index, global_index)
+        if windowed and local + 1 == st["ar_steps"] and not st.get("ar_kv_mode"):
+            # Chained: the window ends at its last denoise step. kv windows
+            # end at their commit iteration instead.
+            return self._finish_window(st, new_latents, time_index, global_index // per)
         return {"latents": [new_latents], "time_index": [time_index + 1]}
 
-    def _finish_window(self, st, window_latents, time_index, global_index) -> dict:
-        """Last denoise step of a window: emit the window's clean latents on
-        the streaming edge and stage the next window — fresh scheduler, fresh
-        noise, and the finished tail re-pinned as clean overlap conditioning
-        through the same vmask machinery video-to-video uses."""
+    def _commit_window(self, cm, st, latents, time_index, window_index) -> dict:
+        """kv-mode commit iteration: run the generation tower over the
+        window's finished clean latents (no timestep embedding — the clean-
+        conditioning convention), appending their K/V to both guidance
+        branches' cache streams, then release context that aged past the
+        horizon and stage the next window. The first commit also protects the
+        text prefix and builds the per-label release sessions — before any
+        release can happen."""
         schedule = st["ar_schedule"]
-        window_index = global_index // st["ar_steps"]
+        plan = schedule.window(window_index)
+        stride = st["ar_tokens_per_unit"]
+        dtype = self.transformer.proj_in.weight.dtype
+        commit_latents = (
+            latents[:, :, plan.cond_units:] if plan.cond_units else latents
+        ).to(dtype)
+        # The commit span's positions are the tail slice of the window's
+        # statics (kv statics carry absolute frames, so the slice is already
+        # at the right absolute positions). Both guidance branches commit,
+        # packed into one pass or sequentially per the batched_cfg regime.
+        offset = plan.cond_units * stride
+        cond_pos = st["cond"]["vision_mrope_ids"][:, offset:]
+        if st["uncond"] is not None and self.batched_cfg:
+            cm.set_active_label(CFG_BATCHED_LABEL)
+            self.transformer.commit_window(
+                commit_latents,
+                [cond_pos, st["uncond"]["vision_mrope_ids"][:, offset:]],
+                cm,
+            )
+        else:
+            cm.set_active_label(COND_LABEL)
+            self.transformer.commit_window(commit_latents, [cond_pos], cm)
+            if st["uncond"] is not None:
+                cm.set_active_label(UNCOND_LABEL)
+                self.transformer.commit_window(
+                    commit_latents,
+                    [st["uncond"]["vision_mrope_ids"][:, offset:]],
+                    cm,
+                )
+        sessions = st.get("ar_kv_sessions")
+        if sessions is None:
+            # The handle's protect/release passthroughs delegate to the
+            # persistent allocation manager, so the session outlives this
+            # forward's cache-manager instance.
+            sessions = {}
+            branches = [(COND_LABEL, st["cond"])]
+            if st["uncond"] is not None:
+                branches.append((UNCOND_LABEL, st["uncond"]))
+            for label, static in branches:
+                session = WindowedKVSession(
+                    cm, st["ar_rid"], label, schedule, tokens_per_unit=stride,
+                )
+                session.protect_prefix(static["und_len"])
+                sessions[label] = session
+            st.add("ar_kv_sessions", sessions)
+        for session in sessions.values():
+            session.after_commit(window_index)
+        return self._finish_window(st, latents, time_index, window_index)
+
+    def _finish_window(self, st, window_latents, time_index, window_index) -> dict:
+        """End of a window: emit the window's clean latents on the streaming
+        edge and stage the next window — fresh scheduler, fresh noise, and
+        (chained mode) the finished tail re-pinned as clean overlap
+        conditioning through the same vmask machinery video-to-video uses."""
+        schedule = st["ar_schedule"]
         outputs = {
             "latents": [window_latents],
             "time_index": [time_index + 1],
@@ -1059,7 +1188,7 @@ class Cosmos3DiTSubmodule(ARNodeSubmodule):
         plan = schedule.window(window_index + 1)
         device = window_latents.device
         dtype = self.transformer.proj_in.weight.dtype
-        cond, uncond = self._window_statics_for(st, plan.units, plan.cond_units, device)
+        cond, uncond = self._window_statics_for(st, plan, device)
         st.add("cond", cond)
         st.add("uncond", uncond)
         st.add("scheduler", self._new_scheduler(

--- a/mstar/model/cosmos3/tests/pipeline.py
+++ b/mstar/model/cosmos3/tests/pipeline.py
@@ -449,3 +449,262 @@ class Cosmos3Pipeline:
         if return_video:
             return action_out, self._decode(latents)
         return action_out
+
+    # ------------------------------------------------------------------
+    # Windowed block-causal reference (the kv-mode oracle): a hand-rolled
+    # window loop with explicit per-layer context K/V, run directly against
+    # the transformer's layers — no engine cache machinery involved.
+    # ------------------------------------------------------------------
+
+    def _ref_und_prefill(
+        self, branch_ids: list[list[int]], branch_pos: list[torch.Tensor]
+    ) -> list[list[tuple[torch.Tensor, torch.Tensor]]]:
+        """Understanding tower over the guidance branches' text prompts,
+        packed [cond | uncond] the way the served prefill runs — projections
+        and MLPs over the packed rows, causal attention per branch — so the
+        collected per-branch, per-layer rotated (k, v) is bit-identical to
+        what the engine caches (a separate per-branch run differs by GEMM
+        tiling rounding, which coarse few-step schedules amplify)."""
+        tf = self.transformer
+        lens = [len(ids) for ids in branch_ids]
+        flat = [i for ids in branch_ids for i in ids]
+        und_seq = tf.embed_tokens(
+            torch.tensor(flat, dtype=torch.long, device=self.device)
+        )
+        pos = branch_pos[0] if len(branch_pos) == 1 else torch.cat(branch_pos, dim=1)
+        cos, sin = tf._rotary(pos, und_seq.device, und_seq.dtype)
+        kvs: list[list[tuple[torch.Tensor, torch.Tensor]]] = [[] for _ in branch_ids]
+        for layer in tf.layers:
+            attn = layer.self_attn
+            h, hkv, d = attn.num_attention_heads, attn.num_key_value_heads, attn.head_dim
+            und_norm = layer.input_layernorm(und_seq)
+            q = attn.norm_q(attn.to_q(und_norm).view(-1, h, d))
+            k = attn.norm_k(attn.to_k(und_norm).view(-1, hkv, d))
+            v = attn.to_v(und_norm).view(-1, hkv, d)
+            q = attn._apply_rope(q, cos, sin)
+            k = attn._apply_rope(k, cos, sin)
+            outs, off = [], 0
+            for bi, n in enumerate(lens):
+                sl = slice(off, off + n)
+                off += n
+                kvs[bi].append((k[sl], v[sl]))
+                outs.append(attn._attend(q[sl], k[sl], v[sl], is_causal=True))
+            out = outs[0] if len(outs) == 1 else torch.cat(outs, 0)
+            residual = und_seq + attn.to_out(out)
+            und_seq = residual + layer.mlp(layer.post_attention_layernorm(residual))
+        return kvs
+
+    def _ref_gen_layers(self, gen_seq, cos, sin, ctx_kv, collect=False):
+        """Generation layer stack with explicit context: each layer attends
+        its fresh tokens over ``ctx_kv[i]`` (the branch's [text | retained
+        frames] K/V) plus itself, non-causally. With ``collect`` the fresh
+        rotated (k, v) per layer is returned — what a commit appends."""
+        tf = self.transformer
+        collected = []
+        for i, layer in enumerate(tf.layers):
+            attn = layer.self_attn
+            h, hkv, d = attn.num_attention_heads, attn.num_key_value_heads, attn.head_dim
+            gen_norm = layer.input_layernorm_moe_gen(gen_seq)
+            q = attn.norm_added_q(attn.add_q_proj(gen_norm).view(-1, h, d))
+            k = attn.norm_added_k(attn.add_k_proj(gen_norm).view(-1, hkv, d))
+            v = attn.add_v_proj(gen_norm).view(-1, hkv, d)
+            q = attn._apply_rope(q, cos, sin)
+            k = attn._apply_rope(k, cos, sin)
+            if collect:
+                collected.append((k, v))
+            ck, cv = ctx_kv[i]
+            out = attn._attend(
+                q, torch.cat([ck, k], 0), torch.cat([cv, v], 0), is_causal=False
+            )
+            residual = gen_seq + attn.to_add_out(out)
+            gen_seq = residual + layer.mlp_moe_gen(
+                layer.post_attention_layernorm_moe_gen(residual)
+            )
+        return gen_seq, collected
+
+    @torch.no_grad()
+    def windowed_kv(
+        self,
+        cond_ids: list[int],
+        uncond_ids: list[int] | None,
+        total_units: int,
+        window_units: int,
+        context_units: int,
+        height: int,
+        width: int,
+        num_inference_steps: int,
+        guidance_scale: float = 6.0,
+        fps: float = 24.0,
+        flow_shift: float | None = None,
+        generator: torch.Generator | None = None,
+        page_size: int = 128,
+    ) -> list[torch.Tensor]:
+        """Block-causal windowed generation, the served kv mode's oracle.
+
+        Per window: denoise over [text | committed context | window] with a
+        fresh scheduler, commit the finished window's clean K/V (no timestep
+        embedding), then evict committed frames older than ``context_units``
+        behind the frontier under the paged cache's contract — whole pages
+        from the first page fully past the text prefix, floor semantics with
+        the shortfall re-offered (``context_units`` 0 retains everything).
+        Noise draws mirror the serving path: window 0 first, then one draw
+        per boundary from the same generator. Returns the per-window clean
+        latents (windows carry no overlap in kv mode)."""
+        from diffusers import UniPCMultistepScheduler
+
+        device, dtype = self.device, self.dtype
+        tf_cfg = self.config
+        # The serving schedule pads requests up to whole windows, so the
+        # reference takes that as a precondition.
+        assert total_units % window_units == 0, "pass a whole-window total"
+        num_windows = total_units // window_units
+        tokens_per_unit = (height // self.vae_scale_spatial // tf_cfg.latent_patch_size) * (
+            width // self.vae_scale_spatial // tf_cfg.latent_patch_size
+        )
+
+        branches = [("cond", cond_ids)]
+        if uncond_ids is not None and guidance_scale != 1.0:
+            branches.append(("uncond", uncond_ids))
+
+        # Per-branch state: text K/V, per-window statics, committed frame K/V
+        # ([tokens, heads, dim] per layer, all committed windows concatenated)
+        # and the release bookkeeping mirroring the allocator's contract.
+        state: dict[str, dict] = {}
+        for name, ids in branches:
+            statics = []
+            for w in range(num_windows):
+                start = w * window_units
+                s = build_static_inputs(
+                    ids,
+                    (1, tf_cfg.latent_channel, window_units,
+                     height // self.vae_scale_spatial, width // self.vae_scale_spatial),
+                    tf_cfg, self.vae_scale_temporal, fps, device,
+                    has_image_condition=False, start_frame_offset=start,
+                )
+                statics.append(s)
+            state[name] = {
+                "statics": statics,
+                "frames": [None] * len(self.transformer.layers),
+                "und_len": len(ids),
+                "released": 0,
+            }
+        branch_kvs = self._ref_und_prefill(
+            [ids for _, ids in branches],
+            [state[name]["statics"][0]["text_mrope_ids"] for name, _ in branches],
+        )
+        for (name, _), kvs in zip(branches, branch_kvs, strict=True):
+            state[name]["text_kv"] = kvs
+
+        def _ctx(branch):
+            """Per-layer [text | retained frames] K/V for one branch. The
+            eviction hole starts at the first page boundary past the text
+            (frame tokens sharing the text's tail page are never released)."""
+            st = state[branch]
+            keep = -(-st["und_len"] // page_size) * page_size - st["und_len"]
+            out = []
+            for i, (tk, tv) in enumerate(st["text_kv"]):
+                fr = st["frames"][i]
+                if fr is None:
+                    out.append((tk, tv))
+                    continue
+                fk, fv = fr
+                k = torch.cat([tk, fk[:keep], fk[keep + st["released"]:]], 0)
+                v = torch.cat([tv, fv[:keep], fv[keep + st["released"]:]], 0)
+                out.append((k, v))
+            return out
+
+        def _release(branch, committed_units):
+            st = state[branch]
+            if context_units == 0:
+                return
+            target = max(0, committed_units - context_units) * tokens_per_unit
+            ask = target - st["released"]
+            if ask <= 0:
+                return
+            stream_len = st["und_len"] + committed_units * tokens_per_unit - st["released"]
+            first = -(-st["und_len"] // page_size)
+            releasable = stream_len // page_size - first
+            k = min(ask // page_size, releasable)
+            if k > 0:
+                st["released"] += k * page_size
+
+        tf = self.transformer
+        gen_latent_shape = (
+            1, tf_cfg.latent_channel, window_units,
+            height // self.vae_scale_spatial, width // self.vae_scale_spatial,
+        )
+        latents = torch.randn(gen_latent_shape, generator=generator, device=device, dtype=dtype)
+        windows_out: list[torch.Tensor] = []
+        for w in range(num_windows):
+            if flow_shift is not None:
+                scheduler = UniPCMultistepScheduler.from_config(
+                    self.scheduler.config, flow_shift=flow_shift
+                )
+            else:
+                scheduler = UniPCMultistepScheduler.from_config(self.scheduler.config)
+            scheduler.set_timesteps(num_inference_steps, device=device)
+            s0 = state["cond"]["statics"][w]
+            num_noisy = s0["num_noisy_vision_tokens"]
+            for t in scheduler.timesteps:
+                vts = torch.full((num_noisy,), t.item(), device=device)
+                vels = {}
+                for name, _ in branches:
+                    st = state[name]
+                    static = st["statics"][w]
+                    packed, orig_shapes = tf._patchify_and_pack_latents([latents.to(dtype)])
+                    packed = tf.proj_in(packed)
+                    ts_embeds = tf.time_embedder(
+                        tf.time_proj(vts * tf_cfg.timestep_scale)
+                    ).to(packed.dtype)
+                    gen_seq = tf._apply_timestep_embeds_to_noisy_tokens(
+                        packed_tokens=packed,
+                        packed_timestep_embeds=ts_embeds,
+                        noisy_frame_indexes=static["vision_noisy_frame_indexes"],
+                        token_shapes=static["vision_token_shapes"],
+                    )
+                    cos, sin = tf._rotary(
+                        static["vision_mrope_ids"], gen_seq.device, gen_seq.dtype
+                    )
+                    gen_seq, _ = self._ref_gen_layers(gen_seq, cos, sin, _ctx(name))
+                    gen_out = tf.norm_moe_gen(gen_seq)
+                    mse_idx = static["vision_mse_loss_indexes"] - static["und_len"]
+                    preds = tf._unpatchify_and_unpack_latents(
+                        tf.proj_out(gen_out[mse_idx]),
+                        token_shapes_vision=static["vision_token_shapes"],
+                        noisy_frame_indexes_vision=static["vision_noisy_frame_indexes"],
+                        original_latent_shapes=orig_shapes,
+                    )
+                    vels[name] = preds[0]
+                if len(branches) > 1:
+                    velocity = vels["uncond"] + guidance_scale * (vels["cond"] - vels["uncond"])
+                else:
+                    velocity = vels["cond"]
+                latents = scheduler.step(
+                    velocity.unsqueeze(0), t, latents.unsqueeze(0), return_dict=False
+                )[0].squeeze(0)
+            windows_out.append(latents.clone())
+
+            # Commit the finished window's clean K/V per branch, then evict.
+            for name, _ in branches:
+                st = state[name]
+                static = st["statics"][w]
+                packed, _ = tf._patchify_and_pack_latents([latents.to(dtype)])
+                gen_seq = tf.proj_in(packed)
+                cos, sin = tf._rotary(
+                    static["vision_mrope_ids"], gen_seq.device, gen_seq.dtype
+                )
+                _, fresh = self._ref_gen_layers(
+                    gen_seq, cos, sin, _ctx(name), collect=True
+                )
+                for i, (k, v) in enumerate(fresh):
+                    fr = st["frames"][i]
+                    st["frames"][i] = (
+                        (k, v) if fr is None
+                        else (torch.cat([fr[0], k], 0), torch.cat([fr[1], v], 0))
+                    )
+                _release(name, (w + 1) * window_units)
+            if w + 1 < num_windows:
+                latents = torch.randn(
+                    gen_latent_shape, generator=generator, device=device, dtype=dtype
+                )
+        return windows_out

--- a/mstar/model/cosmos3/tests/test_engine_cache.py
+++ b/mstar/model/cosmos3/tests/test_engine_cache.py
@@ -49,16 +49,26 @@ class _SdpaCacheHandle:
     branches run in one forward, ``run_attention`` receives the two branches
     concatenated and routes each half to its own label's cached prefix, so the
     batched result equals running the branches sequentially.
+
+    Writes follow the paged cache's commit contract: every attended fresh K/V
+    is staged at the label's tail (a new plan supersedes an earlier staging),
+    and only ``advance_seq_lens`` appends it to the committed stream — so
+    denoise steps overwrite their scratch while prefill and windowed commit
+    passes accumulate. ``protect_prefix``/``release_oldest`` mirror the
+    allocator's page-floor front eviction on the stored stream.
     """
 
-    def __init__(self):
+    def __init__(self, page_size=128):
         self.active = "main"
         self.layer = 0
+        self.page_size = page_size
         self.committed: dict[tuple[str, int], tuple[torch.Tensor, torch.Tensor]] = {}
         self.pending: dict[tuple[str, int], tuple[torch.Tensor, torch.Tensor]] = {}
         self.is_causal: dict[str, bool] = {}
         self.batched_labels: list[str] | None = None
         self.batched_splits: list[int] | None = None
+        self.protected: dict[str, int] = {}
+        self.released: dict[str, int] = {}
 
     def set_active_label(self, label):
         self.active = label
@@ -66,12 +76,19 @@ class _SdpaCacheHandle:
     def set_layer_idx(self, i):
         self.layer = i
 
+    def _clear_pending(self, labels):
+        self.pending = {
+            key: kv for key, kv in self.pending.items() if key[0] not in labels
+        }
+
     def plan_attention(self, seq_lens=None, dtype=None, is_causal=True, write_store=True, label=None, **kwargs):
         self.is_causal[label or self.active] = is_causal
+        self._clear_pending({label or self.active})
 
     def plan_attention_batched_cfg(self, labels, seq_lens, is_causal=False, write_store=False, **kwargs):
         self.batched_labels = list(labels)
         self.is_causal["_cfg_batched"] = is_causal
+        self._clear_pending(set(labels))
         # Per-label token counts of the packed sequence: the prefill plan passes
         # {label: [lens]} (the two prompts differ in length), the denoise plans a
         # shared per-request list (both guidance branches carry the same
@@ -94,10 +111,10 @@ class _SdpaCacheHandle:
 
     def _attend_label(self, label, layer, q, k, v, causal):
         key = (label, layer)
+        self.pending[key] = (k, v)
         if key in self.committed:
             pk, pv = self.committed[key]
             return self._sdpa(q, torch.cat([pk, k], 0), torch.cat([pv, v], 0), causal)
-        self.pending[key] = (k, v)
         return self._sdpa(q, k, v, causal)
 
     def run_attention(self, q, k, v, layer_idx=None):
@@ -113,8 +130,35 @@ class _SdpaCacheHandle:
         return self._attend_label(self.active, layer, q, k, v, self.is_causal[self.active])
 
     def advance_seq_lens(self, pos_id_ns=None):
-        self.committed.update(self.pending)
+        for key, (k, v) in self.pending.items():
+            if key in self.committed:
+                pk, pv = self.committed[key]
+                self.committed[key] = (torch.cat([pk, k], 0), torch.cat([pv, v], 0))
+            else:
+                self.committed[key] = (k, v)
         self.pending = {}
+
+    def protect_prefix(self, request_id, num_tokens, label=None):
+        assert not self.released.get(label), "protect after release"
+        self.protected[label] = int(num_tokens)
+
+    def release_oldest(self, request_id, num_tokens, label=None):
+        ps = self.page_size
+        first = -(-self.protected.get(label, 0) // ps)
+        keys = [key for key in self.committed if key[0] == label]
+        stream_len = self.committed[keys[0]][0].shape[0]
+        releasable = stream_len // ps - first
+        k = min(int(num_tokens) // ps, releasable)
+        if k <= 0:
+            return 0
+        lo, hi = first * ps, first * ps + k * ps
+        for key in keys:
+            ck, cv = self.committed[key]
+            self.committed[key] = (
+                torch.cat([ck[:lo], ck[hi:]], 0), torch.cat([cv[:lo], cv[hi:]], 0),
+            )
+        self.released[label] = self.released.get(label, 0) + k * ps
+        return k * ps
 
 
 def _flashinfer_cache(model, rid, device, dtype, backend=None):
@@ -616,6 +660,175 @@ def test_cross_request_batch_matches_individual() -> None:
     torch.cuda.empty_cache()
 
 
+# Windowed kv-mode oracle geometry: 45 px frames = 12 latent units at 256p
+# (64 tokens per unit, so a 128-token page holds exactly two units), windows
+# of 4 units, a 6-unit context horizon — three windows, with real page-floor
+# evictions after windows 1 and 2. Step count matches the other engine
+# checks: very coarse schedules amplify kernel-level rounding into the
+# latents, which would blur what the parity bars measure.
+WSTEPS = 12
+W_NUM_FRAMES = 45
+W_WINDOW_FRAMES = 13
+W_CONTEXT_FRAMES = 21
+
+
+def _windowed_scenario():
+    """Shared kv-mode context: served knob resolution, token ids, and the
+    block-causal reference's per-window latents."""
+    key = "windowed_kv"
+    if key in _SETUP_CACHE:
+        return _SETUP_CACHE[key]
+    base = _load()
+    if base is None:
+        _SETUP_CACHE[key] = None
+        return None
+    from mstar.model.cosmos3.components.packing import tokenize_prompt
+
+    model, mpipe, device = base["model"], base["mpipe"], base["device"]
+    model.config.enable_windowed_video = True
+    md = model._resolve_gen_params(
+        {
+            "window_mode": "kv", "num_frames": W_NUM_FRAMES, "size": f"{W}x{H}",
+            "window_frames": W_WINDOW_FRAMES, "context_frames": W_CONTEXT_FRAMES,
+            "num_inference_steps": WSTEPS, "guidance_scale": GS,
+        },
+        [], ["video"],
+    )
+    cond_ids, uncond_ids = tokenize_prompt(
+        model.tokenizer, PROMPT, "", num_frames=W_NUM_FRAMES, height=H, width=W
+    )
+    ref = mpipe.windowed_kv(
+        cond_ids, uncond_ids,
+        total_units=md["total_latent_units"],
+        window_units=md["window_latent_units"],
+        context_units=md["context_latent_units"],
+        height=H, width=W, num_inference_steps=WSTEPS, guidance_scale=GS,
+        fps=md["fps"], flow_shift=md.get("flow_shift"),
+        generator=torch.Generator(device=device).manual_seed(SEED),
+    )
+    ctx = dict(md=md, cond=cond_ids, uncond=uncond_ids, ref=ref, **base)
+    _SETUP_CACHE[key] = ctx
+    return ctx
+
+
+@torch.no_grad()
+def _run_windowed_kv_served(model, dit, cm, md, cond_ids, uncond_ids, device):
+    """Drive the served kv path — prefill, then every loop iteration of the
+    AR walk (denoise steps + commit passes) — collecting the streamed
+    per-window latents."""
+    from mstar.conductor.request_info import CurrentForwardPassInfo
+    from mstar.model.submodule_base import ModelInputsFromEngine
+
+    rid = "r0"
+    fwd = CurrentForwardPassInfo(
+        request_id=rid, graph_walk="prefill", requires_cfg=True, fwd_index=0,
+        random_seed=SEED, max_tokens=0, sampling_config={}, step_metadata=md,
+    )
+    ei = ModelInputsFromEngine(request_ids=[rid], per_request_info={rid: fwd}, cache_manager=cm)
+    text_inputs = [
+        torch.tensor(cond_ids, dtype=torch.long, device=device),
+        torch.tensor(uncond_ids, dtype=torch.long, device=device),
+    ]
+    ni = dit.prepare_inputs("prefill", fwd, {"text_inputs": text_inputs})
+    dit.forward("prefill", ei, **dit.preprocess("prefill", ei, [ni]))
+
+    fwd.graph_walk = "video_gen_ar"
+    windows = []
+    inputs = {}
+    for _ in range(md["num_windows"] * (md["num_inference_steps"] + 1)):
+        ni = dit.prepare_inputs("video_gen_ar", fwd, inputs)
+        out = dit.forward("video_gen_ar", ei, **dit.preprocess("video_gen_ar", ei, [ni]))
+        if "window_latents" in out:
+            windows.append(out["window_latents"][0].clone())
+        inputs = {"latents": [out["latents"][0]], "time_index": [out["time_index"][0]]}
+    dit.cleanup_request(rid)
+    return windows
+
+
+def test_windowed_kv_matches_reference() -> None:
+    """The served kv path — block-causal denoise over committed context,
+    commit passes, page-floor eviction — must reproduce the hand-rolled
+    reference bit-tightly on the sdpa cache handle (sequential guidance, the
+    bit-exact regime), window by window."""
+    ctx = _windowed_scenario()
+    if ctx is None:
+        print("  (skipped windowed-kv reference parity: needs COSMOS3_NANO_DIR + CUDA)")
+        return
+    dit, prev = ctx["dit"], ctx["dit"].batched_cfg
+    dit.batched_cfg = False
+    try:
+        wins = _run_windowed_kv_served(
+            ctx["model"], dit, _SdpaCacheHandle(), ctx["md"], ctx["cond"],
+            ctx["uncond"], ctx["device"],
+        )
+    finally:
+        dit.batched_cfg = prev
+    assert len(wins) == len(ctx["ref"]) == ctx["md"]["num_windows"]
+    diffs = []
+    for served, ref in zip(wins, ctx["ref"], strict=True):
+        diffs.append((served.float() - ref.reshape(served.shape).float()).abs().max().item())
+    assert max(diffs) <= 1e-3, f"windowed kv vs reference per-window diffs {diffs}"
+    print("  windowed-kv (sdpa) per-window latent abs-max diffs = "
+          + ", ".join(f"{d:.3e}" for d in diffs))
+
+
+def test_windowed_kv_engine_release_and_psnr() -> None:
+    """The served kv path on the real paged cache (production batched-CFG
+    denoise + commit): pages of aged-out context are freed on the live
+    request with exact page accounting, and window 0 matches the reference
+    within the usual FlashInfer-vs-sdpa precision bar. Later windows denoise
+    against committed K/V that already carries the kernels' rounding, so
+    their trajectories legitimately diverge (autoregressive feedback, not an
+    implementation error — implementation fidelity is the bit-exact sdpa
+    check above); they get a corruption floor, not the precision bar."""
+    ctx = _windowed_scenario()
+    if ctx is None:
+        print("  (skipped windowed-kv engine parity: needs COSMOS3_NANO_DIR + CUDA)")
+        return
+    try:
+        cm = _flashinfer_cache(ctx["model"], "r0", ctx["device"], ctx["dtype"])
+    except Exception as exc:  # noqa: BLE001
+        print(f"  (skipped windowed-kv engine parity: FlashInfer unavailable: {exc})")
+        return
+    alloc = cm.alloc_manager
+    free0 = alloc.num_free_pages
+    wins = _run_windowed_kv_served(
+        ctx["model"], ctx["dit"], cm, ctx["md"], ctx["cond"], ctx["uncond"], ctx["device"],
+    )
+
+    page_size = alloc.config.page_size
+    frame_tokens = ctx["md"]["total_latent_units"] * 64  # 64 tokens/unit at 256p
+    for label, ids in (("main", ctx["cond"]), ("uncond", ctx["uncond"])):
+        state = alloc.request_states["r0"][label]
+        assert state.protected_prefix_tokens == len(ids)
+        # 12 units committed against a 6-unit horizon -> 6 units (384 tokens,
+        # 3 whole pages) released from the live request per label.
+        assert state.released_tokens == 384, (label, state.released_tokens)
+        expected_pages = -(-(len(ids) + frame_tokens) // page_size) - 3
+        assert len(state.page_indices) == expected_pages
+        assert state.seq_len == len(ids) + frame_tokens - 384
+    held = sum(
+        len(alloc.request_states["r0"][label].page_indices)
+        for label in ("main", "uncond")
+    )
+    assert free0 - alloc.num_free_pages == held
+    alloc.remove_request("r0")
+    assert alloc.num_free_pages == free0
+
+    psnrs = []
+    for served, ref in zip(wins, ctx["ref"], strict=True):
+        assert torch.isfinite(served).all()
+        img_served = ctx["mpipe"]._decode(served).squeeze().float().cpu()
+        img_ref = ctx["mpipe"]._decode(ref.reshape(served.shape)).squeeze().float().cpu()
+        mse = (img_served - img_ref).pow(2).mean().item()
+        psnrs.append(float("inf") if mse == 0 else -10 * math.log10(mse))
+    assert psnrs[0] >= 30, f"windowed-kv engine window-0 PSNR {psnrs[0]:.2f} < 30"
+    assert min(psnrs) >= 12, f"windowed-kv engine per-window PSNRs {psnrs}"
+    print("  windowed-kv engine path (flashinfer, batched commit) per-window PSNR = "
+          + ", ".join(f"{p:.2f}" for p in psnrs)
+          + " dB; released 384 tokens/label on the live request")
+
+
 @torch.no_grad()
 def _run_cuda_graph_denoise(ctx):
     """Capture the image denoise step and run the whole loop through the real
@@ -709,6 +922,8 @@ def _main() -> None:
         ("engine_cache_path_video_psnr", test_engine_cache_path_video_psnr),
         ("dense_fa3_image_psnr", test_dense_fa3_image_psnr),
         ("dense_fa3_video_psnr", test_dense_fa3_video_psnr),
+        ("windowed_kv_matches_reference", test_windowed_kv_matches_reference),
+        ("windowed_kv_engine_release_and_psnr", test_windowed_kv_engine_release_and_psnr),
         ("anchor_encode_matches_full", test_anchor_encode_matches_full),
         ("compile_vae_matches_eager", test_compile_vae_matches_eager),
         ("compile_vae_matches_eager_t2v", test_compile_vae_matches_eager_t2v),

--- a/mstar/model/cosmos3/tests/test_engine_cache.py
+++ b/mstar/model/cosmos3/tests/test_engine_cache.py
@@ -829,6 +829,42 @@ def test_windowed_kv_engine_release_and_psnr() -> None:
           + " dB; released 384 tokens/label on the live request")
 
 
+def test_windowed_kv_dense_matches_paged() -> None:
+    """kv-mode denoise on the dense FA3 fast path — whose committed prefix
+    mutates every window and is re-gathered via prefix_epoch — against the
+    pure paged FlashInfer backend. Same machinery, different attention
+    kernel: window 0 must agree at the usual kernel-precision bar; later
+    windows compound the kernels' rounding through the committed context
+    (same autoregressive-feedback regime as the reference comparison) and
+    get the corruption floor."""
+    ctx = _windowed_scenario()
+    if ctx is None:
+        print("  (skipped windowed-kv dense-vs-paged: needs COSMOS3_NANO_DIR + CUDA)")
+        return
+    try:
+        outs = {}
+        for backend in ("flashinfer", "dense_gen"):
+            cm = _flashinfer_cache(ctx["model"], "r0", ctx["device"], ctx["dtype"], backend=backend)
+            outs[backend] = _run_windowed_kv_served(
+                ctx["model"], ctx["dit"], cm, ctx["md"], ctx["cond"], ctx["uncond"],
+                ctx["device"],
+            )
+            cm.alloc_manager.remove_request("r0")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  (skipped windowed-kv dense-vs-paged: FA3/FlashInfer unavailable: {exc})")
+        return
+    psnrs = []
+    for paged, dense in zip(outs["flashinfer"], outs["dense_gen"], strict=True):
+        img_p = ctx["mpipe"]._decode(paged).squeeze().float().cpu()
+        img_d = ctx["mpipe"]._decode(dense).squeeze().float().cpu()
+        mse = (img_p - img_d).pow(2).mean().item()
+        psnrs.append(float("inf") if mse == 0 else -10 * math.log10(mse))
+    assert psnrs[0] >= 30, f"windowed-kv dense vs paged window-0 PSNR {psnrs[0]:.2f} < 30"
+    assert min(psnrs) >= 12, f"windowed-kv dense vs paged per-window PSNRs {psnrs}"
+    print("  windowed-kv dense-FA3 vs paged per-window PSNR = "
+          + ", ".join(f"{p:.2f}" for p in psnrs) + " dB")
+
+
 @torch.no_grad()
 def _run_cuda_graph_denoise(ctx):
     """Capture the image denoise step and run the whole loop through the real
@@ -924,6 +960,7 @@ def _main() -> None:
         ("dense_fa3_video_psnr", test_dense_fa3_video_psnr),
         ("windowed_kv_matches_reference", test_windowed_kv_matches_reference),
         ("windowed_kv_engine_release_and_psnr", test_windowed_kv_engine_release_and_psnr),
+        ("windowed_kv_dense_matches_paged", test_windowed_kv_dense_matches_paged),
         ("anchor_encode_matches_full", test_anchor_encode_matches_full),
         ("compile_vae_matches_eager", test_compile_vae_matches_eager),
         ("compile_vae_matches_eager_t2v", test_compile_vae_matches_eager_t2v),

--- a/mstar/model/cosmos3/tests/test_serving.py
+++ b/mstar/model/cosmos3/tests/test_serving.py
@@ -786,12 +786,15 @@ def test_windowed_gen_params_and_walk_selection() -> None:
     assert not dec.request_done and dec.inputs == []
 
     for bad in (
-        {"window_mode": "kv", "num_frames": 189},
+        {"window_mode": "bogus", "num_frames": 189},
         {"window_mode": "chained", "num_frames": 1},
         {"window_mode": "chained"},  # image output below
+        {"window_mode": "chained", "num_frames": 189, "context_frames": 61},
+        {"window_mode": "kv", "num_frames": 189, "overlap_frames": 8},
+        {"window_mode": "kv", "num_frames": 189, "context_frames": -1},
     ):
         with _pytest.raises(ValueError):
-            out_mod = ["video"] if bad.get("num_frames", 0) > 1 or "kv" in str(bad) else ["image"]
+            out_mod = ["video"] if bad.get("num_frames", 0) > 1 else ["image"]
             model._resolve_gen_params(bad, [], out_mod)
     with _pytest.raises(ValueError):
         model._resolve_gen_params(
@@ -809,6 +812,20 @@ def test_windowed_gen_params_and_walk_selection() -> None:
     # A windowed-enabled deployment serves non-windowed requests unchanged.
     q = model._resolve_gen_params({"num_frames": 189}, [], ["video"])
     assert "window_mode" not in q
+
+    # kv mode: overlap-free windows advancing by the full window, committed
+    # context capped at the (quantized) horizon; context_frames=0 retains all.
+    kv = model._resolve_gen_params(
+        {"window_mode": "kv", "num_frames": 189}, [], ["video"],
+    )
+    assert kv["window_mode"] == "kv"
+    assert kv["overlap_latent_units"] == 0
+    assert kv["context_latent_units"] == 16  # 61 px default -> 16 units
+    assert kv["total_latent_units"] == 48 and kv["num_windows"] == 6
+    keep_all = model._resolve_gen_params(
+        {"window_mode": "kv", "num_frames": 189, "context_frames": 0}, [], ["video"],
+    )
+    assert keep_all["context_latent_units"] == 0
 
 
 def test_windowed_check_stop_counts_all_windows() -> None:
@@ -857,7 +874,7 @@ def test_windowed_finish_window_bookkeeping(monkeypatch) -> None:
     )
     monkeypatch.setattr(sub, "_new_scheduler", lambda *a, **k: "fresh-sched")
     monkeypatch.setattr(
-        sub, "_window_statics_for", lambda st, units, cond, dev: ({"u": units}, None)
+        sub, "_window_statics_for", lambda st, plan, dev: ({"u": plan.units}, None)
     )
 
     st = sub.request_state("r")
@@ -877,7 +894,7 @@ def test_windowed_finish_window_bookkeeping(monkeypatch) -> None:
         .contiguous()
     )
     ti = torch.tensor([4])
-    out = sub._finish_window(st, x0, ti, global_index=4)
+    out = sub._finish_window(st, x0, ti, window_index=0)
     assert torch.equal(out["window_latents"][0], x0)
     assert int(out["time_index"][0].item()) == 5
     # Next window: 5 latent units (12 total - 8 + 1 overlap), head pinned to
@@ -891,9 +908,214 @@ def test_windowed_finish_window_bookkeeping(monkeypatch) -> None:
     # Final window: emit only, no staging.
     st.add("cond", {"u": 5})
     x1 = torch.zeros(sub._window_latent_shape(64, 64, 5))
-    out = sub._finish_window(st, x1, torch.tensor([9]), global_index=9)
+    out = sub._finish_window(st, x1, torch.tensor([9]), window_index=1)
     assert torch.equal(out["window_latents"][0], x1)
     assert torch.equal(out["latents"][0], x1)
+
+
+def test_windowed_kv_prefill_state_and_pacing(monkeypatch) -> None:
+    """A kv request runs steps + 1 loop iterations per window (the +1 is the
+    commit pass); the prefill records the pacing, the release schedule and the
+    per-unit token stride, and check_stop fires after the final commit."""
+    from types import SimpleNamespace
+
+    from mstar.model.cosmos3 import constants as C
+    from mstar.model.cosmos3.submodules import VIDEO_GEN_AR_LOOP, Cosmos3DiTSubmodule
+
+    cfg = Cosmos3Model(model_path_hf="unused", skip_weight_loading=True).config
+    sub = Cosmos3DiTSubmodule(transformer=None, config=cfg, scheduler=None)
+    monkeypatch.setattr(sub, "_new_scheduler", lambda *a, **k: "sched")
+    md = {
+        "window_mode": "kv", "total_latent_units": 12, "window_latent_units": 4,
+        "overlap_latent_units": 0, "context_latent_units": 6,
+    }
+    fwd = SimpleNamespace(request_id="r")
+    sub._prepare_windowed_prefill(
+        fwd, md, list(range(7)), list(range(9)), 64, 64, 24.0, 6.0, 4, "cpu",
+    )
+    st = sub.request_states["r"]
+    assert st["ar_kv_mode"] and st["ar_iters_per_window"] == 5
+    assert st["ar_total_iters"] == 15
+    # 64x64 -> 4x4 latent -> 2x2 patchify -> 4 tokens per latent frame.
+    assert st["ar_tokens_per_unit"] == 4
+    assert st["ar_schedule"].context_units == 6
+
+    info = SimpleNamespace(
+        graph_walk=C.VIDEO_GEN_AR_WALK,
+        dynamic_loop_iter_counts={VIDEO_GEN_AR_LOOP: 13},
+    )
+    assert sub.check_stop("r", info, {}) == set()
+    info.dynamic_loop_iter_counts[VIDEO_GEN_AR_LOOP] = 14
+    assert sub.check_stop("r", info, {}) == {VIDEO_GEN_AR_LOOP}
+
+
+def test_windowed_kv_statics_absolute_positions() -> None:
+    """kv window statics carry absolute temporal mRoPE positions: a window
+    starting at latent frame 8 positions its tokens exactly where the full
+    clip would, the image anchor applies only to the first window, and
+    chained statics keep per-window positions from 0."""
+    import torch
+
+    from mstar.model.cosmos3.submodules import Cosmos3DiTSubmodule
+
+    cfg = Cosmos3Model(model_path_hf="unused", skip_weight_loading=True).config
+    sub = Cosmos3DiTSubmodule(transformer=None, config=cfg, scheduler=None)
+    ids = list(range(7))
+    kw = dict(height=64, width=64, units=4, fps=24.0, has_image_condition=True,
+              cond_units=0, device="cpu")
+    w0, _ = sub._build_window_statics(ids, None, first_window=True, start_unit=0, **{
+        k: v for k, v in kw.items()})
+    w2, _ = sub._build_window_statics(ids, None, first_window=False, start_unit=8, **{
+        k: v for k, v in kw.items()})
+
+    full = sub._build_static(
+        ids, 64, 64, 1 + (12 - 1) * cfg.vae.scale_factor_temporal, 24.0,
+        has_image_condition=True, device="cpu",
+    )
+    stride = full["num_vision_tokens"] // 12
+    assert torch.equal(
+        w2["vision_mrope_ids"], full["vision_mrope_ids"][:, 8 * stride: 12 * stride]
+    )
+    # Anchor only on the first window: window 0 keeps latent frame 0 clean,
+    # a later window predicts every frame.
+    assert w0["num_noisy_vision_tokens"] == 3 * stride
+    assert w2["num_noisy_vision_tokens"] == 4 * stride
+    # Chained (start_unit 0) restarts each window's positions at frame 0.
+    ch, _ = sub._build_window_statics(ids, None, first_window=False, start_unit=0, **{
+        k: v for k, v in kw.items()})
+    assert torch.equal(
+        ch["vision_mrope_ids"], full["vision_mrope_ids"][:, : 4 * stride]
+    )
+
+
+def test_windowed_kv_commit_and_lifecycle(monkeypatch) -> None:
+    """The commit iteration appends exactly the window's new units under both
+    guidance branches, protects each branch's text prefix before any release,
+    releases context past the horizon after each commit (page-floored, with
+    the shortfall re-offered), and stages the next window. Denoise plans for
+    kv requests stay paged (dense fast path off)."""
+    from types import SimpleNamespace
+
+    import torch
+
+    from mstar.engine.windowing import WindowSchedule
+    from mstar.model.cosmos3.submodules import CFG_BATCHED_LABEL, Cosmos3DiTSubmodule
+
+    cfg = Cosmos3Model(model_path_hf="unused", skip_weight_loading=True).config
+    sub = Cosmos3DiTSubmodule(transformer=None, config=cfg, scheduler=None)
+
+    commits = []
+    sub.transformer = SimpleNamespace(
+        proj_in=SimpleNamespace(weight=torch.zeros(1, dtype=torch.float32)),
+        commit_window=lambda latents, positions, cm: commits.append(
+            (latents.clone(), [p.clone() for p in positions])
+        ),
+    )
+    monkeypatch.setattr(sub, "_new_scheduler", lambda *a, **k: "fresh")
+
+    stride = 64  # tokens per latent frame (256p tier: pages hold 2 frames)
+
+    def fake_statics(plan):
+        n = plan.units * stride
+        base = plan.start * stride
+        ids = (torch.arange(n) + base).view(1, -1).expand(3, -1).contiguous()
+        return (
+            {"vision_mrope_ids": ids, "und_len": 7, "num_vision_tokens": n},
+            {"vision_mrope_ids": ids + 100000, "und_len": 9, "num_vision_tokens": n},
+        )
+
+    monkeypatch.setattr(
+        sub, "_window_statics_for", lambda st, plan, dev: fake_statics(plan)
+    )
+
+    class _CM:
+        def __init__(self):
+            self.plans = []
+            self.labels = []
+            self.protected = []
+            self.released = []
+
+        def set_active_label(self, label):
+            self.labels.append(label)
+
+        def plan_attention(self, **kw):
+            self.plans.append(("single", kw))
+
+        def plan_attention_batched_cfg(self, **kw):
+            self.plans.append(("cfg", kw))
+
+        def protect_prefix(self, rid, n, label=None):
+            assert not self.released, "release before protect"
+            self.protected.append((rid, label, n))
+
+        def release_oldest(self, rid, n, label=None):
+            self.released.append((rid, label, n))
+            return (n // 128) * 128  # page-floored, like the allocator
+
+    cm = _CM()
+    schedule = WindowSchedule(
+        total_units=12, window_units=4, context_units=6, overlap_units=0
+    )
+    st = sub.request_state("r")
+    w0 = schedule.window(0)
+    cond0, uncond0 = fake_statics(w0)
+    st.add_all(
+        ar_schedule=schedule, ar_steps=4, ar_iters_per_window=5,
+        ar_total_iters=15, ar_kv_mode=True, ar_rid="r",
+        ar_tokens_per_unit=stride, ar_size=(64, 64),
+        ar_generator=torch.Generator().manual_seed(0),
+        cond=cond0, uncond=uncond0, scheduler="w0-sched",
+        latent_shape=sub._window_latent_shape(64, 64, 4),
+    )
+
+    # Preprocess maps the loop counter: a commit iteration plans the append
+    # (both labels, the window's 4 new units), a denoise iteration plans
+    # paged with the dense fast path off.
+    ei = SimpleNamespace(cache_manager=cm, request_ids=["r"], per_request_states=None)
+    inp = SimpleNamespace(tensor_inputs={
+        "latents": torch.zeros(1), "time_index": torch.tensor([4]),
+    })
+    sub.preprocess("video_gen_ar", ei, [inp])
+    kind, kw = cm.plans[-1]
+    assert kind == "cfg" and kw["seq_lens"] == [4 * stride] and not kw["is_causal"]
+    inp.tensor_inputs["time_index"] = torch.tensor([2])
+    sub.preprocess("video_gen_ar", ei, [inp])
+    kind, kw = cm.plans[-1]
+    assert kind == "cfg" and kw["dense_gen"] is False
+
+    # Window 0 commit: full window appended, prefixes protected per label,
+    # nothing released yet (the horizon still covers everything committed).
+    x0 = torch.arange(4, dtype=torch.float32).view(1, 1, 4, 1, 1).expand(
+        sub._window_latent_shape(64, 64, 4)).contiguous()
+    out = sub._commit_window(cm, st, x0, torch.tensor([4]), window_index=0)
+    assert torch.equal(out["window_latents"][0], x0)
+    assert cm.labels[-1] == CFG_BATCHED_LABEL
+    latents_c, positions_c = commits[-1]
+    assert torch.equal(latents_c, x0)
+    assert torch.equal(positions_c[0], cond0["vision_mrope_ids"])
+    assert torch.equal(positions_c[1], uncond0["vision_mrope_ids"])
+    assert sorted(cm.protected) == [("r", "main", 7), ("r", "uncond", 9)]
+    assert cm.released == []
+    # Staged window 1: fresh scheduler + absolute-position statics.
+    assert st["scheduler"] == "fresh"
+    assert int(st["cond"]["vision_mrope_ids"][0, 0]) == 4 * stride
+
+    # Window 1 commit: 8 units committed, horizon 6 -> 2 units (128 tokens)
+    # age out of each label.
+    out = sub._commit_window(cm, st, x0, torch.tensor([9]), window_index=1)
+    assert [(r, lbl, n) for r, lbl, n in cm.released] == [
+        ("r", "main", 128), ("r", "uncond", 128),
+    ]
+
+    # Window 2 (final) commit: released target grows to 6 units; the sessions
+    # re-offer only the outstanding 256 tokens. No staging past the end.
+    cm.released.clear()
+    out = sub._commit_window(cm, st, x0, torch.tensor([14]), window_index=2)
+    assert [(r, lbl, n) for r, lbl, n in cm.released] == [
+        ("r", "main", 256), ("r", "uncond", 256),
+    ]
+    assert torch.equal(out["window_latents"][0], x0)
+    assert torch.equal(out["latents"][0], x0)
 
 
 def test_windowed_decoder_assembles_stream(monkeypatch) -> None:

--- a/mstar/model/cosmos3/tests/test_serving.py
+++ b/mstar/model/cosmos3/tests/test_serving.py
@@ -1210,23 +1210,16 @@ def test_windowed_can_batch_and_batched_boundary(monkeypatch) -> None:
         sub.cleanup_request(rid)
 
 
-def test_windowed_decoder_assembles_stream(monkeypatch) -> None:
-    """The AR decoder's context-re-decode + trim reproduces the whole-clip
-    decode of the same latent stream, chunk counts drive completion, and the
-    stream's empty terminal flush is skipped."""
+def _tracing_vae():
+    """Stub VAE for the AR-decoder tests: decodes latent value v at latent
+    index i to pixel frames of value v — frame 0 from latent 0, then 4 frames
+    per later latent, the Wan VAE's temporal contract — so every output frame
+    identifies its source latent."""
     from types import SimpleNamespace
 
     import torch
 
-    from mstar.model.cosmos3.config import Cosmos3Config
-    from mstar.model.cosmos3.submodules import Cosmos3VAEDecoderARSubmodule
-
     class _TracingVAE(torch.nn.Module):
-        """Decodes latent value v at latent index i to pixel frames of value
-        v: frame 0 from latent 0, then 4 frames per later latent — the same
-        temporal contract as the Wan VAE, with content that identifies its
-        source latent."""
-
         def __init__(self):
             super().__init__()
             self.weight = torch.nn.Parameter(torch.zeros(1, dtype=torch.float32))
@@ -1242,10 +1235,24 @@ def test_windowed_decoder_assembles_stream(monkeypatch) -> None:
             # forward maps [-1, 1] -> uint8; keep values identity-recoverable.
             return SimpleNamespace(sample=sample / 127.5 - 1.0)
 
+    return _TracingVAE()
+
+
+def test_windowed_decoder_assembles_stream(monkeypatch) -> None:
+    """The AR decoder's context-re-decode + trim reproduces the whole-clip
+    decode of the same latent stream, chunk counts drive completion, and the
+    stream's empty terminal flush is skipped."""
+    from types import SimpleNamespace
+
+    import torch
+
+    from mstar.model.cosmos3.config import Cosmos3Config
+    from mstar.model.cosmos3.submodules import Cosmos3VAEDecoderARSubmodule
+
     monkeypatch.setenv("COSMOS3_COMPILE_VAE", "0")
     cfg = Cosmos3Config()
     cfg.windowed_decode_context_latents = 3
-    sub = Cosmos3VAEDecoderARSubmodule(_TracingVAE(), cfg)
+    sub = Cosmos3VAEDecoderARSubmodule(_tracing_vae(), cfg)
     sub._decode_dtype_cached = torch.float32
 
     # Latent stream of 12 units, value = absolute unit index; windows of 8
@@ -1268,6 +1275,136 @@ def test_windowed_decoder_assembles_stream(monkeypatch) -> None:
     expected = sub._decode_pixels(stream)
     assert video.shape == expected.shape  # 1 + 11*4 = 45 frames
     assert torch.equal(video, expected)
+
+
+def test_windowed_decoder_streams_chunks(monkeypatch) -> None:
+    """stream_video emits each window's pixels as its own chunk with nothing
+    accumulated, the tail chunk is capped at the requested frame count, and
+    the chunks concatenate to the non-streaming assembly."""
+    from types import SimpleNamespace
+
+    import torch
+
+    from mstar.model.cosmos3.config import Cosmos3Config
+    from mstar.model.cosmos3.submodules import Cosmos3VAEDecoderARSubmodule
+
+    monkeypatch.setenv("COSMOS3_COMPILE_VAE", "0")
+    cfg = Cosmos3Config()
+    cfg.windowed_decode_context_latents = 3
+    sub = Cosmos3VAEDecoderARSubmodule(_tracing_vae(), cfg)
+    sub._decode_dtype_cached = torch.float32
+
+    stream = torch.arange(12, dtype=torch.float32).view(1, 1, 12, 1, 1).expand(1, 16, 12, 4, 4).contiguous()
+    # 43 requested frames inside the 45-frame padded schedule: the trim lands
+    # in the tail chunk.
+    md = {
+        "num_windows": 2, "overlap_latent_units": 1, "num_frames": 43,
+        "stream_video": True,
+    }
+    engine_inputs = SimpleNamespace(
+        request_ids=["r"],
+        per_request_info={"r": SimpleNamespace(step_metadata=md)},
+    )
+
+    out0 = sub.forward("video_decode_ar", engine_inputs, stream[:, :, 0:8])
+    out1 = sub.forward("video_decode_ar", engine_inputs, stream[:, :, 7:12])
+    c0 = out0["video_output"][0]
+    c1 = out1["video_output"][0]
+    assert c0.shape[2] == 29 and c1.shape[2] == 14
+    expected = sub._decode_pixels(stream)
+    assert torch.equal(torch.cat([c0, c1], dim=2), expected[:, :, :43])
+    assert sub.request_state("r")["ar_pixels"] == []
+    # The stream's empty terminal flush stays a no-op.
+    assert sub.forward("video_decode_ar", engine_inputs, torch.empty(0)) == {}
+
+
+def test_windowed_stream_video_gen_params() -> None:
+    """stream_video resolves only alongside a windowed mode."""
+    import pytest as _pytest
+
+    model = Cosmos3Model(
+        model_path_hf="unused", skip_weight_loading=True, enable_windowed_video=True,
+    )
+    p = model._resolve_gen_params(
+        {"window_mode": "chained", "num_frames": 189, "stream_video": True}, [], ["video"],
+    )
+    assert p["stream_video"] is True
+    q = model._resolve_gen_params({"window_mode": "kv", "num_frames": 189}, [], ["video"])
+    assert q["stream_video"] is False
+    with _pytest.raises(ValueError):
+        model._resolve_gen_params({"num_frames": 189, "stream_video": True}, [], ["video"])
+
+
+def test_video_streaming_ndjson_lines() -> None:
+    """stream_video turns the video handler into an NDJSON generator: indexed
+    video lines closed by a done line, an in-band error line terminal instead
+    on failure, and the non-streaming path collecting as before."""
+    import asyncio
+    import base64
+    import json
+
+    from mstar.api_server.openai.adapters import get_adapter
+    from mstar.api_server.openai.protocol import VideoGenerationRequest
+    from mstar.api_server.openai.serving_videos import create_videos
+    from mstar.api_server.request_types import ResultChunk
+
+    class _Api:
+        upload_dir = "/tmp"
+
+        def __init__(self, chunks):
+            self._chunks = chunks
+            self.submits = []
+
+        def submit_request(self, **kw):
+            self.submits.append(kw)
+            return kw["request_id"]
+
+        async def iter_result_chunks(self, request_id):  # noqa: ARG002
+            for c in self._chunks:
+                yield c
+
+        async def collect_results(self, request_id, raw_request=None):  # noqa: ARG002
+            return list(self._chunks)
+
+    adapter = get_adapter("cosmos3")
+    streaming_req = VideoGenerationRequest(
+        prompt="x", num_frames=57, window_mode="chained", stream_video=True,
+    )
+
+    async def _lines(api):
+        gen = await create_videos(api, "cosmos3", adapter, streaming_req)
+        return [json.loads(line) async for line in gen]
+
+    api = _Api([
+        ResultChunk(request_id="r", modality="video", data=b"w0"),
+        ResultChunk(request_id="r", modality="video", data=b"w1"),
+    ])
+    lines = asyncio.run(_lines(api))
+    assert api.submits[0]["streaming"] is True
+    assert api.submits[0]["model_kwargs"]["stream_video"] is True
+    assert [ln["modality"] for ln in lines] == ["video", "video", "done"]
+    assert [ln["metadata"]["index"] for ln in lines[:2]] == [0, 1]
+    assert base64.b64decode(lines[0]["data"]) == b"w0"
+    assert base64.b64decode(lines[1]["data"]) == b"w1"
+    assert lines[2]["metadata"]["chunks"] == 2
+
+    api = _Api([
+        ResultChunk(request_id="r", modality="video", data=b"w0"),
+        ResultChunk(
+            request_id="r", modality="error", data=b"boom", metadata={"status": 500},
+        ),
+    ])
+    lines = asyncio.run(_lines(api))
+    assert [ln["modality"] for ln in lines] == ["video", "error"]
+    assert base64.b64decode(lines[1]["data"]) == b"boom"
+
+    api = _Api([ResultChunk(request_id="r", modality="video", data=b"v")])
+    out = asyncio.run(create_videos(
+        api, "cosmos3", adapter, VideoGenerationRequest(prompt="x", num_frames=57),
+    ))
+    assert api.submits[0]["streaming"] is False
+    assert "stream_video" not in api.submits[0]["model_kwargs"]
+    assert base64.b64decode(out["data"][0]["b64_json"]) == b"v"
 
 
 if __name__ == "__main__":

--- a/mstar/model/cosmos3/tests/test_serving.py
+++ b/mstar/model/cosmos3/tests/test_serving.py
@@ -1179,6 +1179,17 @@ def test_windowed_can_batch_and_batched_boundary(monkeypatch) -> None:
     assert sub.can_batch(batch_kv, [inp(1), inp(1)])
     assert not sub.can_batch(batch_kv, [inp(1), inp(4)])  # local 4 == steps
 
+    # A prefill batch carries no time_index; with a windowed request in it the
+    # batch must fall to the sequential path (not raise), while plain-only
+    # prefill batches still batch.
+    noti = SimpleNamespace(tensor_inputs={})
+    batch_pre = SimpleNamespace(graph_walk=C.PREFILL_WALK, request_ids=["a", "p"])
+    sub.request_state("p").add_all(cond={}, uncond={})
+    assert not sub.can_batch(batch_pre, [noti, noti])
+    batch_pp = SimpleNamespace(graph_walk=C.PREFILL_WALK, request_ids=["p", "q"])
+    sub.request_state("q").add_all(cond={}, uncond={})
+    assert sub.can_batch(batch_pp, [noti, noti])
+
     # Batched forward: request "a" at its window-0 boundary (local 3),
     # request "b" mid-window. The boundary request emits + stages.
     sub.transformer = SimpleNamespace(
@@ -1206,7 +1217,7 @@ def test_windowed_can_batch_and_batched_boundary(monkeypatch) -> None:
     assert out["a"]["latents"][0].shape == latent_shape  # staged next window
     assert "window_latents" not in out["b"]
     assert torch.equal(out["b"]["latents"][0], lat["b"] * 0.5)
-    for rid in ("a", "b", "c"):
+    for rid in ("a", "b", "c", "p", "q"):
         sub.cleanup_request(rid)
 
 

--- a/mstar/model/cosmos3/tests/test_serving.py
+++ b/mstar/model/cosmos3/tests/test_serving.py
@@ -1069,8 +1069,9 @@ def test_windowed_kv_commit_and_lifecycle(monkeypatch) -> None:
     )
 
     # Preprocess maps the loop counter: a commit iteration plans the append
-    # (both labels, the window's 4 new units), a denoise iteration plans
-    # paged with the dense fast path off.
+    # (both labels, the window's 4 new units); a denoise iteration plans the
+    # step with the dense fast path eligible (staleness handled by the
+    # dense manager's prefix_epoch re-gather).
     ei = SimpleNamespace(cache_manager=cm, request_ids=["r"], per_request_states=None)
     inp = SimpleNamespace(tensor_inputs={
         "latents": torch.zeros(1), "time_index": torch.tensor([4]),
@@ -1078,10 +1079,11 @@ def test_windowed_kv_commit_and_lifecycle(monkeypatch) -> None:
     sub.preprocess("video_gen_ar", ei, [inp])
     kind, kw = cm.plans[-1]
     assert kind == "cfg" and kw["seq_lens"] == [4 * stride] and not kw["is_causal"]
+    assert "dense_gen" not in kw
     inp.tensor_inputs["time_index"] = torch.tensor([2])
     sub.preprocess("video_gen_ar", ei, [inp])
     kind, kw = cm.plans[-1]
-    assert kind == "cfg" and kw["dense_gen"] is False
+    assert kind == "cfg" and kw["dense_gen"] is True
 
     # Window 0 commit: full window appended, prefixes protected per label,
     # nothing released yet (the horizon still covers everything committed).
@@ -1116,6 +1118,96 @@ def test_windowed_kv_commit_and_lifecycle(monkeypatch) -> None:
     ]
     assert torch.equal(out["window_latents"][0], x0)
     assert torch.equal(out["latents"][0], x0)
+
+
+def test_windowed_can_batch_and_batched_boundary(monkeypatch) -> None:
+    """Windowed denoise steps batch across requests (loop counters mapped to
+    within-window steps per request); any request at a kv commit iteration
+    drops the batch to the sequential path; and a chained window boundary
+    inside the batched forward emits the window and stages the next one like
+    the single-request path."""
+    from types import SimpleNamespace
+
+    import torch
+
+    from mstar.engine.windowing import WindowSchedule
+    from mstar.model.cosmos3 import constants as C
+    from mstar.model.cosmos3.submodules import Cosmos3DiTSubmodule
+
+    cfg = Cosmos3Model(model_path_hf="unused", skip_weight_loading=True).config
+    sub = Cosmos3DiTSubmodule(transformer=None, config=cfg, scheduler=None)
+
+    schedule = WindowSchedule(total_units=14, window_units=8, overlap_units=2)
+    latent_shape = sub._window_latent_shape(64, 64, 8)
+    sched = SimpleNamespace(
+        timesteps=torch.arange(4, 0, -1),
+        step=lambda v, t, lat, return_dict=False: (lat * 0.5,),
+    )
+
+    def add_windowed(rid):
+        st = sub.request_state(rid)
+        n = 8 * 4
+        ids = torch.arange(n).view(1, -1).expand(3, -1).contiguous()
+        static = {
+            "num_vision_tokens": n, "num_noisy_vision_tokens": n,
+            "vision_mrope_ids": ids, "und_len": 7,
+            "vision_token_shapes": [(8, 2, 2)],
+            "vision_noisy_frame_indexes": [torch.arange(8)],
+            "mse_gen_indexes": torch.arange(n),
+        }
+        st.add_all(
+            ar_schedule=schedule, ar_steps=4, ar_iters_per_window=4,
+            ar_kv_mode=False, ar_size=(64, 64), gs=6.0,
+            ar_generator=torch.Generator().manual_seed(0),
+            cond=static, uncond=dict(static), scheduler=sched,
+            latent_shape=latent_shape,
+        )
+        return st
+
+    add_windowed("a")
+    add_windowed("b")
+    batch = SimpleNamespace(graph_walk=C.VIDEO_GEN_AR_WALK, request_ids=["a", "b"])
+    inp = lambda t: SimpleNamespace(tensor_inputs={"time_index": torch.tensor([t])})  # noqa: E731
+    assert sub.can_batch(batch, [inp(1), inp(1)])
+    assert sub.can_batch(batch, [inp(3), inp(5)])  # different windows, both denoise
+
+    # A kv request at its commit iteration vetoes the batch.
+    st_kv = add_windowed("c")
+    st_kv.add("ar_kv_mode", True)
+    st_kv.add("ar_iters_per_window", 5)
+    batch_kv = SimpleNamespace(graph_walk=C.VIDEO_GEN_AR_WALK, request_ids=["a", "c"])
+    assert sub.can_batch(batch_kv, [inp(1), inp(1)])
+    assert not sub.can_batch(batch_kv, [inp(1), inp(4)])  # local 4 == steps
+
+    # Batched forward: request "a" at its window-0 boundary (local 3),
+    # request "b" mid-window. The boundary request emits + stages.
+    sub.transformer = SimpleNamespace(
+        proj_in=SimpleNamespace(weight=torch.zeros(1, dtype=torch.float32)),
+        denoise_step_batched=lambda reqs, cm: [
+            (torch.zeros(latent_shape), torch.zeros(latent_shape)) for _ in reqs
+        ],
+    )
+    monkeypatch.setattr(sub, "_new_scheduler", lambda *a, **k: sched)
+    monkeypatch.setattr(
+        sub, "_window_statics_for",
+        lambda st, plan, dev: (dict(sub.request_states["a"]["cond"]), None),
+    )
+    cm = SimpleNamespace(set_active_label=lambda label: None)
+    ei = SimpleNamespace(
+        cache_manager=cm, request_ids=["a", "b"], per_request_states=None,
+        per_request_info={},
+    )
+    lat = {r: torch.full(latent_shape, 2.0) for r in ("a", "b")}
+    ti = {"a": torch.tensor([3]), "b": torch.tensor([1])}
+    out = sub.forward_batched("video_gen_ar", ei, latents=lat, time_index=ti)
+    assert "window_latents" in out["a"] and torch.equal(
+        out["a"]["window_latents"][0], lat["a"] * 0.5
+    )
+    assert out["a"]["latents"][0].shape == latent_shape  # staged next window
+    assert "window_latents" not in out["b"]
+    assert torch.equal(out["b"]["latents"][0], lat["b"] * 0.5)
+    for rid in ("a", "b", "c"):
+        sub.cleanup_request(rid)
 
 
 def test_windowed_decoder_assembles_stream(monkeypatch) -> None:

--- a/mstar/model/cosmos3/tests/test_serving.py
+++ b/mstar/model/cosmos3/tests/test_serving.py
@@ -745,6 +745,217 @@ def test_video_postprocess_uses_request_fps(tmp_path) -> None:
     assert abs(float(num) / float(den) - 12.0) < 1e-3
 
 
+def test_windowed_gen_params_and_walk_selection() -> None:
+    """Windowed knobs quantize to latent units, the AR walk is selected at the
+    prefill transition, and every rejection fires at request resolution."""
+    import pytest as _pytest
+
+    from mstar.conductor.request_info import CurrentForwardConductorMetadata
+    from mstar.model.cosmos3 import constants as C
+
+    model = Cosmos3Model(
+        model_path_hf="unused", skip_weight_loading=True, enable_windowed_video=True,
+    )
+    p = model._resolve_gen_params(
+        {"window_mode": "chained", "num_frames": 189, "size": "832x480"}, [], ["video"],
+    )
+    # Default overlap = 2 latent units (the V2V pin count); 48 requested units
+    # pad to 50 so every window is full-size (stride 6).
+    assert p["window_latent_units"] == 8 and p["overlap_latent_units"] == 2
+    assert p["total_latent_units"] == 50 and p["num_windows"] == 8
+    assert p["num_frames"] == 189
+
+    md = CurrentForwardConductorMetadata(
+        input_modalities=[], output_modalities=["video"],
+        graph_walk=C.PREFILL_WALK, is_prefill=True, kwargs=p,
+    )
+    args = model.get_partition_forward_pass_args("default", md, {})
+    assert args.full_metadata.graph_walk == C.VIDEO_GEN_AR_WALK
+    done = model.get_partition_forward_pass_args("default", args.full_metadata, {})
+    assert done.request_done
+
+    dec = model.get_partition_forward_pass_args(
+        C.WINDOW_DECODER_PARTITION,
+        CurrentForwardConductorMetadata(
+            input_modalities=[], output_modalities=["video"],
+            graph_walk=C.VIDEO_DECODE_AR_WALK, is_prefill=False, kwargs=p,
+        ),
+        {},
+    )
+    assert dec.full_metadata.graph_walk == C.VIDEO_DECODE_AR_WALK
+    assert not dec.request_done and dec.inputs == []
+
+    for bad in (
+        {"window_mode": "kv", "num_frames": 189},
+        {"window_mode": "chained", "num_frames": 1},
+        {"window_mode": "chained"},  # image output below
+    ):
+        with _pytest.raises(ValueError):
+            out_mod = ["video"] if bad.get("num_frames", 0) > 1 or "kv" in str(bad) else ["image"]
+            model._resolve_gen_params(bad, [], out_mod)
+    with _pytest.raises(ValueError):
+        model._resolve_gen_params(
+            {"window_mode": "chained", "num_frames": 189, "generate_sound": True}, [], ["video"],
+        )
+    with _pytest.raises(ValueError):
+        model._resolve_gen_params(
+            {"window_mode": "chained", "num_frames": 9999999}, [], ["video"],
+        )
+    plain = Cosmos3Model(model_path_hf="unused", skip_weight_loading=True)
+    with _pytest.raises(ValueError):
+        plain._resolve_gen_params(
+            {"window_mode": "chained", "num_frames": 189}, [], ["video"],
+        )
+    # A windowed-enabled deployment serves non-windowed requests unchanged.
+    q = model._resolve_gen_params({"num_frames": 189}, [], ["video"])
+    assert "window_mode" not in q
+
+
+def test_windowed_check_stop_counts_all_windows() -> None:
+    """The AR loop stops at num_windows x steps, not at one scheduler's
+    length."""
+    from types import SimpleNamespace
+
+    from mstar.engine.windowing import WindowSchedule
+    from mstar.model.cosmos3 import constants as C
+    from mstar.model.cosmos3.submodules import VIDEO_GEN_AR_LOOP, Cosmos3DiTSubmodule
+
+    sub = Cosmos3DiTSubmodule(transformer=None, config=Cosmos3Model(
+        model_path_hf="unused", skip_weight_loading=True).config, scheduler=None)
+    st = sub.request_state("r")
+    st.add_all(
+        ar_schedule=WindowSchedule(48, 8, overlap_units=1),
+        ar_total_iters=7 * 5,
+        scheduler=SimpleNamespace(timesteps=list(range(5))),
+    )
+    info = SimpleNamespace(
+        graph_walk=C.VIDEO_GEN_AR_WALK,
+        dynamic_loop_iter_counts={VIDEO_GEN_AR_LOOP: 4},
+    )
+    assert sub.check_stop("r", info, {}) == set()
+    info.dynamic_loop_iter_counts[VIDEO_GEN_AR_LOOP] = 33
+    assert sub.check_stop("r", info, {}) == set()
+    info.dynamic_loop_iter_counts[VIDEO_GEN_AR_LOOP] = 34
+    assert sub.check_stop("r", info, {}) == {VIDEO_GEN_AR_LOOP}
+
+
+def test_windowed_finish_window_bookkeeping(monkeypatch) -> None:
+    """The last step of a window emits the window's latents on the streaming
+    edge, stages the next window (fresh noise, overlap tail pinned clean), and
+    the final window emits without staging."""
+    from types import SimpleNamespace
+
+    import torch
+
+    from mstar.engine.windowing import WindowSchedule
+    from mstar.model.cosmos3.submodules import Cosmos3DiTSubmodule
+
+    cfg = Cosmos3Model(model_path_hf="unused", skip_weight_loading=True).config
+    sub = Cosmos3DiTSubmodule(transformer=None, config=cfg, scheduler=None)
+    sub.transformer = SimpleNamespace(
+        proj_in=SimpleNamespace(weight=torch.zeros(1, dtype=torch.float32))
+    )
+    monkeypatch.setattr(sub, "_new_scheduler", lambda *a, **k: "fresh-sched")
+    monkeypatch.setattr(
+        sub, "_window_statics_for", lambda st, units, cond, dev: ({"u": units}, None)
+    )
+
+    st = sub.request_state("r")
+    schedule = WindowSchedule(total_units=12, window_units=8, overlap_units=1)
+    assert schedule.num_windows == 2
+    st.add_all(
+        ar_schedule=schedule, ar_steps=5, ar_total_iters=10,
+        ar_flow_shift=None, ar_karras=None, ar_size=(64, 64),
+        ar_generator=torch.Generator().manual_seed(0),
+        cond={"u": 8}, uncond=None, scheduler="w0-sched",
+    )
+    w0_shape = sub._window_latent_shape(64, 64, 8)
+    x0 = (
+        torch.arange(8, dtype=torch.float32)
+        .view(1, 1, 8, 1, 1)
+        .expand(w0_shape)
+        .contiguous()
+    )
+    ti = torch.tensor([4])
+    out = sub._finish_window(st, x0, ti, global_index=4)
+    assert torch.equal(out["window_latents"][0], x0)
+    assert int(out["time_index"][0].item()) == 5
+    # Next window: 5 latent units (12 total - 8 + 1 overlap), head pinned to
+    # the previous tail value (7.0), rest fresh noise.
+    nxt = out["latents"][0]
+    assert nxt.shape[2] == 5
+    assert torch.all(nxt[:, :, 0] == 7.0)
+    assert st["scheduler"] == "fresh-sched" and st["cond"] == {"u": 5}
+    assert st["vmask"].shape[2] == 5 and float(st["vmask"][0, 0, 0]) == 1.0
+
+    # Final window: emit only, no staging.
+    st.add("cond", {"u": 5})
+    x1 = torch.zeros(sub._window_latent_shape(64, 64, 5))
+    out = sub._finish_window(st, x1, torch.tensor([9]), global_index=9)
+    assert torch.equal(out["window_latents"][0], x1)
+    assert torch.equal(out["latents"][0], x1)
+
+
+def test_windowed_decoder_assembles_stream(monkeypatch) -> None:
+    """The AR decoder's context-re-decode + trim reproduces the whole-clip
+    decode of the same latent stream, chunk counts drive completion, and the
+    stream's empty terminal flush is skipped."""
+    from types import SimpleNamespace
+
+    import torch
+
+    from mstar.model.cosmos3.config import Cosmos3Config
+    from mstar.model.cosmos3.submodules import Cosmos3VAEDecoderARSubmodule
+
+    class _TracingVAE(torch.nn.Module):
+        """Decodes latent value v at latent index i to pixel frames of value
+        v: frame 0 from latent 0, then 4 frames per later latent — the same
+        temporal contract as the Wan VAE, with content that identifies its
+        source latent."""
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(1, dtype=torch.float32))
+            self.config = SimpleNamespace(latents_mean=[0.0], latents_std=[1.0])
+
+        def decode(self, z):
+            vals = z[0, 0, :, 0, 0]
+            frames = [vals[0].expand(1)]
+            for i in range(1, z.shape[2]):
+                frames.append(vals[i].expand(4))
+            t = torch.cat(frames)
+            sample = t.view(1, 1, -1, 1, 1).expand(1, 3, t.numel(), 4, 4)
+            # forward maps [-1, 1] -> uint8; keep values identity-recoverable.
+            return SimpleNamespace(sample=sample / 127.5 - 1.0)
+
+    monkeypatch.setenv("COSMOS3_COMPILE_VAE", "0")
+    cfg = Cosmos3Config()
+    cfg.windowed_decode_context_latents = 3
+    sub = Cosmos3VAEDecoderARSubmodule(_TracingVAE(), cfg)
+    sub._decode_dtype_cached = torch.float32
+
+    # Latent stream of 12 units, value = absolute unit index; windows of 8
+    # units with 1-unit overlap: [0..8) then [7..12).
+    stream = torch.arange(12, dtype=torch.float32).view(1, 1, 12, 1, 1).expand(1, 16, 12, 4, 4).contiguous()
+    md = {"num_windows": 2, "overlap_latent_units": 1, "num_frames": 45}
+    engine_inputs = SimpleNamespace(
+        request_ids=["r"],
+        per_request_info={"r": SimpleNamespace(step_metadata=md)},
+    )
+
+    flush = sub.prepare_inputs("video_decode_ar", None, {"window_latents": []})
+    assert flush.tensor_inputs["latents"].numel() == 0
+    assert sub.forward("video_decode_ar", engine_inputs, flush.tensor_inputs["latents"]) == {}
+    out = sub.forward("video_decode_ar", engine_inputs, stream[:, :, 0:8])
+    assert out == {}
+    out = sub.forward("video_decode_ar", engine_inputs, stream[:, :, 7:12])
+    video = out["video_output"][0]
+
+    expected = sub._decode_pixels(stream)
+    assert video.shape == expected.shape  # 1 + 11*4 = 45 frames
+    assert torch.equal(video, expected)
+
+
 if __name__ == "__main__":
     test_adapter_registered_for_images()
     test_gen_params_and_step_metadata()

--- a/test/modular/test_api_result_delivery.py
+++ b/test/modular/test_api_result_delivery.py
@@ -208,3 +208,28 @@ def test_stream_carries_error_as_final_chunk():
     chunks = asyncio.run(_collect())
     assert [c.modality for c in chunks] == ["text", "error"]
     assert chunks[-1].metadata["status"] == 500
+
+
+def test_stream_does_not_duplicate_delivered_error_chunk():
+    """A preprocess failure arrives as an in-band error chunk AND sets
+    req.error; the stream must deliver that error exactly once, not append a
+    second synthesized copy."""
+    pw = _StubPreprocessWorker()
+    server = _api_server_stub(pw)
+    req = _pending_request()
+    req.chunks.append(ResultChunk(
+        request_id="r4", modality="error", data=b"bad knob",
+        metadata={"status": 400},
+    ))
+    req.error = "bad knob"
+    req.error_status = 400
+    req.event.set()
+    server.pending_requests["r4"] = req
+
+    async def _collect():
+        return [chunk async for chunk in server.iter_result_chunks("r4")]
+
+    chunks = asyncio.run(_collect())
+    assert [c.modality for c in chunks] == ["error"]
+    assert chunks[0].data == b"bad knob"
+    assert chunks[0].metadata["status"] == 400

--- a/test/modular/test_kv_release.py
+++ b/test/modular/test_kv_release.py
@@ -1,0 +1,367 @@
+"""Tests for partial KV release on a live request: the
+``PagedAllocationManager.protect_prefix`` / ``release_oldest`` primitives and
+their offload round-trip.
+
+The load-bearing invariant throughout: ``page_indices`` stays a contiguous
+logical stream — ``len(page_indices) == ceil(seq_len / page_size)`` — because
+release removes whole pages from the front of the unprotected region and
+drops ``seq_len`` by exactly the freed token count. The planner and the
+retrieve path both index pages as ``token // page_size``, so any drift here
+corrupts attention.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+import threading
+
+sys.path.insert(0, ".")
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pytest
+
+from mstar.engine.cpu_page_pool import OffloadedState
+from mstar.engine.kv_store import (
+    KVCacheConfig,
+    PageAllocator,
+    PagedAllocationManager,
+    StoreWritePolicy,
+)
+
+PS = 8  # page_size used across these tests
+
+
+def _make_manager(max_num_pages: int = 64) -> PagedAllocationManager:
+    """Build a ``PagedAllocationManager`` bypassing ``__init__``'s
+    transfer-engine setup (requires CUDA); only fields the tested paths
+    touch are populated."""
+    manager = PagedAllocationManager.__new__(PagedAllocationManager)
+    manager.config = KVCacheConfig(
+        num_layers=1,
+        num_kv_heads=1,
+        head_dim=1,
+        max_seq_len=max_num_pages * PS,
+        max_num_pages=max_num_pages,
+        page_size=PS,
+    )
+    manager.page_allocator = PageAllocator(max_num_pages)
+    manager.request_states = {}
+    manager.kv_cache = None
+    manager.write_policy = StoreWritePolicy.ALWAYS
+    manager._kv_transfer_engine = None
+    manager._offload_stream = None
+    manager.pending_reads = {}
+    manager._lock = threading.RLock()
+    return manager
+
+
+def _commit(manager, rid, label, seq_len):
+    """Emulate what a prefill/commit pass does: grow pages, advance seq_len."""
+    manager.alloc(rid, label, seq_len)
+    manager.request_states[rid][label].seq_len = seq_len
+
+
+def _assert_stream_coherent(state):
+    assert len(state.page_indices) == -(-state.seq_len // PS), (
+        f"page list {len(state.page_indices)} != ceil({state.seq_len}/{PS})"
+    )
+
+
+class TestReleaseOldest:
+    def test_basic_release_compacts_front(self):
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 10 * PS)
+        st = m.request_states["r"]["main"]
+        original = list(st.page_indices)
+
+        m.protect_prefix("r", "main", 2 * PS)
+        freed = m.release_oldest("r", "main", 3 * PS)
+
+        assert freed == 3 * PS
+        assert st.page_indices == original[:2] + original[5:]
+        assert st.seq_len == 7 * PS
+        assert st.released_tokens == 3 * PS
+        assert st.prefix_epoch == 1
+        _assert_stream_coherent(st)
+        # Freed pages went back to the pool.
+        assert m.page_allocator.num_free == m.config.max_num_pages - 7
+
+    def test_release_floors_to_whole_pages(self):
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 10 * PS)
+        m.protect_prefix("r", "main", PS)
+
+        assert m.release_oldest("r", "main", PS - 1) == 0
+        assert m.release_oldest("r", "main", 2 * PS + 3) == 2 * PS
+
+    def test_protection_boundary_page_never_freed(self):
+        # Protect 1.5 pages: the straddling page (index 1) must survive even
+        # though its tail tokens are unprotected.
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 6 * PS)
+        st = m.request_states["r"]["main"]
+        original = list(st.page_indices)
+
+        m.protect_prefix("r", "main", PS + PS // 2)
+        freed = m.release_oldest("r", "main", 100 * PS)
+
+        # Releasable pages start at page 2; the partially-written tail rule
+        # doesn't bite here (seq_len is page-aligned), so pages 2..5 free.
+        assert freed == 4 * PS
+        assert st.page_indices == original[:2]
+        _assert_stream_coherent(st)
+
+    def test_partial_tail_page_never_freed(self):
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 3 * PS + 1)  # 4 pages, last holds 1 token
+        st = m.request_states["r"]["main"]
+        original = list(st.page_indices)
+
+        freed = m.release_oldest("r", "main", 100 * PS)
+
+        assert freed == 3 * PS
+        assert st.page_indices == [original[3]]
+        assert st.seq_len == 1
+        _assert_stream_coherent(st)
+
+    def test_release_without_protection_frees_from_front(self):
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 4 * PS)
+        st = m.request_states["r"]["main"]
+        original = list(st.page_indices)
+
+        assert m.release_oldest("r", "main", 2 * PS) == 2 * PS
+        assert st.page_indices == original[2:]
+
+    def test_release_invalidates_dense_prefix_and_bumps_epoch(self):
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 4 * PS)
+        st = m.request_states["r"]["main"]
+        st.dense_prefix_kv = {0: "sentinel"}
+
+        m.release_oldest("r", "main", PS)
+        assert st.dense_prefix_kv is None
+        assert st.prefix_epoch == 1
+        # A no-op release must not bump the epoch or touch the cache field.
+        st.dense_prefix_kv = {0: "sentinel"}
+        assert m.release_oldest("r", "main", PS - 1) == 0
+        assert st.dense_prefix_kv == {0: "sentinel"}
+        assert st.prefix_epoch == 1
+
+    def test_position_id_start_untouched(self):
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 6 * PS)
+        st = m.request_states["r"]["main"]
+        st.position_id_start = 123
+        m.release_oldest("r", "main", 2 * PS)
+        assert st.position_id_start == 123
+
+    def test_grow_after_release_stays_coherent(self):
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 6 * PS)
+        m.protect_prefix("r", "main", PS)
+        m.release_oldest("r", "main", 3 * PS)
+
+        # Next window commits: alloc sees the compacted stream and grows it.
+        st = m.request_states["r"]["main"]
+        _commit(m, "r", "main", st.seq_len + 2 * PS + 3)
+        _assert_stream_coherent(st)
+
+    def test_remove_request_after_partial_release_conserves_pages(self):
+        m = _make_manager()
+        m.add_request("r", ["main", "uncond"])
+        _commit(m, "r", "main", 10 * PS)
+        _commit(m, "r", "uncond", 7 * PS)
+        m.protect_prefix("r", "main", PS)
+        m.release_oldest("r", "main", 4 * PS)
+        m.remove_request("r")
+        assert m.page_allocator.num_free == m.config.max_num_pages
+
+
+class TestProtectPrefix:
+    def test_protect_validations(self):
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 4 * PS)
+
+        with pytest.raises(ValueError, match="outside committed seq_len"):
+            m.protect_prefix("r", "main", 5 * PS)
+
+        m.protect_prefix("r", "main", 2 * PS)
+        m.protect_prefix("r", "main", 2 * PS)  # idempotent at same value
+        with pytest.raises(ValueError, match="already"):
+            m.protect_prefix("r", "main", 3 * PS)
+
+        m.release_oldest("r", "main", PS)
+        fresh = _make_manager()
+        fresh.add_request("r", ["main"])
+        _commit(fresh, "r", "main", 4 * PS)
+        fresh.release_oldest("r", "main", PS)
+        with pytest.raises(ValueError, match="precede"):
+            fresh.protect_prefix("r", "main", PS)
+
+    def test_fully_protected_stream_releases_nothing(self):
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 3 * PS)
+        m.protect_prefix("r", "main", 3 * PS)
+        assert m.release_oldest("r", "main", 100 * PS) == 0
+
+
+class TestReleaseRandomized:
+    def test_random_grow_release_sequences_hold_invariants(self):
+        rng = random.Random(0)
+        for trial in range(50):
+            m = _make_manager(max_num_pages=128)
+            m.add_request("r", ["main"])
+            protect = rng.randrange(0, 3 * PS)
+            _commit(m, "r", "main", max(protect, rng.randrange(1, 6 * PS)))
+            if protect:
+                m.protect_prefix("r", "main", protect)
+            st = m.request_states["r"]["main"]
+
+            for _ in range(rng.randrange(3, 12)):
+                if rng.random() < 0.5:
+                    grow = rng.randrange(1, 4 * PS)
+                    _commit(m, "r", "main", st.seq_len + grow)
+                else:
+                    before = st.seq_len
+                    freed = m.release_oldest(
+                        "r", "main", rng.randrange(0, 6 * PS)
+                    )
+                    assert freed % PS == 0
+                    assert st.seq_len == before - freed
+                    # Protected tokens always survive.
+                    assert st.seq_len >= st.protected_prefix_tokens
+                _assert_stream_coherent(st)
+                assert len(set(st.page_indices)) == len(st.page_indices)
+
+            m.remove_request("r")
+            assert m.page_allocator.num_free == m.config.max_num_pages, (
+                f"trial {trial} leaked pages"
+            )
+
+
+class _StubCpuPool:
+    """Duck-typed stand-in for CPUPagePool: records offloads, returns the
+    stored ``OffloadedState`` on reload. Lets the kv_store round-trip run
+    without CUDA (the real pool pins memory and uses CUDA streams)."""
+
+    def __init__(self):
+        self.offloaded = {}
+
+    def offload_pages(
+        self, request_id, label, gpu_kv_cache, gpu_page_indices, seq_len,
+        position_id_start, protected_prefix_tokens=0, released_tokens=0,
+        prefix_epoch=0,
+    ):
+        self.offloaded.setdefault(request_id, {})[label] = OffloadedState(
+            cpu_page_indices=list(range(len(gpu_page_indices))),
+            seq_len=seq_len,
+            position_id_start=position_id_start,
+            protected_prefix_tokens=protected_prefix_tokens,
+            released_tokens=released_tokens,
+            prefix_epoch=prefix_epoch,
+        )
+
+    def reload_pages(self, request_id, label, gpu_kv_cache, gpu_page_indices):
+        state = self.offloaded[request_id][label]
+        del self.offloaded[request_id][label]
+        if not self.offloaded[request_id]:
+            del self.offloaded[request_id]
+        return state
+
+    def sync(self):
+        pass
+
+
+class TestOffloadRoundTrip:
+    def test_release_state_survives_offload_reload(self):
+        m = _make_manager()
+        m.add_request("r", ["main"])
+        _commit(m, "r", "main", 8 * PS)
+        m.protect_prefix("r", "main", 2 * PS)
+        m.release_oldest("r", "main", 3 * PS)
+        st = m.request_states["r"]["main"]
+        st.position_id_start = 42
+        expect = (
+            st.seq_len, st.position_id_start, st.protected_prefix_tokens,
+            st.released_tokens, st.prefix_epoch,
+        )
+
+        pool = _StubCpuPool()
+        freed = m.offload_request("r", pool)
+        assert freed == 5
+        assert st.page_indices == [] and st.seq_len == 0
+
+        # Even if the live state object were replaced while offloaded, the
+        # pool record restores the full stream bookkeeping.
+        m.request_states["r"]["main"] = m._new_state()
+
+        m.reload_request("r", pool)
+        st = m.request_states["r"]["main"]
+        assert (
+            st.seq_len, st.position_id_start, st.protected_prefix_tokens,
+            st.released_tokens, st.prefix_epoch,
+        ) == expect
+        _assert_stream_coherent(st)
+
+        # Lifecycle continues where it left off after reload.
+        assert m.release_oldest("r", "main", PS) == PS
+
+
+class TestReleaseThreadSafety:
+    def test_concurrent_grow_release_conserves_pages(self):
+        m = _make_manager(max_num_pages=128)
+        rid, label = "r", "main"
+        m.add_request(rid, [label])
+        _commit(m, rid, label, 4 * PS)
+        m.protect_prefix(rid, label, PS)
+
+        n_iters = 300
+
+        def grow_worker():
+            for _ in range(n_iters):
+                try:
+                    with m._lock:
+                        st = m.request_states[rid][label]
+                        _commit(m, rid, label, st.seq_len + PS)
+                except (KeyError, RuntimeError):
+                    pass
+
+        def release_worker():
+            for _ in range(n_iters):
+                try:
+                    m.release_oldest(rid, label, 2 * PS)
+                except KeyError:
+                    pass
+
+        with ThreadPoolExecutor(max_workers=4) as ex:
+            futures = [
+                ex.submit(grow_worker),
+                ex.submit(grow_worker),
+                ex.submit(release_worker),
+                ex.submit(release_worker),
+            ]
+            for f in as_completed(futures):
+                f.result()
+
+        st = m.request_states[rid][label]
+        _assert_stream_coherent(st)
+        assert len(set(st.page_indices)) == len(st.page_indices)
+        m.remove_request(rid)
+        assert m.page_allocator.num_free == m.config.max_num_pages
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/modular/test_openai_router.py
+++ b/test/modular/test_openai_router.py
@@ -170,6 +170,36 @@ def test_chat_stream(client_and_stub):
     assert lines[-1]["choices"][0]["finish_reason"] == "stop"
 
 
+def test_videos_stream_ndjson(client_and_stub):
+    client, stub = client_and_stub
+    stub.model_name = "cosmos3"
+    stub.next_chunks = [_Chunk("video", b"mp4-w0"), _Chunk("video", b"mp4-w1")]
+    r = client.post(
+        "/v1/videos/generations",
+        json={
+            "model": "cosmos3", "prompt": "a road", "num_frames": 57,
+            "window_mode": "chained", "stream_video": True,
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/x-ndjson")
+    assert stub.last_submit["streaming"] is True
+    assert stub.last_submit["model_kwargs"]["stream_video"] is True
+    lines = [json.loads(l) for l in r.text.splitlines() if l.strip()]
+    assert [ln["modality"] for ln in lines] == ["video", "video", "done"]
+    assert [base64.b64decode(ln["data"]) for ln in lines[:2]] == [b"mp4-w0", b"mp4-w1"]
+    assert lines[2]["metadata"]["chunks"] == 2
+
+    # Without the flag the endpoint returns the grouped JSON body as before.
+    stub.next_chunks = [_Chunk("video", b"mp4-full")]
+    body = client.post(
+        "/v1/videos/generations",
+        json={"model": "cosmos3", "prompt": "a road", "num_frames": 57},
+    ).json()
+    assert stub.last_submit["streaming"] is False
+    assert base64.b64decode(body["data"][0]["b64_json"]) == b"mp4-full"
+
+
 def test_unsupported_model_404(client_and_stub):
     client, stub = client_and_stub
     stub.model_name = "pi05"

--- a/test/modular/test_windowing.py
+++ b/test/modular/test_windowing.py
@@ -1,0 +1,140 @@
+"""Tests for ``mstar.engine.windowing``: window arithmetic and the KV
+lifecycle session.
+
+The schedule invariant that everything downstream leans on: commit spans
+partition ``[0, total_units)`` exactly — every unit is generated once, no
+gaps, no double-commits — for any (total, window, overlap) combination,
+including a short final window.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+
+sys.path.insert(0, ".")
+
+import pytest
+
+from mstar.engine.windowing import WindowedKVSession, WindowSchedule
+
+
+class TestWindowSchedule:
+    def test_single_window_when_total_fits(self):
+        s = WindowSchedule(total_units=5, window_units=8)
+        assert s.num_windows == 1
+        w = s.window(0)
+        assert (w.start, w.end, w.cond_units) == (0, 5, 0)
+        assert (w.commit_start, w.commit_end) == (0, 5)
+
+    def test_exact_tiling_no_overlap(self):
+        s = WindowSchedule(total_units=48, window_units=8)
+        assert s.num_windows == 6
+        assert [w.start for w in s.windows()] == [0, 8, 16, 24, 32, 40]
+        assert all(w.units == 8 for w in s.windows())
+
+    def test_overlap_and_short_final_window(self):
+        s = WindowSchedule(total_units=48, window_units=8, overlap_units=1)
+        assert s.stride == 7
+        assert s.num_windows == 7
+        last = s.window(6)
+        assert (last.start, last.end, last.cond_units) == (42, 48, 1)
+        assert last.units == 6
+
+    def test_commit_spans_partition_total(self):
+        rng = random.Random(1)
+        for _ in range(200):
+            window = rng.randrange(1, 12)
+            overlap = rng.randrange(0, window)
+            total = rng.randrange(1, 80)
+            s = WindowSchedule(total, window, overlap_units=overlap)
+            covered = 0
+            for w in s.windows():
+                assert w.commit_start == covered, (total, window, overlap)
+                assert w.commit_end > w.commit_start
+                covered = w.commit_end
+            assert covered == total, (total, window, overlap)
+
+    def test_released_end_tracks_context_bound(self):
+        s = WindowSchedule(48, 8, context_units=16)
+        ends = [s.released_end(k) for k in range(s.num_windows)]
+        assert ends == [0, 0, 8, 16, 24, 32]
+        # Retained span after each commit never exceeds the context bound.
+        for k, w in enumerate(s.windows()):
+            assert w.commit_end - ends[k] <= 16
+
+    def test_unbounded_context_never_releases(self):
+        s = WindowSchedule(48, 8, context_units=0)
+        assert all(s.released_end(k) == 0 for k in range(s.num_windows))
+
+    def test_validation(self):
+        with pytest.raises(ValueError):
+            WindowSchedule(0, 8)
+        with pytest.raises(ValueError):
+            WindowSchedule(8, 0)
+        with pytest.raises(ValueError):
+            WindowSchedule(8, 4, overlap_units=4)
+        with pytest.raises(ValueError):
+            WindowSchedule(8, 4, context_units=-1)
+        with pytest.raises(IndexError):
+            WindowSchedule(8, 4).window(2)
+
+
+class _StubHandle:
+    """Cache-handle stub that page-floors releases like the real allocator."""
+
+    def __init__(self, page_size: int):
+        self.page_size = page_size
+        self.protected = {}
+        self.freed_total = 0
+
+    def protect_prefix(self, request_id, num_tokens, label=None):
+        self.protected[(request_id, label)] = num_tokens
+
+    def release_oldest(self, request_id, num_tokens, label=None):
+        freed = (num_tokens // self.page_size) * self.page_size
+        self.freed_total += freed
+        return freed
+
+
+class TestWindowedKVSession:
+    def test_release_targets_with_page_floor_shortfall(self):
+        # 60 tokens/unit against 128-token pages: per-window release asks are
+        # never page-aligned, so the session must re-offer the shortfall.
+        s = WindowSchedule(48, 8, context_units=16)
+        h = _StubHandle(page_size=128)
+        sess = WindowedKVSession(h, "r", "main", s, tokens_per_unit=60)
+
+        sess.protect_prefix(300)
+        assert h.protected[("r", "main")] == 300
+
+        for k in range(s.num_windows):
+            sess.after_commit(k)
+            target = s.released_end(k) * 60
+            # Realized release tracks the nominal target within one page.
+            assert 0 <= target - sess.released_tokens < 128
+
+        assert sess.released_tokens == h.freed_total
+
+    def test_no_release_before_context_fills(self):
+        s = WindowSchedule(48, 8, context_units=16)
+        h = _StubHandle(page_size=8)
+        sess = WindowedKVSession(h, "r", "main", s, tokens_per_unit=8)
+        assert sess.after_commit(0) == 0
+        assert sess.after_commit(1) == 0
+        assert sess.after_commit(2) > 0
+
+    def test_protect_once(self):
+        s = WindowSchedule(8, 8)
+        sess = WindowedKVSession(_StubHandle(8), "r", "main", s, 8)
+        sess.protect_prefix(16)
+        with pytest.raises(RuntimeError, match="already protected"):
+            sess.protect_prefix(16)
+
+    def test_tokens_per_unit_validation(self):
+        with pytest.raises(ValueError):
+            WindowedKVSession(_StubHandle(8), "r", "main", WindowSchedule(8, 8), 0)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

Adds windowed autoregressive video generation to M*: instead of denoising a whole clip at once, the video is produced window-by-window, and each finished window streams to the decoder while the next one denoises. Two layers:
  
 Engine (model-agnostic):
 - PagedAllocationManager.protect_prefix / release_oldest: free the oldest pages of a live request's KV stream (whole-page front compaction) while a protected prefix (e.g. the text-prompt K/V) survives i.e. the core primitive a sliding-window KV lifecycle needs. A prefix_epoch counter lets caches of prefix-derived views (the dense-attention fast path) detect mid-request context changes, and CPU offload/reload round-trips the new state.
 - mstar/engine/windowing.py: WindowSchedule (pure window arithmetic;  commit spans tile the sequence exactly, schedules pad to whole windows) and WindowedKVSession (drives protect/release against the cache handle so models never hand-roll page bookkeeping).
  
Cosmos3 (first adopter, opt-in):
  - A video_gen_ar walk: the existing denoise loop run window-by-window, emitting each finished window's latents on a streaming edge to a new vae_decoder_ar node in its own partition. The decoder consumes one window per chunk, decodes it behind a re-decoded left context (seam-free with the causal Wan VAE), and assembles the final mp4 so decode of window k overlaps denoising of window k+1.
- Chained conditioning mode (window_mode: "chained"): each window is a full bidirectional denoise conditioned on the previous window's tail via the existing v2v clean-frame machinery, so it works with the released checkpoints and lifts the clip-length ceiling (e.g. 381-frame videos).
- Everything is gated by enable_windowed_video (default off): node set, walks, partitions, and outputs of existing deployments are unchanged, and requests opt in per call (window_frames / overlap_frames via extra_body). New serving config:  configs/cosmos3_nano_ar.yaml.

Cross-window attention through committed K/V with eviction (built on the release primitives above) lands next on this branch.

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->
- Unit tests: test/modular/test_kv_release.py + test_windowing.py (allocator invariants under randomized grow/release sequences, protection rules, offload round-trip, thread-safety; schedule tiling/overlap/padding properties; page-floor release behavior) and windowed wiring + decoder-assembly tests in the cosmos3 suite - the decoder's context-re-decode-and-trim reconstruction is checked against a whole-stream decode oracle.
- Full CPU suite: the failure set is byte-identical to main's baseline after each commit (no new failures; all new tests pass).
- Zero regression on existing serving: fixed-seed outputs on an unchanged config are byte-identical to the recorded baselines (t2i at 320×192 and 832×480, t2v at 320×192), and the windowed-enabled config reproduces the same t2i bytes.
- End-to-end serving (H200): windowed 57-frame (3-window) and 381-frame (16-window) generations: frame counts exact, every output visually inspected (window boundaries seam-free; gradual long-horizon drift is the known limit of conditioning-only chaining and is what the upcoming KV-context mode addresses), server logs clean.
- To be extended as the branch grows: KV-mode parity against a reference implementation, TP/SP configs, 480p/720p tiers, and the second cluster.

## Checklist
- [ ] `ruff check .` passes
- [ ] Added or updated tests / docs where relevant
