### PR TITLE
local reduce before all-reduce in tp moe blocks

### DIFF
--- a/mstar/model/components/moe.py
+++ b/mstar/model/components/moe.py
@@ -476,9 +476,9 @@ class ParallelSparseMoeBlock(nn.Module):
             flat, self.experts.gate_up_proj, self.experts.down_proj,
             routing_weights, selected_experts, reduce_results=False,
         )
-        self.comm_group.all_reduce(cache3)
         output = torch.empty_like(flat)
         moe_sum_reduce_triton(cache3, output, routed_scaling_factor=1.0)
+        self.comm_group.all_reduce(output)
         return output
 
 
@@ -585,7 +585,7 @@ class ParallelSparseMoeBlockWithSharedExpert(nn.Module):
             flat, self.experts.gate_up_proj, self.experts.down_proj,
             routing_weights, selected_experts, reduce_results=False,
         )
-        self.comm_group.all_reduce(cache3)
         output = torch.empty_like(flat)
         moe_sum_reduce_triton(cache3, output, routed_scaling_factor=1.0)
+        self.comm_group.all_reduce(output)
         return output


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

Swaps order of local reduce and all-reduce in TP MoE blocks. We now perform local reduction before all-reduction. Reduces traffic on all-reduce by a factor of ~`top_k`. 

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->

## How was it tested?

Ran `./test/qwen3_omni/*request.py` with `qwen3omni_full_tp2.yaml` to ensure no catastrophic failure in output quality. Did not benchmark. I assume it will be a little bit faster, but not by much. 

<!-- Commands you ran, or why tests aren't applicable. -->

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
