### PR TITLE
micro_scheduler: targeted get_next_batch calls must not pop the TP-follow FIFO

### DIFF
--- a/mstar/worker/micro_scheduler.py
+++ b/mstar/worker/micro_scheduler.py
@@ -145,15 +145,19 @@ class MicroScheduler:
     ) -> ScheduledBatch | None:
         if len(self.tp_batches_pending_schedule) == 0:
             return
+        # A TP-follow batch is a mandate from the group leader: once its
+        # ScheduleTPNode is popped from the FIFO, nothing on this worker will
+        # ever reschedule it (followers cannot initiate scheduling for
+        # parallel nodes), so whoever pops it must submit it unconditionally.
+        # Targeted calls come from merge paths (the speculation fresh-rid
+        # merge in ``worker._try_speculate_next``) that may reject or
+        # partially consume the batch they are handed — handing them a
+        # mandate would strand the popped message, and the group would hang
+        # at the next collective. Refuse instead: the message stays queued
+        # for the unconditional scheduling path.
+        if target_node_name is not None or target_graph_walk is not None:
+            return
         first_tp_node: ScheduleTPNode = self.tp_batches_pending_schedule[0]
-        # Respect the caller's filters: a targeted call (e.g. the speculation
-        # path asking for one specific node/walk) must not be handed a TP
-        # follower batch for some other node, or the caller will merge those
-        # node objects into a batch labeled with the target's name.
-        if target_node_name is not None and first_tp_node.node_name != target_node_name:
-            return
-        if target_graph_walk is not None and first_tp_node.graph_walk != target_graph_walk:
-            return
         if exclude_target is not None and \
                 (first_tp_node.node_name, first_tp_node.graph_walk) == exclude_target:
             return

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -1515,17 +1515,12 @@ class Worker:
                     # in-flight step and shouldn't be in ready queues —
                     # but if it does, the in-flight rid wins.
                     #
-                    # KNOWN GAP (latent): if fresh_batch ever came from the
-                    # TP-follow path, ``_try_schedule_tp_follow`` has already
-                    # popped the leader's ScheduleTPNode. Pushing the node
-                    # back onto the ready queue does not undo that, and this
-                    # worker is a follower for that node so nothing will
-                    # reschedule it — the TP group stalls. Unreachable today
-                    # (spec targets exclude ``parallel_nodes``, so the
-                    # target_node_name filter never matches a TP batch), but
-                    # any future overlap needs the scheduler to re-queue the
-                    # message, or to defer the popleft until the caller
-                    # commits to the batch.
+                    # fresh_batch can never be a TP-follow batch here: this
+                    # is a targeted get_next_batch call, and the scheduler
+                    # refuses to pop the TP-follow FIFO for targeted callers
+                    # (``_try_schedule_tp_follow``) precisely because this
+                    # merge may reject rids — a popped ScheduleTPNode has no
+                    # re-queue path, and stranding it stalls the TP group.
                     wg_id = fresh_batch.request_to_worker_graph[rid]
                     self.worker_graphs_manager.queues[wg_id].push_back_node(rid, node)
                     continue

--- a/test/modular/test_tp_follow_targeted_gate.py
+++ b/test/modular/test_tp_follow_targeted_gate.py
@@ -1,0 +1,152 @@
+"""The TP-follow FIFO must never be popped by a targeted get_next_batch call.
+
+A ScheduleTPNode is a mandate from the TP group leader: rank 0 has already
+committed to the batch and will sit on the collective inside the forward
+until every follower joins it (see the note in MicroScheduler.get_next_batch).
+Once the message is popped from the FIFO, nothing on a follower worker will
+ever reschedule that batch — followers cannot initiate scheduling for
+parallel nodes — so whoever pops it must submit it unconditionally.
+
+The only targeted caller in-tree is the speculation fresh-rid merge in
+``worker._try_speculate_next``, which is a discretionary consumer: it may
+reject rids from the batch it is handed (the "in-flight rid wins" branch).
+Handing it a TP-follow batch therefore risks stranding a popped
+ScheduleTPNode with no re-queue path, hanging the whole TP group at the next
+collective. The guard under test: targeted calls leave the FIFO untouched;
+untargeted calls still serve it, in order.
+"""
+
+from mstar.graph.base import GraphNode
+from mstar.utils.ipc_format import ScheduleTPNode
+from mstar.worker.micro_scheduler import MicroScheduler
+
+
+class _FakeEngine:
+    def check_ready(self, node_name, rid, fwd_info):
+        return True
+
+
+class _FakeEngineManager:
+    def get_engine(self, node_name):
+        return _FakeEngine()
+
+
+class _FakeRequestGraph:
+    def __init__(self, ready_node_names):
+        self.ready_node_names = set(ready_node_names)
+
+
+class _FakeQueue:
+    """Just enough of RequestQueues for the TP-follow path."""
+
+    def __init__(self, rids, node_name):
+        self.per_request_queues = {
+            rid: _FakeRequestGraph({node_name}) for rid in rids
+        }
+
+    def pop_ready_nodes(self, rid, node_names):
+        wg = self.per_request_queues[rid]
+        popped = [
+            GraphNode(name=name, input_names=set(), outputs=[])
+            for name in node_names if name in wg.ready_node_names
+        ]
+        wg.ready_node_names -= set(node_names)
+        return popped
+
+    def get_ready_node_names(self):
+        # No locally-initiated work: this worker is a pure TP follower.
+        return {}
+
+
+class _FakeWorkerGraphsManager:
+    def __init__(self, queue):
+        self.queues = {"wg0": queue}
+        self.per_request_info = {}
+
+    def get_partition_for_node(self, node_name):
+        return "p0"
+
+    def get_worker_graph_id_for_node(self, rid, node_name, graph_walk=None):
+        return "wg0"
+
+    def get_fwd_info(self, rid, partition):
+        return None
+
+
+NODE = "LLM"
+WALK = "decode"
+
+
+def _setup(rids=("r0", "r1")):
+    sched = MicroScheduler(
+        engine_manager=_FakeEngineManager(),
+        # Follower role: NODE is parallel here but this rank does not lead it.
+        parallel_leader_nodes=set(),
+    )
+    queue = _FakeQueue(rids, NODE)
+    manager = _FakeWorkerGraphsManager(queue)
+    return sched, manager
+
+
+def _msg(rids=("r0", "r1")):
+    return ScheduleTPNode(node_name=NODE, graph_walk=WALK, request_ids=list(rids))
+
+
+def test_targeted_call_never_pops_tp_follow():
+    sched, manager = _setup()
+    sched.register_tp_follow(_msg())
+
+    # Even an exactly-matching target must be refused: the targeted caller
+    # (the speculation merge) may reject the batch, and a popped message
+    # has no re-queue path.
+    assert sched.get_next_batch(
+        manager, target_node_name=NODE, target_graph_walk=WALK
+    ) is None
+    assert sched.get_next_batch(manager, target_node_name=NODE) is None
+    assert sched.get_next_batch(manager, target_graph_walk=WALK) is None
+    assert len(sched.tp_batches_pending_schedule) == 1
+
+    # The refusals consumed nothing: an untargeted call still builds the
+    # full batch afterwards.
+    batch = sched.get_next_batch(manager)
+    assert batch is not None
+    assert batch.node_name == NODE
+    assert set(batch.node_objects) == {"r0", "r1"}
+
+
+def test_untargeted_call_serves_and_drains():
+    sched, manager = _setup()
+    sched.register_tp_follow(_msg())
+
+    batch = sched.get_next_batch(manager)
+    assert batch is not None
+    assert batch.node_name == NODE
+    assert batch.graph_walk == WALK
+    assert set(batch.node_objects) == {"r0", "r1"}
+    assert len(sched.tp_batches_pending_schedule) == 0
+
+
+def test_exclude_target_skips_head_but_keeps_it_queued():
+    sched, manager = _setup()
+    sched.register_tp_follow(_msg())
+
+    assert sched.get_next_batch(manager, exclude_target=(NODE, WALK)) is None
+    assert len(sched.tp_batches_pending_schedule) == 1
+
+    batch = sched.get_next_batch(manager)
+    assert batch is not None
+    assert set(batch.node_objects) == {"r0", "r1"}
+
+
+def test_fifo_order_survives_refused_targeted_calls():
+    sched, manager = _setup(rids=("r0", "r1", "r2", "r3"))
+    sched.register_tp_follow(_msg(("r0", "r1")))
+    sched.register_tp_follow(_msg(("r2", "r3")))
+
+    assert sched.get_next_batch(manager, target_node_name=NODE) is None
+
+    first = sched.get_next_batch(manager)
+    assert set(first.node_objects) == {"r0", "r1"}
+    second = sched.get_next_batch(manager)
+    assert set(second.node_objects) == {"r2", "r3"}
+    assert len(sched.tp_batches_pending_schedule) == 0

--- a/test/modular/test_tp_follow_targeted_gate.py
+++ b/test/modular/test_tp_follow_targeted_gate.py
@@ -16,9 +16,14 @@ collective. The guard under test: targeted calls leave the FIFO untouched;
 untargeted calls still serve it, in order.
 """
 
-from mstar.graph.base import GraphNode
-from mstar.utils.ipc_format import ScheduleTPNode
-from mstar.worker.micro_scheduler import MicroScheduler
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mstar.graph.base import GraphNode  # noqa: E402
+from mstar.utils.ipc_format import ScheduleTPNode  # noqa: E402
+from mstar.worker.micro_scheduler import MicroScheduler  # noqa: E402
 
 
 class _FakeEngine:


### PR DESCRIPTION
## Problem

`_try_schedule_tp_follow` pops the leader's `ScheduleTPNode` from the FIFO before returning the batch. A TP-follow batch is a mandate: rank 0 has already committed to it and blocks on the collective inside the forward until every follower joins (per the existing note in `get_next_batch`), and a popped message has no re-queue path — followers cannot initiate scheduling for parallel nodes.

The targeted call path (`target_node_name` / `target_graph_walk`, used only by the speculation fresh-rid merge in `_try_speculate_next`) is a discretionary consumer: it may reject rids from the batch it is handed (the "in-flight rid wins" branch). Serving it from the TP FIFO can therefore strand a popped message — the follower never runs the batch, and the TP group hangs at the next collective. This is the `KNOWN GAP (latent)` note in `_try_speculate_next`: unreachable today only because spec targets exclude parallel nodes, reachable the moment speculative scheduling is enabled for lockstep-parallel nodes (the "disable … for now" in `_can_speculate`).

## Change

Refuse the combination at the source: targeted calls never touch the TP-follow FIFO; the message stays queued for the unconditional scheduling path. This replaces the per-target filters, which only made the overlap partially safe. `exclude_target` keeps its filter — its caller (the yield-away path) submits what it receives unconditionally.

No behavior change in any current serving path: with speculation disabled for parallel nodes, no targeted call can be handed a TP-follow batch today. This hardens the invariant ahead of that work.

## Tests

`test/modular/test_tp_follow_targeted_gate.py`:

- targeted calls — including an exactly-matching target — return nothing and leave the FIFO intact
- untargeted calls still serve and drain the FIFO
- `exclude_target` skips the head but keeps it queued
- FIFO order survives refused targeted calls

The two gate tests fail without the fix; the two behavior-preservation tests pass with and without it.
