### PR TITLE
test: update stale orpheus modular test to the decode_finished contract

### DIFF
--- a/test/modular/test_orpheus_model.py
+++ b/test/modular/test_orpheus_model.py
@@ -14,10 +14,6 @@ def _make_model() -> OrpheusModel:
     return model
 
 
-def _audio_token_for_pos(pos: int, code: int = 1) -> int:
-    return 10 + (pos * 4096) + code
-
-
 def test_orpheus_prefill_transitions_to_decode():
     model = _make_model()
     metadata = CurrentForwardConductorMetadata(
@@ -35,8 +31,8 @@ def test_orpheus_prefill_transitions_to_decode():
 
     assert result.full_metadata.graph_walk == "decode"
     assert result.step_metadata["is_prefill"] is False
-    assert result.full_metadata.kwargs["audio_token_count"] == 0
-    assert result.full_metadata.kwargs["decode_finished"] is False
+    assert result.request_done is False
+    assert "decode_finished" not in result.full_metadata.kwargs
 
 
 def test_orpheus_decode_eos_marks_done():
@@ -47,7 +43,6 @@ def test_orpheus_decode_eos_marks_done():
         graph_walk="decode",
         is_prefill=False,
         kwargs={
-            "audio_token_count": 0,
             "decode_finished": False,
         },
     )


### PR DESCRIPTION
The prefill transition test fails on clean main with `KeyError: 'audio_token_count'` (test/modular/test_orpheus_model.py:38)

Looks like the test predates the dynamic loop stop, the model doesnt seed `audio_token_count`/`decode_finished` kwargs at the prefill->decode transition anymore.. `decode_finished` only gets set when the loop exits (orpheus_model.py:240). So I updated the assertions to the current contract (transition leaves kwargs untouched, request not done) and dropped the dead `audio_token_count` input plus an unused helper.

Before: 1 failed 1 passed -> after: 2 passed with `pytest test/modular/test_orpheus_model.py`

Part of the bigger suite drift in #132 , just fixing the file the adding models doc points you at first
