### PR TITLE
Perf(qwen3-tts): fuse CodePredictor RoPE and reuse decode masks

### DIFF
--- a/mstar/model/qwen3_tts/components/talker.py
+++ b/mstar/model/qwen3_tts/components/talker.py
@@ -23,6 +23,7 @@ from mstar.engine.cache_manager import BatchedCacheManager
 from mstar.model.components import RMSNorm
 from mstar.model.components.distributed import ParallelAttention, ParallelGatedMLP
 from mstar.model.qwen3_tts.config import Qwen3TTSModelConfig, Qwen3TTSTalkerConfig
+from mstar.utils.attention import apply_rope_pos_ids, decode_attn_nhd
 
 # ---------------------------------------------------------------------------
 # Talker backbone: autoregression across audio frames
@@ -205,34 +206,6 @@ class Qwen3TTSCodePredictorInnerModel(nn.Module):
         ])
 
 
-def _apply_rope(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    position_ids: torch.Tensor,
-    theta: float,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Apply the checkpoint's non-interleaved RoPE to grouped Q/K tensors."""
-    head_dim = q.shape[-1]
-    inv_freq = 1.0 / (
-        theta ** (
-            torch.arange(0, head_dim, 2, device=q.device, dtype=torch.float32)
-            / head_dim
-        )
-    )
-    angles = position_ids.to(torch.float32).unsqueeze(-1) * inv_freq
-    cos = torch.cat([angles.cos(), angles.cos()], dim=-1).unsqueeze(2)
-    sin = torch.cat([angles.sin(), angles.sin()], dim=-1).unsqueeze(2)
-
-    def rotate_half(x: torch.Tensor) -> torch.Tensor:
-        first, second = x.chunk(2, dim=-1)
-        return torch.cat([-second, first], dim=-1)
-
-    return (
-        q * cos.to(q.dtype) + rotate_half(q) * sin.to(q.dtype),
-        k * cos.to(k.dtype) + rotate_half(k) * sin.to(k.dtype),
-    )
-
-
 class Qwen3TTSCodePredictor(nn.Module):
     """Five-layer decoder that predicts codec groups 1 through 15.
 
@@ -282,7 +255,7 @@ class Qwen3TTSCodePredictor(nn.Module):
         kv_cache: torch.Tensor,
         cache_pos: int,
     ) -> torch.Tensor:
-        """Run all CodePredictor layers for one or more adjacent depth tokens.
+        """Run all CodePredictor layers for one depth token.
 
         ``kv_cache`` layout is ``[layers, batch, K/V, groups, kv_heads,
         head_dim]``. Unlike Talker cache, it is frame-local scratch space:
@@ -290,6 +263,10 @@ class Qwen3TTSCodePredictor(nn.Module):
         """
         hidden_states = inputs_embeds
         batch_size, seq_len, _ = hidden_states.shape
+        if seq_len != 1:
+            raise ValueError("CodePredictor decode expects exactly one token")
+        end = cache_pos + seq_len
+        flat_position_ids = position_ids.reshape(-1).to(torch.int32)
 
         for layer_idx, layer in enumerate(self.model.layers):
             residual = hidden_states
@@ -303,25 +280,32 @@ class Qwen3TTSCodePredictor(nn.Module):
             k = k.view(batch_size, seq_len, attn.num_kv_heads, attn.head_dim)
             v = v.view(batch_size, seq_len, attn.num_kv_heads, attn.head_dim)
             q, k = attn._apply_qk_norm(q, k)
-            q, k = _apply_rope(
-                q, k, position_ids, float(attn.rope_theta)
+            # A stride-aware Triton kernel fuses both half rotations. The
+            # previous tensor expression launched multiple elementwise and
+            # concatenation kernels in every one of the 5 layers × 16 groups.
+            q, k = apply_rope_pos_ids(
+                q.reshape(batch_size * seq_len, attn.num_heads, attn.head_dim),
+                k.reshape(
+                    batch_size * seq_len,
+                    attn.num_kv_heads,
+                    attn.head_dim,
+                ),
+                flat_position_ids,
+                float(attn.rope_theta),
             )
+            q = q.view(batch_size, seq_len, attn.num_heads, attn.head_dim)
+            k = k.view(batch_size, seq_len, attn.num_kv_heads, attn.head_dim)
 
             # Append this depth position, then attend over the prefix already
             # generated within the same codec frame.
-            end = cache_pos + seq_len
             kv_cache[layer_idx, :, 0, cache_pos:end].copy_(k)
             kv_cache[layer_idx, :, 1, cache_pos:end].copy_(v)
-            keys = kv_cache[layer_idx, :, 0, :end].transpose(1, 2)
-            values = kv_cache[layer_idx, :, 1, :end].transpose(1, 2)
-            queries = q.transpose(1, 2)
-            attn_output = F.scaled_dot_product_attention(
-                queries,
-                keys,
-                values,
-                is_causal=False,
-                enable_gqa=True,
-            ).transpose(1, 2)
+            attn_output = decode_attn_nhd(
+                q,
+                kv_cache[layer_idx, :, 0],
+                kv_cache[layer_idx, :, 1],
+                end,
+            )
             attn_output = attn_output.reshape(batch_size, seq_len, -1)
             hidden_states = residual + attn.o_proj(attn_output)
 

--- a/mstar/model/qwen3_tts/submodules.py
+++ b/mstar/model/qwen3_tts/submodules.py
@@ -97,6 +97,7 @@ class TalkerSubmodule(ARNodeSubmodule):
         self.cp_config = config.talker.code_predictor
         self.num_codes = config.talker.num_code_groups
         self._suppress_mask: torch.Tensor | None = None
+        self._decode_last_token_indices: torch.Tensor | None = None
         self._cp_kv_cache: torch.Tensor | None = None
 
     def _get_suppress_mask(self) -> torch.Tensor:
@@ -113,25 +114,41 @@ class TalkerSubmodule(ARNodeSubmodule):
             self._suppress_mask = mask
         return self._suppress_mask
 
-    def _get_batch_suppress_mask(
+    def _get_batch_suppress_eos(
         self, inputs: list[ARNodeInputs]
     ) -> torch.Tensor:
-        """Apply input-carried minimum-length EOS suppression to the base mask.
+        """Pack the input-carried minimum-length EOS flags for this batch.
 
         CUDA Graph replay calls ``preprocess`` with capture-slot dummy request
         ids, so looking up request state here would permanently observe a new
         request at frame zero. ``prepare_inputs`` runs with the real request and
         carries the dynamic flag as a tensor instead.
         """
-        mask = self._get_suppress_mask().unsqueeze(0).expand(
-            len(inputs), -1
-        ).clone()
+        flags = [item.tensor_inputs["suppress_eos"] for item in inputs]
+        packed = flags[0] if len(flags) == 1 else torch.cat(flags)
+        return packed.to(device=self.get_device(), dtype=torch.bool)
+
+    def _get_decode_last_token_indices(self, batch_size: int) -> torch.Tensor:
+        """Return cached packed-sequence indices for one-token decode rows."""
+        if self._decode_last_token_indices is None:
+            self._decode_last_token_indices = torch.arange(
+                self.MAX_BATCH_SIZE,
+                dtype=torch.long,
+                device=self.get_device(),
+            )
+        return self._decode_last_token_indices[:batch_size]
+
+    def _mask_invalid_logits(
+        self, logits: torch.Tensor, suppress_eos: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply the static codec mask and the per-request EOS decision."""
+        logits = logits.masked_fill(
+            self._get_suppress_mask().unsqueeze(0), float("-inf")
+        )
         eos = self.talker_config.codec_eos_token_id
-        if 0 <= eos < mask.shape[1]:
-            mask[:, eos] = torch.cat([
-                item.tensor_inputs["suppress_eos"] for item in inputs
-            ]).to(device=mask.device, dtype=torch.bool)
-        return mask
+        if 0 <= eos < logits.shape[1]:
+            logits[:, eos].masked_fill_(suppress_eos, float("-inf"))
+        return logits
 
     def _get_cp_kv_cache(self, batch_size: int) -> torch.Tensor:
         """Return the fixed CodePredictor scratch cache for this micro-batch.
@@ -348,21 +365,37 @@ class TalkerSubmodule(ARNodeSubmodule):
         request back to the hidden state used for codec-group-0 prediction.
         FlashInfer receives separate sequence lengths and KV page tables.
         """
-        del graph_walk
         cache_manager = engine_inputs.cache_manager
         assert cache_manager is not None
         cache_manager.set_active_label("main")
         seq_lens = [item.input_seq_len for item in inputs]
         cache_manager.plan_attention(seq_lens=seq_lens, is_causal=True, label="main")
         cache_manager.plan_rope(seq_lens=seq_lens, pos_ids=None, label="main")
-        return {
-            "input_embeds": torch.cat([
-                item.input_embeds for item in inputs if item.input_embeds is not None
-            ], dim=0),
-            "last_token_indices": (
+        input_embeds = [
+            item.input_embeds for item in inputs if item.input_embeds is not None
+        ]
+        if graph_walk == "talker_decode":
+            if any(seq_len != 1 for seq_len in seq_lens):
+                raise ValueError("Qwen3-TTS decode expects one token per request")
+            packed_embeds = (
+                input_embeds[0]
+                if len(input_embeds) == 1
+                else torch.cat(input_embeds, dim=0)
+            )
+            last_token_indices = self._get_decode_last_token_indices(len(inputs))
+        else:
+            packed_embeds = torch.cat(input_embeds, dim=0)
+            last_token_indices = (
                 torch.tensor(seq_lens, device=self.get_device()).cumsum(0) - 1
-            ),
-            "suppress_mask": self._get_batch_suppress_mask(inputs),
+            )
+
+        # Materialize the persistent base mask before CUDA Graph capture. Only
+        # the per-request EOS flags need to cross the replay input boundary.
+        self._get_suppress_mask()
+        return {
+            "input_embeds": packed_embeds,
+            "last_token_indices": last_token_indices,
+            "suppress_eos": self._get_batch_suppress_eos(inputs),
         }
 
     def _run_frame(
@@ -370,7 +403,7 @@ class TalkerSubmodule(ARNodeSubmodule):
         engine_inputs: ModelInputsFromEngine,
         input_embeds: torch.Tensor,
         last_token_indices: torch.Tensor,
-        suppress_mask: torch.Tensor,
+        suppress_eos: torch.Tensor,
     ) -> dict[str, torch.Tensor]:
         """Produce one complete codec frame for every request in the batch.
 
@@ -383,7 +416,7 @@ class TalkerSubmodule(ARNodeSubmodule):
         hidden = self.model(input_embeds, engine_inputs.cache_manager)
         last_hidden = hidden.index_select(0, last_token_indices)
         logits = self.model.codec_head(last_hidden)
-        logits = logits.masked_fill(suppress_mask, float("-inf"))
+        logits = self._mask_invalid_logits(logits, suppress_eos)
         sampler = engine_inputs.sampler
         assert sampler is not None
         request_ids = engine_inputs.request_ids
@@ -432,7 +465,7 @@ class TalkerSubmodule(ARNodeSubmodule):
         codec_embed_sum = codec_embed.clone()
 
         cp_cache = self._get_cp_kv_cache(batch_size)
-        pos = torch.zeros(batch_size, 1, dtype=torch.long, device=device)
+        pos = torch.zeros(batch_size, 1, dtype=torch.int32, device=device)
         # Position 0 conditions the depth decoder on the Talker hidden state.
         # Each following position consumes the previous group's embedding.
         self.code_predictor.forward_depth_unrolled(
@@ -508,12 +541,12 @@ class TalkerSubmodule(ARNodeSubmodule):
         engine_inputs: ModelInputsFromEngine,
         input_embeds: torch.Tensor,
         last_token_indices: torch.Tensor,
-        suppress_mask: torch.Tensor,
+        suppress_eos: torch.Tensor,
         **kwargs: Any,
     ) -> NameToTensorList:
         del graph_walk, kwargs
         output = self._run_frame(
-            engine_inputs, input_embeds, last_token_indices, suppress_mask
+            engine_inputs, input_embeds, last_token_indices, suppress_eos
         )
         return {name: [tensor] for name, tensor in output.items()}
 
@@ -523,12 +556,12 @@ class TalkerSubmodule(ARNodeSubmodule):
         engine_inputs: ModelInputsFromEngine,
         input_embeds: torch.Tensor,
         last_token_indices: torch.Tensor,
-        suppress_mask: torch.Tensor,
+        suppress_eos: torch.Tensor,
         **kwargs: Any,
     ) -> dict[str, NameToTensorList]:
         del graph_walk, kwargs
         output = self._run_frame(
-            engine_inputs, input_embeds, last_token_indices, suppress_mask
+            engine_inputs, input_embeds, last_token_indices, suppress_eos
         )
         return {
             request_id: {

--- a/test/integration/test_qwen3_tts_real_weights.py
+++ b/test/integration/test_qwen3_tts_real_weights.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 
 from mstar.model.qwen3_tts.qwen3_tts_model import Qwen3TTSModel
+from mstar.utils.attention import apply_rope_pos_ids, decode_attn_nhd
 
 HF_REPO = "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"
 
@@ -83,6 +84,74 @@ def test_real_checkpoint_loads_all_components(model, talker, codec):
     assert sum(p.numel() for p in codec.decoder.parameters()) == 114_323_137
     assert next(talker.model.parameters()).dtype == torch.bfloat16
     assert next(codec.decoder.parameters()).dtype == torch.float32
+
+
+def test_fused_code_predictor_rope_matches_checkpoint_formula():
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+    head_dim = 128
+    rope_theta = 1_000_000.0
+    position_ids = torch.tensor([7], dtype=torch.int32, device=device)
+    q = torch.randn(1, 16, head_dim, dtype=dtype, device=device)
+    k = torch.randn(1, 8, head_dim, dtype=dtype, device=device)
+
+    inv_freq = 1.0 / (
+        rope_theta ** (
+            torch.arange(
+                0, head_dim, 2, dtype=torch.float32, device=device
+            ) / head_dim
+        )
+    )
+    angles = position_ids.to(torch.float32).unsqueeze(1) * inv_freq
+    cos = torch.cat([angles.cos(), angles.cos()], dim=-1).to(dtype).unsqueeze(1)
+    sin = torch.cat([angles.sin(), angles.sin()], dim=-1).to(dtype).unsqueeze(1)
+
+    def reference(tensor: torch.Tensor) -> torch.Tensor:
+        first, second = tensor.chunk(2, dim=-1)
+        return tensor * cos + torch.cat([-second, first], dim=-1) * sin
+
+    expected_q = reference(q)
+    expected_k = reference(k)
+    actual_q, actual_k = apply_rope_pos_ids(
+        q.clone(), k.clone(), position_ids, rope_theta
+    )
+
+    torch.testing.assert_close(actual_q, expected_q, rtol=1e-2, atol=2e-2)
+    torch.testing.assert_close(actual_k, expected_k, rtol=1e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("cache_len", [1, 8, 16])
+def test_code_predictor_decode_attention_matches_sdpa(cache_len: int):
+    generator = torch.Generator(device="cuda:0").manual_seed(1234 + cache_len)
+    q = torch.randn(
+        2, 1, 16, 128,
+        dtype=torch.bfloat16,
+        device="cuda:0",
+        generator=generator,
+    )
+    k_cache = torch.randn(
+        2, 16, 8, 128,
+        dtype=torch.bfloat16,
+        device="cuda:0",
+        generator=generator,
+    )
+    v_cache = torch.randn(
+        2, 16, 8, 128,
+        dtype=torch.bfloat16,
+        device="cuda:0",
+        generator=generator,
+    )
+
+    expected = torch.nn.functional.scaled_dot_product_attention(
+        q.transpose(1, 2),
+        k_cache[:, :cache_len].transpose(1, 2),
+        v_cache[:, :cache_len].transpose(1, 2),
+        is_causal=False,
+        enable_gqa=True,
+    ).transpose(1, 2)
+    actual = decode_attn_nhd(q, k_cache, v_cache, cache_len)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=2e-2)
 
 
 def test_real_tokenizer_and_prefill_build_expected_hidden_width(model, talker):

--- a/test/modular/test_qwen3_tts_model.py
+++ b/test/modular/test_qwen3_tts_model.py
@@ -416,11 +416,11 @@ def test_qwen3_tts_postprocess_encodes_pcm16():
 def _tiny_model_config() -> Qwen3TTSModelConfig:
     code_predictor = Qwen3TTSCodePredictorConfig(
         num_hidden_layers=1,
-        num_attention_heads=2,
+        num_attention_heads=1,
         num_key_value_heads=1,
         hidden_size=16,
         intermediate_size=32,
-        head_dim=8,
+        head_dim=16,
         vocab_size=32,
         num_code_groups=4,
     )
@@ -590,12 +590,15 @@ def test_qwen3_tts_suppresses_eos_for_official_minimum_frames():
             "suppress_eos": torch.tensor([False]),
         }),
     ]
-    mask = submodule._get_batch_suppress_mask(inputs)
+    suppress_eos = submodule._get_batch_suppress_eos(inputs)
     eos = config.talker.codec_eos_token_id
+    logits = submodule._mask_invalid_logits(
+        torch.zeros(2, config.talker.vocab_size), suppress_eos
+    )
 
-    assert mask.shape == (2, config.talker.vocab_size)
-    assert mask[0, eos].item() is True
-    assert mask[1, eos].item() is False
+    assert suppress_eos.tolist() == [True, False]
+    assert torch.isneginf(logits[0, eos])
+    assert logits[1, eos].item() == 0.0
 
 
 def test_qwen3_tts_eos_suppression_ignores_graph_dummy_request_ids():
@@ -635,7 +638,11 @@ def test_qwen3_tts_eos_suppression_ignores_graph_dummy_request_ids():
 
     eos = config.talker.codec_eos_token_id
     assert prepared.tensor_inputs["suppress_eos"].item() is False
-    assert packed["suppress_mask"][0, eos].item() is False
+    assert packed["suppress_eos"].item() is False
+    logits = submodule._mask_invalid_logits(
+        torch.zeros(1, config.talker.vocab_size), packed["suppress_eos"]
+    )
+    assert logits[0, eos].item() == 0.0
     assert "__graph_dummy__" not in submodule.request_states
 
 
@@ -685,6 +692,7 @@ def test_qwen3_tts_talker_batches_and_captures_decode():
     )
     assert packed["input_embeds"].shape == (2, 16)
     assert packed["last_token_indices"].tolist() == [0, 1]
+    assert packed["suppress_eos"].tolist() == [True, True]
     graph_config = submodule.get_cuda_graph_configs(torch.device("cpu"))[0]
     assert graph_config.capture_graph_walk == "talker_decode"
     assert graph_config.capture_batch_sizes == [1, 2, 4, 8, 16, 32]
@@ -699,28 +707,43 @@ def test_qwen3_tts_talker_batches_and_captures_decode():
     assert submodule.can_use_cuda_graphs(batch, model_inputs)
 
 
-def test_qwen3_tts_code_predictor_uses_native_gqa(monkeypatch):
+def test_qwen3_tts_code_predictor_uses_decode_attn_nhd(monkeypatch):
     config = _tiny_model_config()
     predictor = Qwen3TTSCodePredictor(config)
-    # This CPU-only contract test targets the SDPA call. FlashInfer RMSNorm is
-    # CUDA-only, so replace normalization without changing attention geometry.
+    # This CPU-only contract test targets the decode-attention call. FlashInfer
+    # RMSNorm and the Triton attention kernel are CUDA-only, so replace them
+    # without changing attention geometry.
     for layer in predictor.model.layers:
         layer.input_layernorm = torch.nn.Identity()
         layer.post_attention_layernorm = torch.nn.Identity()
         layer.self_attn.q_norm = torch.nn.Identity()
         layer.self_attn.k_norm = torch.nn.Identity()
     predictor.model.norm = torch.nn.Identity()
-    original_sdpa = torch.nn.functional.scaled_dot_product_attention
-    calls = []
+    rope_calls = []
 
-    def capture_sdpa(query, key, value, **kwargs):
-        calls.append((query.shape, key.shape, value.shape, kwargs))
-        return original_sdpa(query, key, value, **kwargs)
+    def capture_rope(q, k, position_ids, rope_theta):
+        rope_calls.append((q.shape, k.shape, position_ids.dtype, rope_theta))
+        return q, k
 
     monkeypatch.setattr(
-        torch.nn.functional,
-        "scaled_dot_product_attention",
-        capture_sdpa,
+        "mstar.model.qwen3_tts.components.talker.apply_rope_pos_ids",
+        capture_rope,
+    )
+    calls = []
+
+    def capture_decode_attn(q, k_cache, v_cache, cache_len):
+        calls.append((q.shape, k_cache.shape, v_cache.shape, cache_len))
+        return torch.nn.functional.scaled_dot_product_attention(
+            q.transpose(1, 2),
+            k_cache[:, :cache_len].transpose(1, 2),
+            v_cache[:, :cache_len].transpose(1, 2),
+            is_causal=False,
+            enable_gqa=True,
+        ).transpose(1, 2)
+
+    monkeypatch.setattr(
+        "mstar.model.qwen3_tts.components.talker.decode_attn_nhd",
+        capture_decode_attn,
     )
     output = predictor.forward_depth_unrolled(
         inputs_embeds=torch.randn(1, 1, config.talker.hidden_size),
@@ -736,12 +759,16 @@ def test_qwen3_tts_code_predictor_uses_native_gqa(monkeypatch):
         cache_pos=0,
     )
 
-    query_shape, key_shape, value_shape, kwargs = calls[0]
+    query_shape, key_shape, value_shape, cache_len = calls[0]
     assert output.shape == (1, 1, config.talker.hidden_size)
-    assert query_shape[1] == config.talker.code_predictor.num_attention_heads
-    assert key_shape[1] == config.talker.code_predictor.num_key_value_heads
-    assert value_shape[1] == config.talker.code_predictor.num_key_value_heads
-    assert kwargs["enable_gqa"] is True
+    assert query_shape[2] == config.talker.code_predictor.num_attention_heads
+    assert key_shape[2] == config.talker.code_predictor.num_key_value_heads
+    assert value_shape[2] == config.talker.code_predictor.num_key_value_heads
+    assert key_shape[1] == config.talker.num_code_groups
+    assert cache_len == 1
+    assert len(calls) == config.talker.code_predictor.num_hidden_layers
+    assert len(rope_calls) == config.talker.code_predictor.num_hidden_layers
+    assert rope_calls[0][2] == torch.int32
 
 
 @pytest.mark.skipif(

--- a/test/qwen3-tts/benchmark_qwen3_tts.py
+++ b/test/qwen3-tts/benchmark_qwen3_tts.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Deterministic fixed-frame benchmark for the Qwen3-TTS HTTP endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import concurrent.futures
+import json
+import math
+import statistics
+import time
+from typing import Any
+
+import requests
+
+SAMPLE_RATE = 24_000
+SAMPLE_WIDTH = 2
+DEFAULT_TEXT = (
+    "Profiling Qwen three TTS performance with a fixed codec frame workload."
+)
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    index = max(0, math.ceil(percentile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def _request(
+    url: str,
+    payload: dict[str, str],
+    timeout: float,
+) -> tuple[float, int]:
+    start = time.perf_counter()
+    audio_bytes = 0
+    with requests.post(
+        url,
+        data=payload,
+        stream=True,
+        timeout=timeout,
+    ) as response:
+        response.raise_for_status()
+        for line in response.iter_lines():
+            if not line:
+                continue
+            message = json.loads(line)
+            if message.get("modality") != "audio":
+                continue
+            encoded = message.get("data", "")
+            if encoded:
+                audio_bytes += len(base64.b64decode(encoded))
+    return time.perf_counter() - start, audio_bytes
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    model_kwargs = {
+        "voice": args.voice,
+        "language": args.language,
+        "seed": args.seed,
+        "ignore_eos": True,
+        "max_output_tokens": args.frames,
+    }
+    payload = {
+        "text": args.text,
+        "output_modalities": "audio",
+        "model_kwargs": json.dumps(model_kwargs),
+    }
+
+    for _ in range(args.warmup):
+        _request(args.url, payload, args.timeout)
+
+    trial_measurements = []
+    trial_wall_times = []
+    for _ in range(args.trials):
+        start = time.perf_counter()
+        if args.concurrency == 1:
+            measurements = [
+                _request(args.url, payload, args.timeout)
+                for _ in range(args.requests)
+            ]
+        else:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=args.concurrency
+            ) as pool:
+                futures = [
+                    pool.submit(_request, args.url, payload, args.timeout)
+                    for _ in range(args.requests)
+                ]
+                measurements = [future.result() for future in futures]
+        trial_wall_times.append(time.perf_counter() - start)
+        trial_measurements.append(measurements)
+
+    measurements = [
+        measurement
+        for trial in trial_measurements
+        for measurement in trial
+    ]
+    latencies = [latency for latency, _ in measurements]
+    byte_counts = [size for _, size in measurements]
+    if not byte_counts or min(byte_counts) <= 0:
+        raise RuntimeError("Qwen3-TTS benchmark received an empty audio response")
+    actual_audio_durations = [
+        size / (SAMPLE_RATE * SAMPLE_WIDTH) for size in byte_counts
+    ]
+    # The 12 Hz decoder emits 1,920 samples (80 ms) per valid codec frame.
+    # ``ignore_eos`` fixes Talker compute, but Codec intentionally filters any
+    # EOS values sampled inside that fixed sequence, so actual PCM length can
+    # be a few frames shorter. Use nominal duration for comparable compute RTF
+    # and report the observed output range separately.
+    nominal_audio_duration = args.frames * 1_920 / SAMPLE_RATE
+    trial_throughputs = [
+        args.requests / wall_time for wall_time in trial_wall_times
+    ]
+    total_requests = args.requests * args.trials
+    total_wall_time = sum(trial_wall_times)
+    return {
+        "label": args.label,
+        "frames": args.frames,
+        "requests_per_trial": args.requests,
+        "total_requests": total_requests,
+        "trials": args.trials,
+        "warmup": args.warmup,
+        "concurrency": args.concurrency,
+        "audio_bytes_min": min(byte_counts),
+        "audio_bytes_max": max(byte_counts),
+        "audio_duration_mean_s": statistics.mean(actual_audio_durations),
+        "nominal_audio_duration_s": nominal_audio_duration,
+        "wall_time_total_s": total_wall_time,
+        "throughput_requests_per_s": total_requests / total_wall_time,
+        "throughput_trial_median_requests_per_s": statistics.median(
+            trial_throughputs
+        ),
+        "throughput_trial_min_requests_per_s": min(trial_throughputs),
+        "throughput_trial_max_requests_per_s": max(trial_throughputs),
+        "latency_mean_ms": statistics.mean(latencies) * 1000,
+        "latency_median_ms": statistics.median(latencies) * 1000,
+        "latency_p95_ms": _percentile(latencies, 0.95) * 1000,
+        "latency_min_ms": min(latencies) * 1000,
+        "latency_max_ms": max(latencies) * 1000,
+        "rtf_nominal_mean": statistics.mean(latencies) / nominal_audio_duration,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default="http://127.0.0.1:8000/generate")
+    parser.add_argument("--label", default="qwen3_tts")
+    parser.add_argument("--frames", type=int, default=64)
+    parser.add_argument("--requests", type=int, default=10)
+    parser.add_argument("--trials", type=int, default=1)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--voice", default="Vivian")
+    parser.add_argument("--language", default="English")
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    args = parser.parse_args()
+    if args.frames <= 0 or args.requests <= 0 or args.trials <= 0:
+        parser.error("frames, requests, and trials must be positive")
+    if args.warmup < 0:
+        parser.error("warmup cannot be negative")
+    if not 1 <= args.concurrency <= args.requests:
+        parser.error("concurrency must be between 1 and requests")
+    print(json.dumps(run(args), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What does this PR do?

Optimizes the Qwen3-TTS autoregressive generation path.

- Replaces the repeated PyTorch RoPE operations in CodePredictor with the fused Triton `apply_rope_pos_ids` kernel.
- Reuses the static invalid-token mask during decode and passes only the per-request `suppress_eos` flag into the CUDA Graph.
- Adds correctness coverage and a deterministic fixed-frame benchmark.

On an NVIDIA H20, CodePredictor CUDA Graph latency decreased by 35.8-36.9%, end-to-end latency decreased by 4.1-4.4%, and worker GPU memory decreased by about 1.5%. 

## How was it tested?

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q test/modular/test_qwen3_tts_model.py` (`35 passed`)
- `CUDA_VISIBLE_DEVICES=0 HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 .venv/bin/pytest -q test/integration/test_qwen3_tts_real_weights.py` (`5 passed`)
- End-to-end fixed-frame benchmarks for 32, 64, and 128 frames, plus concurrency 2, 4, and 8 and natural-EOS validation.

### Performance results

Measured with `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice` on one NVIDIA H20:

| Metric | Baseline | Optimized | Change |
|---|---:|---:|---:|
| CodePredictor CUDA Graph, BS=1 | 10.077 ms | 6.359 ms | -36.9% |
| End-to-end latency, 32 frames | 333.1 ms | 318.6 ms | -4.3% |
| End-to-end latency, 64 frames | 587.4 ms | 561.7 ms | -4.4% |
| End-to-end latency, 128 frames | 1,146.4 ms | 1,099.7 ms | -4.1% |

The CodePredictor improvement was 35.8-36.9% across BS=1/2/4/8. At concurrency 2, throughput improved by 2.9%; concurrency 4 and 8 were saturated and showed no statistically clear gain or regression. Three natural-EOS requests produced non-empty audio and stopped before `talker_max_tokens`.

## Checklist

- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
