### PR TITLE
[WIP] Add NVIDIA NemotronLabs VoiceChat-11B (full-duplex S2S)

### DIFF
--- a/configs/nemotron_duplex.yaml
+++ b/configs/nemotron_duplex.yaml
@@ -1,0 +1,22 @@
+# NVIDIA NemotronLabs VoiceChat-11B — single-GPU draft (text path first).
+#
+# Node -> rank map. The audio nodes (conformer_encoder, eartts_talker,
+# audio_codec) are declared for the full duplex layout but are Phase 4/5 stubs;
+# on rank 0 they load in dummy mode until implemented. Once the audio stages
+# land, split them onto their own ranks and add async partitions (see the
+# duplex design note in nemotron_duplex_model.py).
+model: "nemotron_duplex"
+max_seq_len: 12288  # config: voicechat streaming_max_len / vllm_max_model_len
+
+node_groups:
+  - node_names:
+      - nano_llm
+    ranks:
+      - 0
+
+  - node_names:
+      - conformer_encoder
+      - eartts_talker
+      - audio_codec
+    ranks:
+      - 0

--- a/configs/nemotron_duplex.yaml
+++ b/configs/nemotron_duplex.yaml
@@ -1,10 +1,11 @@
-# NVIDIA NemotronLabs VoiceChat-11B — single-GPU draft (text path first).
+# NVIDIA NemotronLabs VoiceChat-11B — single-GPU full-duplex layout.
 #
-# Node -> rank map. The audio nodes (conformer_encoder, eartts_talker,
-# audio_codec) are declared for the full duplex layout but are Phase 4/5 stubs;
-# on rank 0 they load in dummy mode until implemented. Once the audio stages
-# land, split them onto their own ranks and add async partitions (see the
-# duplex design note in nemotron_duplex_model.py).
+# All four stages (conformer_encoder, nano_llm, eartts_talker, audio_codec)
+# run on rank 0: the encoder + LLM decode loop, the talker loop, and the codec
+# all share one worker/GPU thread. This is the simplest working deployment and
+# produces the same text + audio as the disaggregated layout
+# (configs/nemotron_duplex_disagg.yaml), which instead puts each
+# stream-consuming loop on its own GPU thread for pipeline parallelism.
 model: "nemotron_duplex"
 max_seq_len: 12288  # config: voicechat streaming_max_len / vllm_max_model_len
 

--- a/configs/nemotron_duplex_disagg.yaml
+++ b/configs/nemotron_duplex_disagg.yaml
@@ -1,0 +1,30 @@
+# NVIDIA NemotronLabs VoiceChat-11B — disaggregated duplex layout.
+#
+# Each streaming consumer runs on its own GPU (its own worker thread) so the
+# frame-synchronous decode loop and the talker loop don't serialize on one GPU
+# thread (the colocated single-GPU layout deadlocks: two stream-consuming loops
+# on one worker). Encoder + LLM share rank 0 (the encoder runs once up front,
+# then the LLM decode loop consumes its frames — no interleaving between them).
+#
+#   rank 0: conformer_encoder (Encoder) + nano_llm (LLM)
+#   rank 1: eartts_talker     (Talker)
+#   rank 2: audio_codec       (Codec)
+model: "nemotron_duplex"
+max_seq_len: 12288
+
+node_groups:
+  - node_names:
+      - conformer_encoder
+      - nano_llm
+    ranks:
+      - 0
+
+  - node_names:
+      - eartts_talker
+    ranks:
+      - 1
+
+  - node_names:
+      - audio_codec
+    ranks:
+      - 2

--- a/configs/nemotron_duplex_disagg.yaml
+++ b/configs/nemotron_duplex_disagg.yaml
@@ -1,10 +1,12 @@
 # NVIDIA NemotronLabs VoiceChat-11B — disaggregated duplex layout.
 #
-# Each streaming consumer runs on its own GPU (its own worker thread) so the
-# frame-synchronous decode loop and the talker loop don't serialize on one GPU
-# thread (the colocated single-GPU layout deadlocks: two stream-consuming loops
-# on one worker). Encoder + LLM share rank 0 (the encoder runs once up front,
-# then the LLM decode loop consumes its frames — no interleaving between them).
+# Each streaming consumer runs on its own GPU / worker thread so the
+# frame-synchronous decode loop, the talker loop, and the codec run in a
+# pipeline instead of serializing on one GPU thread. The colocated single-GPU
+# layout (configs/nemotron_duplex.yaml) also works and produces identical
+# output; this layout trades GPUs for pipeline parallelism / throughput.
+# Encoder + LLM share rank 0 (the encoder runs once up front, then the LLM
+# decode loop consumes its frames — no interleaving between them).
 #
 #   rank 0: conformer_encoder (Encoder) + nano_llm (LLM)
 #   rank 1: eartts_talker     (Talker)

--- a/mstar/cli/main.py
+++ b/mstar/cli/main.py
@@ -38,6 +38,8 @@ DEFAULT_CONFIGS: dict[str, str] = {
     "whisper_large": "whisper_large.yaml",
     "higgs_audio": "higgs_audio.yaml",
     "wan22": "wan22.yaml",
+    # Half-duplex S2S (Beta) — text path first; audio stages Phase 4/5.
+    "nemotron_duplex": "nemotron_duplex.yaml",
 }
 
 

--- a/mstar/graph/base.py
+++ b/mstar/graph/base.py
@@ -506,6 +506,16 @@ class Loop(GraphSection):
         self.curr_iter += 1
         self.inner_registry.reset_for_iter()
         self._uncache_outputs()
+        # Re-arm pure-streaming inner nodes (no loop-back) so the poll can feed
+        # them the next streamed chunk on this new iteration. Walk up through
+        # any enclosing loops to the worker-graph registry that owns the
+        # ready_for_streaming set.
+        reg = self._managing_registry
+        while isinstance(reg, LoopStateRegistry):
+            reg = reg.loop._managing_registry
+        rearm = getattr(reg, "rearm_streaming", None)
+        if rearm is not None:
+            rearm(set(self.section.get_nodes().keys()))
 
     def ingest_external_input(self, graph_edge: GraphEdge):
         # track one copy of each external input for re-injection on the next iteration
@@ -778,6 +788,20 @@ class WorkerGraphStateRegistry(GraphStateRegistry):
         self.ready_for_streaming, self.ready_streaming_next_iter = (
             self.ready_streaming_next_iter, self.ready_for_streaming
         )
+
+    def rearm_streaming(self, node_names: set[str]):
+        """Re-add a loop's pure-streaming inner nodes to ``ready_for_streaming``.
+
+        Called when a Loop advances an iteration. A node whose inputs are ALL
+        streaming has no loop-back edge, so nothing re-injects into it across
+        iterations and ``register_ingested_input`` already dropped it from
+        ``ready_for_streaming`` when it consumed the previous chunk. Without
+        this the loop stalls after one item (the talker / codec stream-consuming
+        loops). Loop-back nodes are re-armed implicitly by their re-injected
+        inputs, so intersecting with ``only_streaming_inputs`` leaves them
+        untouched.
+        """
+        self.ready_for_streaming |= (node_names & self.only_streaming_inputs)
 
     def clear(self):
         super().clear()

--- a/mstar/model/nemotron_duplex/E5_RESUME.md
+++ b/mstar/model/nemotron_duplex/E5_RESUME.md
@@ -62,12 +62,48 @@ Decision tree from the traces:
   (verify the `StreamingConnectionState` fields `producer_done`/`consumed_count`/
   `token_count` are the right names/semantics).
 
-**Likely fix direction** (if the stream doesn't deliver): reshape the Encoder→LLM
-coupling to a supported pattern — e.g. make the encoder the first node of a
-`prefill_audio` `Sequential` in the LLM partition that emits the whole `audio_frame`
-stream, rather than a standalone producer partition. Compare to
-`mstar/model/qwen3_omni` `get_graph_walk_graphs` / `get_partitions` /
-`get_partition_topology` and its conductor `_get_*_forward` state machines.
+**Confident diagnosis (static, from comparing to qwen3_omni's Thinker→Talker — a
+proven stream-consuming KV-cache decode loop):**
+
+The LLM `decode` loop lacks the **consumer-gating** qwen3's Talker has. Specifics:
+
+1. qwen3's Talker (the consumer of the `thinker_states` stream) does NOT start in its
+   decode loop. It starts in `talker_prefill` (input_names include the streamed
+   `thinker_states`/`thinker_mask` **and** a conductor `talker_trigger`), counts
+   `num_thinker_prefill_steps`, transitions `talker_prefill → talker_last_prefill →
+   talker_decode`. Only then does the decode Loop run. This gating is what
+   synchronizes the consumer with the producer and prevents the loop from starting on
+   an empty stream. **Our LLM `decode` is the *initial* walk with no gating** — on a
+   single worker the decode Loop can start before the Encoder has produced frames, then
+   block on the empty `audio_frame` StreamBuffer, and since it holds the worker's GPU
+   thread the Encoder never runs → deadlock. This matches the observed hang (request
+   accepted, then nothing).
+2. The streamed tensor arrives via the **StreamBuffer**, not via forward-pass-args
+   `inputs`; the conductor only supplies non-streamed / self-fed inputs (qwen3 supplies
+   `talker_trigger` then `talker_input_embeds`). Our `get_partition_forward_pass_args`
+   for the LLM correctly supplies `prev_text`/`prev_func`, but **loop termination should
+   not hinge on `_stream_exhausted`** — qwen3's decode loop ends via its own
+   `check_stop`/`max_iters` (worker-side Loop), and the conductor sets `request_done`
+   only when the Loop returns control (see qwen3 `_get_talker_forward`, `talker_decode`
+   branch: it just returns `request_done=True`).
+
+**Fix plan (apply on a box with a GPU and iterate against the NDTRACE trace):**
+- Add an LLM consumer-gating walk analogous to `talker_prefill`: an `encode_gate` (or
+  reuse `prefill_audio`) `GraphNode(name="nano_llm", input_names=["audio_frame", ...,
+  "llm_trigger"])` that the conductor drives while the Encoder streams, then transition
+  into `decode`. Give the LLM partition `initial_walk` that walk (not `decode`
+  directly), and count encoder frames like qwen3 counts prefill steps.
+- Make `_get_llm_forward` mirror `_get_talker_forward`: gate → transition → in the
+  `decode` branch just return `request_done=True` (let the worker-side Loop's
+  `check_stop` end it). Drop the `_stream_exhausted`-based termination.
+- Alternatively (simpler, less reference-aligned): fold the encoder into a
+  `prefill_audio` `Sequential([conformer_encoder, nano_llm])` in the LLM partition so
+  the encoder runs first within the same partition step, emitting the whole
+  `audio_frame` stream before the decode Loop consumes it.
+
+Reference to copy verbatim: `mstar/model/qwen3_omni/qwen3_omni_model.py`
+`_get_talker_forward` / `_get_code2wav_forward` + the `talker_prefill`/`talker_decode`
+walks + `get_partitions` (`producer_partitions`) + `get_partition_topology`.
 
 Strip the `NDTRACE` lines once E5 is green.
 

--- a/mstar/model/nemotron_duplex/E5_RESUME.md
+++ b/mstar/model/nemotron_duplex/E5_RESUME.md
@@ -1,0 +1,104 @@
+# Nemotron-Duplex — engine integration resume notes (E5)
+
+Migration/handoff doc for continuing on another server (e.g. **ptc**). The branch
+`keisuke/model-support-nemotron-duplex` (PR #215) is the source of truth — everything
+below is committed through `bf3fe346`.
+
+## Status at a glance
+
+| Milestone | State |
+|---|---|
+| E1 batched Mamba (`Mamba2Mixer` + `MambaStateAccessor`) | done, verified 8.5e-4 vs standalone |
+| E1 nano node batching (`can_batch`/`forward_batched`/`seq_lens`) | done |
+| E2 `conformer_encoder.forward`, `audio_codec.forward` | done, bit-exact vs standalone |
+| E3 `eartts_talker.forward` (internal MoG/CFG, per-request state) | done, bit-exact codes |
+| E4 walks + partitions + topology + fusion + function aux | done; `get_worker_graphs` derives all 5; 8 CI tests in `test/modular/test_nemotron_duplex_model.py` |
+| E4 multi-partition forward-pass-args driver | done; routing + prefill→decode verified |
+| E5 live serving (conductor + worker + GPU) | **in progress — hangs; see below** |
+
+**Standalone oracle (use to validate engine output):** `offline_inference` (text 100%
+token-match vs the NeMo reference) and `DuplexStream` / `create_stream`. Audio is
+stochastic (noise+Gumbel) but seeded (`eartts.inference_seed`).
+
+## What the live E5 run proved
+
+Launched the full stack via `mstar-serve` with the model on cuda:0:
+- All four engines load (`stateless.audio_codec`, `kv_cache` = nano+talker,
+  `stateless.enc_dec` = conformer_encoder).
+- All five walks are served: `encode`, `prefill_text`, `decode`, `talker_decode`,
+  `codec_chunk`. CUDA-graph warmup runs the forwards (nano/talker eager by design,
+  conformer torch.compiled) — no `NotImplementedError`, no crash.
+- A request with audio input is accepted, audio ingested + routed, pipeline starts.
+
+Three real integration bugs were found + fixed live (commit `bf3fe346`):
+1. `load_audio` — decode uploads via `soundfile` (base uses torchcodec, native libs
+   unavailable here).
+2. `process_prompt` — map the data worker's `audio_inputs` key → `audio_features`.
+3. `conformer_encoder.forward` — emit under `audio_frame` (the LLM decode edge name);
+   was `audio_embeds`, so the LLM decode loop never received frames.
+
+## The open bug (resume here)
+
+An audio request **hangs** (no crash, no error) after `Request … submitted`. The stall
+is in the **frame-synchronous Encoder→LLM streaming loop** — the deepest runtime piece.
+Note this is an unusual shape: no reference model streams an encoder *frame-by-frame*
+into an LLM *decode* loop (qwen3_omni folds its encoder into a `prefill_audio`
+`Sequential`, then the LLM decodes self-fed).
+
+`NDTRACE` logging is committed (WIP) to localize it — `grep NDTRACE <server-log>`:
+- `conformer_encoder.forward` (encoder ran, T frames)
+- `nano.prepare_inputs walk=… keys=…`
+- `get_initial_forward_pass_args` / `get_partition_forward_pass_args` (partition scheduling)
+
+Decision tree from the traces:
+- **No `encoder.forward` trace** → the Encoder partition isn't being scheduled →
+  look at partition scheduling / `get_partitions` producer wiring.
+- **Encoder fires, `nano.prepare_inputs walk=decode` never fires** → the `audio_frame`
+  stream isn't delivering to the LLM decode loop → the cross-partition streaming
+  (`StreamingGraphEdge` + `FixedChunkPolicy(chunk=1)` on the Encoder→LLM connection),
+  or a single-worker scheduling deadlock (Encoder must produce before LLM consumes).
+- **`nano.prepare_inputs` fires N times then stops** → the decode loop doesn't
+  terminate/emit → `_stream_exhausted` completion in `get_partition_forward_pass_args`
+  (verify the `StreamingConnectionState` fields `producer_done`/`consumed_count`/
+  `token_count` are the right names/semantics).
+
+**Likely fix direction** (if the stream doesn't deliver): reshape the Encoder→LLM
+coupling to a supported pattern — e.g. make the encoder the first node of a
+`prefill_audio` `Sequential` in the LLM partition that emits the whole `audio_frame`
+stream, rather than a standalone producer partition. Compare to
+`mstar/model/qwen3_omni` `get_graph_walk_graphs` / `get_partitions` /
+`get_partition_topology` and its conductor `_get_*_forward` state machines.
+
+Strip the `NDTRACE` lines once E5 is green.
+
+## Repro on the new server
+
+Env: mstar serving deps + the NeMo-reference deps (the `nemoref` conda env used on the
+dev box), plus the HF weights cached: `nvidia/NVIDIA-NemotronLabs-VoiceChat-11B` and the
+`pipecat-ai/NVIDIA-NemotronLabs-VoiceChat-11B-Spark` tokenizer repo.
+
+Serve (single GPU). Two gotchas that cost time here:
+- `PYTHONPATH` must point at this checkout so `import mstar` resolves this branch (the
+  installed `mstar-serve` otherwise imports the main checkout, which lacks the
+  `nemotron_duplex` registration).
+- `--tensor-comm-protocol SHM` (single node; RDMA/InfiniBand mlx5 devices are inactive
+  here, so the default RDMA Mooncake registration fails).
+
+```bash
+CUDA_VISIBLE_DEVICES=0 PYTHONPATH=$PWD PYTHONUNBUFFERED=1 \
+  mstar-serve --config configs/nemotron_duplex.yaml \
+  --host 127.0.0.1 --port 8019 --tensor-comm-protocol SHM \
+  --socket-path-prefix /tmp/mstar_nd/ --upload-dir /tmp/mstar_nd_up/
+```
+
+Request:
+```python
+from mstar.client.client import MStarClient
+c = MStarClient("http://127.0.0.1:8019", timeout=150)
+r = c.generate(audio="user_16k_mono.wav", input_modalities=("audio",),
+               output_modalities=("text", "audio"), temperature=0.0)
+print(r.text, len(r.audio or b""))
+```
+
+Validate engine output per-request against `offline_inference` on the same wav (the
+verified oracle). Then confirm true batching with ≥2 concurrent requests.

--- a/mstar/model/nemotron_duplex/E5_RESUME.md
+++ b/mstar/model/nemotron_duplex/E5_RESUME.md
@@ -39,6 +39,24 @@ Three real integration bugs were found + fixed live (commit `bf3fe346`):
 
 ## The open bug (resume here)
 
+### Attempted fix applied (UNVERIFIED — run on ptc to confirm)
+
+Mechanistic root cause pinned by static analysis: the `decode` loop node's
+`input_names = [audio_frame, prev_text, prev_func]` are ALL required for the node to be
+"ready", but on **frame 0** of an audio-only request there is no prior sampled token, so
+`prev_text`/`prev_func` are never delivered → the node never runs → hang (matches the
+observed "submitted then nothing"). qwen3 avoids this: its `talker_prefill` seeds
+`talker_input_embeds` before the decode loop.
+
+Fix applied (commit after this doc): `process_prompt` now emits `prev_text=[BOS]` and
+`prev_func=[PAD]`, and `get_initial_forward_pass_args` (LLM, audio-only → `decode`)
+provides them as frame-0 inputs; iterations ≥1 get them from the loop-back edges.
+**Not run yet** — verify on ptc: serve, send an audio request, and check the `NDTRACE`
+lines now show `nano.prepare_inputs walk=decode` firing repeatedly (one per frame). If it
+still hangs, fall through to the gating/termination analysis below.
+
+### If the seeding fix isn't enough
+
 An audio request **hangs** (no crash, no error) after `Request … submitted`. The stall
 is in the **frame-synchronous Encoder→LLM streaming loop** — the deepest runtime piece.
 Note this is an unusual shape: no reference model streams an encoder *frame-by-frame*

--- a/mstar/model/nemotron_duplex/ENGINE_INTEGRATION.md
+++ b/mstar/model/nemotron_duplex/ENGINE_INTEGRATION.md
@@ -1,0 +1,56 @@
+# Nemotron-Duplex — M* serving-engine integration plan
+
+Goal: production serving via the M* engine (walk graphs + wired audio submodule
+forwards) with **true batched inference** of concurrent real-time requests.
+
+Oracle for every phase: the verified standalone paths (`offline_inference`,
+`DuplexStream`) — engine output must match them per-request.
+
+## Node → engine mapping (template: `mstar/model/qwen3_omni`)
+
+| Node | Engine | Analog | Role |
+|---|---|---|---|
+| `conformer_encoder` | STATELESS (`enc_dec`) | audio_encoder | audio chunk → `combined_embeds` (+ RNN-T `transcript`) |
+| `nano_llm` | KV_CACHE (+ Mamba pool) | Thinker | frame loop: fuse(audio, prev_text, prev_func) → text/func token |
+| `eartts_talker` | KV_CACHE | Talker | text token → 31 RVQ codes (MoG+MaskGIT+CFG, internal sampling) |
+| `audio_codec` | STATELESS (`audio_codec`) | Code2Wav | codes → 22.05 kHz PCM chunk |
+
+Key structural difference vs qwen3_omni: the nano decode loop is **frame-driven**
+(each step consumes a new `audio_embeds` frame streamed from the encoder, fused
+with its own previous token) rather than purely self-fed. So the nano decode node
+takes two inputs: streamed `audio_embeds` + self-feedback `prev_text`/`prev_func`.
+
+## Phases (each committed + verified against the oracle)
+
+- **E1 — Batched Mamba decode (this is the core of "true batch inference").**
+  Make `Mamba2Mixer.forward` + `MambaStateAccessor` batch-aware: stack each
+  request's conv/ssm state → one fused SSD scan/step → unstack. `NemotronHLLM`
+  batched forward segments the packed `(L,H)` by per-request seq_lens. Nano
+  submodule: `can_batch=True`, `forward_batched`. Attention already batches via the
+  paged-KV pool; only conv/ssm state needs batching. Eager first (state lives in
+  `PerRequestState`); CUDA-graph capture (fixed-buffer Option-B pool) is a later
+  perf layer. Verify: batched engine nano decode == per-request standalone tokens.
+- **E2 — Stateless submodule forwards.** `ConformerEncoderSubmodule.forward`
+  (audio→combined_embeds, + RNN-T transcript), `AudioCodecDecoderSubmodule.forward`
+  (codes→PCM, `audio_codec` flavor, left-context trim). Each verified vs standalone.
+- **E3 — Talker submodule forward (AR).** `EarTTSTalkerSubmodule` per-frame:
+  text token → MoG/MaskGIT/CFG internal sampling → 31 codes. Verified vs standalone.
+- **E4 — Walks + partitions + topology.** `prefill_audio` (Sequential enc→nano),
+  frame-driven `decode` Loop (streams text→talker), `talker_decode` Loop
+  (streams codes→codec), `codec_chunk`. Partitions ENC/LLM, Talker, Codec with
+  StreamingGraphEdge + chunk policies. Emit text + audio (+ transcript) modalities.
+- **E5 — End-to-end batched serving check.** N concurrent audio requests through
+  the engine → per-request outputs match standalone; confirm one fused batched
+  step advances all requests.
+- **E6 (later perf) — CUDA-graph capture** via a fixed-buffer conv/ssm pool
+  (mirror `kv_store` paged pool + `cuda_graph_runner` dummy-rid state swap).
+
+## Batched Mamba decode — mechanism (E1)
+
+Decode step: `L == B` (1 token/request). Reshape packed `(B,H)` → per-request.
+- conv: stack `prev_conv (B, conv_dim, k-1)` + new col → depthwise conv over the
+  last-k window per request → new `(B, conv_dim, k-1)`.
+- ssm: stack `h0 (B, nheads, head_dim, d_state)`; batched single SSD step.
+- Fresh requests (no state yet) seed zeros.
+Prefill (varlen, per request at turn start) handled by segmenting on seq_lens.
+`MambaStateAccessor` gains `request_ids` + `seq_lens`; read/write iterate the batch.

--- a/mstar/model/nemotron_duplex/__init__.py
+++ b/mstar/model/nemotron_duplex/__init__.py
@@ -1,0 +1,4 @@
+"""NVIDIA NemotronLabs VoiceChat-11B (duplex speech-to-speech) support for M*."""
+from mstar.model.nemotron_duplex.nemotron_duplex_model import NemotronDuplexModel
+
+__all__ = ["NemotronDuplexModel"]

--- a/mstar/model/nemotron_duplex/components/__init__.py
+++ b/mstar/model/nemotron_duplex/components/__init__.py
@@ -1,0 +1,2 @@
+"""Nemotron-VoiceChat components: the Nemotron-H backbone (implemented),
+and the Conformer STT encoder / EarTTS talker + RVQ codec (Phase 4/5 stubs)."""

--- a/mstar/model/nemotron_duplex/components/_util.py
+++ b/mstar/model/nemotron_duplex/components/_util.py
@@ -1,0 +1,34 @@
+"""Small helpers shared by the Nemotron-VoiceChat component ports.
+
+These stages (Conformer STT, RNN-T, EarTTS talker, RVQ codec) are ported to
+**exact checkpoint parity** so the single composite ``model.safetensors`` loads
+with no missing / unexpected / shape-mismatched tensors. The forward passes for
+the audio stages are Phase 4/5 (they need the NeMo / EarTTS reference to verify
+numerically); the module *trees* here are authoritative and load-verified.
+"""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+_FLOAT_DTYPES = (torch.float32, torch.float16, torch.bfloat16, torch.float64)
+
+
+def param(*shape: int, dtype: torch.dtype = torch.float32) -> nn.Parameter:
+    """A parameter of an exact shape/dtype. Int tensors (checkpoint buffers such
+    as flag tables / control codes) are registered as non-trainable parameters
+    so the standard M* loader — which fills ``named_parameters()`` only — loads
+    them too."""
+    return nn.Parameter(torch.empty(shape, dtype=dtype), requires_grad=dtype in _FLOAT_DTYPES)
+
+
+class RawWeight(nn.Module):
+    """Module holding a single bare ``weight`` parameter of an exact shape.
+
+    Used where the checkpoint stores ``<layer>.weight`` directly on a module
+    (e.g. the codec's strided resample convs, whose Conv1d-vs-ConvTranspose1d
+    orientation isn't needed for loading)."""
+
+    def __init__(self, *shape: int):
+        super().__init__()
+        self.weight = param(*shape)

--- a/mstar/model/nemotron_duplex/components/audio_codec.py
+++ b/mstar/model/nemotron_duplex/components/audio_codec.py
@@ -8,77 +8,91 @@ Channel schedule (from the checkpoint):
     encoder: 18 ->[384]x3 ->768 ->[768]x3 ->1536 ->[1536]x3 ->512(latent)
     decoder: 512 ->1536 ->[1536]x3 ->768 ->[768]x3 ->384 ->[384]x3 ->18
 
-Built to exact param parity; the encode/decode forward is Phase 5 (needs the
-EarTTS reference for stride/orientation of the resample convs). The three
-top-level TTS buffers (``_control_codes``, ``codec_silence_tokens``,
-``audio_prompt_latents``) are loaded here too.
+Forward is a faithful port of NeMo ``RVQVAEModel`` / ``Wav2Latent`` /
+``Latent2Wav`` / ``PreTrainedProbabilisticVQ``
+(``nemo/collections/speechlm2/modules/ear_tts_vae_codec.py``, branch
+``nemotron-labs-voicechat``). Config (from the checkpoint ``codec_config``):
+``n_fft=16 hop_length=4 base_hidden_size=384 channel_mult=(1,2,4)
+rates=(7,7,9) num_blocks=3 kernel_size=7 latent_size=512 codebook_size=1024
+num_quantizers=31 wav_to_token_ratio=1764``.
+
+The encoder's spectrogram/STFT and the decoder's inverse-STFT overlap-add are
+ported verbatim. ConvNeXt blocks are *causal* (left-padded) and use a
+channel-dim LayerNorm with eps 1e-6.
 """
 from __future__ import annotations
 
+import math
+
 import torch
 from torch import nn
+from torch.nn import functional as F
 
 from mstar.model.nemotron_duplex.components._util import RawWeight, param
+from mstar.model.nemotron_duplex.config import CodecConfig
 
-# Per-index layer spec: ("conv", (shape...)) for a bare-weight resample conv,
-# or ("block", ch) for a ConvNeXt block at channel width ch.
-_ENCODER_LAYERS = [
-    ("conv", (384, 18, 1)),
-    ("block", 384), ("block", 384), ("block", 384),
-    ("conv", (768, 384, 7)),
-    ("block", 768), ("block", 768), ("block", 768),
-    ("conv", (1536, 768, 7)),
-    ("block", 1536), ("block", 1536), ("block", 1536),
-    ("conv", (512, 1536, 9)),
-]
-_DECODER_LAYERS = [
-    ("conv", (512, 1536, 9)),
-    ("block", 1536), ("block", 1536), ("block", 1536),
-    ("conv", (1536, 768, 7)),
-    ("block", 768), ("block", 768), ("block", 768),
-    ("conv", (768, 384, 7)),
-    ("block", 384), ("block", 384), ("block", 384),
-    ("conv", (18, 384, 1)),
-]
-
-NUM_QUANTIZERS = 31
-CODEBOOK_SIZE = 1024
-LATENT_DIM = 512
+# The encoder/decoder layer specs — (kind, weight_shape, stride, transpose) for
+# conv layers, ("block", dim) for ConvNeXt blocks — are derived from
+# ``CodecConfig`` (channel schedule + rates + num_blocks), not hardcoded.
 
 
 class ConvNeXtBlock(nn.Module):
-    """ConvNeXt block: depthwise conv -> LayerNorm -> pointwise expand -> pointwise project."""
+    """Causal 1D ConvNeXt block (ports NeMo ``ConvNeXt1d``).
+
+    Depthwise conv (left-padded for causality) -> channel-dim LayerNorm ->
+    pointwise expand -> GELU -> pointwise project, with a residual add.
+    """
 
     def __init__(self, dim: int, expand: int = 4, kernel: int = 7):
         super().__init__()
-        self.dwconv = nn.Conv1d(dim, dim, kernel_size=kernel, groups=dim, padding=kernel // 2)
-        self.norm = nn.LayerNorm(dim)
+        self.kernel = kernel
+        # No conv padding: causality handled by explicit left pad in forward.
+        self.dwconv = nn.Conv1d(dim, dim, kernel_size=kernel, groups=dim)
+        # eps 1e-6 to match NeMo ``LayerNormNd``.
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
         self.pwconv1 = nn.Conv1d(dim, expand * dim, kernel_size=1)
         self.pwconv2 = nn.Conv1d(expand * dim, dim, kernel_size=1)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         residual = x
+        x = F.pad(x, [self.kernel - 1, 0])  # causal left pad
         x = self.dwconv(x)
+        # Channel-dim LayerNorm: normalize over C (== nn.LayerNorm over the
+        # transposed last dim), eps 1e-6, biased variance.
         x = self.norm(x.transpose(1, 2)).transpose(1, 2)
-        x = self.pwconv2(torch.nn.functional.gelu(self.pwconv1(x)))
+        x = self.pwconv2(F.gelu(self.pwconv1(x)))
         return residual + x
 
 
-def _build_stack(spec) -> nn.ModuleList:
+def _build_stack(spec, kernel: int) -> tuple[nn.ModuleList, list]:
     layers: list[nn.Module] = []
-    for kind, arg in spec:
-        layers.append(RawWeight(*arg) if kind == "conv" else ConvNeXtBlock(arg))
-    return nn.ModuleList(layers)
+    meta: list = []
+    for entry in spec:
+        if entry[0] == "conv":
+            _, shape, stride, transpose = entry
+            layers.append(RawWeight(*shape))
+            meta.append(("conv", stride, transpose))
+        else:
+            layers.append(ConvNeXtBlock(entry[1], kernel=kernel))
+            meta.append(("block", None, None))
+    return nn.ModuleList(layers), meta
 
 
-class ProjectedRVQ(nn.Module):
-    """Projected residual vector quantizer: per-quantizer codebooks (``mus_list``)
-    and running variances (``_variance_list``)."""
-
-    def __init__(self, num_quantizers: int = NUM_QUANTIZERS, codebook: int = CODEBOOK_SIZE, dim: int = LATENT_DIM):
+class _CodecHalf(nn.Module):
+    def __init__(self, spec, kernel: int):
         super().__init__()
-        self.mus_list = nn.ParameterList([param(codebook, dim) for _ in range(num_quantizers)])
-        self._variance_list = nn.ModuleList([_Variance() for _ in range(num_quantizers)])
+        self.layers, self._meta = _build_stack(spec, kernel)
+
+    def run(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the conv/block stack to a ``[B, C, T]`` tensor."""
+        for layer, (kind, stride, transpose) in zip(self.layers, self._meta, strict=True):
+            if kind == "block":
+                x = layer(x)
+            elif transpose:
+                x = F.conv_transpose1d(x, layer.weight, stride=stride)
+            else:
+                x = F.conv1d(x, layer.weight, stride=stride)
+        return x
 
 
 class _Variance(nn.Module):
@@ -87,12 +101,159 @@ class _Variance(nn.Module):
         self.variance = param()  # scalar
 
 
-class AudioCodec(nn.Module):
-    def __init__(self):
+class ProjectedRVQ(nn.Module):
+    """Projected residual vector quantizer (ports NeMo ``PreTrainedProbabilisticVQ``).
+
+    Per-quantizer codebooks (``mus_list``) and running variances
+    (``_variance_list``).  ``encode`` greedily selects the nearest codebook
+    entry per residual level; ``decode`` sums the selected embeddings.
+    """
+
+    def __init__(self, num_quantizers: int, codebook: int, dim: int):
         super().__init__()
-        self.encoder = _CodecHalf(_ENCODER_LAYERS)
-        self.decoder = _CodecHalf(_DECODER_LAYERS)
-        self.prvq = ProjectedRVQ()
+        self.mus_list = nn.ParameterList([param(codebook, dim) for _ in range(num_quantizers)])
+        self._variance_list = nn.ModuleList([_Variance() for _ in range(num_quantizers)])
+
+    def encode(self, z: torch.Tensor) -> torch.Tensor:
+        """``[B, T, dim]`` continuous latents -> ``[B, T, num_quantizers]`` codes."""
+        r = z
+        ids = []
+        for mus in self.mus_list:
+            # squared distance to each codebook entry: |r|^2 + |mus|^2 - 2 r.mus
+            dist = (
+                r.pow(2).sum(-1, keepdim=True)
+                + mus.pow(2).sum(-1)
+                - 2.0 * (r.unsqueeze(-2) @ mus.transpose(-1, -2)).squeeze(-2)
+            )
+            idx = dist.argmin(-1)
+            r = r - F.embedding(idx, mus)
+            ids.append(idx)
+        return torch.stack(ids, -1)
+
+    def decode(self, code: torch.Tensor) -> torch.Tensor:
+        """``[B, T, num_quantizers]`` codes -> ``[B, T, dim]`` continuous latents."""
+        mus0 = self.mus_list[0]
+        z = torch.zeros((*code.shape[:-1], mus0.shape[-1]), device=code.device, dtype=mus0.dtype)
+        for i, mus in enumerate(self.mus_list):
+            z = z + F.embedding(code[..., i], mus)
+        return z
+
+
+def _spectrogram(wav: torch.Tensor, n_fft: int, hop_length: int, win_length: int) -> torch.Tensor:
+    """STFT with manual centering pad (ports NeMo ``spectrogram``)."""
+    pad_l = (n_fft - hop_length) // 2
+    pad_r = (n_fft - hop_length) - pad_l
+    with torch.autocast(device_type=wav.device.type, enabled=False):
+        wav = F.pad(wav.float(), (pad_l, pad_r))
+        window = torch.hann_window(win_length, dtype=torch.float, device=wav.device)
+        spec = torch.stft(
+            wav, n_fft, hop_length=hop_length, win_length=win_length, window=window,
+            center=False, normalized=False, onesided=True, return_complex=True,
+        )
+    return spec
+
+
+def _spec_to_wav(
+    spec: torch.Tensor, n_fft: int, hop_length: int, win_length: int, constrain_value_range: bool = True,
+) -> torch.Tensor:
+    """Inverse STFT via windowed overlap-add (ports NeMo ``spec_to_wav``)."""
+    with torch.autocast(device_type=spec.device.type, enabled=False):
+        pad = (win_length - hop_length) // 2
+        T = spec.size(-1)
+        window = torch.hann_window(win_length, device=spec.device)
+
+        ifft = torch.fft.irfft(spec, n=n_fft, dim=-2, norm="backward")
+        window_unsqz = window.unsqueeze(-1)
+
+        if constrain_value_range:
+            ifft = torch.where(
+                ifft >= 0,
+                torch.minimum(ifft, window_unsqz),
+                torch.maximum(ifft, -window_unsqz),
+            )
+
+        ifft = ifft * window_unsqz
+
+        output_size = (T - 1) * hop_length + win_length
+        wav = F.fold(
+            ifft, output_size=(1, output_size), kernel_size=(1, win_length), stride=(1, hop_length),
+        )[..., 0, 0, pad:-pad]
+
+        window_sq = window.square().expand(T, -1).transpose(0, 1)
+        window_envelope = F.fold(
+            window_sq, output_size=(1, output_size), kernel_size=(1, win_length), stride=(1, hop_length),
+        ).squeeze()[pad:-pad]
+
+        assert (window_envelope > 1e-11).all(), "Window envelope has zero values, cannot normalize."
+        wav = wav / window_envelope
+        return wav
+
+
+class AudioCodec(nn.Module):
+    def __init__(self, config: CodecConfig | None = None):
+        super().__init__()
+        cfg = config or CodecConfig()
+        self.config = cfg
+        self.encoder = _CodecHalf(cfg.encoder_layers(), kernel=cfg.kernel_size)
+        self.decoder = _CodecHalf(cfg.decoder_layers(), kernel=cfg.kernel_size)
+        self.prvq = ProjectedRVQ(cfg.num_quantizers, cfg.codebook_size, cfg.latent_size)
+        self.n_fft = cfg.n_fft
+        self.hop_length = cfg.hop_length
+        self.wav_to_token_ratio = cfg.wav_to_token_ratio
+        self.max_magnitude = cfg.max_magnitude
+
+    # ---- autoencoder halves -------------------------------------------------
+    def ae_encode(self, x: torch.Tensor) -> torch.Tensor:
+        """Waveform ``[B, 1, T]`` -> continuous latents ``[B, T', latent]``."""
+        with torch.autocast(device_type=x.device.type, enabled=False):
+            spec = _spectrogram(x.squeeze(1), n_fft=self.n_fft, hop_length=self.hop_length, win_length=self.n_fft)
+            mag, ph = torch.view_as_real(spec).chunk(2, dim=-1)
+            x = torch.cat([mag, ph], 1).squeeze(-1)
+        x = self.encoder.run(x)
+        return x.transpose(-1, -2)
+
+    def ae_decode(self, x: torch.Tensor, constrain_value_range: bool = True) -> torch.Tensor:
+        """Continuous latents ``[B, T', latent]`` -> waveform ``[B, 1, T]``."""
+        x = x.transpose(-1, -2)
+        x = self.decoder.run(x)
+        with torch.autocast(device_type=x.device.type, enabled=False):
+            mag, ph = x.float().chunk(2, dim=1)
+            mag = self.max_magnitude * torch.exp(-F.softplus(-mag + math.log(self.max_magnitude)))
+
+            mag_dc, mag_mid, mag_nyquist = mag.split([1, mag.size(1) - 2, 1], dim=1)
+            ph_dc, ph_mid, ph_nyquist = torch.cos(ph).split([1, ph.size(1) - 2, 1], dim=1)
+            ph_imag = torch.sin(ph[:, 1:-1, :])
+
+            spec_real = mag_mid * ph_mid
+            spec_imag = mag_mid * ph_imag
+            spec = torch.cat([mag_dc * ph_dc, spec_real + 1j * spec_imag, mag_nyquist * ph_nyquist], 1)
+
+            x = _spec_to_wav(
+                spec, self.n_fft, self.hop_length, self.n_fft, constrain_value_range=constrain_value_range,
+            ).unsqueeze(1)
+        return x
+
+    # ---- quantizer wrappers -------------------------------------------------
+    def quantize(self, z: torch.Tensor) -> torch.Tensor:
+        return self.prvq.encode(z)
+
+    def dequantize(self, code: torch.Tensor) -> torch.Tensor:
+        return self.prvq.decode(code)
+
+    # ---- public API ---------------------------------------------------------
+    def encode(self, x: torch.Tensor, x_len: torch.Tensor | None = None):
+        """Waveform ``[B, 1, T]`` -> (codes ``[B, T', num_quantizers]``, code_len)."""
+        z_e = self.ae_encode(x)
+        code = self.quantize(z_e)
+        code_len = x_len // self.wav_to_token_ratio if x_len is not None else None
+        return code, code_len
+
+    def decode(self, code: torch.Tensor, code_len: torch.Tensor | None = None, constrain_value_range: bool = True):
+        """Codes ``[B, T', num_quantizers]`` -> (waveform ``[B, 1, T]``, wav_len)."""
+        z_q = self.dequantize(code)
+        x_hat = self.ae_decode(z_q, constrain_value_range=constrain_value_range)
+        wav_len = code_len * self.wav_to_token_ratio if code_len is not None else None
+        return x_hat, wav_len
 
     @staticmethod
     def remap(name: str) -> str | None:
@@ -104,9 +265,3 @@ class AudioCodec(nn.Module):
         from mstar.model.loader import load_hf_weights
 
         return load_hf_weights(self, weights, stacked_params=[], name_remapper=self.remap)
-
-
-class _CodecHalf(nn.Module):
-    def __init__(self, spec):
-        super().__init__()
-        self.layers = _build_stack(spec)

--- a/mstar/model/nemotron_duplex/components/audio_codec.py
+++ b/mstar/model/nemotron_duplex/components/audio_codec.py
@@ -1,0 +1,112 @@
+"""EarTTS RVQ audio codec (``tts_model.audio_codec.*``).
+
+A DAC/Vocos-style ConvNeXt codec: a downsampling encoder and an upsampling
+decoder, each a heterogeneous stack of strided resample convs and ConvNeXt
+blocks, plus a projected-RVQ quantizer (``prvq``).
+
+Channel schedule (from the checkpoint):
+    encoder: 18 ->[384]x3 ->768 ->[768]x3 ->1536 ->[1536]x3 ->512(latent)
+    decoder: 512 ->1536 ->[1536]x3 ->768 ->[768]x3 ->384 ->[384]x3 ->18
+
+Built to exact param parity; the encode/decode forward is Phase 5 (needs the
+EarTTS reference for stride/orientation of the resample convs). The three
+top-level TTS buffers (``_control_codes``, ``codec_silence_tokens``,
+``audio_prompt_latents``) are loaded here too.
+"""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from mstar.model.nemotron_duplex.components._util import RawWeight, param
+
+# Per-index layer spec: ("conv", (shape...)) for a bare-weight resample conv,
+# or ("block", ch) for a ConvNeXt block at channel width ch.
+_ENCODER_LAYERS = [
+    ("conv", (384, 18, 1)),
+    ("block", 384), ("block", 384), ("block", 384),
+    ("conv", (768, 384, 7)),
+    ("block", 768), ("block", 768), ("block", 768),
+    ("conv", (1536, 768, 7)),
+    ("block", 1536), ("block", 1536), ("block", 1536),
+    ("conv", (512, 1536, 9)),
+]
+_DECODER_LAYERS = [
+    ("conv", (512, 1536, 9)),
+    ("block", 1536), ("block", 1536), ("block", 1536),
+    ("conv", (1536, 768, 7)),
+    ("block", 768), ("block", 768), ("block", 768),
+    ("conv", (768, 384, 7)),
+    ("block", 384), ("block", 384), ("block", 384),
+    ("conv", (18, 384, 1)),
+]
+
+NUM_QUANTIZERS = 31
+CODEBOOK_SIZE = 1024
+LATENT_DIM = 512
+
+
+class ConvNeXtBlock(nn.Module):
+    """ConvNeXt block: depthwise conv -> LayerNorm -> pointwise expand -> pointwise project."""
+
+    def __init__(self, dim: int, expand: int = 4, kernel: int = 7):
+        super().__init__()
+        self.dwconv = nn.Conv1d(dim, dim, kernel_size=kernel, groups=dim, padding=kernel // 2)
+        self.norm = nn.LayerNorm(dim)
+        self.pwconv1 = nn.Conv1d(dim, expand * dim, kernel_size=1)
+        self.pwconv2 = nn.Conv1d(expand * dim, dim, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = self.dwconv(x)
+        x = self.norm(x.transpose(1, 2)).transpose(1, 2)
+        x = self.pwconv2(torch.nn.functional.gelu(self.pwconv1(x)))
+        return residual + x
+
+
+def _build_stack(spec) -> nn.ModuleList:
+    layers: list[nn.Module] = []
+    for kind, arg in spec:
+        layers.append(RawWeight(*arg) if kind == "conv" else ConvNeXtBlock(arg))
+    return nn.ModuleList(layers)
+
+
+class ProjectedRVQ(nn.Module):
+    """Projected residual vector quantizer: per-quantizer codebooks (``mus_list``)
+    and running variances (``_variance_list``)."""
+
+    def __init__(self, num_quantizers: int = NUM_QUANTIZERS, codebook: int = CODEBOOK_SIZE, dim: int = LATENT_DIM):
+        super().__init__()
+        self.mus_list = nn.ParameterList([param(codebook, dim) for _ in range(num_quantizers)])
+        self._variance_list = nn.ModuleList([_Variance() for _ in range(num_quantizers)])
+
+
+class _Variance(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.variance = param()  # scalar
+
+
+class AudioCodec(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.encoder = _CodecHalf(_ENCODER_LAYERS)
+        self.decoder = _CodecHalf(_DECODER_LAYERS)
+        self.prvq = ProjectedRVQ()
+
+    @staticmethod
+    def remap(name: str) -> str | None:
+        prefix = "tts_model.audio_codec."
+        return name[len(prefix):] if name.startswith(prefix) else None
+
+    def load_weights(self, weights):
+        """Load the ``tts_model.audio_codec.*`` subtree."""
+        from mstar.model.loader import load_hf_weights
+
+        return load_hf_weights(self, weights, stacked_params=[], name_remapper=self.remap)
+
+
+class _CodecHalf(nn.Module):
+    def __init__(self, spec):
+        super().__init__()
+        self.layers = _build_stack(spec)

--- a/mstar/model/nemotron_duplex/components/conformer.py
+++ b/mstar/model/nemotron_duplex/components/conformer.py
@@ -5,7 +5,9 @@ NeMo Fast-Conformer: mel preprocessor -> dw-striding conv subsampling ->
 the nano LLM hidden space (1024 -> 4480).
 
 Ported to exact checkpoint parity **and** numerically verified against the NeMo
-``nemotron-labs-voicechat`` reference. Config (from the model's ``config.json``):
+``nemotron-labs-voicechat`` reference. Every architecture dim comes from
+``ConformerSTTConfig`` (populated from the checkpoint's ``config.json`` ->
+``model.stt.model.perception``); nothing is hardcoded here. Config highlights:
 ``att_context_size=[70, 0]`` chunked-limited (left window 70, causal), causal
 ``dw_striding`` subsampling factor 8, ``conv_context_size='causal'`` depthwise
 conv, ``conv_norm_type='layer_norm'`` (so the ``conv.batch_norm`` tensor is a
@@ -23,27 +25,11 @@ import torch.nn.functional as F
 from torch import nn
 
 from mstar.model.nemotron_duplex.components._util import param
+from mstar.model.nemotron_duplex.config import ConformerSTTConfig
 
-D = 1024          # encoder d_model
-N_HEADS = 8
-HEAD_DIM = 128
-FF = 4096
-NUM_LAYERS = 24
-SUB_CH = 256      # subsampling channels
-LLM_HIDDEN = 4480
-CONV_KERNEL = 9
-SUB_FLAT = 4352   # SUB_CH * 17 (freq after 3 causal stride-2 stages)
-ATT_LEFT = 70     # att_context_size = [70, 0]  (chunked_limited, chunk_size 1)
-INF_VAL = 10000.0
-
-# mel featurizer
-N_FFT = 512
-WIN_LENGTH = 400
-HOP_LENGTH = 160
-N_MELS = 128
-PREEMPH = 0.97
-MAG_POWER = 2.0
-LOG_GUARD = 2.0 ** -24
+# Pure numerical constants (not architecture dims / not in config.json).
+INF_VAL = 10000.0        # attention mask fill value (NeMo RelPos MHA)
+LOG_GUARD = 2.0 ** -24   # log-mel zero guard (NeMo FilterbankFeatures log_zero_guard_value)
 
 
 class _CausalConv2d(nn.Conv2d):
@@ -66,27 +52,30 @@ class _Featurizer(nn.Module):
     ``fb`` (mel filterbank) and ``window`` (Hann) are loaded from the checkpoint.
     """
 
-    def __init__(self):
+    def __init__(self, config: ConformerSTTConfig):
         super().__init__()
-        self.fb = param(1, N_MELS, N_FFT // 2 + 1)   # mel filterbank
-        self.window = param(WIN_LENGTH)               # STFT window (Hann, periodic=False)
+        self.config = config
+        self.fb = param(1, config.n_mels, config.n_fft // 2 + 1)   # mel filterbank
+        self.window = param(config.win_length)                     # STFT window (Hann, periodic=False)
 
     def get_seq_len(self, seq_len: torch.Tensor) -> torch.Tensor:
-        pad_amount = N_FFT // 2 * 2
-        return torch.floor_divide(seq_len + pad_amount - N_FFT, HOP_LENGTH) + 1
+        cfg = self.config
+        pad_amount = cfg.n_fft // 2 * 2
+        return torch.floor_divide(seq_len + pad_amount - cfg.n_fft, cfg.hop_length) + 1
 
     def forward(self, x: torch.Tensor, seq_len: torch.Tensor):
+        cfg = self.config
         out_len = self.get_seq_len(seq_len)
         # preemphasis
-        x = torch.cat((x[:, 0].unsqueeze(1), x[:, 1:] - PREEMPH * x[:, :-1]), dim=1)
+        x = torch.cat((x[:, 0].unsqueeze(1), x[:, 1:] - cfg.preemph * x[:, :-1]), dim=1)
         spec = torch.stft(
-            x, n_fft=N_FFT, hop_length=HOP_LENGTH, win_length=WIN_LENGTH,
+            x, n_fft=cfg.n_fft, hop_length=cfg.hop_length, win_length=cfg.win_length,
             center=True, window=self.window.to(torch.float32), return_complex=True,
         )
         spec = torch.view_as_real(spec)
         mag = torch.sqrt(spec.pow(2).sum(-1))
-        if MAG_POWER != 1.0:
-            mag = mag.pow(MAG_POWER)
+        if cfg.mag_power != 1.0:
+            mag = mag.pow(cfg.mag_power)
         mel = torch.matmul(self.fb.to(mag.dtype), mag)     # (B, n_mels, T)
         mel = torch.log(mel + LOG_GUARD)                    # normalize="NA" -> no-op
         max_len = mel.size(-1)
@@ -96,9 +85,9 @@ class _Featurizer(nn.Module):
 
 
 class Preprocessor(nn.Module):
-    def __init__(self):
+    def __init__(self, config: ConformerSTTConfig):
         super().__init__()
-        self.featurizer = _Featurizer()
+        self.featurizer = _Featurizer(config)
 
     def forward(self, x, seq_len):
         return self.featurizer(x, seq_len)
@@ -108,25 +97,23 @@ class ConvSubsampling(nn.Module):
     """Causal dw-striding subsampling (factor 8): CausalConv2d, ReLU,
     (depthwise CausalConv2d, pointwise, ReLU) x2 -> Linear(4352 -> d_model)."""
 
-    def __init__(self):
+    def __init__(self, config: ConformerSTTConfig):
         super().__init__()
-        self.conv = nn.Sequential(
-            _CausalConv2d(1, SUB_CH, 3, stride=2),                       # 0
-            nn.ReLU(),                                                    # 1
-            _CausalConv2d(SUB_CH, SUB_CH, 3, stride=2, groups=SUB_CH),   # 2 depthwise
-            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=1),                    # 3 pointwise
-            nn.ReLU(),                                                    # 4
-            _CausalConv2d(SUB_CH, SUB_CH, 3, stride=2, groups=SUB_CH),   # 5 depthwise
-            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=1),                    # 6 pointwise
-            nn.ReLU(),                                                    # 7
-        )
-        self.out = nn.Linear(SUB_FLAT, D)
+        self.config = config
+        ch = config.subsampling_conv_channels
+        self._num_stages = int(math.log2(config.subsampling_factor))
+        layers: list[nn.Module] = [_CausalConv2d(1, ch, 3, stride=2), nn.ReLU()]
+        for _ in range(self._num_stages - 1):
+            layers.append(_CausalConv2d(ch, ch, 3, stride=2, groups=ch))   # depthwise
+            layers.append(nn.Conv2d(ch, ch, kernel_size=1))                # pointwise
+            layers.append(nn.ReLU())
+        self.conv = nn.Sequential(*layers)
+        self.out = nn.Linear(config.subsampling_flat, config.d_model)
 
-    @staticmethod
-    def calc_length(lengths: torch.Tensor) -> torch.Tensor:
-        # 3 stride-2 causal stages: all_paddings=(k-1)+(s-1)=3, kernel=3, stride=2
+    def calc_length(self, lengths: torch.Tensor) -> torch.Tensor:
+        # stride-2 causal stages: all_paddings=(k-1)+(s-1)=3, kernel=3, stride=2 -> add_pad=0
         add_pad = 3 - 3
-        for _ in range(3):
+        for _ in range(self._num_stages):
             lengths = torch.floor(torch.div(lengths.to(torch.float32) + add_pad, 2) + 1.0)
         return lengths.to(torch.int64)
 
@@ -142,16 +129,19 @@ class ConvSubsampling(nn.Module):
 class _RelPosMHA(nn.Module):
     """Transformer-XL relative-position multi-head attention (rel_pos)."""
 
-    def __init__(self):
+    def __init__(self, config: ConformerSTTConfig):
         super().__init__()
-        self.linear_q = nn.Linear(D, D, bias=False)
-        self.linear_k = nn.Linear(D, D, bias=False)
-        self.linear_v = nn.Linear(D, D, bias=False)
-        self.linear_out = nn.Linear(D, D, bias=False)
-        self.linear_pos = nn.Linear(D, D, bias=False)
-        self.pos_bias_u = param(N_HEADS, HEAD_DIM)
-        self.pos_bias_v = param(N_HEADS, HEAD_DIM)
-        self.s_d_k = math.sqrt(HEAD_DIM)
+        d = config.d_model
+        self.n_heads = config.num_heads
+        self.head_dim = config.head_dim
+        self.linear_q = nn.Linear(d, d, bias=False)
+        self.linear_k = nn.Linear(d, d, bias=False)
+        self.linear_v = nn.Linear(d, d, bias=False)
+        self.linear_out = nn.Linear(d, d, bias=False)
+        self.linear_pos = nn.Linear(d, d, bias=False)
+        self.pos_bias_u = param(self.n_heads, self.head_dim)
+        self.pos_bias_v = param(self.n_heads, self.head_dim)
+        self.s_d_k = math.sqrt(self.head_dim)
 
     @staticmethod
     def _rel_shift(x: torch.Tensor) -> torch.Tensor:
@@ -162,11 +152,12 @@ class _RelPosMHA(nn.Module):
 
     def forward(self, x: torch.Tensor, mask: torch.Tensor, pos_emb: torch.Tensor) -> torch.Tensor:
         n_batch = x.size(0)
-        q = self.linear_q(x).view(n_batch, -1, N_HEADS, HEAD_DIM)
-        k = self.linear_k(x).view(n_batch, -1, N_HEADS, HEAD_DIM).transpose(1, 2)
-        v = self.linear_v(x).view(n_batch, -1, N_HEADS, HEAD_DIM).transpose(1, 2)
+        h, dk, d = self.n_heads, self.head_dim, self.n_heads * self.head_dim
+        q = self.linear_q(x).view(n_batch, -1, h, dk)
+        k = self.linear_k(x).view(n_batch, -1, h, dk).transpose(1, 2)
+        v = self.linear_v(x).view(n_batch, -1, h, dk).transpose(1, 2)
         # q kept as (B, t1, h, d_k) to add per-head biases
-        p = self.linear_pos(pos_emb).view(pos_emb.size(0), -1, N_HEADS, HEAD_DIM).transpose(1, 2)
+        p = self.linear_pos(pos_emb).view(pos_emb.size(0), -1, h, dk).transpose(1, 2)
         q_u = (q + self.pos_bias_u).transpose(1, 2)   # (B, h, t1, d_k)
         q_v = (q + self.pos_bias_v).transpose(1, 2)
         matrix_bd = torch.matmul(q_v, p.transpose(-2, -1))
@@ -180,15 +171,15 @@ class _RelPosMHA(nn.Module):
             attn = torch.softmax(scores, dim=-1).masked_fill(m, 0.0)
         else:
             attn = torch.softmax(scores, dim=-1)
-        out = torch.matmul(attn, v).transpose(1, 2).reshape(n_batch, -1, D)
+        out = torch.matmul(attn, v).transpose(1, 2).reshape(n_batch, -1, d)
         return self.linear_out(out)
 
 
 class _FeedForward(nn.Module):
-    def __init__(self):
+    def __init__(self, config: ConformerSTTConfig):
         super().__init__()
-        self.linear1 = nn.Linear(D, FF, bias=False)
-        self.linear2 = nn.Linear(FF, D, bias=False)
+        self.linear1 = nn.Linear(config.d_model, config.ff_dim, bias=False)
+        self.linear2 = nn.Linear(config.ff_dim, config.d_model, bias=False)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.linear2(F.silu(self.linear1(x)))
@@ -198,13 +189,15 @@ class _ConvModule(nn.Module):
     """Conformer conv module: pointwise -> GLU -> causal depthwise -> LayerNorm
     (checkpoint's ``batch_norm`` is a LayerNorm) -> SiLU -> pointwise."""
 
-    def __init__(self):
+    def __init__(self, config: ConformerSTTConfig):
         super().__init__()
-        self.pointwise_conv1 = nn.Conv1d(D, 2 * D, kernel_size=1, bias=False)
+        d = config.d_model
+        self.kernel_size = config.conv_kernel_size
+        self.pointwise_conv1 = nn.Conv1d(d, 2 * d, kernel_size=1, bias=False)
         # causal depthwise: left pad k-1, right pad 0
-        self.depthwise_conv = nn.Conv1d(D, D, kernel_size=CONV_KERNEL, padding=0, groups=D, bias=False)
-        self.batch_norm = nn.LayerNorm(D)
-        self.pointwise_conv2 = nn.Conv1d(D, D, kernel_size=1, bias=False)
+        self.depthwise_conv = nn.Conv1d(d, d, kernel_size=self.kernel_size, padding=0, groups=d, bias=False)
+        self.batch_norm = nn.LayerNorm(d)
+        self.pointwise_conv2 = nn.Conv1d(d, d, kernel_size=1, bias=False)
 
     def forward(self, x: torch.Tensor, pad_mask: torch.Tensor | None) -> torch.Tensor:
         x = x.transpose(1, 2)                    # (B, D, T)
@@ -212,7 +205,7 @@ class _ConvModule(nn.Module):
         x = F.glu(x, dim=1)
         if pad_mask is not None:
             x = x.masked_fill(pad_mask.unsqueeze(1), 0.0)
-        x = F.pad(x, (CONV_KERNEL - 1, 0))       # causal padding
+        x = F.pad(x, (self.kernel_size - 1, 0))  # causal padding
         x = self.depthwise_conv(x)
         x = x.transpose(1, 2)                     # (B, T, D)
         x = self.batch_norm(x)                    # LayerNorm over channels
@@ -225,17 +218,18 @@ class _ConvModule(nn.Module):
 class ConformerLayer(nn.Module):
     FC_FACTOR = 0.5
 
-    def __init__(self):
+    def __init__(self, config: ConformerSTTConfig):
         super().__init__()
-        self.norm_feed_forward1 = nn.LayerNorm(D)
-        self.feed_forward1 = _FeedForward()
-        self.norm_self_att = nn.LayerNorm(D)
-        self.self_attn = _RelPosMHA()
-        self.norm_conv = nn.LayerNorm(D)
-        self.conv = _ConvModule()
-        self.norm_feed_forward2 = nn.LayerNorm(D)
-        self.feed_forward2 = _FeedForward()
-        self.norm_out = nn.LayerNorm(D)
+        d = config.d_model
+        self.norm_feed_forward1 = nn.LayerNorm(d)
+        self.feed_forward1 = _FeedForward(config)
+        self.norm_self_att = nn.LayerNorm(d)
+        self.self_attn = _RelPosMHA(config)
+        self.norm_conv = nn.LayerNorm(d)
+        self.conv = _ConvModule(config)
+        self.norm_feed_forward2 = nn.LayerNorm(d)
+        self.feed_forward2 = _FeedForward(config)
+        self.norm_out = nn.LayerNorm(d)
 
     def forward(self, x, att_mask, pos_emb, pad_mask):
         residual = x + self.FC_FACTOR * self.feed_forward1(self.norm_feed_forward1(x))
@@ -246,10 +240,11 @@ class ConformerLayer(nn.Module):
 
 
 class ConformerEncoder(nn.Module):
-    def __init__(self):
+    def __init__(self, config: ConformerSTTConfig):
         super().__init__()
-        self.pre_encode = ConvSubsampling()
-        self.layers = nn.ModuleList([ConformerLayer() for _ in range(NUM_LAYERS)])
+        self.config = config
+        self.pre_encode = ConvSubsampling(config)
+        self.layers = nn.ModuleList([ConformerLayer(config) for _ in range(config.num_layers)])
 
     @staticmethod
     def _rel_pos_emb(length: int, dim: int, device, dtype) -> torch.Tensor:
@@ -263,12 +258,12 @@ class ConformerEncoder(nn.Module):
         pe[:, 1::2] = torch.cos(positions * div_term)
         return pe.unsqueeze(0).to(dtype)
 
-    @staticmethod
-    def _create_masks(length: torch.Tensor, max_len: int, device):
-        # chunked_limited, att_context_size=[70, 0] -> chunk_size=1, left window 70
+    def _create_masks(self, length: torch.Tensor, max_len: int, device):
+        # chunked_limited, att_context_size=(left, 0) -> chunk_size=1, left window = left
+        att_left = self.config.att_context_size[0]
         idx = torch.arange(0, max_len, device=device)
         diff = idx.unsqueeze(1) - idx.unsqueeze(0)
-        att_ok = (diff <= ATT_LEFT) & (diff >= 0)                       # (T, T)
+        att_ok = (diff <= att_left) & (diff >= 0)                       # (T, T)
         pad_ok = torch.arange(0, max_len, device=device).expand(length.size(0), -1) < length.unsqueeze(-1)
         pad_att = pad_ok.unsqueeze(1).repeat(1, max_len, 1)
         pad_att = pad_att & pad_att.transpose(1, 2)
@@ -281,7 +276,8 @@ class ConformerEncoder(nn.Module):
         audio_signal = audio_signal.transpose(1, 2)                   # (B, T, feat)
         audio_signal, length = self.pre_encode(audio_signal, length)  # (B, T', D)
         max_audio_length = audio_signal.size(1)
-        pos_emb = self._rel_pos_emb(max_audio_length, D, audio_signal.device, audio_signal.dtype)
+        pos_emb = self._rel_pos_emb(max_audio_length, self.config.d_model,
+                                    audio_signal.device, audio_signal.dtype)
         pad_mask, att_mask = self._create_masks(length, max_audio_length, audio_signal.device)
         for layer in self.layers:
             audio_signal = layer(audio_signal, att_mask, pos_emb, pad_mask)
@@ -291,11 +287,12 @@ class ConformerEncoder(nn.Module):
 class Perception(nn.Module):
     """Full perception stack: preprocessor + conformer encoder + LLM projection."""
 
-    def __init__(self):
+    def __init__(self, config: ConformerSTTConfig | None = None):
         super().__init__()
-        self.preprocessor = Preprocessor()
-        self.encoder = ConformerEncoder()
-        self.proj = nn.Linear(D, LLM_HIDDEN)  # 1024 -> 4480, into nano hidden
+        self.config = config or ConformerSTTConfig()
+        self.preprocessor = Preprocessor(self.config)
+        self.encoder = ConformerEncoder(self.config)
+        self.proj = nn.Linear(self.config.d_model, self.config.output_dim)  # 1024 -> 4480, into nano hidden
 
     def forward(
         self,

--- a/mstar/model/nemotron_duplex/components/conformer.py
+++ b/mstar/model/nemotron_duplex/components/conformer.py
@@ -4,13 +4,22 @@ NeMo Fast-Conformer: mel preprocessor -> dw-striding conv subsampling ->
 24 Conformer layers (Macaron FF, rel-pos MHA, conv module) -> projection into
 the nano LLM hidden space (1024 -> 4480).
 
-Ported to exact checkpoint parity. FF/attention/conv linears are bias-free;
-norms are LayerNorm; the conv module's BatchNorm keeps only weight+bias in the
-checkpoint (running stats are absent — a Phase-4 numerics note). Forward is
-Phase 4 (audio-in); the tree here is load-verified.
+Ported to exact checkpoint parity **and** numerically verified against the NeMo
+``nemotron-labs-voicechat`` reference. Config (from the model's ``config.json``):
+``att_context_size=[70, 0]`` chunked-limited (left window 70, causal), causal
+``dw_striding`` subsampling factor 8, ``conv_context_size='causal'`` depthwise
+conv, ``conv_norm_type='layer_norm'`` (so the ``conv.batch_norm`` tensor is a
+LayerNorm over channels -- which is why the checkpoint has only weight+bias and
+no running stats), Macaron 0.5 FF scaling, ``xscaling=False``, ``use_bias=False``
+on all FF/attn/conv linears, Swish (SiLU) activations, mel power spectrum with
+preemphasis 0.97.
 """
 from __future__ import annotations
 
+import math
+
+import torch
+import torch.nn.functional as F
 from torch import nn
 
 from mstar.model.nemotron_duplex.components._util import param
@@ -22,13 +31,68 @@ FF = 4096
 NUM_LAYERS = 24
 SUB_CH = 256      # subsampling channels
 LLM_HIDDEN = 4480
+CONV_KERNEL = 9
+SUB_FLAT = 4352   # SUB_CH * 17 (freq after 3 causal stride-2 stages)
+ATT_LEFT = 70     # att_context_size = [70, 0]  (chunked_limited, chunk_size 1)
+INF_VAL = 10000.0
+
+# mel featurizer
+N_FFT = 512
+WIN_LENGTH = 400
+HOP_LENGTH = 160
+N_MELS = 128
+PREEMPH = 0.97
+MAG_POWER = 2.0
+LOG_GUARD = 2.0 ** -24
+
+
+class _CausalConv2d(nn.Conv2d):
+    """nn.Conv2d with NeMo ``CausalConv2D`` padding (left=k-1, right=stride-1 on
+    both time and freq axes). Keeps ``weight``/``bias`` param names for loading."""
+
+    def __init__(self, in_channels, out_channels, kernel_size, stride, groups=1):
+        self._left_padding = kernel_size - 1
+        self._right_padding = stride - 1
+        super().__init__(in_channels, out_channels, kernel_size, stride, padding=0, groups=groups)
+
+    def forward(self, x):
+        x = F.pad(x, (self._left_padding, self._right_padding, self._left_padding, self._right_padding))
+        return super().forward(x)
 
 
 class _Featurizer(nn.Module):
+    """Log-mel power spectrogram (``AudioToMelSpectrogramPreprocessor.featurizer``).
+
+    ``fb`` (mel filterbank) and ``window`` (Hann) are loaded from the checkpoint.
+    """
+
     def __init__(self):
         super().__init__()
-        self.fb = param(1, 128, 257)      # mel filterbank
-        self.window = param(400)          # STFT window
+        self.fb = param(1, N_MELS, N_FFT // 2 + 1)   # mel filterbank
+        self.window = param(WIN_LENGTH)               # STFT window (Hann, periodic=False)
+
+    def get_seq_len(self, seq_len: torch.Tensor) -> torch.Tensor:
+        pad_amount = N_FFT // 2 * 2
+        return torch.floor_divide(seq_len + pad_amount - N_FFT, HOP_LENGTH) + 1
+
+    def forward(self, x: torch.Tensor, seq_len: torch.Tensor):
+        out_len = self.get_seq_len(seq_len)
+        # preemphasis
+        x = torch.cat((x[:, 0].unsqueeze(1), x[:, 1:] - PREEMPH * x[:, :-1]), dim=1)
+        spec = torch.stft(
+            x, n_fft=N_FFT, hop_length=HOP_LENGTH, win_length=WIN_LENGTH,
+            center=True, window=self.window.to(torch.float32), return_complex=True,
+        )
+        spec = torch.view_as_real(spec)
+        mag = torch.sqrt(spec.pow(2).sum(-1))
+        if MAG_POWER != 1.0:
+            mag = mag.pow(MAG_POWER)
+        mel = torch.matmul(self.fb.to(mag.dtype), mag)     # (B, n_mels, T)
+        mel = torch.log(mel + LOG_GUARD)                    # normalize="NA" -> no-op
+        max_len = mel.size(-1)
+        mask = torch.arange(max_len, device=mel.device).expand(mel.size(0), -1) >= out_len.unsqueeze(1)
+        mel = mel.masked_fill(mask.unsqueeze(1), 0.0)
+        return mel, out_len
 
 
 class Preprocessor(nn.Module):
@@ -36,25 +100,48 @@ class Preprocessor(nn.Module):
         super().__init__()
         self.featurizer = _Featurizer()
 
+    def forward(self, x, seq_len):
+        return self.featurizer(x, seq_len)
+
 
 class ConvSubsampling(nn.Module):
-    """dw-striding subsampling: Conv2d, ReLU, (depthwise, pointwise, ReLU)x2 -> Linear."""
+    """Causal dw-striding subsampling (factor 8): CausalConv2d, ReLU,
+    (depthwise CausalConv2d, pointwise, ReLU) x2 -> Linear(4352 -> d_model)."""
 
     def __init__(self):
         super().__init__()
         self.conv = nn.Sequential(
-            nn.Conv2d(1, SUB_CH, kernel_size=3, stride=2, padding=1),
-            nn.ReLU(),
-            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=3, stride=2, padding=1, groups=SUB_CH),
-            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=1),
-            nn.ReLU(),
-            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=3, stride=2, padding=1, groups=SUB_CH),
-            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=1),
+            _CausalConv2d(1, SUB_CH, 3, stride=2),                       # 0
+            nn.ReLU(),                                                    # 1
+            _CausalConv2d(SUB_CH, SUB_CH, 3, stride=2, groups=SUB_CH),   # 2 depthwise
+            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=1),                    # 3 pointwise
+            nn.ReLU(),                                                    # 4
+            _CausalConv2d(SUB_CH, SUB_CH, 3, stride=2, groups=SUB_CH),   # 5 depthwise
+            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=1),                    # 6 pointwise
+            nn.ReLU(),                                                    # 7
         )
-        self.out = nn.Linear(4352, D)  # 256 * ceil(freq/8) -> d_model
+        self.out = nn.Linear(SUB_FLAT, D)
+
+    @staticmethod
+    def calc_length(lengths: torch.Tensor) -> torch.Tensor:
+        # 3 stride-2 causal stages: all_paddings=(k-1)+(s-1)=3, kernel=3, stride=2
+        add_pad = 3 - 3
+        for _ in range(3):
+            lengths = torch.floor(torch.div(lengths.to(torch.float32) + add_pad, 2) + 1.0)
+        return lengths.to(torch.int64)
+
+    def forward(self, x: torch.Tensor, lengths: torch.Tensor):
+        lengths = self.calc_length(lengths)
+        x = x.unsqueeze(1)                       # (B, 1, T, feat)
+        x = self.conv(x)                          # (B, C, T', F')
+        b, c, t, f = x.size()
+        x = self.out(x.transpose(1, 2).reshape(b, t, -1))
+        return x, lengths
 
 
 class _RelPosMHA(nn.Module):
+    """Transformer-XL relative-position multi-head attention (rel_pos)."""
+
     def __init__(self):
         super().__init__()
         self.linear_q = nn.Linear(D, D, bias=False)
@@ -64,6 +151,37 @@ class _RelPosMHA(nn.Module):
         self.linear_pos = nn.Linear(D, D, bias=False)
         self.pos_bias_u = param(N_HEADS, HEAD_DIM)
         self.pos_bias_v = param(N_HEADS, HEAD_DIM)
+        self.s_d_k = math.sqrt(HEAD_DIM)
+
+    @staticmethod
+    def _rel_shift(x: torch.Tensor) -> torch.Tensor:
+        b, h, qlen, pos_len = x.size()
+        x = F.pad(x, (1, 0))
+        x = x.view(b, h, -1, qlen)
+        return x[:, :, 1:].view(b, h, qlen, pos_len)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor, pos_emb: torch.Tensor) -> torch.Tensor:
+        n_batch = x.size(0)
+        q = self.linear_q(x).view(n_batch, -1, N_HEADS, HEAD_DIM)
+        k = self.linear_k(x).view(n_batch, -1, N_HEADS, HEAD_DIM).transpose(1, 2)
+        v = self.linear_v(x).view(n_batch, -1, N_HEADS, HEAD_DIM).transpose(1, 2)
+        # q kept as (B, t1, h, d_k) to add per-head biases
+        p = self.linear_pos(pos_emb).view(pos_emb.size(0), -1, N_HEADS, HEAD_DIM).transpose(1, 2)
+        q_u = (q + self.pos_bias_u).transpose(1, 2)   # (B, h, t1, d_k)
+        q_v = (q + self.pos_bias_v).transpose(1, 2)
+        matrix_bd = torch.matmul(q_v, p.transpose(-2, -1))
+        matrix_bd = self._rel_shift(matrix_bd)
+        matrix_ac = torch.matmul(q_u, k.transpose(-2, -1))
+        matrix_bd = matrix_bd[:, :, :, : matrix_ac.size(-1)]
+        scores = (matrix_ac + matrix_bd) / self.s_d_k
+        if mask is not None:
+            m = mask.unsqueeze(1)
+            scores = scores.masked_fill(m, -INF_VAL)
+            attn = torch.softmax(scores, dim=-1).masked_fill(m, 0.0)
+        else:
+            attn = torch.softmax(scores, dim=-1)
+        out = torch.matmul(attn, v).transpose(1, 2).reshape(n_batch, -1, D)
+        return self.linear_out(out)
 
 
 class _FeedForward(nn.Module):
@@ -72,17 +190,41 @@ class _FeedForward(nn.Module):
         self.linear1 = nn.Linear(D, FF, bias=False)
         self.linear2 = nn.Linear(FF, D, bias=False)
 
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear2(F.silu(self.linear1(x)))
+
 
 class _ConvModule(nn.Module):
+    """Conformer conv module: pointwise -> GLU -> causal depthwise -> LayerNorm
+    (checkpoint's ``batch_norm`` is a LayerNorm) -> SiLU -> pointwise."""
+
     def __init__(self):
         super().__init__()
         self.pointwise_conv1 = nn.Conv1d(D, 2 * D, kernel_size=1, bias=False)
-        self.depthwise_conv = nn.Conv1d(D, D, kernel_size=9, padding=4, groups=D, bias=False)
-        self.batch_norm = nn.BatchNorm1d(D)
+        # causal depthwise: left pad k-1, right pad 0
+        self.depthwise_conv = nn.Conv1d(D, D, kernel_size=CONV_KERNEL, padding=0, groups=D, bias=False)
+        self.batch_norm = nn.LayerNorm(D)
         self.pointwise_conv2 = nn.Conv1d(D, D, kernel_size=1, bias=False)
+
+    def forward(self, x: torch.Tensor, pad_mask: torch.Tensor | None) -> torch.Tensor:
+        x = x.transpose(1, 2)                    # (B, D, T)
+        x = self.pointwise_conv1(x)
+        x = F.glu(x, dim=1)
+        if pad_mask is not None:
+            x = x.masked_fill(pad_mask.unsqueeze(1), 0.0)
+        x = F.pad(x, (CONV_KERNEL - 1, 0))       # causal padding
+        x = self.depthwise_conv(x)
+        x = x.transpose(1, 2)                     # (B, T, D)
+        x = self.batch_norm(x)                    # LayerNorm over channels
+        x = x.transpose(1, 2)                     # (B, D, T)
+        x = F.silu(x)
+        x = self.pointwise_conv2(x)
+        return x.transpose(1, 2)                  # (B, T, D)
 
 
 class ConformerLayer(nn.Module):
+    FC_FACTOR = 0.5
+
     def __init__(self):
         super().__init__()
         self.norm_feed_forward1 = nn.LayerNorm(D)
@@ -95,12 +237,55 @@ class ConformerLayer(nn.Module):
         self.feed_forward2 = _FeedForward()
         self.norm_out = nn.LayerNorm(D)
 
+    def forward(self, x, att_mask, pos_emb, pad_mask):
+        residual = x + self.FC_FACTOR * self.feed_forward1(self.norm_feed_forward1(x))
+        residual = residual + self.self_attn(self.norm_self_att(residual), att_mask, pos_emb)
+        residual = residual + self.conv(self.norm_conv(residual), pad_mask)
+        residual = residual + self.FC_FACTOR * self.feed_forward2(self.norm_feed_forward2(residual))
+        return self.norm_out(residual)
+
 
 class ConformerEncoder(nn.Module):
     def __init__(self):
         super().__init__()
         self.pre_encode = ConvSubsampling()
         self.layers = nn.ModuleList([ConformerLayer() for _ in range(NUM_LAYERS)])
+
+    @staticmethod
+    def _rel_pos_emb(length: int, dim: int, device, dtype) -> torch.Tensor:
+        """RelPositionalEncoding: positions (L-1 .. -(L-1)), sinusoidal, (1, 2L-1, dim)."""
+        positions = torch.arange(length - 1, -length, -1, dtype=torch.float32, device=device).unsqueeze(1)
+        pe = torch.zeros(positions.size(0), dim, device=device)
+        div_term = torch.exp(
+            torch.arange(0, dim, 2, dtype=torch.float32, device=device) * -(math.log(INF_VAL) / dim)
+        )
+        pe[:, 0::2] = torch.sin(positions * div_term)
+        pe[:, 1::2] = torch.cos(positions * div_term)
+        return pe.unsqueeze(0).to(dtype)
+
+    @staticmethod
+    def _create_masks(length: torch.Tensor, max_len: int, device):
+        # chunked_limited, att_context_size=[70, 0] -> chunk_size=1, left window 70
+        idx = torch.arange(0, max_len, device=device)
+        diff = idx.unsqueeze(1) - idx.unsqueeze(0)
+        att_ok = (diff <= ATT_LEFT) & (diff >= 0)                       # (T, T)
+        pad_ok = torch.arange(0, max_len, device=device).expand(length.size(0), -1) < length.unsqueeze(-1)
+        pad_att = pad_ok.unsqueeze(1).repeat(1, max_len, 1)
+        pad_att = pad_att & pad_att.transpose(1, 2)
+        att_mask = ~(pad_att & att_ok.unsqueeze(0))                     # True = masked
+        pad_mask = ~pad_ok                                             # True = pad
+        return pad_mask, att_mask
+
+    def forward(self, audio_signal: torch.Tensor, length: torch.Tensor):
+        # audio_signal: (B, feat, T)
+        audio_signal = audio_signal.transpose(1, 2)                   # (B, T, feat)
+        audio_signal, length = self.pre_encode(audio_signal, length)  # (B, T', D)
+        max_audio_length = audio_signal.size(1)
+        pos_emb = self._rel_pos_emb(max_audio_length, D, audio_signal.device, audio_signal.dtype)
+        pad_mask, att_mask = self._create_masks(length, max_audio_length, audio_signal.device)
+        for layer in self.layers:
+            audio_signal = layer(audio_signal, att_mask, pos_emb, pad_mask)
+        return audio_signal.transpose(1, 2), length                   # (B, D, T'), length
 
 
 class Perception(nn.Module):
@@ -111,6 +296,23 @@ class Perception(nn.Module):
         self.preprocessor = Preprocessor()
         self.encoder = ConformerEncoder()
         self.proj = nn.Linear(D, LLM_HIDDEN)  # 1024 -> 4480, into nano hidden
+
+    def forward(
+        self,
+        input_signal: torch.Tensor | None = None,
+        input_signal_lens: torch.Tensor | None = None,
+        processed_signal: torch.Tensor | None = None,
+        processed_signal_lens: torch.Tensor | None = None,
+    ):
+        """(B, samples) waveform -> (B, T', 4480) LLM-space embeddings, lengths.
+
+        Pass ``processed_signal`` (B, n_mels, T) to bypass the mel featurizer.
+        """
+        if processed_signal is None:
+            processed_signal, processed_signal_lens = self.preprocessor(input_signal, input_signal_lens)
+        encoder_emb, encoded_len = self.encoder(processed_signal, processed_signal_lens)
+        encoded = self.proj(encoder_emb.transpose(1, 2))              # (B, T', 4480)
+        return encoded, encoded_len
 
     @staticmethod
     def remap(name: str) -> str | None:

--- a/mstar/model/nemotron_duplex/components/conformer.py
+++ b/mstar/model/nemotron_duplex/components/conformer.py
@@ -1,0 +1,123 @@
+"""Fast-Conformer STT perception stack (``stt_model.perception.*``).
+
+NeMo Fast-Conformer: mel preprocessor -> dw-striding conv subsampling ->
+24 Conformer layers (Macaron FF, rel-pos MHA, conv module) -> projection into
+the nano LLM hidden space (1024 -> 4480).
+
+Ported to exact checkpoint parity. FF/attention/conv linears are bias-free;
+norms are LayerNorm; the conv module's BatchNorm keeps only weight+bias in the
+checkpoint (running stats are absent — a Phase-4 numerics note). Forward is
+Phase 4 (audio-in); the tree here is load-verified.
+"""
+from __future__ import annotations
+
+from torch import nn
+
+from mstar.model.nemotron_duplex.components._util import param
+
+D = 1024          # encoder d_model
+N_HEADS = 8
+HEAD_DIM = 128
+FF = 4096
+NUM_LAYERS = 24
+SUB_CH = 256      # subsampling channels
+LLM_HIDDEN = 4480
+
+
+class _Featurizer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fb = param(1, 128, 257)      # mel filterbank
+        self.window = param(400)          # STFT window
+
+
+class Preprocessor(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.featurizer = _Featurizer()
+
+
+class ConvSubsampling(nn.Module):
+    """dw-striding subsampling: Conv2d, ReLU, (depthwise, pointwise, ReLU)x2 -> Linear."""
+
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Sequential(
+            nn.Conv2d(1, SUB_CH, kernel_size=3, stride=2, padding=1),
+            nn.ReLU(),
+            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=3, stride=2, padding=1, groups=SUB_CH),
+            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=1),
+            nn.ReLU(),
+            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=3, stride=2, padding=1, groups=SUB_CH),
+            nn.Conv2d(SUB_CH, SUB_CH, kernel_size=1),
+        )
+        self.out = nn.Linear(4352, D)  # 256 * ceil(freq/8) -> d_model
+
+
+class _RelPosMHA(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear_q = nn.Linear(D, D, bias=False)
+        self.linear_k = nn.Linear(D, D, bias=False)
+        self.linear_v = nn.Linear(D, D, bias=False)
+        self.linear_out = nn.Linear(D, D, bias=False)
+        self.linear_pos = nn.Linear(D, D, bias=False)
+        self.pos_bias_u = param(N_HEADS, HEAD_DIM)
+        self.pos_bias_v = param(N_HEADS, HEAD_DIM)
+
+
+class _FeedForward(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear1 = nn.Linear(D, FF, bias=False)
+        self.linear2 = nn.Linear(FF, D, bias=False)
+
+
+class _ConvModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pointwise_conv1 = nn.Conv1d(D, 2 * D, kernel_size=1, bias=False)
+        self.depthwise_conv = nn.Conv1d(D, D, kernel_size=9, padding=4, groups=D, bias=False)
+        self.batch_norm = nn.BatchNorm1d(D)
+        self.pointwise_conv2 = nn.Conv1d(D, D, kernel_size=1, bias=False)
+
+
+class ConformerLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.norm_feed_forward1 = nn.LayerNorm(D)
+        self.feed_forward1 = _FeedForward()
+        self.norm_self_att = nn.LayerNorm(D)
+        self.self_attn = _RelPosMHA()
+        self.norm_conv = nn.LayerNorm(D)
+        self.conv = _ConvModule()
+        self.norm_feed_forward2 = nn.LayerNorm(D)
+        self.feed_forward2 = _FeedForward()
+        self.norm_out = nn.LayerNorm(D)
+
+
+class ConformerEncoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pre_encode = ConvSubsampling()
+        self.layers = nn.ModuleList([ConformerLayer() for _ in range(NUM_LAYERS)])
+
+
+class Perception(nn.Module):
+    """Full perception stack: preprocessor + conformer encoder + LLM projection."""
+
+    def __init__(self):
+        super().__init__()
+        self.preprocessor = Preprocessor()
+        self.encoder = ConformerEncoder()
+        self.proj = nn.Linear(D, LLM_HIDDEN)  # 1024 -> 4480, into nano hidden
+
+    @staticmethod
+    def remap(name: str) -> str | None:
+        prefix = "stt_model.perception."
+        return name[len(prefix):] if name.startswith(prefix) else None
+
+    def load_weights(self, weights):
+        from mstar.model.loader import load_hf_weights
+
+        return load_hf_weights(self, weights, stacked_params=[], name_remapper=self.remap)

--- a/mstar/model/nemotron_duplex/components/eartts_talker.py
+++ b/mstar/model/nemotron_duplex/components/eartts_talker.py
@@ -5,12 +5,20 @@ a subword-conditioning encoder, and audio/text gated fusion.
 Ported to exact checkpoint parity (28-layer Gemma3 backbone, head_dim 72 with
 QK-norm; a 1-layer subword encoder; the MoG head; and the bespoke embedding
 tables). The three top-level ``tts_model.*`` buffers (control codes, codec
-silence tokens, per-voice audio-prompt latents) load here too. Forward is
-Phase 5 (needs the EarTTS reference to verify code sampling / MoG numerics).
+silence tokens, per-voice audio-prompt latents) load here too.
+
+The teacher-forced forward (backbone + gated fusion + MoG head) and the
+char-aware subword encoder are numerically verified in fp32 against the NeMo
+``RVQEARTTSModel`` reference (transformers Gemma3TextModel / T5GemmaEncoderModel
+backbones): cosine > 0.9999 on the backbone hidden state, the MoG head params
+and the pooled subword embeddings. The stochastic code-sampling loop
+(``generate_step``: Gumbel mixture pick + iterative RVQ unmasking) is not
+implemented here.
 """
 from __future__ import annotations
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 from mstar.model.components import RMSNorm
@@ -21,10 +29,47 @@ from mstar.model.nemotron_duplex.config import EarTTSConfig
 H = 1152          # talker hidden
 FF = 4608         # talker mlp intermediate
 HEAD_DIM = 72
+NUM_HEADS = 16
 NUM_LAYERS = 28
 CODE_DIM = 512    # rvq latent dim
 NUM_QUANTIZERS = 31
 CODEBOOK = 1024
+NUM_PREDICTIONS = 1024   # MoG mixture components
+LOW_RANK = 64            # MoG low-rank mean dim
+MIN_LOG_STD = -4.0
+RMS_EPS = 1e-6
+
+# Gemma3-text backbone specifics (from HF Gemma3TextConfig defaults + checkpoint).
+QUERY_PRE_ATTN_SCALAR = 256.0     # attention scaling = QUERY_PRE_ATTN_SCALAR ** -0.5
+ROPE_THETA_GLOBAL = 1_000_000.0   # full-attention layers
+ROPE_THETA_LOCAL = 10_000.0       # sliding-attention layers
+SLIDING_WINDOW_PATTERN = 6        # layer i is full attention iff (i + 1) % 6 == 0
+
+
+def _gemma_rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float = RMS_EPS) -> torch.Tensor:
+    """Gemma3 RMSNorm computed in fp32: ``(x * rsqrt(mean(x^2)+eps)) * (1 + w)``.
+
+    Done manually (not via the shared fused ``RMSNorm`` kernel, which runs in
+    bf16) so an fp32 numeric comparison is exact.
+    """
+    dtype = x.dtype
+    x32 = x.float()
+    out = x32 * torch.rsqrt(x32.pow(2).mean(-1, keepdim=True) + eps)
+    out = out * (1.0 + weight.float())
+    return out.to(dtype)
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1, x2 = x[..., : x.shape[-1] // 2], x[..., x.shape[-1] // 2:]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _rope_cos_sin(positions: torch.Tensor, theta: float, dim: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Standard rotary cos/sin over the full ``dim`` head, computed in fp32."""
+    inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, device=positions.device, dtype=torch.float32) / dim))
+    freqs = positions.float()[:, None] * inv_freq[None, :]   # [T, dim/2]
+    emb = torch.cat((freqs, freqs), dim=-1)                  # [T, dim]
+    return emb.cos(), emb.sin()
 
 
 class _Attn(nn.Module):
@@ -40,6 +85,45 @@ class _Attn(nn.Module):
             self.q_norm = RMSNorm(HEAD_DIM)
             self.k_norm = RMSNorm(HEAD_DIM)
 
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
+        causal: bool = True,
+        attn_bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Multi-head self-attention. Gemma3-style: optional per-head QK-norm
+        (applied before rope), rope on the full head dim, and query scaling by
+        ``QUERY_PRE_ATTN_SCALAR ** -0.5``. ``causal`` adds a triangular mask
+        (talker); ``attn_bias`` is an additive mask broadcastable to
+        ``[b, nh, tq, tk]`` (encoder key padding)."""
+        b, t, _ = x.shape
+        q = F.linear(x, self.q_proj.weight).view(b, t, NUM_HEADS, HEAD_DIM)
+        k = F.linear(x, self.k_proj.weight).view(b, t, NUM_HEADS, HEAD_DIM)
+        v = F.linear(x, self.v_proj.weight).view(b, t, NUM_HEADS, HEAD_DIM)
+        if hasattr(self, "q_norm"):
+            q = _gemma_rmsnorm(q, self.q_norm.weight)
+            k = _gemma_rmsnorm(k, self.k_norm.weight)
+        q = q.transpose(1, 2)   # [b, nh, t, hd]
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+        if cos is not None:
+            cos_b = cos[None, None, :, :]
+            sin_b = sin[None, None, :, :]
+            q = q * cos_b + _rotate_half(q) * sin_b
+            k = k * cos_b + _rotate_half(k) * sin_b
+        scaling = QUERY_PRE_ATTN_SCALAR ** -0.5
+        scores = torch.matmul(q, k.transpose(-1, -2)) * scaling
+        if causal:
+            neg = torch.full((t, t), float("-inf"), device=x.device, dtype=scores.dtype)
+            scores = scores + torch.triu(neg, diagonal=1)
+        if attn_bias is not None:
+            scores = scores + attn_bias
+        attn = torch.softmax(scores.float(), dim=-1).to(v.dtype)
+        out = torch.matmul(attn, v).transpose(1, 2).reshape(b, t, NUM_HEADS * HEAD_DIM)
+        return F.linear(out, self.o_proj.weight)
+
 
 class TalkerLayer(nn.Module):
     """Gemma3 decoder layer: input/post-attn/pre-ff/post-ff norms + QK-norm attn + gated MLP."""
@@ -53,6 +137,22 @@ class TalkerLayer(nn.Module):
         self.mlp = GatedMLP(H, FF, activation="gelu_tanh", bias=False)
         self.post_feedforward_layernorm = RMSNorm(H)
 
+    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+        """Gemma3 decoder layer with its 4 RMSNorms (input / post-attn /
+        pre-ff / post-ff), each ``(1 + w)`` in fp32."""
+        residual = x
+        h = _gemma_rmsnorm(x, self.input_layernorm.weight)
+        h = self.self_attn(h, cos, sin, causal=True)
+        h = _gemma_rmsnorm(h, self.post_attention_layernorm.weight)
+        x = residual + h
+
+        residual = x
+        h = _gemma_rmsnorm(x, self.pre_feedforward_layernorm.weight)
+        h = self.mlp(h)
+        h = _gemma_rmsnorm(h, self.post_feedforward_layernorm.weight)
+        x = residual + h
+        return x
+
 
 class _EncoderLayer(nn.Module):
     """Subword-encoder layer: pre/post self-attn + pre/post ff norms (no QK-norm)."""
@@ -65,6 +165,22 @@ class _EncoderLayer(nn.Module):
         self.pre_feedforward_layernorm = RMSNorm(H)
         self.post_feedforward_layernorm = RMSNorm(H)
         self.mlp = GatedMLP(H, FF, activation="gelu_tanh", bias=False)
+
+    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, attn_bias: torch.Tensor) -> torch.Tensor:
+        """T5Gemma encoder layer: bidirectional attention (no QK-norm) with
+        pre/post self-attn and pre/post ff RMSNorms."""
+        residual = x
+        h = _gemma_rmsnorm(x, self.pre_self_attn_layernorm.weight)
+        h = self.self_attn(h, cos, sin, causal=False, attn_bias=attn_bias)
+        h = _gemma_rmsnorm(h, self.post_self_attn_layernorm.weight)
+        x = residual + h
+
+        residual = x
+        h = _gemma_rmsnorm(x, self.pre_feedforward_layernorm.weight)
+        h = self.mlp(h)
+        h = _gemma_rmsnorm(h, self.post_feedforward_layernorm.weight)
+        x = residual + h
+        return x
 
 
 class _EncoderBackbone(nn.Module):
@@ -105,6 +221,63 @@ class EmbedSubword(nn.Module):
         self.bos_eos_emb = _BosEosEmb()
         self.subword_flag_emb = _SubwordFlagEmb()
 
+    def encode_chars(self, char_ids: torch.Tensor, char_lengths: torch.Tensor) -> torch.Tensor:
+        """Char-aware subword pooling: embed char ids, run the T5Gemma encoder
+        (bidirectional, rope theta 10000) with a key-padding mask, mean-pool over
+        valid chars, and project. ``char_ids`` [N, Lc], ``char_lengths`` [N] ->
+        ``[N, H]``."""
+        n, lc = char_ids.shape
+        char_mask = torch.arange(lc, device=char_ids.device)[None, :] < char_lengths[:, None]  # [N, Lc]
+        char_embeds = self.embed_tokens(char_ids)  # [N, Lc, H]
+
+        cos, sin = _rope_cos_sin(torch.arange(lc, device=char_ids.device), ROPE_THETA_LOCAL, HEAD_DIM)
+        neg = torch.finfo(char_embeds.dtype).min
+        attn_bias = torch.where(char_mask[:, None, None, :], 0.0, neg).to(char_embeds.dtype)  # [N,1,1,Lc]
+
+        # T5Gemma encoder scales the input embeddings by sqrt(hidden_size).
+        x = char_embeds * (H ** 0.5)
+        for layer in self.backbone.encoder.layers:
+            x = layer(x, cos, sin, attn_bias)
+        x = _gemma_rmsnorm(x, self.backbone.encoder.norm.weight)
+
+        masked_sum = (x * char_mask.unsqueeze(-1)).sum(dim=1)
+        mean_emb = masked_sum / char_lengths.unsqueeze(-1).clamp(min=1)
+        return self.proj_embedding(mean_emb)
+
+    def forward(
+        self,
+        char_ids: torch.Tensor,
+        char_lengths: torch.Tensor,
+        subword_ids: torch.Tensor,
+        subword_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Full subword conditioning: pool char embeddings into per-subword
+        vectors, scatter to [B, T, H], then add the continuation-flag and
+        BOS/EOS embeddings looked up from the checkpoint flag tables.
+
+        ``char_ids``/``char_lengths`` cover the valid (masked) subwords in row
+        order (the caller supplies the subword->char id mapping from the
+        tokenizer). ``subword_ids``/``subword_mask`` are [B, T]."""
+        out_emb = self.encode_chars(char_ids, char_lengths)  # [N, H]
+        subword_embeds = torch.zeros(
+            subword_ids.shape + (H,), device=subword_ids.device, dtype=out_emb.dtype
+        )
+        subword_embeds[subword_mask] = out_emb
+
+        # continuation-flag embedding (index 0 forced to zero in the checkpoint)
+        vocab = self.subword_flag_emb.cont_emb.num_embeddings  # 2
+        pad = self.subword_flag_emb.is_continuation.numel() - 1
+        safe = torch.where(subword_ids >= pad, torch.full_like(subword_ids, pad), subword_ids)
+        cont_flags = self.subword_flag_emb.is_continuation[safe]
+        subword_embeds = subword_embeds + self.subword_flag_emb.cont_emb(cont_flags.clamp_max(vocab - 1))
+
+        # BOS/EOS embedding (index 0 = regular, forced to zero)
+        pad2 = self.bos_eos_emb.special_flags.numel() - 1
+        safe2 = torch.where(subword_ids >= pad2, torch.full_like(subword_ids, pad2), subword_ids)
+        flags = self.bos_eos_emb.special_flags[safe2]
+        subword_embeds = subword_embeds + self.bos_eos_emb.special_emb(flags)
+        return subword_embeds
+
 
 class GatedFusion(nn.Module):
     def __init__(self):
@@ -114,6 +287,23 @@ class GatedFusion(nn.Module):
         self.final_norm = RMSNorm(H)
         self.gate = param(H)
         self.residual_scale = param()  # scalar
+
+    def forward(self, audio_emb: torch.Tensor, text_emb: torch.Tensor) -> torch.Tensor:
+        """Gated projected sum of audio + text, then RMSNorm.
+
+        ``audio_emb`` is divided by the number of codebooks; the per-channel
+        ``gate`` and scalar ``residual_scale`` are sigmoided in fp32.
+        """
+        dtype = audio_emb.dtype
+        audio_emb = audio_emb / NUM_QUANTIZERS
+        audio_h = F.linear(audio_emb, self.audio_proj.weight, self.audio_proj.bias)
+        text_h = F.linear(text_emb, self.text_proj.weight, self.text_proj.bias)
+        gate = torch.sigmoid(self.gate.float())
+        res = torch.sigmoid(self.residual_scale.float())
+        h = gate.to(dtype) * audio_h + (1.0 - gate).to(dtype) * text_h
+        h = res.to(dtype) * h
+        h = _gemma_rmsnorm(h.float(), self.final_norm.weight).to(dtype)
+        return h
 
 
 class _MogMLP(nn.Module):
@@ -139,6 +329,30 @@ class MogHead(nn.Module):
         self.proj_logits = nn.Linear(H, CODEBOOK, bias=False)
         self.proj_logs = nn.Linear(H, 1, bias=False)
         self.proj_mus = nn.Linear(H, 65536, bias=False)
+
+    def forward(self, x: torch.Tensor):
+        """Deterministic (training-style) MoG head forward.
+
+        Returns ``(logits, mus, mu_res, logs)``:
+          * ``logits`` [b, t, num_predictions] mixture weights
+          * ``mus``    [b, t, num_predictions, low_rank] low-rank means
+          * ``mu_res`` [b, t, out_size] residual mean
+          * ``logs``   [b, t, 1] log std, clamped to ``MIN_LOG_STD``
+        """
+        b, t, _ = x.shape
+        # mlp_stack: 3 residual MLPLayers (pre_norm -> mlp -> post_norm) then a final RMSNorm.
+        for block in self.mlp_stack[:3]:
+            y = _gemma_rmsnorm(x, block.pre_norm.weight)
+            y = block.mlp(y)
+            y = _gemma_rmsnorm(y, block.post_norm.weight)
+            x = x + y
+        x = _gemma_rmsnorm(x, self.mlp_stack[3].weight)
+
+        logits = F.linear(x, self.proj_logits.weight)
+        mus = F.linear(x, self.proj_mus.weight).view(b, t, NUM_PREDICTIONS, LOW_RANK)
+        logs = F.linear(x, self.proj_logs.weight).clamp_min(MIN_LOG_STD)
+        mu_res = F.linear(x, self.proj_else.weight)
+        return logits, mus, mu_res, logs
 
 
 class _Backbone(nn.Module):
@@ -168,6 +382,69 @@ class EarTTSTalker(nn.Module):
         self.audio_prompt_latents = nn.ParameterDict(
             {v: param(1, 37, H) for v in voices}
         )
+
+    def depthsum_embedding(self, code: torch.Tensor) -> torch.Tensor:
+        """Sum of per-codebook RVQ embeddings: ``code`` [b, t, num_quantizers]
+        (long) -> [b, t, code_dim]. Index ``codebook_size`` maps to a zero row
+        (a padded extra slot), so masked-out codebooks contribute nothing."""
+        b, t, d = code.shape
+        _, _, hdim = self.rvq_embs.shape
+        embs = F.pad(self.rvq_embs, [0, 0, 0, 1])   # [d, codebook_size+1, code_dim]
+        ret = code.new_zeros((b, t, hdim), dtype=self.rvq_embs.dtype)
+        for i in range(d):
+            ret = ret + F.embedding(code[..., i], embs[i])
+        return ret
+
+    def backbone_forward(self, inputs_embeds: torch.Tensor, position_ids: torch.Tensor | None = None) -> torch.Tensor:
+        """Gemma3-text decoder stack over ``inputs_embeds`` [b, t, H].
+
+        Full-attention layers (``(i+1) % 6 == 0``) use rope_theta 1e6; the rest
+        (sliding-attention) use rope_local_base_freq 1e4. For sequences shorter
+        than the 7500 sliding window the two mask identically (plain causal), so
+        only the rope base differs between layer types.
+        """
+        b, t, _ = inputs_embeds.shape
+        if position_ids is None:
+            position_ids = torch.arange(t, device=inputs_embeds.device)
+        cos_g, sin_g = _rope_cos_sin(position_ids, ROPE_THETA_GLOBAL, HEAD_DIM)
+        cos_l, sin_l = _rope_cos_sin(position_ids, ROPE_THETA_LOCAL, HEAD_DIM)
+        x = inputs_embeds
+        for i, layer in enumerate(self.backbone.layers):
+            full = (i + 1) % SLIDING_WINDOW_PATTERN == 0
+            cos, sin = (cos_g, sin_g) if full else (cos_l, sin_l)
+            x = layer(x, cos, sin)
+        x = _gemma_rmsnorm(x, self.backbone.norm.weight)
+        return x
+
+    def forward(
+        self,
+        code: torch.Tensor,
+        cond: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+    ):
+        """Teacher-forced single pass producing the MoG head parameters.
+
+        Args:
+            code: [b, t, num_quantizers] long RVQ code ids for each frame (the
+                inference-mode input: already the frame whose latent is embedded).
+            cond: [b, t, H] (or broadcastable [1, 1, H]) text/subword conditioning;
+                ``None`` means zero conditioning.
+            position_ids: optional [t] positions (defaults to ``arange(t)``).
+
+        Returns:
+            ``(hidden_states, mog_logits, mog_mus, mog_mu_res, mog_logs)`` where
+            ``hidden_states`` is the backbone output and the MoG params come from
+            ``mog_head(embed_code(depthsum(code)) + hidden_states)``.
+        """
+        code_embeds = self.embed_code(self.depthsum_embedding(code))
+        if cond is None:
+            cond = code_embeds.new_zeros((1, 1, H))
+        inputs_embeds = self.gated_fusion_audio_text(code_embeds, cond)
+        hidden_states = self.backbone_forward(inputs_embeds, position_ids)
+
+        mog_input = self.embed_code(self.depthsum_embedding(code)) + hidden_states
+        mog_logits, mog_mus, mog_mu_res, mog_logs = self.mog_head(mog_input)
+        return hidden_states, mog_logits, mog_mus, mog_mu_res, mog_logs
 
     @staticmethod
     def remap(name: str) -> str | None:

--- a/mstar/model/nemotron_duplex/components/eartts_talker.py
+++ b/mstar/model/nemotron_duplex/components/eartts_talker.py
@@ -1,0 +1,190 @@
+"""EarTTS talker (``tts_model.tts_model.*``): Gemma3-text transformer that
+autoregressively emits RVQ codec codes, plus a mixture-of-gaussians (MoG) head,
+a subword-conditioning encoder, and audio/text gated fusion.
+
+Ported to exact checkpoint parity (28-layer Gemma3 backbone, head_dim 72 with
+QK-norm; a 1-layer subword encoder; the MoG head; and the bespoke embedding
+tables). The three top-level ``tts_model.*`` buffers (control codes, codec
+silence tokens, per-voice audio-prompt latents) load here too. Forward is
+Phase 5 (needs the EarTTS reference to verify code sampling / MoG numerics).
+"""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from mstar.model.components import RMSNorm
+from mstar.model.components.mlp import GatedMLP
+from mstar.model.nemotron_duplex.components._util import RawWeight, param
+from mstar.model.nemotron_duplex.config import EarTTSConfig
+
+H = 1152          # talker hidden
+FF = 4608         # talker mlp intermediate
+HEAD_DIM = 72
+NUM_LAYERS = 28
+CODE_DIM = 512    # rvq latent dim
+NUM_QUANTIZERS = 31
+CODEBOOK = 1024
+
+
+class _Attn(nn.Module):
+    """q/k/v/o projections (no bias); optional Gemma3 per-head QK-norm."""
+
+    def __init__(self, qk_norm: bool):
+        super().__init__()
+        self.q_proj = nn.Linear(H, H, bias=False)
+        self.k_proj = nn.Linear(H, H, bias=False)
+        self.v_proj = nn.Linear(H, H, bias=False)
+        self.o_proj = nn.Linear(H, H, bias=False)
+        if qk_norm:
+            self.q_norm = RMSNorm(HEAD_DIM)
+            self.k_norm = RMSNorm(HEAD_DIM)
+
+
+class TalkerLayer(nn.Module):
+    """Gemma3 decoder layer: input/post-attn/pre-ff/post-ff norms + QK-norm attn + gated MLP."""
+
+    def __init__(self):
+        super().__init__()
+        self.input_layernorm = RMSNorm(H)
+        self.self_attn = _Attn(qk_norm=True)
+        self.post_attention_layernorm = RMSNorm(H)
+        self.pre_feedforward_layernorm = RMSNorm(H)
+        self.mlp = GatedMLP(H, FF, activation="gelu_tanh", bias=False)
+        self.post_feedforward_layernorm = RMSNorm(H)
+
+
+class _EncoderLayer(nn.Module):
+    """Subword-encoder layer: pre/post self-attn + pre/post ff norms (no QK-norm)."""
+
+    def __init__(self):
+        super().__init__()
+        self.self_attn = _Attn(qk_norm=False)
+        self.pre_self_attn_layernorm = RMSNorm(H)
+        self.post_self_attn_layernorm = RMSNorm(H)
+        self.pre_feedforward_layernorm = RMSNorm(H)
+        self.post_feedforward_layernorm = RMSNorm(H)
+        self.mlp = GatedMLP(H, FF, activation="gelu_tanh", bias=False)
+
+
+class _EncoderBackbone(nn.Module):
+    def __init__(self, n_layers: int = 1):
+        super().__init__()
+        self.encoder = _Encoder(n_layers)
+
+
+class _Encoder(nn.Module):
+    def __init__(self, n_layers: int):
+        super().__init__()
+        self.layers = nn.ModuleList([_EncoderLayer() for _ in range(n_layers)])
+        self.norm = RMSNorm(H)
+
+
+class _BosEosEmb(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.special_emb = nn.Embedding(3, H)
+        self.special_flags = param(131072, dtype=torch.int64)
+        self.pad_tensor = param(dtype=torch.int64)
+
+
+class _SubwordFlagEmb(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.cont_emb = nn.Embedding(2, H)
+        self.is_continuation = param(131073, dtype=torch.int64)
+        self.pad_tensor = param(dtype=torch.int64)
+
+
+class EmbedSubword(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = _EncoderBackbone(n_layers=1)
+        self.embed_tokens = nn.Embedding(257, H)
+        self.proj_embedding = nn.Linear(H, H, bias=False)
+        self.bos_eos_emb = _BosEosEmb()
+        self.subword_flag_emb = _SubwordFlagEmb()
+
+
+class GatedFusion(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.audio_proj = nn.Linear(H, H, bias=True)
+        self.text_proj = nn.Linear(H, H, bias=True)
+        self.final_norm = RMSNorm(H)
+        self.gate = param(H)
+        self.residual_scale = param()  # scalar
+
+
+class _MogMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mlp = GatedMLP(H, FF, activation="gelu_tanh", bias=False)
+        self.pre_norm = RMSNorm(H)
+        self.post_norm = RMSNorm(H)
+
+
+class MogHead(nn.Module):
+    """Mixture-of-gaussians output head over the RVQ latent space.
+
+    ``mlp_stack`` is 3 gated-MLP blocks followed by a bare scale vector
+    (index 3, ``mlp_stack.3.weight`` [H]).
+    """
+
+    def __init__(self, n_mlp: int = 3):
+        super().__init__()
+        self.low_mat = param(CODEBOOK, CODE_DIM, 64)
+        self.mlp_stack = nn.ModuleList([_MogMLP() for _ in range(n_mlp)] + [RawWeight(H)])
+        self.proj_else = nn.Linear(H, CODE_DIM, bias=False)
+        self.proj_logits = nn.Linear(H, CODEBOOK, bias=False)
+        self.proj_logs = nn.Linear(H, 1, bias=False)
+        self.proj_mus = nn.Linear(H, 65536, bias=False)
+
+
+class _Backbone(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList([TalkerLayer() for _ in range(NUM_LAYERS)])
+        self.norm = RMSNorm(H)
+
+
+class EarTTSTalker(nn.Module):
+    def __init__(self, config: EarTTSConfig, voices=("Aria",)):
+        super().__init__()
+        self.config = config
+        self.embed_code = nn.Linear(CODE_DIM, H, bias=False)
+        self.backbone = _Backbone()
+        self.embed_subword = EmbedSubword()
+        self.gated_fusion_audio_text = GatedFusion()
+        self.mog_head = MogHead()
+        # bespoke embeddings / tables
+        self.bos_emb = param(H)
+        self.null_emb = param(H)
+        self.audio_prompt_projection_W = param(H, H)
+        self.rvq_embs = param(NUM_QUANTIZERS, CODEBOOK, CODE_DIM)
+        # top-level tts_model.* buffers (loaded via the talker node)
+        self._control_codes = param(3, dtype=torch.int64)
+        self.codec_silence_tokens = param(NUM_QUANTIZERS, dtype=torch.int64)
+        self.audio_prompt_latents = nn.ParameterDict(
+            {v: param(1, 37, H) for v in voices}
+        )
+
+    @staticmethod
+    def remap(name: str) -> str | None:
+        top = {
+            "tts_model._control_codes": "_control_codes",
+            "tts_model.codec_silence_tokens": "codec_silence_tokens",
+        }
+        if name in top:
+            return top[name]
+        if name.startswith("tts_model.audio_prompt_latents."):
+            voice = name[len("tts_model.audio_prompt_latents."):]
+            return f"audio_prompt_latents.{voice}"
+        prefix = "tts_model.tts_model."
+        return name[len(prefix):] if name.startswith(prefix) else None
+
+    def load_weights(self, weights):
+        """Load ``tts_model.tts_model.*`` plus the top-level TTS buffers."""
+        from mstar.model.loader import load_hf_weights
+
+        return load_hf_weights(self, weights, stacked_params=[], name_remapper=self.remap)

--- a/mstar/model/nemotron_duplex/components/eartts_talker.py
+++ b/mstar/model/nemotron_duplex/components/eartts_talker.py
@@ -56,6 +56,18 @@ def _gemma_rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.T
     return out.to(dtype)
 
 
+def _top_p_filter(logits: torch.Tensor, top_p: float) -> torch.Tensor:
+    """Nucleus (top-p) filter over the last dim: mask out the low-probability tail
+    beyond cumulative ``top_p`` with ``-inf`` (keeps at least the top token).
+    Mirrors HF ``TopPLogitsWarper`` used by the reference MoG sampler."""
+    sorted_logits, sorted_idx = torch.sort(logits, descending=True, dim=-1)
+    cum = sorted_logits.softmax(-1).cumsum(-1)
+    remove = cum - sorted_logits.softmax(-1) > top_p          # keep tokens whose left-cum <= top_p
+    remove[..., 0] = False                                     # always keep the top token
+    mask = torch.zeros_like(remove).scatter(-1, sorted_idx, remove)
+    return logits.masked_fill(mask, float("-inf"))
+
+
 def _rotate_half(x: torch.Tensor) -> torch.Tensor:
     x1, x2 = x[..., : x.shape[-1] // 2], x[..., x.shape[-1] // 2:]
     return torch.cat((-x2, x1), dim=-1)
@@ -452,22 +464,31 @@ class MogHead(nn.Module):
         self,
         x: torch.Tensor,
         temperature: float = 0.0,
+        guidance_scale: float = 0.0,
+        top_p: float | None = None,
         generator: torch.Generator | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Sample a mixture component and return its target latent mean + log-std.
 
-        Greedy (``temperature == 0``, the offline default) picks the component
-        by ``argmax(logits)``; ``temperature > 0`` uses the Gumbel-max trick over
-        ``log_softmax(logits) / temperature``. The chosen component's low-rank
-        mean ``mu`` is projected up through the component-specific ``low_mat``,
-        scaled by ``exp(logs)`` and offset by the residual mean ``mu_res``:
-        returns ``(mu * exp(logs) + mu_res, logs)`` — the mean of the Gaussian
-        that the RVQ residual-quantizer then encodes."""
-        b, t, _ = x.shape
+        Port of the reference ``MogHead.infer``. When ``guidance_scale > 0`` the
+        input ``x`` is the stacked ``[cond; uncond]`` batch; after the trunk it is
+        combined as ``x_cond + guidance_scale * (x_cond - x_uncond)`` (classifier-
+        free guidance). ``top_p`` applies nucleus filtering to the mixture logits.
+        The component is drawn by Gumbel-max (stochastic) when ``top_p`` is set or
+        ``temperature > 0``; otherwise greedy ``argmax``. The chosen component's
+        low-rank mean is projected up through ``low_mat``, scaled by ``exp(logs)``
+        and offset by ``mu_res``: returns ``(mu * exp(logs) + mu_res, logs)``."""
         x = self._trunk(x)
+        if guidance_scale and guidance_scale > 0.0:
+            x_cond, x_uncond = x.chunk(2, dim=0)
+            x = x_cond + guidance_scale * (x_cond - x_uncond)
+        b, t, _ = x.shape
         logits = F.linear(x, self.proj_logits.weight)                       # [b, t, n]
-        if temperature and temperature > 0.0:
-            logp = F.log_softmax(logits, dim=-1) / temperature
+        if top_p is not None and 0.0 < top_p < 1.0:
+            logits = _top_p_filter(logits, top_p)
+        if (top_p is not None and top_p < 1.0) or (temperature and temperature > 0.0):
+            temp = temperature if (temperature and temperature > 0.0) else 1.0
+            logp = F.log_softmax(logits, dim=-1) / temp
             u = torch.rand(logp.shape, device=logp.device, dtype=logp.dtype, generator=generator)
             gumbel = -torch.log(-torch.log(u + 1e-8) + 1e-8)
             idx = (logp + gumbel).argmax(-1)                                # [b, t]
@@ -589,28 +610,33 @@ class EarTTSTalker(nn.Module):
     def generate_step(
         self,
         hidden_states: torch.Tensor,
+        hidden_uncond: torch.Tensor | None = None,
         num_iter: int = 8,
         exponent: float = 3.0,
         temperature: float = 0.0,
+        guidance_scale: float = 0.0,
         noise_scale: float = 0.0,
+        top_p: float | None = None,
         generator: torch.Generator | None = None,
     ) -> torch.Tensor:
-        """Iterative MoG-conditioned RVQ decode of one (or more) frame(s).
+        """Iterative MoG-conditioned RVQ decode of one (or more) frame(s) — port
+        of the reference ``generate_step``.
 
-        Given the backbone hidden state ``[b, t, H]``, fills the
-        ``num_quantizers`` RVQ codebooks over ``num_iter`` MaskGIT-style
-        iterations. Each iteration re-embeds the current partial code, adds the
-        hidden state, samples the MoG target latent ``z`` (greedy +
-        deterministic by default: ``temperature=0``, ``noise_scale=0``), then
-        residual-quantizes the next block of codebooks. Returns ``[b, t,
-        num_quantizers]`` long codes in ``[0, codebook_size)``. CFG guidance is
-        not implemented (single, conditional stream).
+        Given the conditional backbone hidden state ``[b, t, H]`` (and, for
+        classifier-free guidance, the unconditional ``hidden_uncond``), fills the
+        ``num_quantizers`` RVQ codebooks over ``num_iter`` MaskGIT iterations.
+        Each iteration re-embeds the current partial code, adds the hidden state,
+        samples the MoG latent ``z = mu + exp(logs)*eps*noise_scale`` (mixture
+        component drawn by Gumbel-top-p; guidance applied inside ``mog_head.infer``
+        on the stacked ``[cond; uncond]`` batch), then residual-quantizes the next
+        block of codebooks. Returns ``[b, t, num_quantizers]`` in ``[0, codebook_size)``.
         """
         cfg = self.config
         b, t, _ = hidden_states.shape
         d = cfg.num_quantizers
         device = hidden_states.device
         code = torch.full((b, t, d), cfg.codebook_size, dtype=torch.long, device=device)
+        guided = guidance_scale and guidance_scale > 0.0 and hidden_uncond is not None
 
         rates = torch.linspace(0.0, 1.0, num_iter + 1, device=device)[:-1].unsqueeze(-1)
         num_maskings = torch.ceil(_masking_rate(rates, exponent) * d).long()
@@ -620,8 +646,18 @@ class EarTTSTalker(nn.Module):
             k = int(ks[i, 0].item())
             if k == 0:
                 continue
-            mog_input = self.embed_code(self.depthsum_embedding(code)) + hidden_states
-            mu, logs = self.mog_head.infer(mog_input, temperature=temperature, generator=generator)
+            code_embed = self.embed_code(self.depthsum_embedding(code))
+            if guided:
+                mog_input = torch.cat([code_embed + hidden_states, code_embed + hidden_uncond], dim=0)
+                mu, logs = self.mog_head.infer(
+                    mog_input, temperature=temperature, guidance_scale=guidance_scale,
+                    top_p=top_p, generator=generator,
+                )
+            else:
+                mog_input = code_embed + hidden_states
+                mu, logs = self.mog_head.infer(
+                    mog_input, temperature=temperature, top_p=top_p, generator=generator,
+                )
             z = mu
             if noise_scale:
                 eps = torch.randn(mu.shape, device=device, dtype=mu.dtype, generator=generator)
@@ -707,7 +743,13 @@ class EarTTSTalker(nn.Module):
 
         inputs_embeds = self.gated_fusion_audio_text(code_embeds, cond)
         _, cache = self.backbone_forward(inputs_embeds, start_pos=0, kv_cache=None, return_cache=True)
-        return {"kv": cache, "pos": p, "prev_codes": prev_codes}
+        # Unconditional stream for classifier-free guidance: same code (speaker)
+        # embeddings, but the text conditioning replaced by the learned null embed
+        # at every warmup position (reference ``uncond_dec_flag`` -> ``null_emb``).
+        null_cond = self.null_emb.to(code_embeds).view(1, 1, h).expand(b, code_embeds.shape[1], h)
+        inputs_uncond = self.gated_fusion_audio_text(code_embeds, null_cond)
+        _, cache_uncond = self.backbone_forward(inputs_uncond, start_pos=0, kv_cache=None, return_cache=True)
+        return {"kv": cache, "kv_uncond": cache_uncond, "pos": p, "prev_codes": prev_codes}
 
     def initial_prev_codes(self, batch_size: int, device=None) -> torch.Tensor:
         """The frame-0 ``prev_codes`` [B, num_quantizers]: the codec silence
@@ -729,7 +771,9 @@ class EarTTSTalker(nn.Module):
         text_eos_id: int | None = None,
         num_iter: int = 8,
         temperature: float = 0.0,
+        guidance_scale: float = 0.0,
         noise_scale: float = 0.0,
+        top_p: float | None = None,
         generator: torch.Generator | None = None,
     ) -> tuple[torch.Tensor, dict]:
         """One autoregressive frame step.
@@ -767,10 +811,23 @@ class EarTTSTalker(nn.Module):
         hidden, new_cache = self.backbone_forward(
             inputs_embeds, kv_cache=state["kv"], start_pos=state["pos"], return_cache=True
         )
+        # Unconditional stream (classifier-free guidance): same code embeds, text
+        # conditioning replaced by the learned null embedding, own KV cache.
+        hidden_uncond, new_uncond = None, None
+        guided = guidance_scale and guidance_scale > 0.0 and state.get("kv_uncond") is not None
+        if guided:
+            h = self.config.hidden_size
+            null_cond = self.null_emb.to(code_embeds).view(1, 1, h).expand_as(code_embeds)
+            inputs_uncond = self.gated_fusion_audio_text(code_embeds, null_cond)
+            hidden_uncond, new_uncond = self.backbone_forward(
+                inputs_uncond, kv_cache=state["kv_uncond"], start_pos=state["pos"], return_cache=True
+            )
         codes = self.generate_step(
-            hidden, num_iter=num_iter, temperature=temperature, noise_scale=noise_scale, generator=generator,
+            hidden, hidden_uncond=hidden_uncond, num_iter=num_iter, temperature=temperature,
+            guidance_scale=guidance_scale if guided else 0.0, noise_scale=noise_scale,
+            top_p=top_p, generator=generator,
         )
-        new_state = {"kv": new_cache, "pos": state["pos"] + 1}
+        new_state = {"kv": new_cache, "kv_uncond": new_uncond, "pos": state["pos"] + 1}
         return codes.squeeze(1), new_state
 
     def forward(
@@ -853,7 +910,10 @@ class EarTTSTalker(nn.Module):
         tokenizer,
         speaker: str = "Aria",
         temperature: float = 0.0,
-        num_iter: int = 8,
+        num_iter: int | None = None,
+        guidance_scale: float | None = None,
+        noise_scale: float | None = None,
+        top_p: float | None = None,
         text_eos_id: int | None = None,
         text_pad_id: int | None = None,
         speech_pad_id: int | None = None,
@@ -873,6 +933,17 @@ class EarTTSTalker(nn.Module):
         exact NeMo warmup (see ``init_state``); otherwise the simplified
         latent-only warmup is used.
         """
+        # Inference sampling defaults from config (real speech needs CFG + noise +
+        # top-p; without them the MoG head collapses to near-silence).
+        if num_iter is None:
+            num_iter = self.config.inference_num_iter
+        if guidance_scale is None:
+            guidance_scale = self.config.inference_guidance_scale
+        if noise_scale is None:
+            noise_scale = self.config.inference_noise_scale
+        if top_p is None:
+            top_p = self.config.inference_top_p
+
         b, t = subword_stream.shape
         device = subword_stream.device
         dtype = self.embed_code.weight.dtype
@@ -898,7 +969,8 @@ class EarTTSTalker(nn.Module):
             cond = self.text_conditioning(cur, mask, s2c, char_pad_idx)
             codes, state = self.infer_codes_one_step(
                 state, cur, prev, prev_codes, cond=cond, text_eos_id=text_eos_id,
-                num_iter=num_iter, temperature=temperature, generator=generator,
+                num_iter=num_iter, temperature=temperature, guidance_scale=guidance_scale,
+                noise_scale=noise_scale, top_p=top_p, generator=generator,
             )
             all_codes.append(codes)
             prev_codes = codes

--- a/mstar/model/nemotron_duplex/components/eartts_talker.py
+++ b/mstar/model/nemotron_duplex/components/eartts_talker.py
@@ -69,6 +69,12 @@ def _rope_cos_sin(positions: torch.Tensor, theta: float, dim: int) -> tuple[torc
     return emb.cos(), emb.sin()
 
 
+def _masking_rate(rate: torch.Tensor, exponent: float) -> torch.Tensor:
+    """MaskGIT keep-rate -> masking-rate schedule: ``(1 - rate**e) ** (1/e)``
+    (its own inverse). Matches NeMo ``get_masking_rate``."""
+    return (1.0 - rate.pow(exponent)).pow(1.0 / exponent)
+
+
 class _Attn(nn.Module):
     """q/k/v/o projections (no bias); optional Gemma3 per-head QK-norm.
 
@@ -98,12 +104,20 @@ class _Attn(nn.Module):
         sin: torch.Tensor | None = None,
         causal: bool = True,
         attn_bias: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+        past_kv: tuple[torch.Tensor, torch.Tensor] | None = None,
+        return_kv: bool = False,
+    ):
         """Multi-head self-attention. Gemma3-style: optional per-head QK-norm
         (applied before rope), rope on the full head dim, and query scaling by
         ``query_pre_attn_scalar ** -0.5``. ``causal`` adds a triangular mask
         (talker); ``attn_bias`` is an additive mask broadcastable to
-        ``[b, nh, tq, tk]`` (encoder key padding)."""
+        ``[b, nh, tq, tk]`` (encoder key padding).
+
+        For autoregressive decoding, ``past_kv`` (rope-applied ``(k, v)`` from
+        earlier positions) is concatenated with the new keys/values and, when
+        ``return_kv`` is set, the updated cache is returned. rope on the new
+        query/key uses their absolute positions via ``cos``/``sin``; the causal
+        mask offsets so the new queries attend all cached keys plus themselves."""
         b, t, _ = x.shape
         nh, hd = self.num_heads, self.head_dim
         q = F.linear(x, self.q_proj.weight).view(b, t, nh, hd)
@@ -120,15 +134,24 @@ class _Attn(nn.Module):
             sin_b = sin[None, None, :, :]
             q = q * cos_b + _rotate_half(q) * sin_b
             k = k * cos_b + _rotate_half(k) * sin_b
+        if past_kv is not None:
+            k = torch.cat((past_kv[0], k), dim=2)
+            v = torch.cat((past_kv[1], v), dim=2)
+        new_kv = (k, v) if return_kv else None
+        t_tot = k.shape[2]
         scores = torch.matmul(q, k.transpose(-1, -2)) * self.scaling
         if causal:
-            neg = torch.full((t, t), float("-inf"), device=x.device, dtype=scores.dtype)
-            scores = scores + torch.triu(neg, diagonal=1)
+            offset = t_tot - t   # absolute index of the first query position
+            neg = torch.full((t, t_tot), float("-inf"), device=x.device, dtype=scores.dtype)
+            scores = scores + torch.triu(neg, diagonal=offset + 1)
         if attn_bias is not None:
             scores = scores + attn_bias
         attn = torch.softmax(scores.float(), dim=-1).to(v.dtype)
         out = torch.matmul(attn, v).transpose(1, 2).reshape(b, t, nh * hd)
-        return F.linear(out, self.o_proj.weight)
+        out = F.linear(out, self.o_proj.weight)
+        if return_kv:
+            return out, new_kv
+        return out
 
 
 class TalkerLayer(nn.Module):
@@ -145,12 +168,24 @@ class TalkerLayer(nn.Module):
         self.mlp = GatedMLP(h, config.intermediate_size, activation="gelu_tanh", bias=False)
         self.post_feedforward_layernorm = RMSNorm(h)
 
-    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        past_kv: tuple[torch.Tensor, torch.Tensor] | None = None,
+        return_kv: bool = False,
+    ):
         """Gemma3 decoder layer with its 4 RMSNorms (input / post-attn /
-        pre-ff / post-ff), each ``(1 + w)`` in fp32."""
+        pre-ff / post-ff), each ``(1 + w)`` in fp32. Optionally reads/updates a
+        per-layer ``(k, v)`` cache for autoregressive decoding."""
         residual = x
         h = _gemma_rmsnorm(x, self.input_layernorm.weight, self.eps)
-        h = self.self_attn(h, cos, sin, causal=True)
+        attn_out = self.self_attn(h, cos, sin, causal=True, past_kv=past_kv, return_kv=return_kv)
+        if return_kv:
+            h, new_kv = attn_out
+        else:
+            h, new_kv = attn_out, None
         h = _gemma_rmsnorm(h, self.post_attention_layernorm.weight, self.eps)
         x = residual + h
 
@@ -159,6 +194,8 @@ class TalkerLayer(nn.Module):
         h = self.mlp(h)
         h = _gemma_rmsnorm(h, self.post_feedforward_layernorm.weight, self.eps)
         x = residual + h
+        if return_kv:
+            return x, new_kv
         return x
 
 
@@ -360,6 +397,16 @@ class MogHead(nn.Module):
         self.proj_logs = nn.Linear(h, 1, bias=False)
         self.proj_mus = nn.Linear(h, self.num_predictions * self.low_rank, bias=False)
 
+    def _trunk(self, x: torch.Tensor) -> torch.Tensor:
+        """``mlp_stack``: ``num_layers`` residual MLPLayers (pre_norm -> mlp ->
+        post_norm) followed by a final RMSNorm."""
+        for block in self.mlp_stack[: self.num_layers]:
+            y = _gemma_rmsnorm(x, block.pre_norm.weight, self.eps)
+            y = block.mlp(y)
+            y = _gemma_rmsnorm(y, block.post_norm.weight, self.eps)
+            x = x + y
+        return _gemma_rmsnorm(x, self.mlp_stack[self.num_layers].weight, self.eps)
+
     def forward(self, x: torch.Tensor):
         """Deterministic (training-style) MoG head forward.
 
@@ -370,19 +417,49 @@ class MogHead(nn.Module):
           * ``logs``   [b, t, 1] log std, clamped to ``mog_min_log_std``
         """
         b, t, _ = x.shape
-        # mlp_stack: residual MLPLayers (pre_norm -> mlp -> post_norm) then a final RMSNorm.
-        for block in self.mlp_stack[: self.num_layers]:
-            y = _gemma_rmsnorm(x, block.pre_norm.weight, self.eps)
-            y = block.mlp(y)
-            y = _gemma_rmsnorm(y, block.post_norm.weight, self.eps)
-            x = x + y
-        x = _gemma_rmsnorm(x, self.mlp_stack[self.num_layers].weight, self.eps)
-
+        x = self._trunk(x)
         logits = F.linear(x, self.proj_logits.weight)
         mus = F.linear(x, self.proj_mus.weight).view(b, t, self.num_predictions, self.low_rank)
         logs = F.linear(x, self.proj_logs.weight).clamp_min(self.min_log_std)
         mu_res = F.linear(x, self.proj_else.weight)
         return logits, mus, mu_res, logs
+
+    def infer(
+        self,
+        x: torch.Tensor,
+        temperature: float = 0.0,
+        generator: torch.Generator | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Sample a mixture component and return its target latent mean + log-std.
+
+        Greedy (``temperature == 0``, the offline default) picks the component
+        by ``argmax(logits)``; ``temperature > 0`` uses the Gumbel-max trick over
+        ``log_softmax(logits) / temperature``. The chosen component's low-rank
+        mean ``mu`` is projected up through the component-specific ``low_mat``,
+        scaled by ``exp(logs)`` and offset by the residual mean ``mu_res``:
+        returns ``(mu * exp(logs) + mu_res, logs)`` — the mean of the Gaussian
+        that the RVQ residual-quantizer then encodes."""
+        b, t, _ = x.shape
+        x = self._trunk(x)
+        logits = F.linear(x, self.proj_logits.weight)                       # [b, t, n]
+        if temperature and temperature > 0.0:
+            logp = F.log_softmax(logits, dim=-1) / temperature
+            u = torch.rand(logp.shape, device=logp.device, dtype=logp.dtype, generator=generator)
+            gumbel = -torch.log(-torch.log(u + 1e-8) + 1e-8)
+            idx = (logp + gumbel).argmax(-1)                                # [b, t]
+        else:
+            idx = logits.argmax(-1)                                        # [b, t]
+
+        mus = F.linear(x, self.proj_mus.weight).view(b, t, self.num_predictions, self.low_rank)
+        sel = idx[..., None, None].expand(b, t, 1, self.low_rank)
+        mu = mus.gather(2, sel).squeeze(2)                                  # [b, t, low_rank]
+
+        low_mat_sel = self.low_mat[idx]                                    # [b, t, out_size, low_rank]
+        mu = torch.matmul(low_mat_sel, mu.unsqueeze(-1)).squeeze(-1)        # [b, t, out_size]
+
+        mu_res = F.linear(x, self.proj_else.weight)                        # [b, t, out_size]
+        logs = F.linear(x, self.proj_logs.weight).clamp_min(self.min_log_std)  # [b, t, 1]
+        return mu * torch.exp(logs) + mu_res, logs
 
 
 class _Backbone(nn.Module):
@@ -426,27 +503,197 @@ class EarTTSTalker(nn.Module):
             ret = ret + F.embedding(code[..., i], embs[i])
         return ret
 
-    def backbone_forward(self, inputs_embeds: torch.Tensor, position_ids: torch.Tensor | None = None) -> torch.Tensor:
+    def backbone_forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        kv_cache: list | None = None,
+        start_pos: int = 0,
+        return_cache: bool = False,
+    ):
         """Gemma3-text decoder stack over ``inputs_embeds`` [b, t, H].
 
         Full-attention layers (``(i+1) % sliding_window_pattern == 0``) use
         ``rope_theta_full``; the rest (sliding-attention) use
         ``rope_theta_local``. For sequences shorter than the sliding window the
         two mask identically (plain causal), so only the rope base differs.
+
+        For autoregressive decoding, pass the per-layer ``kv_cache`` list and the
+        absolute ``start_pos`` of the new tokens; with ``return_cache`` the
+        updated per-layer ``(k, v)`` list is returned alongside the hidden state.
         """
         cfg = self.config
         b, t, _ = inputs_embeds.shape
         if position_ids is None:
-            position_ids = torch.arange(t, device=inputs_embeds.device)
+            position_ids = torch.arange(start_pos, start_pos + t, device=inputs_embeds.device)
         cos_g, sin_g = _rope_cos_sin(position_ids, cfg.rope_theta_full, cfg.head_dim)
         cos_l, sin_l = _rope_cos_sin(position_ids, cfg.rope_theta_local, cfg.head_dim)
+        new_cache = [] if return_cache else None
         x = inputs_embeds
         for i, layer in enumerate(self.backbone.layers):
             full = (i + 1) % cfg.sliding_window_pattern == 0
             cos, sin = (cos_g, sin_g) if full else (cos_l, sin_l)
-            x = layer(x, cos, sin)
+            past = kv_cache[i] if kv_cache is not None else None
+            out = layer(x, cos, sin, past_kv=past, return_kv=return_cache)
+            if return_cache:
+                x, kv = out
+                new_cache.append(kv)
+            else:
+                x = out
         x = _gemma_rmsnorm(x, self.backbone.norm.weight, cfg.rms_norm_eps)
+        if return_cache:
+            return x, new_cache
         return x
+
+    def _rvq_quantize(self, z: torch.Tensor, code: torch.Tensor, depth_str: int, k: int) -> torch.Tensor:
+        """Residual vector quantization of latent ``z`` [b, t, code_dim] into
+        codebooks ``[depth_str, depth_str + k)``. Faithful port of NeMo
+        ``depthsum_encoding_step``: nearest RVQ entry per codebook (minimising
+        ``||e||^2 - 2<r, e>``), subtracting the chosen entry from the running
+        residual ``r`` (which starts at ``z``)."""
+        code = code.clone()
+        r = z
+        for i in range(depth_str, depth_str + k):
+            ei = self.rvq_embs[i]                                            # [codebook_size, code_dim]
+            dist = ei.pow(2).sum(-1) - 2.0 * torch.matmul(r, ei.transpose(-1, -2))  # [b, t, codebook_size]
+            idx = dist.argmin(-1)                                            # [b, t]
+            r = r - F.embedding(idx, ei)
+            code[..., i] = idx
+        return code
+
+    @torch.no_grad()
+    def generate_step(
+        self,
+        hidden_states: torch.Tensor,
+        num_iter: int = 8,
+        exponent: float = 3.0,
+        temperature: float = 0.0,
+        noise_scale: float = 0.0,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        """Iterative MoG-conditioned RVQ decode of one (or more) frame(s).
+
+        Given the backbone hidden state ``[b, t, H]``, fills the
+        ``num_quantizers`` RVQ codebooks over ``num_iter`` MaskGIT-style
+        iterations. Each iteration re-embeds the current partial code, adds the
+        hidden state, samples the MoG target latent ``z`` (greedy +
+        deterministic by default: ``temperature=0``, ``noise_scale=0``), then
+        residual-quantizes the next block of codebooks. Returns ``[b, t,
+        num_quantizers]`` long codes in ``[0, codebook_size)``. CFG guidance is
+        not implemented (single, conditional stream).
+        """
+        cfg = self.config
+        b, t, _ = hidden_states.shape
+        d = cfg.num_quantizers
+        device = hidden_states.device
+        code = torch.full((b, t, d), cfg.codebook_size, dtype=torch.long, device=device)
+
+        rates = torch.linspace(0.0, 1.0, num_iter + 1, device=device)[:-1].unsqueeze(-1)
+        num_maskings = torch.ceil(_masking_rate(rates, exponent) * d).long()
+        ks = num_maskings - F.pad(num_maskings[1:], [0, 0, 0, 1])           # per-iter codebook counts, sum == d
+        cnt = 0
+        for i in range(num_iter):
+            k = int(ks[i, 0].item())
+            if k == 0:
+                continue
+            mog_input = self.embed_code(self.depthsum_embedding(code)) + hidden_states
+            mu, logs = self.mog_head.infer(mog_input, temperature=temperature, generator=generator)
+            z = mu
+            if noise_scale:
+                eps = torch.randn(mu.shape, device=device, dtype=mu.dtype, generator=generator)
+                z = z + torch.exp(logs) * eps * noise_scale
+            code = self._rvq_quantize(z, code, cnt, k)
+            cnt += k
+        return code
+
+    @torch.no_grad()
+    def init_state(self, batch_size: int, speaker: str = "Aria", device=None, dtype=None) -> dict:
+        """Warm up the autoregressive KV cache from a pre-baked speaker prompt.
+
+        Uses the cached ``audio_prompt_latents[speaker]`` [1, P, H] as the
+        pre-BOS audio-prompt frames (already in model hidden space), adds
+        ``bos_emb`` to the final prompt frame to mark the generation boundary,
+        runs the block through the gated fusion (zero text conditioning) and the
+        backbone, and returns the populated per-layer cache plus the next
+        absolute position. NOTE: this is a self-contained faithful setup — it
+        uses the pre-baked latent directly rather than re-encoding prompt audio
+        with the codec, and omits any text/system-prompt prefix.
+        """
+        latent = self.audio_prompt_latents[speaker]
+        if device is not None:
+            latent = latent.to(device)
+        if dtype is not None:
+            latent = latent.to(dtype)
+        prompt = latent.expand(batch_size, -1, -1).clone()                  # [B, P, H]
+        prompt[:, -1] = prompt[:, -1] + self.bos_emb.to(prompt)
+        cond = prompt.new_zeros((1, 1, self.config.hidden_size))
+        inputs_embeds = self.gated_fusion_audio_text(prompt, cond)
+        _, cache = self.backbone_forward(inputs_embeds, start_pos=0, kv_cache=None, return_cache=True)
+        return {"kv": cache, "pos": prompt.shape[1]}
+
+    def initial_prev_codes(self, batch_size: int, device=None) -> torch.Tensor:
+        """The frame-0 ``prev_codes`` [B, num_quantizers]: the codec silence
+        frame (the natural carry-in after the audio prompt)."""
+        silence = self.codec_silence_tokens
+        if device is not None:
+            silence = silence.to(device)
+        return silence.view(1, -1).expand(batch_size, -1).contiguous()
+
+    @torch.no_grad()
+    def infer_codes_one_step(
+        self,
+        state: dict,
+        current_subword_id: torch.Tensor,
+        prev_subword_id: torch.Tensor | None,
+        prev_codes: torch.Tensor,
+        cond: torch.Tensor | None = None,
+        current_subword_mask: torch.Tensor | None = None,
+        text_eos_id: int | None = None,
+        num_iter: int = 8,
+        temperature: float = 0.0,
+        noise_scale: float = 0.0,
+        generator: torch.Generator | None = None,
+    ) -> tuple[torch.Tensor, dict]:
+        """One autoregressive frame step.
+
+        Args:
+            state: cache dict from ``init_state`` / a previous step
+                (``{"kv", "pos"}``).
+            current_subword_id: [B, 1] nano text token id conditioning this frame
+                (used only to force a codec-silence frame on text-EOS).
+            prev_subword_id: [B, 1] previous text id — unused in this
+                configuration (``context_hidden_size`` is ``None``); accepted for
+                signature parity.
+            prev_codes: [B, num_quantizers] codes emitted for the previous frame.
+            cond: optional [B, 1, H] (or [1, 1, H]) precomputed text/subword
+                conditioning (the caller runs ``embed_subword`` to build it, as
+                that needs the tokenizer's subword->char map). ``None`` -> zero
+                conditioning.
+            text_eos_id: if given and ``current_subword_id == text_eos_id``,
+                ``prev_codes`` is replaced by the codec silence frame before
+                embedding (``inference_force_speech_silence_on_eos``).
+
+        Returns:
+            ``(codes [B, num_quantizers], new_state)`` — greedy + deterministic
+            by default (``temperature == 0``, ``noise_scale == 0``).
+        """
+        if text_eos_id is not None:
+            silence = self.codec_silence_tokens.view(1, -1).to(prev_codes.device).expand_as(prev_codes)
+            prev_codes = torch.where(current_subword_id == text_eos_id, silence, prev_codes)
+
+        code_embeds = self.embed_code(self.depthsum_embedding(prev_codes.unsqueeze(1)))  # [B, 1, H]
+        if cond is None:
+            cond = code_embeds.new_zeros((1, 1, self.config.hidden_size))
+        inputs_embeds = self.gated_fusion_audio_text(code_embeds, cond)
+
+        hidden, new_cache = self.backbone_forward(
+            inputs_embeds, kv_cache=state["kv"], start_pos=state["pos"], return_cache=True
+        )
+        codes = self.generate_step(
+            hidden, num_iter=num_iter, temperature=temperature, noise_scale=noise_scale, generator=generator,
+        )
+        new_state = {"kv": new_cache, "pos": state["pos"] + 1}
+        return codes.squeeze(1), new_state
 
     def forward(
         self,

--- a/mstar/model/nemotron_duplex/components/eartts_talker.py
+++ b/mstar/model/nemotron_duplex/components/eartts_talker.py
@@ -75,6 +75,30 @@ def _masking_rate(rate: torch.Tensor, exponent: float) -> torch.Tensor:
     return (1.0 - rate.pow(exponent)).pow(1.0 / exponent)
 
 
+def build_char_vocab(tokenizer) -> dict[str, int]:
+    """Character vocabulary derived from the subword tokenizer (port of NeMo
+    ``build_vocabs._build_char_vocab``): every single-character token in
+    ``tokenizer.tokenizer.vocab``, densely re-indexed in ascending original-id
+    order. ``char_vocab[char] -> dense index in [0, num_chars)``."""
+    vocab = tokenizer.tokenizer.vocab                       # {token_str: id}
+    single = {s: i for s, i in vocab.items() if len(s) == 1}
+    ordered = sorted(single.keys(), key=lambda s: single[s])
+    return {c: i for i, c in enumerate(ordered)}
+
+
+def subword_to_char_ids(tokenizer, char_vocab: dict[str, int]) -> tuple[dict[int, tuple[int, ...]], int]:
+    """Map each subword id to the tuple of its in-vocab character ids (port of
+    NeMo ``build_vocabs`` steps 2-3). Subwords with no representable characters
+    are dropped; a padding subword id ``len(tokenizer.vocab)`` maps to the char
+    padding id ``len(char_vocab)``. Returns ``(map, subword_padding_idx)``."""
+    vocab = tokenizer.tokenizer.vocab
+    s2c = {sid: tuple(char_vocab[c] for c in s if c in char_vocab) for s, sid in vocab.items()}
+    s2c = {k: v for k, v in s2c.items() if v}
+    pad_idx = len(tokenizer.vocab)
+    s2c[pad_idx] = (len(char_vocab),)
+    return s2c, pad_idx
+
+
 class _Attn(nn.Module):
     """q/k/v/o projections (no bias); optional Gemma3 per-head QK-norm.
 
@@ -724,6 +748,95 @@ class EarTTSTalker(nn.Module):
         mog_input = self.embed_code(self.depthsum_embedding(code)) + hidden_states
         mog_logits, mog_mus, mog_mu_res, mog_logs = self.mog_head(mog_input)
         return hidden_states, mog_logits, mog_mus, mog_mu_res, mog_logs
+
+    def _prepare_char_inputs(
+        self,
+        subword_ids: torch.Tensor,
+        subword_mask: torch.Tensor,
+        subword_id_to_char_ids: dict,
+        char_pad_idx: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Turn the valid (masked) subword ids into a padded char-id batch, in
+        the row-major order ``embed_subword`` expects (port of NeMo
+        ``CharAwareSubwordEncoder.prepare_inputs``)."""
+        device = subword_ids.device
+        sel = torch.masked_select(subword_ids, subword_mask).cpu().tolist()
+        char_lists = [subword_id_to_char_ids.get(int(x), ()) for x in sel]
+        lengths = torch.tensor([len(c) for c in char_lists], dtype=torch.long, device=device)
+        n = lengths.numel()
+        max_len = int(lengths.max().item()) if n > 0 else 0
+        char_ids = torch.full((n, max_len), char_pad_idx, dtype=torch.long, device=device)
+        for i, c in enumerate(char_lists):
+            if c:
+                char_ids[i, : len(c)] = torch.tensor(c, dtype=torch.long, device=device)
+        return char_ids, lengths
+
+    def text_conditioning(
+        self,
+        subword_ids: torch.Tensor,
+        subword_mask: torch.Tensor | None,
+        subword_id_to_char_ids: dict,
+        char_pad_idx: int,
+    ) -> torch.Tensor:
+        """Per-frame text conditioning ``cond`` [B, T, H] (port of the NeMo
+        ``_prepare_conditioning`` path for ``context_hidden_size is None``):
+        run ``embed_subword`` on the subwords' char ids and add the subword-flag
+        and BOS/EOS embeddings. Positions outside ``subword_mask`` stay zero."""
+        if subword_mask is None:
+            subword_mask = torch.ones_like(subword_ids, dtype=torch.bool)
+        cond = self.embed_code.weight.new_zeros((*subword_ids.shape, self.config.hidden_size))
+        if not bool(subword_mask.any()):
+            return cond
+        char_ids, char_lengths = self._prepare_char_inputs(
+            subword_ids, subword_mask, subword_id_to_char_ids, char_pad_idx
+        )
+        return self.embed_subword(char_ids, char_lengths, subword_ids, subword_mask)
+
+    @torch.no_grad()
+    def generate_codes(
+        self,
+        subword_stream: torch.Tensor,
+        tokenizer,
+        speaker: str = "Aria",
+        temperature: float = 0.0,
+        num_iter: int = 8,
+        text_eos_id: int | None = None,
+        prev_codes: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        """Full autoregressive TTS: turn a subword/text-token stream ``[B, T]``
+        into RVQ codes ``[B, T, num_quantizers]``.
+
+        Builds the char-vocab maps from ``tokenizer`` once, warms the KV cache
+        from the speaker prompt (``init_state``), then per frame computes the
+        text conditioning from the current subword id and runs one
+        ``infer_codes_one_step`` (greedy + deterministic by default). If
+        ``text_eos_id`` is given, an EOS text token forces a codec-silence frame.
+        """
+        b, t = subword_stream.shape
+        device = subword_stream.device
+        dtype = self.embed_code.weight.dtype
+        char_vocab = build_char_vocab(tokenizer)
+        s2c, _ = subword_to_char_ids(tokenizer, char_vocab)
+        char_pad_idx = len(char_vocab)
+
+        state = self.init_state(b, speaker=speaker, device=device, dtype=dtype)
+        if prev_codes is None:
+            prev_codes = self.initial_prev_codes(b, device=device)
+
+        all_codes = []
+        for i in range(t):
+            cur = subword_stream[:, i: i + 1]
+            prev = subword_stream[:, i - 1: i] if i > 0 else cur
+            mask = torch.ones_like(cur, dtype=torch.bool)
+            cond = self.text_conditioning(cur, mask, s2c, char_pad_idx)
+            codes, state = self.infer_codes_one_step(
+                state, cur, prev, prev_codes, cond=cond, text_eos_id=text_eos_id,
+                num_iter=num_iter, temperature=temperature, generator=generator,
+            )
+            all_codes.append(codes)
+            prev_codes = codes
+        return torch.stack(all_codes, dim=1)
 
     @staticmethod
     def remap(name: str) -> str | None:

--- a/mstar/model/nemotron_duplex/components/eartts_talker.py
+++ b/mstar/model/nemotron_duplex/components/eartts_talker.py
@@ -7,6 +7,13 @@ QK-norm; a 1-layer subword encoder; the MoG head; and the bespoke embedding
 tables). The three top-level ``tts_model.*`` buffers (control codes, codec
 silence tokens, per-voice audio-prompt latents) load here too.
 
+Every architecture dimension / hyperparameter is read from ``EarTTSConfig``
+(populated from the checkpoint's ``config.json``) and threaded down into the
+submodules — there are no hardcoded model hyperparameters here. The only bare
+literals are fixed table cardinalities that are not part of ``EarTTSConfig``
+(the char-embedding vocab, the flag-embedding categories, and the
+tokenizer-sized flag buffers).
+
 The teacher-forced forward (backbone + gated fusion + MoG head) and the
 char-aware subword encoder are numerically verified in fp32 against the NeMo
 ``RVQEARTTSModel`` reference (transformers Gemma3TextModel / T5GemmaEncoderModel
@@ -26,27 +33,17 @@ from mstar.model.components.mlp import GatedMLP
 from mstar.model.nemotron_duplex.components._util import RawWeight, param
 from mstar.model.nemotron_duplex.config import EarTTSConfig
 
-H = 1152          # talker hidden
-FF = 4608         # talker mlp intermediate
-HEAD_DIM = 72
-NUM_HEADS = 16
-NUM_LAYERS = 28
-CODE_DIM = 512    # rvq latent dim
-NUM_QUANTIZERS = 31
-CODEBOOK = 1024
-NUM_PREDICTIONS = 1024   # MoG mixture components
-LOW_RANK = 64            # MoG low-rank mean dim
-MIN_LOG_STD = -4.0
-RMS_EPS = 1e-6
-
-# Gemma3-text backbone specifics (from HF Gemma3TextConfig defaults + checkpoint).
-QUERY_PRE_ATTN_SCALAR = 256.0     # attention scaling = QUERY_PRE_ATTN_SCALAR ** -0.5
-ROPE_THETA_GLOBAL = 1_000_000.0   # full-attention layers
-ROPE_THETA_LOCAL = 10_000.0       # sliding-attention layers
-SLIDING_WINDOW_PATTERN = 6        # layer i is full attention iff (i + 1) % 6 == 0
+# Fixed table cardinalities that are NOT model hyperparameters in EarTTSConfig
+# (tokenizer / vocabulary sizes baked into the checkpoint's flag tables).
+_CHAR_VOCAB = 257            # embed_tokens rows: 256 chars + 1 padding slot
+_SPECIAL_FLAG_CATS = 3       # BOS/EOS flag categories (0=regular, 1=BOS, 2=EOS)
+_CONT_FLAG_CATS = 2          # continuation flag categories (0=word-start, 1=cont)
+_SPECIAL_FLAGS_LEN = 131072  # bos/eos flag buffer length (text vocab size)
+_CONT_FLAGS_LEN = 131073     # continuation flag buffer length (text vocab + pad)
+_AUDIO_PROMPT_FRAMES = 37     # per-voice cached audio-prompt latent length
 
 
-def _gemma_rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float = RMS_EPS) -> torch.Tensor:
+def _gemma_rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
     """Gemma3 RMSNorm computed in fp32: ``(x * rsqrt(mean(x^2)+eps)) * (1 + w)``.
 
     Done manually (not via the shared fused ``RMSNorm`` kernel, which runs in
@@ -73,17 +70,26 @@ def _rope_cos_sin(positions: torch.Tensor, theta: float, dim: int) -> tuple[torc
 
 
 class _Attn(nn.Module):
-    """q/k/v/o projections (no bias); optional Gemma3 per-head QK-norm."""
+    """q/k/v/o projections (no bias); optional Gemma3 per-head QK-norm.
 
-    def __init__(self, qk_norm: bool):
+    All dims (hidden size, head count/dim, query scaling, norm eps) come from
+    ``EarTTSConfig``.
+    """
+
+    def __init__(self, config: EarTTSConfig, qk_norm: bool):
         super().__init__()
-        self.q_proj = nn.Linear(H, H, bias=False)
-        self.k_proj = nn.Linear(H, H, bias=False)
-        self.v_proj = nn.Linear(H, H, bias=False)
-        self.o_proj = nn.Linear(H, H, bias=False)
+        h = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.scaling = config.query_pre_attn_scalar ** -0.5
+        self.eps = config.rms_norm_eps
+        self.q_proj = nn.Linear(h, self.num_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(h, self.num_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(h, self.num_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, h, bias=False)
         if qk_norm:
-            self.q_norm = RMSNorm(HEAD_DIM)
-            self.k_norm = RMSNorm(HEAD_DIM)
+            self.q_norm = RMSNorm(self.head_dim)
+            self.k_norm = RMSNorm(self.head_dim)
 
     def forward(
         self,
@@ -95,16 +101,17 @@ class _Attn(nn.Module):
     ) -> torch.Tensor:
         """Multi-head self-attention. Gemma3-style: optional per-head QK-norm
         (applied before rope), rope on the full head dim, and query scaling by
-        ``QUERY_PRE_ATTN_SCALAR ** -0.5``. ``causal`` adds a triangular mask
+        ``query_pre_attn_scalar ** -0.5``. ``causal`` adds a triangular mask
         (talker); ``attn_bias`` is an additive mask broadcastable to
         ``[b, nh, tq, tk]`` (encoder key padding)."""
         b, t, _ = x.shape
-        q = F.linear(x, self.q_proj.weight).view(b, t, NUM_HEADS, HEAD_DIM)
-        k = F.linear(x, self.k_proj.weight).view(b, t, NUM_HEADS, HEAD_DIM)
-        v = F.linear(x, self.v_proj.weight).view(b, t, NUM_HEADS, HEAD_DIM)
+        nh, hd = self.num_heads, self.head_dim
+        q = F.linear(x, self.q_proj.weight).view(b, t, nh, hd)
+        k = F.linear(x, self.k_proj.weight).view(b, t, nh, hd)
+        v = F.linear(x, self.v_proj.weight).view(b, t, nh, hd)
         if hasattr(self, "q_norm"):
-            q = _gemma_rmsnorm(q, self.q_norm.weight)
-            k = _gemma_rmsnorm(k, self.k_norm.weight)
+            q = _gemma_rmsnorm(q, self.q_norm.weight, self.eps)
+            k = _gemma_rmsnorm(k, self.k_norm.weight, self.eps)
         q = q.transpose(1, 2)   # [b, nh, t, hd]
         k = k.transpose(1, 2)
         v = v.transpose(1, 2)
@@ -113,43 +120,44 @@ class _Attn(nn.Module):
             sin_b = sin[None, None, :, :]
             q = q * cos_b + _rotate_half(q) * sin_b
             k = k * cos_b + _rotate_half(k) * sin_b
-        scaling = QUERY_PRE_ATTN_SCALAR ** -0.5
-        scores = torch.matmul(q, k.transpose(-1, -2)) * scaling
+        scores = torch.matmul(q, k.transpose(-1, -2)) * self.scaling
         if causal:
             neg = torch.full((t, t), float("-inf"), device=x.device, dtype=scores.dtype)
             scores = scores + torch.triu(neg, diagonal=1)
         if attn_bias is not None:
             scores = scores + attn_bias
         attn = torch.softmax(scores.float(), dim=-1).to(v.dtype)
-        out = torch.matmul(attn, v).transpose(1, 2).reshape(b, t, NUM_HEADS * HEAD_DIM)
+        out = torch.matmul(attn, v).transpose(1, 2).reshape(b, t, nh * hd)
         return F.linear(out, self.o_proj.weight)
 
 
 class TalkerLayer(nn.Module):
     """Gemma3 decoder layer: input/post-attn/pre-ff/post-ff norms + QK-norm attn + gated MLP."""
 
-    def __init__(self):
+    def __init__(self, config: EarTTSConfig):
         super().__init__()
-        self.input_layernorm = RMSNorm(H)
-        self.self_attn = _Attn(qk_norm=True)
-        self.post_attention_layernorm = RMSNorm(H)
-        self.pre_feedforward_layernorm = RMSNorm(H)
-        self.mlp = GatedMLP(H, FF, activation="gelu_tanh", bias=False)
-        self.post_feedforward_layernorm = RMSNorm(H)
+        h = config.hidden_size
+        self.eps = config.rms_norm_eps
+        self.input_layernorm = RMSNorm(h)
+        self.self_attn = _Attn(config, qk_norm=True)
+        self.post_attention_layernorm = RMSNorm(h)
+        self.pre_feedforward_layernorm = RMSNorm(h)
+        self.mlp = GatedMLP(h, config.intermediate_size, activation="gelu_tanh", bias=False)
+        self.post_feedforward_layernorm = RMSNorm(h)
 
     def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
         """Gemma3 decoder layer with its 4 RMSNorms (input / post-attn /
         pre-ff / post-ff), each ``(1 + w)`` in fp32."""
         residual = x
-        h = _gemma_rmsnorm(x, self.input_layernorm.weight)
+        h = _gemma_rmsnorm(x, self.input_layernorm.weight, self.eps)
         h = self.self_attn(h, cos, sin, causal=True)
-        h = _gemma_rmsnorm(h, self.post_attention_layernorm.weight)
+        h = _gemma_rmsnorm(h, self.post_attention_layernorm.weight, self.eps)
         x = residual + h
 
         residual = x
-        h = _gemma_rmsnorm(x, self.pre_feedforward_layernorm.weight)
+        h = _gemma_rmsnorm(x, self.pre_feedforward_layernorm.weight, self.eps)
         h = self.mlp(h)
-        h = _gemma_rmsnorm(h, self.post_feedforward_layernorm.weight)
+        h = _gemma_rmsnorm(h, self.post_feedforward_layernorm.weight, self.eps)
         x = residual + h
         return x
 
@@ -157,88 +165,97 @@ class TalkerLayer(nn.Module):
 class _EncoderLayer(nn.Module):
     """Subword-encoder layer: pre/post self-attn + pre/post ff norms (no QK-norm)."""
 
-    def __init__(self):
+    def __init__(self, config: EarTTSConfig):
         super().__init__()
-        self.self_attn = _Attn(qk_norm=False)
-        self.pre_self_attn_layernorm = RMSNorm(H)
-        self.post_self_attn_layernorm = RMSNorm(H)
-        self.pre_feedforward_layernorm = RMSNorm(H)
-        self.post_feedforward_layernorm = RMSNorm(H)
-        self.mlp = GatedMLP(H, FF, activation="gelu_tanh", bias=False)
+        h = config.hidden_size
+        self.eps = config.rms_norm_eps
+        self.self_attn = _Attn(config, qk_norm=False)
+        self.pre_self_attn_layernorm = RMSNorm(h)
+        self.post_self_attn_layernorm = RMSNorm(h)
+        self.pre_feedforward_layernorm = RMSNorm(h)
+        self.post_feedforward_layernorm = RMSNorm(h)
+        self.mlp = GatedMLP(h, config.intermediate_size, activation="gelu_tanh", bias=False)
 
     def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, attn_bias: torch.Tensor) -> torch.Tensor:
         """T5Gemma encoder layer: bidirectional attention (no QK-norm) with
         pre/post self-attn and pre/post ff RMSNorms."""
         residual = x
-        h = _gemma_rmsnorm(x, self.pre_self_attn_layernorm.weight)
+        h = _gemma_rmsnorm(x, self.pre_self_attn_layernorm.weight, self.eps)
         h = self.self_attn(h, cos, sin, causal=False, attn_bias=attn_bias)
-        h = _gemma_rmsnorm(h, self.post_self_attn_layernorm.weight)
+        h = _gemma_rmsnorm(h, self.post_self_attn_layernorm.weight, self.eps)
         x = residual + h
 
         residual = x
-        h = _gemma_rmsnorm(x, self.pre_feedforward_layernorm.weight)
+        h = _gemma_rmsnorm(x, self.pre_feedforward_layernorm.weight, self.eps)
         h = self.mlp(h)
-        h = _gemma_rmsnorm(h, self.post_feedforward_layernorm.weight)
+        h = _gemma_rmsnorm(h, self.post_feedforward_layernorm.weight, self.eps)
         x = residual + h
         return x
 
 
 class _EncoderBackbone(nn.Module):
-    def __init__(self, n_layers: int = 1):
+    def __init__(self, config: EarTTSConfig, n_layers: int = 1):
         super().__init__()
-        self.encoder = _Encoder(n_layers)
+        self.encoder = _Encoder(config, n_layers)
 
 
 class _Encoder(nn.Module):
-    def __init__(self, n_layers: int):
+    def __init__(self, config: EarTTSConfig, n_layers: int):
         super().__init__()
-        self.layers = nn.ModuleList([_EncoderLayer() for _ in range(n_layers)])
-        self.norm = RMSNorm(H)
+        self.layers = nn.ModuleList([_EncoderLayer(config) for _ in range(n_layers)])
+        self.norm = RMSNorm(config.hidden_size)
 
 
 class _BosEosEmb(nn.Module):
-    def __init__(self):
+    def __init__(self, hidden_size: int):
         super().__init__()
-        self.special_emb = nn.Embedding(3, H)
-        self.special_flags = param(131072, dtype=torch.int64)
+        self.special_emb = nn.Embedding(_SPECIAL_FLAG_CATS, hidden_size)
+        self.special_flags = param(_SPECIAL_FLAGS_LEN, dtype=torch.int64)
         self.pad_tensor = param(dtype=torch.int64)
 
 
 class _SubwordFlagEmb(nn.Module):
-    def __init__(self):
+    def __init__(self, hidden_size: int):
         super().__init__()
-        self.cont_emb = nn.Embedding(2, H)
-        self.is_continuation = param(131073, dtype=torch.int64)
+        self.cont_emb = nn.Embedding(_CONT_FLAG_CATS, hidden_size)
+        self.is_continuation = param(_CONT_FLAGS_LEN, dtype=torch.int64)
         self.pad_tensor = param(dtype=torch.int64)
 
 
 class EmbedSubword(nn.Module):
-    def __init__(self):
+    def __init__(self, config: EarTTSConfig):
         super().__init__()
-        self.backbone = _EncoderBackbone(n_layers=1)
-        self.embed_tokens = nn.Embedding(257, H)
-        self.proj_embedding = nn.Linear(H, H, bias=False)
-        self.bos_eos_emb = _BosEosEmb()
-        self.subword_flag_emb = _SubwordFlagEmb()
+        h = config.hidden_size
+        self.hidden_size = h
+        self.head_dim = config.head_dim
+        self.rope_theta_local = config.rope_theta_local
+        self.eps = config.rms_norm_eps
+        self.backbone = _EncoderBackbone(config, n_layers=1)
+        self.embed_tokens = nn.Embedding(_CHAR_VOCAB, h)
+        self.proj_embedding = nn.Linear(h, h, bias=False)
+        self.bos_eos_emb = _BosEosEmb(h)
+        self.subword_flag_emb = _SubwordFlagEmb(h)
 
     def encode_chars(self, char_ids: torch.Tensor, char_lengths: torch.Tensor) -> torch.Tensor:
         """Char-aware subword pooling: embed char ids, run the T5Gemma encoder
-        (bidirectional, rope theta 10000) with a key-padding mask, mean-pool over
-        valid chars, and project. ``char_ids`` [N, Lc], ``char_lengths`` [N] ->
-        ``[N, H]``."""
+        (bidirectional, rope ``rope_theta_local``) with a key-padding mask,
+        mean-pool over valid chars, and project. ``char_ids`` [N, Lc],
+        ``char_lengths`` [N] -> ``[N, H]``."""
         n, lc = char_ids.shape
         char_mask = torch.arange(lc, device=char_ids.device)[None, :] < char_lengths[:, None]  # [N, Lc]
         char_embeds = self.embed_tokens(char_ids)  # [N, Lc, H]
 
-        cos, sin = _rope_cos_sin(torch.arange(lc, device=char_ids.device), ROPE_THETA_LOCAL, HEAD_DIM)
+        cos, sin = _rope_cos_sin(
+            torch.arange(lc, device=char_ids.device), self.rope_theta_local, self.head_dim
+        )
         neg = torch.finfo(char_embeds.dtype).min
         attn_bias = torch.where(char_mask[:, None, None, :], 0.0, neg).to(char_embeds.dtype)  # [N,1,1,Lc]
 
         # T5Gemma encoder scales the input embeddings by sqrt(hidden_size).
-        x = char_embeds * (H ** 0.5)
+        x = char_embeds * (self.hidden_size ** 0.5)
         for layer in self.backbone.encoder.layers:
             x = layer(x, cos, sin, attn_bias)
-        x = _gemma_rmsnorm(x, self.backbone.encoder.norm.weight)
+        x = _gemma_rmsnorm(x, self.backbone.encoder.norm.weight, self.eps)
 
         masked_sum = (x * char_mask.unsqueeze(-1)).sum(dim=1)
         mean_emb = masked_sum / char_lengths.unsqueeze(-1).clamp(min=1)
@@ -260,12 +277,12 @@ class EmbedSubword(nn.Module):
         tokenizer). ``subword_ids``/``subword_mask`` are [B, T]."""
         out_emb = self.encode_chars(char_ids, char_lengths)  # [N, H]
         subword_embeds = torch.zeros(
-            subword_ids.shape + (H,), device=subword_ids.device, dtype=out_emb.dtype
+            subword_ids.shape + (self.hidden_size,), device=subword_ids.device, dtype=out_emb.dtype
         )
         subword_embeds[subword_mask] = out_emb
 
         # continuation-flag embedding (index 0 forced to zero in the checkpoint)
-        vocab = self.subword_flag_emb.cont_emb.num_embeddings  # 2
+        vocab = self.subword_flag_emb.cont_emb.num_embeddings
         pad = self.subword_flag_emb.is_continuation.numel() - 1
         safe = torch.where(subword_ids >= pad, torch.full_like(subword_ids, pad), subword_ids)
         cont_flags = self.subword_flag_emb.is_continuation[safe]
@@ -280,12 +297,15 @@ class EmbedSubword(nn.Module):
 
 
 class GatedFusion(nn.Module):
-    def __init__(self):
+    def __init__(self, config: EarTTSConfig):
         super().__init__()
-        self.audio_proj = nn.Linear(H, H, bias=True)
-        self.text_proj = nn.Linear(H, H, bias=True)
-        self.final_norm = RMSNorm(H)
-        self.gate = param(H)
+        h = config.hidden_size
+        self.num_quantizers = config.num_quantizers
+        self.eps = config.rms_norm_eps
+        self.audio_proj = nn.Linear(h, h, bias=True)
+        self.text_proj = nn.Linear(h, h, bias=True)
+        self.final_norm = RMSNorm(h)
+        self.gate = param(h)
         self.residual_scale = param()  # scalar
 
     def forward(self, audio_emb: torch.Tensor, text_emb: torch.Tensor) -> torch.Tensor:
@@ -295,40 +315,50 @@ class GatedFusion(nn.Module):
         ``gate`` and scalar ``residual_scale`` are sigmoided in fp32.
         """
         dtype = audio_emb.dtype
-        audio_emb = audio_emb / NUM_QUANTIZERS
+        audio_emb = audio_emb / self.num_quantizers
         audio_h = F.linear(audio_emb, self.audio_proj.weight, self.audio_proj.bias)
         text_h = F.linear(text_emb, self.text_proj.weight, self.text_proj.bias)
         gate = torch.sigmoid(self.gate.float())
         res = torch.sigmoid(self.residual_scale.float())
         h = gate.to(dtype) * audio_h + (1.0 - gate).to(dtype) * text_h
         h = res.to(dtype) * h
-        h = _gemma_rmsnorm(h.float(), self.final_norm.weight).to(dtype)
+        h = _gemma_rmsnorm(h.float(), self.final_norm.weight, self.eps).to(dtype)
         return h
 
 
 class _MogMLP(nn.Module):
-    def __init__(self):
+    def __init__(self, config: EarTTSConfig):
         super().__init__()
-        self.mlp = GatedMLP(H, FF, activation="gelu_tanh", bias=False)
-        self.pre_norm = RMSNorm(H)
-        self.post_norm = RMSNorm(H)
+        h = config.hidden_size
+        self.mlp = GatedMLP(h, config.mog_intermediate_size, activation="gelu_tanh", bias=False)
+        self.pre_norm = RMSNorm(h)
+        self.post_norm = RMSNorm(h)
 
 
 class MogHead(nn.Module):
     """Mixture-of-gaussians output head over the RVQ latent space.
 
-    ``mlp_stack`` is 3 gated-MLP blocks followed by a bare scale vector
-    (index 3, ``mlp_stack.3.weight`` [H]).
+    ``mlp_stack`` is ``mog_num_layers`` gated-MLP blocks followed by a bare
+    scale vector (final index, ``mlp_stack.<n>.weight`` [H]).
     """
 
-    def __init__(self, n_mlp: int = 3):
+    def __init__(self, config: EarTTSConfig):
         super().__init__()
-        self.low_mat = param(CODEBOOK, CODE_DIM, 64)
-        self.mlp_stack = nn.ModuleList([_MogMLP() for _ in range(n_mlp)] + [RawWeight(H)])
-        self.proj_else = nn.Linear(H, CODE_DIM, bias=False)
-        self.proj_logits = nn.Linear(H, CODEBOOK, bias=False)
-        self.proj_logs = nn.Linear(H, 1, bias=False)
-        self.proj_mus = nn.Linear(H, 65536, bias=False)
+        h = config.hidden_size
+        self.num_predictions = config.mog_num_predictions
+        self.low_rank = config.mog_low_rank
+        self.out_size = config.code_dim
+        self.min_log_std = config.mog_min_log_std
+        self.eps = config.mog_eps
+        self.num_layers = config.mog_num_layers
+        self.low_mat = param(self.num_predictions, self.out_size, self.low_rank)
+        self.mlp_stack = nn.ModuleList(
+            [_MogMLP(config) for _ in range(self.num_layers)] + [RawWeight(h)]
+        )
+        self.proj_else = nn.Linear(h, self.out_size, bias=False)
+        self.proj_logits = nn.Linear(h, self.num_predictions, bias=False)
+        self.proj_logs = nn.Linear(h, 1, bias=False)
+        self.proj_mus = nn.Linear(h, self.num_predictions * self.low_rank, bias=False)
 
     def forward(self, x: torch.Tensor):
         """Deterministic (training-style) MoG head forward.
@@ -337,50 +367,51 @@ class MogHead(nn.Module):
           * ``logits`` [b, t, num_predictions] mixture weights
           * ``mus``    [b, t, num_predictions, low_rank] low-rank means
           * ``mu_res`` [b, t, out_size] residual mean
-          * ``logs``   [b, t, 1] log std, clamped to ``MIN_LOG_STD``
+          * ``logs``   [b, t, 1] log std, clamped to ``mog_min_log_std``
         """
         b, t, _ = x.shape
-        # mlp_stack: 3 residual MLPLayers (pre_norm -> mlp -> post_norm) then a final RMSNorm.
-        for block in self.mlp_stack[:3]:
-            y = _gemma_rmsnorm(x, block.pre_norm.weight)
+        # mlp_stack: residual MLPLayers (pre_norm -> mlp -> post_norm) then a final RMSNorm.
+        for block in self.mlp_stack[: self.num_layers]:
+            y = _gemma_rmsnorm(x, block.pre_norm.weight, self.eps)
             y = block.mlp(y)
-            y = _gemma_rmsnorm(y, block.post_norm.weight)
+            y = _gemma_rmsnorm(y, block.post_norm.weight, self.eps)
             x = x + y
-        x = _gemma_rmsnorm(x, self.mlp_stack[3].weight)
+        x = _gemma_rmsnorm(x, self.mlp_stack[self.num_layers].weight, self.eps)
 
         logits = F.linear(x, self.proj_logits.weight)
-        mus = F.linear(x, self.proj_mus.weight).view(b, t, NUM_PREDICTIONS, LOW_RANK)
-        logs = F.linear(x, self.proj_logs.weight).clamp_min(MIN_LOG_STD)
+        mus = F.linear(x, self.proj_mus.weight).view(b, t, self.num_predictions, self.low_rank)
+        logs = F.linear(x, self.proj_logs.weight).clamp_min(self.min_log_std)
         mu_res = F.linear(x, self.proj_else.weight)
         return logits, mus, mu_res, logs
 
 
 class _Backbone(nn.Module):
-    def __init__(self):
+    def __init__(self, config: EarTTSConfig):
         super().__init__()
-        self.layers = nn.ModuleList([TalkerLayer() for _ in range(NUM_LAYERS)])
-        self.norm = RMSNorm(H)
+        self.layers = nn.ModuleList([TalkerLayer(config) for _ in range(config.num_hidden_layers)])
+        self.norm = RMSNorm(config.hidden_size)
 
 
 class EarTTSTalker(nn.Module):
     def __init__(self, config: EarTTSConfig, voices=("Aria",)):
         super().__init__()
         self.config = config
-        self.embed_code = nn.Linear(CODE_DIM, H, bias=False)
-        self.backbone = _Backbone()
-        self.embed_subword = EmbedSubword()
-        self.gated_fusion_audio_text = GatedFusion()
-        self.mog_head = MogHead()
+        h = config.hidden_size
+        self.embed_code = nn.Linear(config.code_dim, h, bias=False)
+        self.backbone = _Backbone(config)
+        self.embed_subword = EmbedSubword(config)
+        self.gated_fusion_audio_text = GatedFusion(config)
+        self.mog_head = MogHead(config)
         # bespoke embeddings / tables
-        self.bos_emb = param(H)
-        self.null_emb = param(H)
-        self.audio_prompt_projection_W = param(H, H)
-        self.rvq_embs = param(NUM_QUANTIZERS, CODEBOOK, CODE_DIM)
+        self.bos_emb = param(h)
+        self.null_emb = param(h)
+        self.audio_prompt_projection_W = param(h, h)
+        self.rvq_embs = param(config.num_quantizers, config.codebook_size, config.code_dim)
         # top-level tts_model.* buffers (loaded via the talker node)
         self._control_codes = param(3, dtype=torch.int64)
-        self.codec_silence_tokens = param(NUM_QUANTIZERS, dtype=torch.int64)
+        self.codec_silence_tokens = param(config.num_quantizers, dtype=torch.int64)
         self.audio_prompt_latents = nn.ParameterDict(
-            {v: param(1, 37, H) for v in voices}
+            {v: param(1, _AUDIO_PROMPT_FRAMES, h) for v in voices}
         )
 
     def depthsum_embedding(self, code: torch.Tensor) -> torch.Tensor:
@@ -398,22 +429,23 @@ class EarTTSTalker(nn.Module):
     def backbone_forward(self, inputs_embeds: torch.Tensor, position_ids: torch.Tensor | None = None) -> torch.Tensor:
         """Gemma3-text decoder stack over ``inputs_embeds`` [b, t, H].
 
-        Full-attention layers (``(i+1) % 6 == 0``) use rope_theta 1e6; the rest
-        (sliding-attention) use rope_local_base_freq 1e4. For sequences shorter
-        than the 7500 sliding window the two mask identically (plain causal), so
-        only the rope base differs between layer types.
+        Full-attention layers (``(i+1) % sliding_window_pattern == 0``) use
+        ``rope_theta_full``; the rest (sliding-attention) use
+        ``rope_theta_local``. For sequences shorter than the sliding window the
+        two mask identically (plain causal), so only the rope base differs.
         """
+        cfg = self.config
         b, t, _ = inputs_embeds.shape
         if position_ids is None:
             position_ids = torch.arange(t, device=inputs_embeds.device)
-        cos_g, sin_g = _rope_cos_sin(position_ids, ROPE_THETA_GLOBAL, HEAD_DIM)
-        cos_l, sin_l = _rope_cos_sin(position_ids, ROPE_THETA_LOCAL, HEAD_DIM)
+        cos_g, sin_g = _rope_cos_sin(position_ids, cfg.rope_theta_full, cfg.head_dim)
+        cos_l, sin_l = _rope_cos_sin(position_ids, cfg.rope_theta_local, cfg.head_dim)
         x = inputs_embeds
         for i, layer in enumerate(self.backbone.layers):
-            full = (i + 1) % SLIDING_WINDOW_PATTERN == 0
+            full = (i + 1) % cfg.sliding_window_pattern == 0
             cos, sin = (cos_g, sin_g) if full else (cos_l, sin_l)
             x = layer(x, cos, sin)
-        x = _gemma_rmsnorm(x, self.backbone.norm.weight)
+        x = _gemma_rmsnorm(x, self.backbone.norm.weight, cfg.rms_norm_eps)
         return x
 
     def forward(
@@ -438,7 +470,7 @@ class EarTTSTalker(nn.Module):
         """
         code_embeds = self.embed_code(self.depthsum_embedding(code))
         if cond is None:
-            cond = code_embeds.new_zeros((1, 1, H))
+            cond = code_embeds.new_zeros((1, 1, self.config.hidden_size))
         inputs_embeds = self.gated_fusion_audio_text(code_embeds, cond)
         hidden_states = self.backbone_forward(inputs_embeds, position_ids)
 

--- a/mstar/model/nemotron_duplex/components/eartts_talker.py
+++ b/mstar/model/nemotron_duplex/components/eartts_talker.py
@@ -631,29 +631,83 @@ class EarTTSTalker(nn.Module):
         return code
 
     @torch.no_grad()
-    def init_state(self, batch_size: int, speaker: str = "Aria", device=None, dtype=None) -> dict:
-        """Warm up the autoregressive KV cache from a pre-baked speaker prompt.
+    def init_state(
+        self,
+        batch_size: int,
+        speaker: str = "Aria",
+        device=None,
+        dtype=None,
+        subword_id_to_char_ids: dict | None = None,
+        char_pad_idx: int | None = None,
+        text_pad_id: int | None = None,
+        text_eos_id: int | None = None,
+        speech_pad_id: int | None = None,
+    ) -> dict:
+        """Warm up the autoregressive KV cache from a pre-baked speaker prompt,
+        replicating the NeMo ``set_init_inputs(speaker_name=...)`` -> warmup path.
 
-        Uses the cached ``audio_prompt_latents[speaker]`` [1, P, H] as the
-        pre-BOS audio-prompt frames (already in model hidden space), adds
-        ``bos_emb`` to the final prompt frame to mark the generation boundary,
-        runs the block through the gated fusion (zero text conditioning) and the
-        backbone, and returns the populated per-layer cache plus the next
-        absolute position. NOTE: this is a self-contained faithful setup — it
-        uses the pre-baked latent directly rather than re-encoding prompt audio
-        with the codec, and omits any text/system-prompt prefix.
+        The prompt is ``P`` frames (``P == len(audio_prompt_latents[speaker])``,
+        37 for Aria). The reference builds a silent-carrier audio prompt whose
+        codec codes are all the codec-silence frame; the pre-baked latent then
+        *replaces* the code embedding at every pre-BOS position, so no codec
+        encode is needed. The layout of the ``P`` warmup positions is:
+
+          * positions ``0 .. P-2``: the audio-prompt latent frames (pre-BOS);
+          * position ``P-1`` (the BOS frame): ``embed_code(depthsum(silence))``
+            (the shifted last silence code) ``+ bos_emb``.
+
+        Text conditioning during warmup is the shifted prompt text — pad tokens
+        with the trailing EOS — active only on the last two positions
+        (``subword_mask`` = ``[.., P-2, P-1]``), matching the reference.
+
+        When the token-id args (``text_pad_id`` / ``text_eos_id`` /
+        ``speech_pad_id``) and char maps are supplied, the warmup is exact and
+        the returned ``prev_codes`` is the ``speech_pad`` frame the reference
+        carries in. Otherwise a simplified latent-only warmup is used (BOS added
+        to the last latent frame, zero text conditioning) and ``prev_codes``
+        falls back to the codec-silence frame.
         """
         latent = self.audio_prompt_latents[speaker]
         if device is not None:
             latent = latent.to(device)
         if dtype is not None:
             latent = latent.to(dtype)
-        prompt = latent.expand(batch_size, -1, -1).clone()                  # [B, P, H]
-        prompt[:, -1] = prompt[:, -1] + self.bos_emb.to(prompt)
-        cond = prompt.new_zeros((1, 1, self.config.hidden_size))
-        inputs_embeds = self.gated_fusion_audio_text(prompt, cond)
+        b = batch_size
+        h = self.config.hidden_size
+        p = latent.shape[1]
+        latent = latent.expand(b, -1, -1)
+        dev = latent.device
+
+        faithful = (
+            subword_id_to_char_ids is not None
+            and char_pad_idx is not None
+            and text_pad_id is not None
+            and text_eos_id is not None
+            and speech_pad_id is not None
+        )
+
+        if faithful:
+            # position P-1 code embed: embed_code(depthsum(last silence code)).
+            silence = self.codec_silence_tokens.to(dev).view(1, 1, -1).expand(b, 1, -1)
+            bos_frame = self.embed_code(self.depthsum_embedding(silence)) + self.bos_emb.to(latent)
+            code_embeds = torch.cat([latent[:, : p - 1], bos_frame], dim=1)     # [B, P, H]
+
+            # warmup text: [pad ... pad, eos] with mask on the last two positions.
+            subword_ids = torch.full((b, p), int(text_pad_id), dtype=torch.long, device=dev)
+            subword_ids[:, p - 1] = int(text_eos_id)
+            subword_mask = torch.zeros((b, p), dtype=torch.bool, device=dev)
+            subword_mask[:, p - 2:] = True
+            cond = self.text_conditioning(subword_ids, subword_mask, subword_id_to_char_ids, char_pad_idx)
+            prev_codes = torch.full((b, self.config.num_quantizers), int(speech_pad_id), dtype=torch.long, device=dev)
+        else:
+            code_embeds = latent.clone()
+            code_embeds[:, -1] = code_embeds[:, -1] + self.bos_emb.to(latent)
+            cond = latent.new_zeros((1, 1, h))
+            prev_codes = self.initial_prev_codes(b, device=dev)
+
+        inputs_embeds = self.gated_fusion_audio_text(code_embeds, cond)
         _, cache = self.backbone_forward(inputs_embeds, start_pos=0, kv_cache=None, return_cache=True)
-        return {"kv": cache, "pos": prompt.shape[1]}
+        return {"kv": cache, "pos": p, "prev_codes": prev_codes}
 
     def initial_prev_codes(self, batch_size: int, device=None) -> torch.Tensor:
         """The frame-0 ``prev_codes`` [B, num_quantizers]: the codec silence
@@ -801,6 +855,8 @@ class EarTTSTalker(nn.Module):
         temperature: float = 0.0,
         num_iter: int = 8,
         text_eos_id: int | None = None,
+        text_pad_id: int | None = None,
+        speech_pad_id: int | None = None,
         prev_codes: torch.Tensor | None = None,
         generator: torch.Generator | None = None,
     ) -> torch.Tensor:
@@ -812,6 +868,10 @@ class EarTTSTalker(nn.Module):
         text conditioning from the current subword id and runs one
         ``infer_codes_one_step`` (greedy + deterministic by default). If
         ``text_eos_id`` is given, an EOS text token forces a codec-silence frame.
+
+        Passing ``text_pad_id`` / ``text_eos_id`` / ``speech_pad_id`` enables the
+        exact NeMo warmup (see ``init_state``); otherwise the simplified
+        latent-only warmup is used.
         """
         b, t = subword_stream.shape
         device = subword_stream.device
@@ -820,9 +880,15 @@ class EarTTSTalker(nn.Module):
         s2c, _ = subword_to_char_ids(tokenizer, char_vocab)
         char_pad_idx = len(char_vocab)
 
-        state = self.init_state(b, speaker=speaker, device=device, dtype=dtype)
+        state = self.init_state(
+            b, speaker=speaker, device=device, dtype=dtype,
+            subword_id_to_char_ids=s2c, char_pad_idx=char_pad_idx,
+            text_pad_id=text_pad_id, text_eos_id=text_eos_id, speech_pad_id=speech_pad_id,
+        )
         if prev_codes is None:
-            prev_codes = self.initial_prev_codes(b, device=device)
+            prev_codes = state.get("prev_codes")
+            if prev_codes is None:
+                prev_codes = self.initial_prev_codes(b, device=device)
 
         all_codes = []
         for i in range(t):

--- a/mstar/model/nemotron_duplex/components/nemotron_h.py
+++ b/mstar/model/nemotron_duplex/components/nemotron_h.py
@@ -89,11 +89,36 @@ class MambaStateAccessor:
 # ---------------------------------------------------------------------------
 
 
+def _rms_fp32(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """Llama-style RMSNorm in fp32 (offline path — avoids the bf16 fused kernel)."""
+    dtype = x.dtype
+    x = x.float()
+    x = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+    return (x * weight.float()).to(dtype)
+
+
 class NemotronHAttention(Attention):
     """GQA self-attention with NoPE (Nemotron-H applies no positional encoding)."""
 
     def _apply_rope(self, q, k, cache_handle):  # noqa: ARG002 - override to disable RoPE
         return q, k
+
+    def offline_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Eager full-sequence causal self-attention for offline inference.
+
+        ``hidden_states``: ``(L, H)`` (single sequence). Mirrors the reference
+        ``NemotronHAttention`` (GQA, NoPE, SDPA default scale, causal).
+        """
+        L = hidden_states.shape[0]
+        q = self.q_proj(hidden_states).view(L, self.num_heads, self.head_dim).transpose(0, 1)
+        k = self.k_proj(hidden_states).view(L, self.num_kv_heads, self.head_dim).transpose(0, 1)
+        v = self.v_proj(hidden_states).view(L, self.num_kv_heads, self.head_dim).transpose(0, 1)
+        n_rep = self.num_heads // self.num_kv_heads
+        k = k.repeat_interleave(n_rep, dim=0)
+        v = v.repeat_interleave(n_rep, dim=0)
+        out = F.scaled_dot_product_attention(q, k, v, is_causal=True)  # (heads, L, hd)
+        out = out.transpose(0, 1).reshape(L, self.num_heads * self.head_dim)
+        return self.o_proj(out)
 
 
 class NemotronHMLP(nn.Module):
@@ -109,17 +134,29 @@ class NemotronHMLP(nn.Module):
 
 
 class _RMSNormGated(nn.Module):
-    """Mamba-2 gated RMSNorm: ``rmsnorm(y * silu(z)) * weight``."""
+    """Mamba-2 gated RMSNorm (grouped): gate, then per-group RMS-normalize.
 
-    def __init__(self, dim: int, eps: float):
+    Matches the reference ``MambaRMSNormGated`` with ``norm_before_gate=False``:
+    ``x = x * silu(z)`` first, then RMS-normalize *within each group* of
+    ``group_size`` channels (group_size = intermediate / n_groups), then scale by
+    the per-channel weight. Computed in fp32.
+    """
+
+    def __init__(self, dim: int, eps: float, group_size: int):
         super().__init__()
         self.weight = nn.Parameter(torch.ones(dim))
         self.eps = eps
+        self.group_size = group_size
+        self.n_groups = dim // group_size
 
     def forward(self, y: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
-        y = y * F.silu(z)
+        dtype = y.dtype
+        y = y.float() * F.silu(z.float())
+        shape = y.shape
+        y = y.reshape(*shape[:-1], self.n_groups, self.group_size)
         y = y * torch.rsqrt(y.pow(2).mean(-1, keepdim=True) + self.eps)
-        return y * self.weight
+        y = y.reshape(shape)
+        return (y * self.weight.float()).to(dtype)
 
 
 class Mamba2Mixer(nn.Module):
@@ -156,7 +193,9 @@ class Mamba2Mixer(nn.Module):
         self.A_log = nn.Parameter(torch.empty(self.nheads))
         self.D = nn.Parameter(torch.empty(self.nheads))
         self.dt_bias = nn.Parameter(torch.empty(self.nheads))
-        self.norm = _RMSNormGated(self.d_inner, eps=config.rms_norm_eps)
+        self.norm = _RMSNormGated(
+            self.d_inner, eps=config.rms_norm_eps, group_size=self.d_inner // self.n_groups
+        )
         self.out_proj = nn.Linear(self.d_inner, config.hidden_size, bias=config.mamba_proj_bias)
 
     # -- helpers ---------------------------------------------------------
@@ -283,6 +322,15 @@ class NemotronHBlock(nn.Module):
         out = self.mixer(normed, cache_handle=cache_handle, mamba_state=mamba_state)
         return residual + out
 
+    def offline_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Engine-free block for offline inference; ``hidden_states`` is ``(L, H)``."""
+        normed = _rms_fp32(hidden_states, self.norm.weight, self.norm.variance_epsilon)
+        if self.kind == "attention":
+            out = self.mixer.offline_forward(normed)
+        else:  # mamba (full-seq scan) / mlp — both run engine-free with no state
+            out = self.mixer(normed, cache_handle=None, mamba_state=None)
+        return hidden_states + out
+
 
 class NemotronHLLM(nn.Module):
     """The ``llm`` container: hybrid layer stack + final norm (no embeddings)."""
@@ -313,6 +361,13 @@ class NemotronHLLM(nn.Module):
         cache_handle.advance_seq_lens()
         return self.norm_f(hidden)
 
+    def offline_forward(self, input_embeds: torch.Tensor) -> torch.Tensor:
+        """Engine-free full-sequence forward; ``input_embeds`` is ``(L, H)``."""
+        hidden = input_embeds
+        for block in self.layers:
+            hidden = block.offline_forward(hidden)
+        return _rms_fp32(hidden, self.norm_f.weight, self.norm_f.variance_epsilon)
+
 
 class NemotronHForCausalLM(nn.Module):
     def __init__(self, config: NanoConfig):
@@ -331,6 +386,12 @@ class NemotronHForCausalLM(nn.Module):
 
     def forward(self, input_embeds, cache_handle, mamba_state=None) -> torch.Tensor:
         return self.llm(input_embeds, cache_handle=cache_handle, mamba_state=mamba_state)
+
+    def offline_forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Full-sequence offline forward: ``input_ids`` (L,) -> logits (L, vocab)."""
+        hidden = self.embed_tokens(input_ids)
+        hidden = self.llm.offline_forward(hidden)
+        return self.lm_head(hidden)
 
     @staticmethod
     def remap(name: str) -> str | None:

--- a/mstar/model/nemotron_duplex/components/nemotron_h.py
+++ b/mstar/model/nemotron_duplex/components/nemotron_h.py
@@ -49,34 +49,44 @@ from mstar.model.nemotron_duplex.config import NanoConfig
 
 @dataclass
 class MambaStateAccessor:
-    """Read/write view over one batch's Mamba conv+ssm state.
+    """Batched read/write view over one batch's Mamba conv+ssm state.
 
-    Built by the submodule from ``engine_inputs.per_request_states`` and the
-    current walk. Correctness draft is bs=1 (one request); kept indexable so the
-    batched Option-B pool can drop in later. State tensors live in each request's
-    ``PerRequestState.tensors`` under ``mamba{layer}.conv`` / ``.ssm``.
+    Built by the submodule from ``engine_inputs.per_request_states``, the batch's
+    ``request_ids``, the current walk (``is_prefill``), and the per-request token
+    counts ``seq_lens`` (how the packed ``hidden_states`` [sum(seq_lens), H] splits
+    into requests). Each request's state lives in its ``PerRequestState.tensors``
+    under ``mamba{layer}.conv`` / ``.ssm`` — one Option-A slot per request, so B>1
+    requests advance in a single fused forward (true batched inference). The
+    CUDA-graph-capturable fixed-buffer pool (Option B) can replace the dict without
+    touching the mixer, which only calls ``read``/``write`` by batch position.
     """
 
     request_states: dict
     request_ids: list
     is_prefill: bool
+    # Per-request token counts splitting the packed rows. ``None`` => treat the whole
+    # packed input as one request's sequence (the single-sequence / bs=1 path); the
+    # submodule passes real seq_lens to enable batched (B>1) stepping.
+    seq_lens: list | None = None
 
     def _keys(self, layer_idx: int):
         return f"mamba{layer_idx}.conv", f"mamba{layer_idx}.ssm"
 
-    def read(self, layer_idx: int):
+    def read(self, layer_idx: int, req_idx: int = 0):
+        """Return ``(conv, ssm)`` for the request at batch position ``req_idx``
+        (``(None, None)`` on prefill or a fresh request → the mixer seeds zeros)."""
         if self.is_prefill or not self.request_ids or self.request_states is None:
             return None, None
-        st = self.request_states.get(self.request_ids[0])
+        st = self.request_states.get(self.request_ids[req_idx])
         if st is None:
             return None, None
         ck, sk = self._keys(layer_idx)
         return st.get(ck), st.get(sk)
 
-    def write(self, layer_idx: int, conv_state: torch.Tensor, ssm_state: torch.Tensor):
+    def write(self, layer_idx: int, conv_state: torch.Tensor, ssm_state: torch.Tensor, req_idx: int = 0):
         if not self.request_ids or self.request_states is None:
             return
-        st = self.request_states.get(self.request_ids[0])
+        st = self.request_states.get(self.request_ids[req_idx])
         if st is None:
             return
         ck, sk = self._keys(layer_idx)
@@ -316,22 +326,67 @@ class Mamba2Mixer(nn.Module):
         cache_handle: BatchedCacheManager | None = None,  # noqa: ARG002
         mamba_state: MambaStateAccessor | None = None,
     ) -> torch.Tensor:
+        """Engine forward over a packed batch ``hidden_states`` [sum(seq_lens), H].
+
+        ``mamba_state.seq_lens`` says how the packed rows split into requests, each
+        carrying its own conv/ssm state. True batched inference: all-decode batches
+        (1 token/request) run one fused tensor step over B; varlen prefill segments
+        per request (each still one engine step). ``mamba_state=None`` is the
+        single-sequence path (offline / bs=1)."""
+        if mamba_state is None:
+            out, _, _ = self._forward_seq(hidden_states, None, None)
+            return out
+
+        seq_lens = mamba_state.seq_lens or [hidden_states.shape[0]]
+        li = self.layer_idx
+
+        # Fast path: every request contributes exactly one token -> fused batch step.
+        if len(seq_lens) > 1 and all(s == 1 for s in seq_lens):
+            B = len(seq_lens)
+            conv_b, ssm_b = [], []
+            for i in range(B):
+                c, s = mamba_state.read(li, i)
+                conv_b.append(c if c is not None else hidden_states.new_zeros(self.conv_dim, self.conv_kernel - 1))
+                ssm_b.append(s if s is not None else hidden_states.new_zeros(self.nheads, self.head_dim, self.d_state))
+            out, new_conv, new_ssm = self._decode_batched(
+                hidden_states, torch.stack(conv_b, 0), torch.stack(ssm_b, 0).float()
+            )
+            for i in range(B):
+                mamba_state.write(li, new_conv[i], new_ssm[i], i)
+            return out
+
+        # General path: segment the packed rows by request and run each sequence.
+        outs, off = [], 0
+        for i, s in enumerate(seq_lens):
+            prev_conv, prev_ssm = mamba_state.read(li, i)
+            out, new_conv, new_ssm = self._forward_seq(hidden_states[off:off + s], prev_conv, prev_ssm)
+            mamba_state.write(li, new_conv, new_ssm, i)
+            outs.append(out)
+            off += s
+        return torch.cat(outs, dim=0)
+
+    def _forward_seq(self, hidden_states, prev_conv, prev_ssm):
+        """One request's full-sequence Mamba over ``hidden_states`` [L, H] with its
+        incoming ``prev_conv`` [conv_dim, k-1] / ``prev_ssm`` [nheads, head_dim,
+        d_state] (or ``None`` to seed fresh). Returns ``(out [L,H], new_conv, new_ssm)``,
+        the conv state left-zero-padded to a fixed [conv_dim, k-1] for decode."""
         L = hidden_states.shape[0]
         z, xBC, dt = self._split_in_proj(self.in_proj(hidden_states))
 
-        prev_conv, prev_ssm = (None, None)
-        if mamba_state is not None:
-            prev_conv, prev_ssm = mamba_state.read(self.layer_idx)
-
-        # --- causal depthwise conv over (x|B|C) ---
         xBC_t = xBC.transpose(0, 1).unsqueeze(0)  # (1, conv_dim, L)
         if prev_conv is not None:
-            xBC_t = torch.cat([prev_conv, xBC_t], dim=-1)
+            xBC_t = torch.cat([prev_conv.unsqueeze(0), xBC_t], dim=-1)
         conv_out = self.conv1d(xBC_t)[..., : xBC_t.shape[-1]]
         conv_out = conv_out[..., -L:]  # keep the L new positions
         xBC = F.silu(conv_out.squeeze(0).transpose(0, 1))  # (L, conv_dim)
-        # conv state = last (conv_kernel-1) inputs, for the next step
-        new_conv_state = xBC_t[..., -(self.conv_kernel - 1):].detach()
+        # fixed [conv_dim, k-1] rolling buffer of raw inputs (left-pad when short)
+        raw = xBC_t.squeeze(0)  # (conv_dim, seen)
+        k1 = self.conv_kernel - 1
+        if raw.shape[-1] >= k1:
+            new_conv = raw[:, -k1:].contiguous()
+        else:
+            pad = raw.new_zeros(self.conv_dim, k1 - raw.shape[-1])
+            new_conv = torch.cat([pad, raw], dim=-1)
 
         x, B, C = torch.split(
             xBC,
@@ -347,12 +402,44 @@ class Mamba2Mixer(nn.Module):
 
         y, new_ssm = self._ssd_scan(x.float(), dt, A, B.float(), C.float(), h0=prev_ssm)
         y = y.reshape(L, self.d_inner).to(hidden_states.dtype)
-
-        if mamba_state is not None:
-            mamba_state.write(self.layer_idx, new_conv_state, new_ssm)
-
         y = self.norm(y, z)
-        return self.out_proj(y)
+        return self.out_proj(y), new_conv.detach(), new_ssm.detach()
+
+    def _decode_batched(self, hidden, conv_b, ssm_b):
+        """Fused single-token decode over a batch. ``hidden`` [B, H], ``conv_b``
+        [B, conv_dim, k-1], ``ssm_b`` [B, nheads, head_dim, d_state]. Batched form of
+        :meth:`decode_step`: rolling conv + one SSD step, all requests in parallel.
+        Returns ``(out [B, H], new_conv [B, conv_dim, k-1], new_ssm [B, ...])``."""
+        Bn = hidden.shape[0]
+        z, xBC, dt = self._split_in_proj(self.in_proj(hidden))     # each (B, ·)
+        window = torch.cat([conv_b, xBC.unsqueeze(-1)], dim=-1)     # (B, conv_dim, k)
+        w = self.conv1d.weight[:, 0, :]                            # (conv_dim, k)
+        conv_out = (window * w).sum(-1)                           # (B, conv_dim)
+        if self.conv1d.bias is not None:
+            conv_out = conv_out + self.conv1d.bias
+        new_conv = window[:, :, 1:].contiguous()                  # (B, conv_dim, k-1)
+        xBC = F.silu(conv_out)
+
+        x, B, C = torch.split(
+            xBC, [self.d_inner, self.n_groups * self.d_state, self.n_groups * self.d_state], dim=-1
+        )
+        x = x.view(Bn, self.nheads, self.head_dim)
+        B = B.view(Bn, self.n_groups, self.d_state)
+        C = C.view(Bn, self.n_groups, self.d_state)
+        A = -torch.exp(self.A_log.float())
+        dt = F.softplus(dt.float() + self.dt_bias.float())        # (B, nheads)
+
+        hpg = self.nheads // self.n_groups
+        Bx = B.repeat_interleave(hpg, dim=1).float()              # (B, nheads, d_state)
+        Cx = C.repeat_interleave(hpg, dim=1).float()
+        dA = torch.exp(dt * A)                                    # (B, nheads)
+        dBx = (dt.unsqueeze(-1) * x.float()).unsqueeze(-1) * Bx.unsqueeze(2)  # (B, nh, hd, ds)
+        h = dA.view(Bn, self.nheads, 1, 1) * ssm_b + dBx
+        y = torch.einsum("bhpn,bhn->bhp", h, Cx)                  # (B, nh, hd)
+        y = y + self.D.view(1, -1, 1) * x.float()
+        y = y.reshape(Bn, self.d_inner).to(hidden.dtype)
+        y = self.norm(y, z)
+        return self.out_proj(y), new_conv.detach(), h.detach()
 
     # -- cached O(T) decode path -----------------------------------------
 

--- a/mstar/model/nemotron_duplex/components/nemotron_h.py
+++ b/mstar/model/nemotron_duplex/components/nemotron_h.py
@@ -217,7 +217,10 @@ class Mamba2Mixer(nn.Module):
         """
         L = x.shape[0]
         heads_per_group = self.nheads // self.n_groups
-        # expand groups -> heads
+        # expand groups -> heads (contiguous: head i uses group i // heads_per_group).
+        # This matches the mamba_ssm kernel / reference decode path (the deployed
+        # behavior). NOTE: the reference's *naive prefill* uses .repeat (tile,
+        # i % n_groups) instead — an HF fallback quirk we intentionally do NOT copy.
         B = B.repeat_interleave(heads_per_group, dim=1)  # (L, nheads, d_state)
         C = C.repeat_interleave(heads_per_group, dim=1)
         dA = torch.exp(dt * A)  # (L, nheads)

--- a/mstar/model/nemotron_duplex/components/nemotron_h.py
+++ b/mstar/model/nemotron_duplex/components/nemotron_h.py
@@ -332,24 +332,23 @@ class NemotronHForCausalLM(nn.Module):
     def forward(self, input_embeds, cache_handle, mamba_state=None) -> torch.Tensor:
         return self.llm(input_embeds, cache_handle=cache_handle, mamba_state=mamba_state)
 
-    def load_weights(self, weights):
-        """Load the nano subtree from the composite checkpoint.
+    @staticmethod
+    def remap(name: str) -> str | None:
+        """Map a composite-checkpoint key to a nano param path, or ``None`` to skip.
 
         The checkpoint bundles every stage under ``stt_model.`` / ``tts_model.``;
-        the remapper keeps only the LLM tensors (embed_tokens / lm_head /
-        function_head / llm.*) and drops the rest (perception, rnnt, tts) so the
-        stream loads cleanly into this module alone.
+        keep only the LLM tensors (embed_tokens / lm_head / function_head / llm.*)
+        and drop the rest (perception, rnnt, tts) so the stream loads cleanly
+        into this module alone.
         """
+        if not name.startswith("stt_model."):
+            return None
+        rest = name[len("stt_model."):]
+        if rest.startswith(("embed_tokens.", "lm_head.", "function_head.", "llm.")):
+            return rest
+        return None
+
+    def load_weights(self, weights):
         from mstar.model.loader import load_hf_weights
 
-        keep_after_stt = ("embed_tokens.", "lm_head.", "function_head.", "llm.")
-
-        def name_remapper(name: str) -> str | None:
-            if not name.startswith("stt_model."):
-                return None
-            rest = name[len("stt_model."):]
-            if rest.startswith(keep_after_stt):
-                return rest
-            return None
-
-        return load_hf_weights(self, weights, stacked_params=[], name_remapper=name_remapper)
+        return load_hf_weights(self, weights, stacked_params=[], name_remapper=self.remap)

--- a/mstar/model/nemotron_duplex/components/nemotron_h.py
+++ b/mstar/model/nemotron_duplex/components/nemotron_h.py
@@ -564,7 +564,14 @@ class NemotronHBlock(nn.Module):
     def forward(self, hidden_states, cache_handle, mamba_state):
         residual = hidden_states
         normed = self.norm(hidden_states)
-        out = self.mixer(normed, cache_handle=cache_handle, mamba_state=mamba_state)
+        # Only the Mamba mixer consumes mamba_state; the attention mixer
+        # (paged KV via cache_handle) and the stateless MLP inherit the base
+        # Attention.forward(hidden_states, cache_handle) signature, which has no
+        # mamba_state parameter — passing it there is a TypeError.
+        if self.kind == "mamba":
+            out = self.mixer(normed, cache_handle=cache_handle, mamba_state=mamba_state)
+        else:  # attention / mlp
+            out = self.mixer(normed, cache_handle=cache_handle)
         return residual + out
 
     def offline_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/mstar/model/nemotron_duplex/components/nemotron_h.py
+++ b/mstar/model/nemotron_duplex/components/nemotron_h.py
@@ -31,7 +31,7 @@ TODO(verify): numeric parity of the scan against the HF NemotronHMamba2Mixer.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch
 import torch.nn.functional as F
@@ -85,6 +85,37 @@ class MambaStateAccessor:
 
 
 # ---------------------------------------------------------------------------
+# Cached decode state (engine-free O(T) path; additive to offline_forward)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NemotronHCache:
+    """Per-layer decode cache for the O(T) cached path (single sequence).
+
+    Populated by :meth:`NemotronHLLM.prefill` and mutated in place by
+    :meth:`NemotronHLLM.decode_step`. Only the layer kinds that carry state
+    have entries:
+
+        * ``attn[layer_idx]``  -> ``[k, v]``, each ``(Lh, num_kv_heads, head_dim)``
+          — the running key/value history for a ``*`` attention layer (NoPE, so
+          no per-position rotation to reconcile: entries are position-agnostic).
+        * ``conv[layer_idx]``  -> ``(conv_dim, conv_kernel-1)`` — the rolling
+          buffer of the last ``conv_kernel-1`` *raw* (pre-conv, pre-silu) xBC
+          inputs for an ``M`` mamba layer. FIXED length, left-zero-padded when
+          fewer than ``conv_kernel-1`` tokens have been seen.
+        * ``ssm[layer_idx]``   -> ``(nheads, head_dim, d_state)`` — the SSM
+          recurrent state for an ``M`` mamba layer (fp32).
+
+    ``-`` MLP layers are stateless and appear in none of the dicts.
+    """
+
+    attn: dict[int, list[torch.Tensor]] = field(default_factory=dict)
+    conv: dict[int, torch.Tensor] = field(default_factory=dict)
+    ssm: dict[int, torch.Tensor] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
 # Mixers
 # ---------------------------------------------------------------------------
 
@@ -119,6 +150,45 @@ class NemotronHAttention(Attention):
         out = F.scaled_dot_product_attention(q, k, v, is_causal=True)  # (heads, L, hd)
         out = out.transpose(0, 1).reshape(L, self.num_heads * self.head_dim)
         return self.o_proj(out)
+
+    def prefill(self, hidden_states: torch.Tensor):
+        """Cached-path prefill: same math as :meth:`offline_forward`, but also
+        returns the per-token ``k`` / ``v`` (pre-GQA-expansion) to seed the cache.
+
+        Returns ``(out (L, H), k (L, num_kv_heads, head_dim), v (...))``.
+        """
+        L = hidden_states.shape[0]
+        q = self.q_proj(hidden_states).view(L, self.num_heads, self.head_dim)
+        k = self.k_proj(hidden_states).view(L, self.num_kv_heads, self.head_dim)
+        v = self.v_proj(hidden_states).view(L, self.num_kv_heads, self.head_dim)
+        n_rep = self.num_heads // self.num_kv_heads
+        kh = k.transpose(0, 1).repeat_interleave(n_rep, dim=0)
+        vh = v.transpose(0, 1).repeat_interleave(n_rep, dim=0)
+        out = F.scaled_dot_product_attention(q.transpose(0, 1), kh, vh, is_causal=True)
+        out = out.transpose(0, 1).reshape(L, self.num_heads * self.head_dim)
+        return self.o_proj(out), k.detach(), v.detach()
+
+    def decode_forward(self, x: torch.Tensor, kv_cache_for_layer):
+        """Single-token cached decode.
+
+        ``x``: ``(1, H)`` — the new token. ``kv_cache_for_layer``: ``[k, v]``,
+        each ``(Lh, num_kv_heads, head_dim)`` — the cached history. Appends the
+        new token's k/v and attends over all cached keys (NoPE; no causal mask
+        is needed since the query is the last position). Returns
+        ``(out (1, H), (k_all, v_all))``.
+        """
+        k_cache, v_cache = kv_cache_for_layer
+        q = self.q_proj(x).view(1, self.num_heads, self.head_dim)
+        k_new = self.k_proj(x).view(1, self.num_kv_heads, self.head_dim)
+        v_new = self.v_proj(x).view(1, self.num_kv_heads, self.head_dim)
+        k_all = torch.cat([k_cache, k_new], dim=0)  # (Lh+1, num_kv_heads, hd)
+        v_all = torch.cat([v_cache, v_new], dim=0)
+        n_rep = self.num_heads // self.num_kv_heads
+        kh = k_all.transpose(0, 1).repeat_interleave(n_rep, dim=0)  # (heads, Lh+1, hd)
+        vh = v_all.transpose(0, 1).repeat_interleave(n_rep, dim=0)
+        out = F.scaled_dot_product_attention(q.transpose(0, 1), kh, vh, is_causal=False)
+        out = out.transpose(0, 1).reshape(1, self.num_heads * self.head_dim)
+        return self.o_proj(out), (k_all.detach(), v_all.detach())
 
 
 class NemotronHMLP(nn.Module):
@@ -284,6 +354,91 @@ class Mamba2Mixer(nn.Module):
         y = self.norm(y, z)
         return self.out_proj(y)
 
+    # -- cached O(T) decode path -----------------------------------------
+
+    def prefill(self, hidden_states: torch.Tensor):
+        """Cached-path prefill: numerically identical to ``forward`` with no
+        prior state, but also returns the recurrent state to seed the cache.
+
+        Returns ``(out (L, H), conv_state (conv_dim, conv_kernel-1), ssm_state)``.
+        The conv state is the last ``conv_kernel-1`` *raw* xBC inputs, a FIXED
+        length buffer left-zero-padded when ``L < conv_kernel-1``.
+        """
+        L = hidden_states.shape[0]
+        z, xBC, dt = self._split_in_proj(self.in_proj(hidden_states))
+
+        # causal depthwise conv over (x|B|C) — no prior conv state at prefill
+        xBC_t = xBC.transpose(0, 1).unsqueeze(0)  # (1, conv_dim, L)
+        conv_out = self.conv1d(xBC_t)[..., :L]
+        xBC_c = F.silu(conv_out.squeeze(0).transpose(0, 1))  # (L, conv_dim)
+
+        # fixed-length rolling conv buffer of raw (pre-conv) xBC inputs
+        k1 = self.conv_kernel - 1
+        raw = xBC_t.squeeze(0)  # (conv_dim, L)
+        if L >= k1:
+            conv_state = raw[:, -k1:].contiguous()
+        else:
+            pad = raw.new_zeros(self.conv_dim, k1 - L)
+            conv_state = torch.cat([pad, raw], dim=-1)
+
+        x, B, C = torch.split(
+            xBC_c,
+            [self.d_inner, self.n_groups * self.d_state, self.n_groups * self.d_state],
+            dim=-1,
+        )
+        x = x.view(L, self.nheads, self.head_dim)
+        B = B.view(L, self.n_groups, self.d_state)
+        C = C.view(L, self.n_groups, self.d_state)
+
+        A = -torch.exp(self.A_log.float())
+        dt = F.softplus(dt.float() + self.dt_bias.float())
+
+        y, new_ssm = self._ssd_scan(x.float(), dt, A, B.float(), C.float(), h0=None)
+        y = y.reshape(L, self.d_inner).to(hidden_states.dtype)
+        y = self.norm(y, z)
+        return self.out_proj(y), conv_state.detach(), new_ssm.detach()
+
+    def decode_step(self, hidden_state: torch.Tensor, conv_state: torch.Tensor, ssm_state: torch.Tensor):
+        """Single-token Mamba recurrence from cached conv/ssm state.
+
+        ``hidden_state``: ``(1, H)``. ``conv_state``: ``(conv_dim, conv_kernel-1)``
+        rolling buffer of raw xBC inputs. ``ssm_state``: ``(nheads, head_dim,
+        d_state)``. Returns ``(out (1, H), new_conv_state, new_ssm_state)``.
+
+        The conv step is an explicit dot product over a fixed window rather than
+        the padded ``conv1d`` used at prefill: window = [buffer(k-1) | new(1)],
+        which reproduces the causal conv at the new position exactly, and the
+        buffer rolls forward by dropping its oldest column.
+        """
+        z, xBC, dt = self._split_in_proj(self.in_proj(hidden_state))
+
+        # rolling conv: append the new raw xBC, take the last conv_kernel window
+        xBC_new = xBC.transpose(0, 1)  # (conv_dim, 1)
+        window = torch.cat([conv_state, xBC_new], dim=-1)  # (conv_dim, conv_kernel)
+        w = self.conv1d.weight[:, 0, :]  # (conv_dim, conv_kernel)
+        conv_out = (window * w).sum(-1)  # (conv_dim,)
+        if self.conv1d.bias is not None:
+            conv_out = conv_out + self.conv1d.bias
+        new_conv_state = window[:, 1:].contiguous()  # (conv_dim, conv_kernel-1)
+        xBC_c = F.silu(conv_out).unsqueeze(0)  # (1, conv_dim)
+
+        x, B, C = torch.split(
+            xBC_c,
+            [self.d_inner, self.n_groups * self.d_state, self.n_groups * self.d_state],
+            dim=-1,
+        )
+        x = x.view(1, self.nheads, self.head_dim)
+        B = B.view(1, self.n_groups, self.d_state)
+        C = C.view(1, self.n_groups, self.d_state)
+
+        A = -torch.exp(self.A_log.float())
+        dt = F.softplus(dt.float() + self.dt_bias.float())
+
+        y, new_ssm = self._ssd_scan(x.float(), dt, A, B.float(), C.float(), h0=ssm_state)
+        y = y.reshape(1, self.d_inner).to(hidden_state.dtype)
+        y = self.norm(y, z)
+        return self.out_proj(y), new_conv_state.detach(), new_ssm.detach()
+
 
 # ---------------------------------------------------------------------------
 # Block + model
@@ -334,6 +489,40 @@ class NemotronHBlock(nn.Module):
             out = self.mixer(normed, cache_handle=None, mamba_state=None)
         return hidden_states + out
 
+    def prefill(self, hidden_states: torch.Tensor, cache: NemotronHCache) -> torch.Tensor:
+        """Cached-path prefill for one block; populates ``cache`` in place.
+
+        Same residual/norm math as :meth:`offline_forward`; differs only in that
+        stateful mixers hand back their state to seed the cache.
+        """
+        normed = _rms_fp32(hidden_states, self.norm.weight, self.norm.variance_epsilon)
+        if self.kind == "attention":
+            out, k, v = self.mixer.prefill(normed)
+            cache.attn[self.layer_idx] = [k, v]
+        elif self.kind == "mamba":
+            out, conv_state, ssm_state = self.mixer.prefill(normed)
+            cache.conv[self.layer_idx] = conv_state
+            cache.ssm[self.layer_idx] = ssm_state
+        else:  # mlp — stateless
+            out = self.mixer(normed, cache_handle=None, mamba_state=None)
+        return hidden_states + out
+
+    def decode_step(self, hidden_state: torch.Tensor, cache: NemotronHCache) -> torch.Tensor:
+        """Cached-path single-token decode for one block; mutates ``cache``."""
+        normed = _rms_fp32(hidden_state, self.norm.weight, self.norm.variance_epsilon)
+        if self.kind == "attention":
+            out, new_kv = self.mixer.decode_forward(normed, cache.attn[self.layer_idx])
+            cache.attn[self.layer_idx] = [new_kv[0], new_kv[1]]
+        elif self.kind == "mamba":
+            out, new_conv, new_ssm = self.mixer.decode_step(
+                normed, cache.conv[self.layer_idx], cache.ssm[self.layer_idx]
+            )
+            cache.conv[self.layer_idx] = new_conv
+            cache.ssm[self.layer_idx] = new_ssm
+        else:  # mlp — stateless
+            out = self.mixer(normed, cache_handle=None, mamba_state=None)
+        return hidden_state + out
+
 
 class NemotronHLLM(nn.Module):
     """The ``llm`` container: hybrid layer stack + final norm (no embeddings)."""
@@ -371,6 +560,28 @@ class NemotronHLLM(nn.Module):
             hidden = block.offline_forward(hidden)
         return _rms_fp32(hidden, self.norm_f.weight, self.norm_f.variance_epsilon)
 
+    def prefill(self, input_embeds: torch.Tensor):
+        """Cached O(T) prefill. ``input_embeds`` ``(L, H)`` -> ``(hidden (L, H),
+        cache)``. Runs the full-sequence offline math while populating a fresh
+        :class:`NemotronHCache` for subsequent single-token decode.
+        """
+        cache = NemotronHCache()
+        hidden = input_embeds
+        for block in self.layers:
+            hidden = block.prefill(hidden, cache)
+        hidden = _rms_fp32(hidden, self.norm_f.weight, self.norm_f.variance_epsilon)
+        return hidden, cache
+
+    def decode_step(self, input_embed: torch.Tensor, cache: NemotronHCache) -> torch.Tensor:
+        """Cached O(T) decode of one new token. ``input_embed`` ``(1, H)`` ->
+        ``hidden (1, H)``; mutates ``cache`` in place (appends attention k/v,
+        rolls conv buffers, advances ssm state).
+        """
+        hidden = input_embed
+        for block in self.layers:
+            hidden = block.decode_step(hidden, cache)
+        return _rms_fp32(hidden, self.norm_f.weight, self.norm_f.variance_epsilon)
+
 
 class NemotronHForCausalLM(nn.Module):
     def __init__(self, config: NanoConfig):
@@ -395,6 +606,19 @@ class NemotronHForCausalLM(nn.Module):
         hidden = self.embed_tokens(input_ids)
         hidden = self.llm.offline_forward(hidden)
         return self.lm_head(hidden)
+
+    def prefill(self, input_embeds: torch.Tensor):
+        """Cached O(T) prefill over embeddings. ``input_embeds`` ``(L, H)`` ->
+        ``(hidden (L, H), cache)`` (post final-norm hidden; apply ``lm_head`` for
+        logits). Additive to :meth:`offline_forward` — leaves it unchanged.
+        """
+        return self.llm.prefill(input_embeds)
+
+    def decode_step(self, input_embed: torch.Tensor, cache: NemotronHCache) -> torch.Tensor:
+        """Cached O(T) decode of one token. ``input_embed`` ``(1, H)`` ->
+        ``hidden (1, H)``; mutates ``cache`` in place.
+        """
+        return self.llm.decode_step(input_embed, cache)
 
     @staticmethod
     def remap(name: str) -> str | None:

--- a/mstar/model/nemotron_duplex/components/nemotron_h.py
+++ b/mstar/model/nemotron_duplex/components/nemotron_h.py
@@ -1,0 +1,355 @@
+"""Nemotron-H hybrid Mamba-2 / attention / MLP backbone (the ``nano`` LLM).
+
+M* port of ``NemotronHForCausalLM`` (HF ``model_type='nemotron_h'``). Layers are
+heterogeneous, driven by ``NanoConfig.hybrid_override_pattern``:
+
+    * ``M`` Mamba-2 mixer   — recurrent (conv + ssm) state per request
+    * ``*`` self-attention  — NoPE, GQA, paged KV cache (only these get a cache)
+    * ``-`` MLP             — squared-ReLU, non-gated
+
+Module tree mirrors the checkpoint (``stt_model.`` prefix stripped by the
+remapper) so weights load by name with no per-tensor renames:
+
+    embed_tokens.weight              -> self.embed_tokens
+    lm_head.weight                   -> self.lm_head
+    function_head.weight             -> self.function_head
+    llm.norm_f.weight                -> self.llm.norm_f
+    llm.layers.{i}.norm.weight       -> self.llm.layers[i].norm
+    llm.layers.{i}.mixer.*           -> self.llm.layers[i].mixer
+
+Design notes:
+  * NoPE — attention layers apply no RoPE; we subclass ``Attention`` and make
+    ``_apply_rope`` a no-op.
+  * Mamba state (Option A) — the engine has no SSM-state pool yet, so conv/ssm
+    state lives in the submodule's per-request ``PerRequestState`` and is
+    threaded here via ``MambaStateAccessor``. Eager-only; the Option-B pool
+    (batching + CUDA graphs) is the Phase-10 follow-up.
+
+The Mamba-2 forward is a pure-PyTorch reference scan (no ``mamba_ssm`` kernel
+dependency) — correct but not fast; the kernel fast path is a later swap.
+TODO(verify): numeric parity of the scan against the HF NemotronHMamba2Mixer.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from mstar.engine.cache_manager import BatchedCacheManager
+from mstar.model.components.attention import Attention
+from mstar.model.components.norm import RMSNorm
+from mstar.model.nemotron_duplex.config import NanoConfig
+
+# ---------------------------------------------------------------------------
+# Per-request Mamba state plumbing (Option A: submodule-owned state)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MambaStateAccessor:
+    """Read/write view over one batch's Mamba conv+ssm state.
+
+    Built by the submodule from ``engine_inputs.per_request_states`` and the
+    current walk. Correctness draft is bs=1 (one request); kept indexable so the
+    batched Option-B pool can drop in later. State tensors live in each request's
+    ``PerRequestState.tensors`` under ``mamba{layer}.conv`` / ``.ssm``.
+    """
+
+    request_states: dict
+    request_ids: list
+    is_prefill: bool
+
+    def _keys(self, layer_idx: int):
+        return f"mamba{layer_idx}.conv", f"mamba{layer_idx}.ssm"
+
+    def read(self, layer_idx: int):
+        if self.is_prefill or not self.request_ids or self.request_states is None:
+            return None, None
+        st = self.request_states.get(self.request_ids[0])
+        if st is None:
+            return None, None
+        ck, sk = self._keys(layer_idx)
+        return st.get(ck), st.get(sk)
+
+    def write(self, layer_idx: int, conv_state: torch.Tensor, ssm_state: torch.Tensor):
+        if not self.request_ids or self.request_states is None:
+            return
+        st = self.request_states.get(self.request_ids[0])
+        if st is None:
+            return
+        ck, sk = self._keys(layer_idx)
+        st.add(ck, conv_state.detach())
+        st.add(sk, ssm_state.detach())
+
+
+# ---------------------------------------------------------------------------
+# Mixers
+# ---------------------------------------------------------------------------
+
+
+class NemotronHAttention(Attention):
+    """GQA self-attention with NoPE (Nemotron-H applies no positional encoding)."""
+
+    def _apply_rope(self, q, k, cache_handle):  # noqa: ARG002 - override to disable RoPE
+        return q, k
+
+
+class NemotronHMLP(nn.Module):
+    """Non-gated squared-ReLU MLP: ``down_proj(relu(up_proj(x))**2)``."""
+
+    def __init__(self, config: NanoConfig):
+        super().__init__()
+        self.up_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=config.mlp_bias)
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=config.mlp_bias)
+
+    def forward(self, hidden_states: torch.Tensor, cache_handle=None, mamba_state=None) -> torch.Tensor:  # noqa: ARG002
+        return self.down_proj(torch.square(F.relu(self.up_proj(hidden_states))))
+
+
+class _RMSNormGated(nn.Module):
+    """Mamba-2 gated RMSNorm: ``rmsnorm(y * silu(z)) * weight``."""
+
+    def __init__(self, dim: int, eps: float):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def forward(self, y: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+        y = y * F.silu(z)
+        y = y * torch.rsqrt(y.pow(2).mean(-1, keepdim=True) + self.eps)
+        return y * self.weight
+
+
+class Mamba2Mixer(nn.Module):
+    """Mamba-2 mixer with M*-owned per-request recurrent state.
+
+    Param layout matches HF ``NemotronHMamba2Mixer``:
+        in_proj: [z (d_inner) | xBC (conv_dim) | dt (nheads)]
+        conv1d: depthwise over conv_dim channels, kernel=conv_kernel (causal)
+        A_log, D, dt_bias per head; gated RMSNorm(d_inner); out_proj
+    """
+
+    def __init__(self, config: NanoConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.nheads = config.mamba_num_heads
+        self.head_dim = config.mamba_head_dim
+        self.d_inner = config.d_inner
+        self.d_state = config.ssm_state_size
+        self.n_groups = config.n_groups
+        self.conv_kernel = config.conv_kernel
+        self.conv_dim = config.conv_dim
+        self.time_step_limit = (0.0, float("inf"))
+
+        in_proj_out = 2 * self.d_inner + 2 * self.n_groups * self.d_state + self.nheads
+        self.in_proj = nn.Linear(config.hidden_size, in_proj_out, bias=config.mamba_proj_bias)
+        self.conv1d = nn.Conv1d(
+            in_channels=self.conv_dim,
+            out_channels=self.conv_dim,
+            kernel_size=self.conv_kernel,
+            groups=self.conv_dim,
+            padding=self.conv_kernel - 1,
+            bias=config.use_conv_bias,
+        )
+        self.A_log = nn.Parameter(torch.empty(self.nheads))
+        self.D = nn.Parameter(torch.empty(self.nheads))
+        self.dt_bias = nn.Parameter(torch.empty(self.nheads))
+        self.norm = _RMSNormGated(self.d_inner, eps=config.rms_norm_eps)
+        self.out_proj = nn.Linear(self.d_inner, config.hidden_size, bias=config.mamba_proj_bias)
+
+    # -- helpers ---------------------------------------------------------
+
+    def _split_in_proj(self, projected: torch.Tensor):
+        z, xBC, dt = torch.split(
+            projected, [self.d_inner, self.conv_dim, self.nheads], dim=-1
+        )
+        return z, xBC, dt
+
+    def _ssd_scan(self, x, dt, A, B, C, h0=None):
+        """Sequential SSD reference scan.
+
+        Shapes (L = tokens):
+            x:  (L, nheads, head_dim)   dt: (L, nheads)   A: (nheads,)
+            B:  (L, ngroups, d_state)   C:  (L, ngroups, d_state)
+            h0: (nheads, head_dim, d_state) or None
+        Returns y (L, nheads, head_dim) and final state h (nheads, head_dim, d_state).
+        """
+        L = x.shape[0]
+        heads_per_group = self.nheads // self.n_groups
+        # expand groups -> heads
+        B = B.repeat_interleave(heads_per_group, dim=1)  # (L, nheads, d_state)
+        C = C.repeat_interleave(heads_per_group, dim=1)
+        dA = torch.exp(dt * A)  # (L, nheads)
+        h = (
+            h0
+            if h0 is not None
+            else x.new_zeros(self.nheads, self.head_dim, self.d_state)
+        )
+        ys = []
+        for t in range(L):
+            # dBx: (nheads, head_dim, d_state)
+            dBx = (dt[t].unsqueeze(-1) * x[t]).unsqueeze(-1) * B[t].unsqueeze(1)
+            h = dA[t].view(-1, 1, 1) * h + dBx
+            y_t = torch.einsum("hpn,hn->hp", h, C[t])  # (nheads, head_dim)
+            ys.append(y_t)
+        y = torch.stack(ys, dim=0)  # (L, nheads, head_dim)
+        y = y + self.D.view(1, -1, 1) * x
+        return y, h
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cache_handle: BatchedCacheManager | None = None,  # noqa: ARG002
+        mamba_state: MambaStateAccessor | None = None,
+    ) -> torch.Tensor:
+        L = hidden_states.shape[0]
+        z, xBC, dt = self._split_in_proj(self.in_proj(hidden_states))
+
+        prev_conv, prev_ssm = (None, None)
+        if mamba_state is not None:
+            prev_conv, prev_ssm = mamba_state.read(self.layer_idx)
+
+        # --- causal depthwise conv over (x|B|C) ---
+        xBC_t = xBC.transpose(0, 1).unsqueeze(0)  # (1, conv_dim, L)
+        if prev_conv is not None:
+            xBC_t = torch.cat([prev_conv, xBC_t], dim=-1)
+        conv_out = self.conv1d(xBC_t)[..., : xBC_t.shape[-1]]
+        conv_out = conv_out[..., -L:]  # keep the L new positions
+        xBC = F.silu(conv_out.squeeze(0).transpose(0, 1))  # (L, conv_dim)
+        # conv state = last (conv_kernel-1) inputs, for the next step
+        new_conv_state = xBC_t[..., -(self.conv_kernel - 1):].detach()
+
+        x, B, C = torch.split(
+            xBC,
+            [self.d_inner, self.n_groups * self.d_state, self.n_groups * self.d_state],
+            dim=-1,
+        )
+        x = x.view(L, self.nheads, self.head_dim)
+        B = B.view(L, self.n_groups, self.d_state)
+        C = C.view(L, self.n_groups, self.d_state)
+
+        A = -torch.exp(self.A_log.float())  # (nheads,)
+        dt = F.softplus(dt.float() + self.dt_bias.float())  # (L, nheads)
+
+        y, new_ssm = self._ssd_scan(x.float(), dt, A, B.float(), C.float(), h0=prev_ssm)
+        y = y.reshape(L, self.d_inner).to(hidden_states.dtype)
+
+        if mamba_state is not None:
+            mamba_state.write(self.layer_idx, new_conv_state, new_ssm)
+
+        y = self.norm(y, z)
+        return self.out_proj(y)
+
+
+# ---------------------------------------------------------------------------
+# Block + model
+# ---------------------------------------------------------------------------
+
+
+def _build_mixer(config: NanoConfig, kind: str, layer_idx: int) -> nn.Module:
+    if kind == "mamba":
+        return Mamba2Mixer(config, layer_idx)
+    if kind == "attention":
+        return NemotronHAttention(
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            qkv_bias=config.attention_bias,
+            o_bias=config.attention_bias,
+            qk_norm=False,
+            rms_norm_eps=config.rms_norm_eps,
+        )
+    if kind == "mlp":
+        return NemotronHMLP(config)
+    raise ValueError(f"Unknown layer kind: {kind!r}")
+
+
+class NemotronHBlock(nn.Module):
+    """Pre-norm residual block: ``h + mixer(norm(h))`` (single norm per block)."""
+
+    def __init__(self, config: NanoConfig, kind: str, layer_idx: int):
+        super().__init__()
+        self.kind = kind
+        self.layer_idx = layer_idx
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.mixer = _build_mixer(config, kind, layer_idx)
+
+    def forward(self, hidden_states, cache_handle, mamba_state):
+        residual = hidden_states
+        normed = self.norm(hidden_states)
+        out = self.mixer(normed, cache_handle=cache_handle, mamba_state=mamba_state)
+        return residual + out
+
+
+class NemotronHLLM(nn.Module):
+    """The ``llm`` container: hybrid layer stack + final norm (no embeddings)."""
+
+    def __init__(self, config: NanoConfig):
+        super().__init__()
+        self.config = config
+        kinds = config.layer_types
+        self.layers = nn.ModuleList(
+            [NemotronHBlock(config, kinds[i], i) for i in range(config.num_hidden_layers)]
+        )
+        self.norm_f = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        # attention layer -> dense KV-cache index (only ``*`` layers have a slot)
+        self._attn_cache_idx: dict[int, int] = {}
+        a = 0
+        for i, kind in enumerate(kinds):
+            if kind == "attention":
+                self._attn_cache_idx[i] = a
+                a += 1
+
+    def forward(self, input_embeds, cache_handle, mamba_state=None):
+        hidden = input_embeds
+        for block in self.layers:
+            if block.kind == "attention":
+                cache_handle.set_layer_idx(self._attn_cache_idx[block.layer_idx])
+            hidden = block(hidden, cache_handle=cache_handle, mamba_state=mamba_state)
+        cache_handle.advance_seq_lens()
+        return self.norm_f(hidden)
+
+
+class NemotronHForCausalLM(nn.Module):
+    def __init__(self, config: NanoConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, padding_idx=config.pad_token_id)
+        self.llm = NemotronHLLM(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        # Function-calling head (custom_outputs: function_tokens/function_logits).
+        if config.has_function_head:
+            self.function_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    @property
+    def embeddings(self) -> nn.Embedding:
+        return self.embed_tokens
+
+    def forward(self, input_embeds, cache_handle, mamba_state=None) -> torch.Tensor:
+        return self.llm(input_embeds, cache_handle=cache_handle, mamba_state=mamba_state)
+
+    def load_weights(self, weights):
+        """Load the nano subtree from the composite checkpoint.
+
+        The checkpoint bundles every stage under ``stt_model.`` / ``tts_model.``;
+        the remapper keeps only the LLM tensors (embed_tokens / lm_head /
+        function_head / llm.*) and drops the rest (perception, rnnt, tts) so the
+        stream loads cleanly into this module alone.
+        """
+        from mstar.model.loader import load_hf_weights
+
+        keep_after_stt = ("embed_tokens.", "lm_head.", "function_head.", "llm.")
+
+        def name_remapper(name: str) -> str | None:
+            if not name.startswith("stt_model."):
+                return None
+            rest = name[len("stt_model."):]
+            if rest.startswith(keep_after_stt):
+                return rest
+            return None
+
+        return load_hf_weights(self, weights, stacked_params=[], name_remapper=name_remapper)

--- a/mstar/model/nemotron_duplex/components/rnnt.py
+++ b/mstar/model/nemotron_duplex/components/rnnt.py
@@ -4,23 +4,33 @@ The streaming user-transcription branch: a 2-layer LSTM prediction network and a
 joint network combining encoder + prediction features. Ported to exact
 checkpoint parity; the LSTM params are declared by hand (matching ``nn.LSTM``'s
 ``weight_ih_l{n}`` / ``weight_hh_l{n}`` / ``bias_*`` names) to avoid meta-device
-init issues. Forward is Phase 4.
+init issues.
+
+Forward math mirrors NeMo ``RNNTDecoder.predict`` / ``RNNTJoint.joint``
+(branch ``nemotron-labs-voicechat``, ``nemo/collections/asr/modules/rnnt.py``):
+
+  * predict: ``embed(y)`` -> optional zero SOS prepend -> ``nn.LSTM`` (time-first,
+    ``batch_first=False``, plain LSTM since ``normalization_mode is None``) ->
+    prediction features ``g`` [B, U(+1), H] plus LSTM ``(h, c)`` state.
+  * joint: ``enc(f)`` [B, T, H] and ``pred(g)`` [B, U, H] broadcast-added as
+    ``enc(f)[:, :, None, :] + pred(g)[:, None, :, :]`` -> ``joint_net`` (ReLU ->
+    Dropout(id in eval) -> Linear 640->1025) -> raw logits [B, T, U, 1025].
+    ``log_softmax`` is ``None`` in the checkpoint config, so on CUDA no
+    log-softmax is applied (raw logits are returned); argmax-equivalent either way.
 """
 from __future__ import annotations
 
+import torch
 from torch import nn
 
 from mstar.model.nemotron_duplex.components._util import param
-
-PRED_HIDDEN = 640
-ENC_DIM = 1024
-VOCAB = 1025      # RNN-T vocab incl. blank
+from mstar.model.nemotron_duplex.config import RnntConfig
 
 
 class _LSTM(nn.Module):
-    """Hand-rolled 2-layer LSTM parameter set matching ``nn.LSTM`` names."""
+    """Hand-rolled LSTM parameter set matching ``nn.LSTM`` names."""
 
-    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 2):
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int):
         super().__init__()
         gate = 4 * hidden_size
         for layer in range(num_layers):
@@ -32,22 +42,26 @@ class _LSTM(nn.Module):
 
 
 class _DecRnn(nn.Module):
-    def __init__(self):
+    def __init__(self, pred_hidden: int, num_layers: int):
         super().__init__()
-        self.lstm = _LSTM(PRED_HIDDEN, PRED_HIDDEN, num_layers=2)
+        self.lstm = _LSTM(pred_hidden, pred_hidden, num_layers)
 
 
 class _Prediction(nn.Module):
-    def __init__(self):
+    def __init__(self, num_classes: int, pred_hidden: int, num_layers: int):
         super().__init__()
-        self.embed = nn.Embedding(VOCAB, PRED_HIDDEN)
-        self.dec_rnn = _DecRnn()
+        self.embed = nn.Embedding(num_classes, pred_hidden)
+        self.dec_rnn = _DecRnn(pred_hidden, num_layers)
 
 
 class RnntDecoder(nn.Module):
-    def __init__(self):
+    def __init__(self, config: RnntConfig | None = None):
         super().__init__()
-        self.prediction = _Prediction()
+        self.config = config or RnntConfig()
+        self.prediction = _Prediction(
+            self.config.num_classes, self.config.pred_hidden, self.config.pred_rnn_layers,
+        )
+        self._lstm_cache: nn.LSTM | None = None
 
     @staticmethod
     def remap(name: str) -> str | None:
@@ -59,14 +73,83 @@ class RnntDecoder(nn.Module):
 
         return load_hf_weights(self, weights, stacked_params=[], name_remapper=self.remap)
 
+    def _lstm(self) -> nn.LSTM:
+        """Build (and cache) a real ``nn.LSTM`` from the hand-rolled params.
+
+        Weights are fixed after loading, so the module is built once. Runs in
+        eval mode: the checkpoint's inter-layer dropout (0.2) is inactive, so the
+        forward is deterministic and matches the NeMo reference at inference.
+        """
+        hand = self.prediction.dec_rnn.lstm
+        ref = hand.weight_ih_l0
+        h, n = self.config.pred_hidden, self.config.pred_rnn_layers
+        cache = self._lstm_cache
+        if cache is None or cache.weight_ih_l0.device != ref.device or cache.weight_ih_l0.dtype != ref.dtype:
+            lstm = nn.LSTM(h, h, num_layers=n, batch_first=False)
+            lstm = lstm.to(device=ref.device, dtype=ref.dtype)
+            with torch.no_grad():
+                for layer in range(n):
+                    for tag in ("weight_ih", "weight_hh", "bias_ih", "bias_hh"):
+                        name = f"{tag}_l{layer}"
+                        getattr(lstm, name).copy_(getattr(hand, name))
+            lstm.eval()
+            self._lstm_cache = lstm
+            cache = lstm
+        return cache
+
+    def predict(self, y, state=None, add_sos: bool = True, batch_size: int | None = None):
+        """Prediction-network forward (NeMo ``RNNTDecoder.predict``).
+
+        Args:
+            y: token ids ``[B, U]`` (long) or ``None`` (zero pad-token embedding).
+            state: optional ``(h, c)`` each ``[L, B, H]``; ``None`` -> zeros.
+            add_sos: prepend a zero "start of sequence" step -> output ``[B, U+1, H]``.
+            batch_size: batch size when ``y`` and ``state`` are both ``None``.
+
+        Returns:
+            ``(g, (h, c))`` with ``g`` shape ``[B, U(+1), H]`` and state ``[L, B, H]``.
+        """
+        embed = self.prediction.embed
+        device = embed.weight.device
+        dtype = embed.weight.dtype
+
+        if y is not None:
+            if y.device != device:
+                y = y.to(device)
+            g = embed(y)  # [B, U, H]
+        else:
+            if batch_size is None:
+                b = 1 if state is None else state[0].size(1)
+            else:
+                b = batch_size
+            g = torch.zeros((b, 1, self.config.pred_hidden), device=device, dtype=dtype)
+
+        if add_sos:
+            b, _, h = g.shape
+            start = torch.zeros((b, 1, h), device=g.device, dtype=g.dtype)
+            g = torch.cat([start, g], dim=1).contiguous()  # [B, U+1, H]
+
+        g = g.transpose(0, 1)  # [U(+1), B, H] time-first
+        g, hid = self._lstm()(g, state)
+        g = g.transpose(0, 1)  # [B, U(+1), H]
+        return g, hid
+
+    forward = predict
+
+
+_ACT = {"relu": nn.ReLU, "tanh": nn.Tanh, "sigmoid": nn.Sigmoid}
+
 
 class RnntJoint(nn.Module):
-    def __init__(self):
+    def __init__(self, config: RnntConfig | None = None):
         super().__init__()
-        self.enc = nn.Linear(ENC_DIM, PRED_HIDDEN)
-        self.pred = nn.Linear(PRED_HIDDEN, PRED_HIDDEN)
+        self.config = config or RnntConfig()
+        c = self.config
+        self.enc = nn.Linear(c.encoder_hidden, c.joint_hidden)
+        self.pred = nn.Linear(c.pred_hidden, c.joint_hidden)
         # joint_net: [activation, dropout, Linear] — only index 2 carries params.
-        self.joint_net = nn.Sequential(nn.ReLU(), nn.Dropout(0.0), nn.Linear(PRED_HIDDEN, VOCAB))
+        act = _ACT.get(c.activation, nn.ReLU)()
+        self.joint_net = nn.Sequential(act, nn.Dropout(0.0), nn.Linear(c.joint_hidden, c.num_classes))
 
     @staticmethod
     def remap(name: str) -> str | None:
@@ -77,3 +160,35 @@ class RnntJoint(nn.Module):
         from mstar.model.loader import load_hf_weights
 
         return load_hf_weights(self, weights, stacked_params=[], name_remapper=self.remap)
+
+    def project_encoder(self, f: torch.Tensor) -> torch.Tensor:
+        """Project encoder features ``[B, T, 1024]`` -> ``[B, T, 640]``."""
+        return self.enc(f)
+
+    def project_prednet(self, g: torch.Tensor) -> torch.Tensor:
+        """Project prediction features ``[B, U, 640]`` -> ``[B, U, 640]``."""
+        return self.pred(g)
+
+    def joint_after_projection(self, f: torch.Tensor, g: torch.Tensor) -> torch.Tensor:
+        """Combine projected enc ``f`` ``[B, T, H]`` and pred ``g`` ``[B, U, H]``.
+
+        ``f[:, :, None, :] + g[:, None, :, :]`` -> ``joint_net`` -> ``[B, T, U, 1025]``.
+        Returns raw logits (``log_softmax is None`` -> not applied on CUDA).
+        """
+        inp = f.unsqueeze(dim=2) + g.unsqueeze(dim=1)  # [B, T, U, H]
+        return self.joint_net(inp)  # [B, T, U, V+1]
+
+    def joint(self, f: torch.Tensor, g: torch.Tensor) -> torch.Tensor:
+        """Full joint step: project encoder ``[B, T, 1024]`` + prednet ``[B, U, 640]``."""
+        return self.joint_after_projection(self.project_encoder(f), self.project_prednet(g))
+
+    def forward(self, encoder_outputs: torch.Tensor, decoder_outputs: torch.Tensor) -> torch.Tensor:
+        """NeMo ``RNNTJoint.forward`` (non-fused logits path).
+
+        ``encoder_outputs`` ``[B, D=1024, T]`` and ``decoder_outputs`` ``[B, D=640, U]``
+        (time-last, as produced by the conformer / decoder); transposed to
+        ``[B, T, D]`` / ``[B, U, D]`` then jointed -> logits ``[B, T, U, 1025]``.
+        """
+        f = encoder_outputs.transpose(1, 2)  # [B, T, 1024]
+        g = decoder_outputs.transpose(1, 2)  # [B, U, 640]
+        return self.joint(f, g)

--- a/mstar/model/nemotron_duplex/components/rnnt.py
+++ b/mstar/model/nemotron_duplex/components/rnnt.py
@@ -1,0 +1,79 @@
+"""RNN-T transcription head (``stt_model.rnnt_decoder.*`` / ``rnnt_joint.*``).
+
+The streaming user-transcription branch: a 2-layer LSTM prediction network and a
+joint network combining encoder + prediction features. Ported to exact
+checkpoint parity; the LSTM params are declared by hand (matching ``nn.LSTM``'s
+``weight_ih_l{n}`` / ``weight_hh_l{n}`` / ``bias_*`` names) to avoid meta-device
+init issues. Forward is Phase 4.
+"""
+from __future__ import annotations
+
+from torch import nn
+
+from mstar.model.nemotron_duplex.components._util import param
+
+PRED_HIDDEN = 640
+ENC_DIM = 1024
+VOCAB = 1025      # RNN-T vocab incl. blank
+
+
+class _LSTM(nn.Module):
+    """Hand-rolled 2-layer LSTM parameter set matching ``nn.LSTM`` names."""
+
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 2):
+        super().__init__()
+        gate = 4 * hidden_size
+        for layer in range(num_layers):
+            in_dim = input_size if layer == 0 else hidden_size
+            setattr(self, f"weight_ih_l{layer}", param(gate, in_dim))
+            setattr(self, f"weight_hh_l{layer}", param(gate, hidden_size))
+            setattr(self, f"bias_ih_l{layer}", param(gate))
+            setattr(self, f"bias_hh_l{layer}", param(gate))
+
+
+class _DecRnn(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lstm = _LSTM(PRED_HIDDEN, PRED_HIDDEN, num_layers=2)
+
+
+class _Prediction(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed = nn.Embedding(VOCAB, PRED_HIDDEN)
+        self.dec_rnn = _DecRnn()
+
+
+class RnntDecoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.prediction = _Prediction()
+
+    @staticmethod
+    def remap(name: str) -> str | None:
+        prefix = "stt_model.rnnt_decoder."
+        return name[len(prefix):] if name.startswith(prefix) else None
+
+    def load_weights(self, weights):
+        from mstar.model.loader import load_hf_weights
+
+        return load_hf_weights(self, weights, stacked_params=[], name_remapper=self.remap)
+
+
+class RnntJoint(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.enc = nn.Linear(ENC_DIM, PRED_HIDDEN)
+        self.pred = nn.Linear(PRED_HIDDEN, PRED_HIDDEN)
+        # joint_net: [activation, dropout, Linear] — only index 2 carries params.
+        self.joint_net = nn.Sequential(nn.ReLU(), nn.Dropout(0.0), nn.Linear(PRED_HIDDEN, VOCAB))
+
+    @staticmethod
+    def remap(name: str) -> str | None:
+        prefix = "stt_model.rnnt_joint."
+        return name[len(prefix):] if name.startswith(prefix) else None
+
+    def load_weights(self, weights):
+        from mstar.model.loader import load_hf_weights
+
+        return load_hf_weights(self, weights, stacked_params=[], name_remapper=self.remap)

--- a/mstar/model/nemotron_duplex/config.py
+++ b/mstar/model/nemotron_duplex/config.py
@@ -144,6 +144,15 @@ class EarTTSConfig:
     mog_intermediate_size: int = 4608
     mog_eps: float = 1e-6
 
+    # --- MaskGIT / MoG inference sampling (reference ``_get_generation_config``) ---
+    # Real speech needs classifier-free guidance + injected noise + top-p mixture
+    # sampling; without them the MoG head collapses to (near-)silent codes.
+    mog_exponent: float = 3.0                 # masking-schedule exponent
+    inference_num_iter: int = 8               # MaskGIT unmasking iterations
+    inference_guidance_scale: float = 0.5     # classifier-free guidance weight
+    inference_noise_scale: float = 0.8        # MoG latent noise (z = mu + exp(logs)*eps*ns)
+    inference_top_p: float = 0.8              # nucleus filter on the mixture logits
+
     sample_rate: int = 22050
 
 
@@ -167,6 +176,13 @@ class ConformerSTTConfig:
     subsampling_factor: int = 8
     att_context_size: tuple[int, int] = (70, 0)
     output_dim: int = 4480                   # projection into the nano hidden size
+    # Right-context lookahead of the encoder, in output frames: the newest output
+    # frame is not final until this many more input frames arrive (the striding-conv
+    # subsampling has a small future receptive field even though attention is causal
+    # [70,0]). The streaming path holds back this many trailing frames so its
+    # re-encoded embeddings match the offline (full-clip) encoding exactly. Measured
+    # structurally as 1 frame (~80 ms) for this Fast-Conformer.
+    streaming_lookahead_frames: int = 1
 
     # --- mel preprocessor (``perception.preprocessor``) ---
     sample_rate: int = 16000
@@ -384,6 +400,11 @@ class NemotronDuplexConfig:
             mog_num_layers=mog["num_layers"],
             mog_intermediate_size=mog["intermediate_size"],
             mog_eps=mog["eps"],
+            mog_exponent=mog.get("exponent", 3.0),
+            inference_num_iter=tts.get("inference_num_iter", 8),
+            inference_guidance_scale=tts.get("inference_guidance_scale", 0.5),
+            inference_noise_scale=tts.get("inference_noise_scale", 0.8),
+            inference_top_p=tts.get("inference_top_p_or_k", 0.8),
         )
 
         enc = raw["model"]["stt"]["model"]["perception"]["encoder"]

--- a/mstar/model/nemotron_duplex/config.py
+++ b/mstar/model/nemotron_duplex/config.py
@@ -109,51 +109,99 @@ class NanoConfig:
 
 @dataclass
 class EarTTSConfig:
-    """Audio-output stage (``eartts/config.json``).
+    """Audio-output stage (``config.json`` -> ``model.speech_generation.model.tts_config``).
 
     A Gemma3-text "talker" transformer autoregressively emits RVQ codec codes
-    (``num_quantizers`` codebooks of ``codebook_size``), which the codec decoder
-    turns into a 22.05 kHz waveform.
+    (``num_quantizers`` codebooks of ``codebook_size``), then a mixture-of-
+    gaussians (MoG) head over the ``code_dim`` RVQ latent space.
     """
 
-    # talker transformer (backbone_type == "gemma3_text")
+    # --- Gemma3-text backbone (``tts_config.backbone_config``) ---
     hidden_size: int = 1152
+    intermediate_size: int = 4608
     num_hidden_layers: int = 28
     num_attention_heads: int = 16
     num_key_value_heads: int = 16
     head_dim: int = 72
+    sliding_window: int = 7500
+    rms_norm_eps: float = 1e-6
+    # Gemma3TextConfig defaults (not in the checkpoint's backbone_config subset).
+    query_pre_attn_scalar: float = 256.0
+    rope_theta_full: float = 1_000_000.0     # full-attention layers
+    rope_theta_local: float = 10_000.0       # sliding-attention layers
+    sliding_window_pattern: int = 6          # layer i is full-attn iff (i+1) % 6 == 0
 
-    # RVQ codec
+    # --- RVQ code space (``tts_config``) ---
     num_quantizers: int = 31          # codebooks emitted per audio frame
     codebook_size: int = 1024
-    codec_hidden_size: int = 384
-    codec_latent_size: int = 512
+    code_dim: int = 512               # RVQ latent dim (``latent_size``)
+
+    # --- MoG head (``tts_config.mog_head_config``) ---
+    mog_num_predictions: int = 1024   # mixture components
+    mog_low_rank: int = 64
+    mog_min_log_std: float = -4.0
+    mog_num_layers: int = 3
+    mog_intermediate_size: int = 4608
+    mog_eps: float = 1e-6
 
     sample_rate: int = 22050
-
-    # TODO(verify): talker rope/eps, exact code-frame layout, and how the nano
-    # LLM hidden state conditions the talker — confirm against the NeMo ref.
 
 
 @dataclass
 class ConformerSTTConfig:
-    """Audio-input stage: Fast-Conformer streaming encoder + RNN-T head.
+    """Audio-input stage (``config.json`` -> ``model.stt.model.perception``).
 
-    From Nemotron-Speech-Streaming-En-0.6b. Encodes 16 kHz speech into
-    LLM-space embeddings and emits a streaming user transcription (RNN-T,
-    ``rnnt_vocab_size`` tokens; tokenizer in the base repo's ``rnnt_tokenizer/``).
+    Fast-Conformer streaming encoder + mel preprocessor. Encodes 16 kHz speech
+    into LLM-space embeddings (``output_dim``); the RNN-T head (``RnntConfig``)
+    emits the streaming user transcription.
     """
 
+    # --- encoder (``perception.encoder``) ---
     d_model: int = 1024
     num_heads: int = 8
     num_layers: int = 24
-    feat_in: int = 128               # log-mel bins
-    input_sample_rate: int = 16000
-    rnnt_vocab_size: int = 1024
+    feat_in: int = 128                       # log-mel bins
+    ff_expansion_factor: int = 4
+    conv_kernel_size: int = 9
+    subsampling_conv_channels: int = 256
+    subsampling_factor: int = 8
+    att_context_size: tuple[int, int] = (70, 0)
+    output_dim: int = 4480                   # projection into the nano hidden size
 
-    # 1500-position sliding window (model card). TODO(verify): subsampling
-    # factor, conv kernel sizes, and projection into the nano hidden space.
-    sliding_window: int = 1500
+    # --- mel preprocessor (``perception.preprocessor``) ---
+    sample_rate: int = 16000
+    n_fft: int = 512
+    window_size: float = 0.025               # seconds -> win_length = round(sr*window_size)
+    window_stride: float = 0.01              # seconds -> hop_length = round(sr*window_stride)
+    n_mels: int = 128
+    preemph: float = 0.97
+    mag_power: float = 2.0
+
+    @property
+    def head_dim(self) -> int:
+        return self.d_model // self.num_heads
+
+    @property
+    def ff_dim(self) -> int:
+        return self.ff_expansion_factor * self.d_model
+
+    @property
+    def win_length(self) -> int:
+        return round(self.sample_rate * self.window_size)
+
+    @property
+    def hop_length(self) -> int:
+        return round(self.sample_rate * self.window_stride)
+
+    @property
+    def subsampling_flat(self) -> int:
+        # Freq after log2(factor) causal stride-2 conv stages (kernel 3, causal
+        # pad k-1 + stride-1): out = in // 2 + 1 per stage (128->65->33->17).
+        import math
+        freq = self.n_mels
+        for _ in range(int(math.log2(self.subsampling_factor))):
+            freq = freq // 2 + 1
+        return self.subsampling_conv_channels * freq
 
 
 @dataclass
@@ -300,5 +348,46 @@ class NemotronDuplexConfig:
             joint_hidden=jc["jointnet"]["joint_hidden"],
             vocab_size=dc["vocab_size"],
             activation=jc["jointnet"]["activation"],
+        )
+
+        tts = raw["model"]["speech_generation"]["model"]["tts_config"]
+        bb, mog = tts["backbone_config"], tts["mog_head_config"]
+        cfg.eartts = EarTTSConfig(
+            hidden_size=bb["hidden_size"],
+            intermediate_size=bb["intermediate_size"],
+            num_hidden_layers=bb["num_hidden_layers"],
+            num_attention_heads=bb["num_attention_heads"],
+            num_key_value_heads=bb["num_key_value_heads"],
+            head_dim=bb["head_dim"],
+            sliding_window=bb["sliding_window"],
+            num_quantizers=tts["num_quantizers"],
+            codebook_size=tts["codebook_size"],
+            code_dim=tts["latent_size"],
+            mog_num_predictions=mog["num_predictions"],
+            mog_low_rank=mog["low_rank"],
+            mog_min_log_std=mog["min_log_std"],
+            mog_num_layers=mog["num_layers"],
+            mog_intermediate_size=mog["intermediate_size"],
+            mog_eps=mog["eps"],
+        )
+
+        enc = raw["model"]["stt"]["model"]["perception"]["encoder"]
+        pre = raw["model"]["stt"]["model"]["perception"]["preprocessor"]
+        cfg.stt = ConformerSTTConfig(
+            d_model=enc["d_model"],
+            num_heads=enc["n_heads"],
+            num_layers=enc["n_layers"],
+            feat_in=enc["feat_in"],
+            ff_expansion_factor=enc["ff_expansion_factor"],
+            conv_kernel_size=enc["conv_kernel_size"],
+            subsampling_conv_channels=enc["subsampling_conv_channels"],
+            subsampling_factor=enc["subsampling_factor"],
+            att_context_size=tuple(enc["att_context_size"]),
+            output_dim=raw["model"]["stt"]["model"]["perception"]["output_dim"],
+            sample_rate=pre["sample_rate"],
+            n_fft=pre["n_fft"],
+            window_size=pre["window_size"],
+            window_stride=pre["window_stride"],
+            n_mels=pre["features"],
         )
         return cfg

--- a/mstar/model/nemotron_duplex/config.py
+++ b/mstar/model/nemotron_duplex/config.py
@@ -1,0 +1,182 @@
+"""Config dataclasses for NVIDIA NemotronLabs VoiceChat-11B (duplex).
+
+The base checkpoint (``nvidia/NVIDIA-NemotronLabs-VoiceChat-11B``) is a single
+``model.safetensors`` composite of three stages, whose per-stage architecture
+dims come from the Spark repo's per-folder ``config.json`` files:
+
+    * ``nano/``    — Nemotron-H hybrid Mamba-2 / attention / MLP LLM (9B)
+    * ``eartts/``  — Gemma3-text "talker" transformer + RVQ codec (audio out)
+    * (stt)        — Fast-Conformer streaming encoder + RNN-T head (audio in)
+
+Only the fields M* actually needs are translated here. Numbers are taken
+verbatim from the published ``nano/config.json`` / ``eartts/config.json``;
+see the module docstrings for the source keys. Anything still unverified
+against the NeMo reference (``nemotron-labs-voicechat`` branch of
+NVIDIA-NeMo/Speech) is flagged with ``TODO(verify)``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class NanoConfig:
+    """Nemotron-H backbone (``nano/config.json``, ``model_type='nemotron_h'``).
+
+    ``hybrid_override_pattern`` is the per-layer type string: ``M`` = Mamba-2
+    mixer, ``*`` = self-attention (NoPE), ``-`` = MLP (squared-ReLU). Its
+    length equals ``num_hidden_layers``.
+    """
+
+    # --- backbone dims ---
+    num_hidden_layers: int = 56
+    hidden_size: int = 4480
+    intermediate_size: int = 15680
+    vocab_size: int = 131072
+    rms_norm_eps: float = 1e-5
+    tie_word_embeddings: bool = False
+
+    hybrid_override_pattern: str = (
+        "M-M-M-MM-M-M-M*-M-M-M*-M-M-M-M*-M-M-M-M*-M-MM-M-M-M-M-M-"
+    )
+
+    # --- attention (the ``*`` layers) — NoPE, no bias, no QK-norm ---
+    num_attention_heads: int = 40
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    attention_bias: bool = False
+    max_position_embeddings: int = 131072
+
+    # --- Mamba-2 mixer (the ``M`` layers) ---
+    mamba_num_heads: int = 128
+    mamba_head_dim: int = 80
+    ssm_state_size: int = 128          # d_state
+    conv_kernel: int = 4              # d_conv
+    n_groups: int = 8
+    mamba_expand: int = 2             # d_inner = expand * hidden_size
+    mamba_chunk_size: int = 1         # voicechat runs chunk_size=1 (streaming)
+    time_step_rank: int = 256
+    use_conv_bias: bool = True
+    mamba_proj_bias: bool = False
+    mamba_hidden_act: str = "silu"
+
+    # --- MLP (the ``-`` layers) ---
+    mlp_bias: bool = False
+    mlp_hidden_act: str = "relu2"     # squared ReLU
+
+    # --- VoiceChat fusion / heads ---
+    # The voicechat path feeds a pre-fused audio+text embedding ("combined_embeds",
+    # dim == hidden_size) instead of bare token ids; a function-calling head emits
+    # (function_tokens, function_logits). See ``custom_input_specs`` /
+    # ``custom_outputs`` in nano/config.json.
+    combined_embed_dim: int = 4480
+    has_function_head: bool = True
+
+    # --- special tokens ---
+    bos_token_id: int = 1
+    eos_token_id: int = 12
+    pad_token_id: int = 0
+    # VoiceChat "pad-pair" turn-taking token (config: voicechat_pad_pair_token_id).
+    pad_pair_token_id: int = 12
+
+    @property
+    def d_inner(self) -> int:
+        # Mamba-2 inner width is heads*head_dim (10240 here). NOTE: this is
+        # NOT expand*hidden (8960) — ``mamba_expand`` is nominal in Nemotron-H;
+        # the SSM path is sized by mamba_num_heads*mamba_head_dim.
+        # TODO(verify) against the HF NemotronH mixer construction.
+        return self.mamba_num_heads * self.mamba_head_dim
+
+    @property
+    def conv_dim(self) -> int:
+        # in_proj produces [z, x, B, C, dt]; the conv1d spans x + B + C.
+        return self.d_inner + 2 * self.n_groups * self.ssm_state_size
+
+    @property
+    def layer_types(self) -> list[str]:
+        """Per-layer kind: ``"mamba"`` | ``"attention"`` | ``"mlp"``."""
+        assert len(self.hybrid_override_pattern) == self.num_hidden_layers, (
+            f"hybrid_override_pattern len {len(self.hybrid_override_pattern)} "
+            f"!= num_hidden_layers {self.num_hidden_layers}"
+        )
+        kind = {"M": "mamba", "*": "attention", "-": "mlp"}
+        return [kind[c] for c in self.hybrid_override_pattern]
+
+    @property
+    def num_attention_layers(self) -> int:
+        return self.hybrid_override_pattern.count("*")
+
+
+@dataclass
+class EarTTSConfig:
+    """Audio-output stage (``eartts/config.json``).
+
+    A Gemma3-text "talker" transformer autoregressively emits RVQ codec codes
+    (``num_quantizers`` codebooks of ``codebook_size``), which the codec decoder
+    turns into a 22.05 kHz waveform.
+    """
+
+    # talker transformer (backbone_type == "gemma3_text")
+    hidden_size: int = 1152
+    num_hidden_layers: int = 28
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 16
+    head_dim: int = 72
+
+    # RVQ codec
+    num_quantizers: int = 31          # codebooks emitted per audio frame
+    codebook_size: int = 1024
+    codec_hidden_size: int = 384
+    codec_latent_size: int = 512
+
+    sample_rate: int = 22050
+
+    # TODO(verify): talker rope/eps, exact code-frame layout, and how the nano
+    # LLM hidden state conditions the talker — confirm against the NeMo ref.
+
+
+@dataclass
+class ConformerSTTConfig:
+    """Audio-input stage: Fast-Conformer streaming encoder + RNN-T head.
+
+    From Nemotron-Speech-Streaming-En-0.6b. Encodes 16 kHz speech into
+    LLM-space embeddings and emits a streaming user transcription (RNN-T,
+    ``rnnt_vocab_size`` tokens; tokenizer in the base repo's ``rnnt_tokenizer/``).
+    """
+
+    d_model: int = 1024
+    num_heads: int = 8
+    num_layers: int = 24
+    feat_in: int = 128               # log-mel bins
+    input_sample_rate: int = 16000
+    rnnt_vocab_size: int = 1024
+
+    # 1500-position sliding window (model card). TODO(verify): subsampling
+    # factor, conv kernel sizes, and projection into the nano hidden space.
+    sliding_window: int = 1500
+
+
+@dataclass
+class NemotronDuplexConfig:
+    """Top-level config bundling the three stages plus generation defaults."""
+
+    nano: NanoConfig = field(default_factory=NanoConfig)
+    eartts: EarTTSConfig = field(default_factory=EarTTSConfig)
+    stt: ConformerSTTConfig = field(default_factory=ConformerSTTConfig)
+
+    # generation defaults (text path). TODO(verify) against the model's
+    # recommended sampling for the voicechat contract.
+    temperature: float = 0.7
+    top_p: float = 0.9
+    repetition_penalty: float = 1.0
+    ignore_eos: bool = False
+    max_new_tokens: int = 2048
+
+    # convenience passthroughs used by the Model glue
+    @property
+    def vocab_size(self) -> int:
+        return self.nano.vocab_size
+
+    @property
+    def eos_token_id(self) -> int:
+        return self.nano.eos_token_id

--- a/mstar/model/nemotron_duplex/config.py
+++ b/mstar/model/nemotron_duplex/config.py
@@ -158,6 +158,12 @@ class EarTTSConfig:
     # constant-code RNG states that an uncontrolled global RNG occasionally hits.
     inference_seed: int = 0
 
+    # Streaming codec chunking (engine Talker->Codec connection): decode `chunk` new
+    # code frames with `left_context` prior frames so the causal codec has enough
+    # receptive field, emitting only the new tail (see AudioCodecDecoderSubmodule).
+    codec_chunk_frames: int = 5
+    codec_left_context_frames: int = 15
+
     sample_rate: int = 22050
 
 

--- a/mstar/model/nemotron_duplex/config.py
+++ b/mstar/model/nemotron_duplex/config.py
@@ -157,12 +157,91 @@ class ConformerSTTConfig:
 
 
 @dataclass
+class CodecConfig:
+    """RVQ audio codec (``config.json`` -> ``model.speech_generation.model.codec_config``).
+
+    The encoder/decoder conv+ConvNeXt-block stacks are *derived* from these
+    fields (channel schedule from ``base_hidden_size`` * ``channel_mult``,
+    strides from ``rates``, ``num_blocks`` blocks per stage) rather than
+    hardcoded — see ``encoder_layers`` / ``decoder_layers``.
+    """
+
+    base_hidden_size: int = 384
+    channel_mult: tuple[int, ...] = (1, 2, 4)
+    codebook_size: int = 1024
+    groups: int = 1
+    hop_length: int = 4
+    kernel_size: int = 7
+    latent_size: int = 512
+    n_fft: int = 16
+    num_blocks: int = 3
+    num_quantizers: int = 31
+    rates: tuple[int, ...] = (7, 7, 9)
+    wav_to_token_ratio: int = 1764
+    # Fixed NeMo codec constant (magnitude ceiling); not present in config.json.
+    max_magnitude: float = 100.0
+
+    @property
+    def spec_channels(self) -> int:
+        """Encoder input channels = (n_fft/2 + 1) real + imag = 2*(n_fft/2+1)."""
+        return 2 * (self.n_fft // 2 + 1)
+
+    @property
+    def channels(self) -> list[int]:
+        return [self.base_hidden_size * m for m in self.channel_mult]
+
+    def encoder_layers(self) -> list[tuple]:
+        """(kind, weight_shape, stride, transpose) per encoder layer."""
+        ch = self.channels
+        spec: list[tuple] = [("conv", (ch[0], self.spec_channels, 1), 1, False)]
+        for i in range(len(ch)):
+            spec += [("block", ch[i])] * self.num_blocks
+            out = ch[i + 1] if i + 1 < len(ch) else self.latent_size
+            spec.append(("conv", (out, ch[i], self.rates[i]), self.rates[i], False))
+        return spec
+
+    def decoder_layers(self) -> list[tuple]:
+        ch = self.channels
+        spec: list[tuple] = []
+        prev = self.latent_size
+        for i in reversed(range(len(ch))):
+            spec.append(("conv", (prev, ch[i], self.rates[i]), self.rates[i], True))
+            spec += [("block", ch[i])] * self.num_blocks
+            prev = ch[i]
+        spec.append(("conv", (self.spec_channels, ch[0], 1), 1, False))
+        return spec
+
+
+@dataclass
+class RnntConfig:
+    """RNN-T transcription head (``config.json`` -> ``_rnnt_merge_info``)."""
+
+    pred_hidden: int = 640
+    pred_rnn_layers: int = 2
+    encoder_hidden: int = 1024
+    joint_hidden: int = 640
+    vocab_size: int = 1024        # excludes the RNN-T blank
+    activation: str = "relu"
+
+    @property
+    def num_classes(self) -> int:
+        return self.vocab_size + 1  # + blank
+
+
+@dataclass
 class NemotronDuplexConfig:
-    """Top-level config bundling the three stages plus generation defaults."""
+    """Top-level config bundling the stages plus generation defaults.
+
+    Use :meth:`from_pretrained` to populate every sub-config from the
+    checkpoint's ``config.json``; the dataclass defaults mirror that file so
+    dummy-mode / weightless construction still works.
+    """
 
     nano: NanoConfig = field(default_factory=NanoConfig)
     eartts: EarTTSConfig = field(default_factory=EarTTSConfig)
     stt: ConformerSTTConfig = field(default_factory=ConformerSTTConfig)
+    codec: CodecConfig = field(default_factory=CodecConfig)
+    rnnt: RnntConfig = field(default_factory=RnntConfig)
 
     # generation defaults (text path). TODO(verify) against the model's
     # recommended sampling for the voicechat contract.
@@ -180,3 +259,46 @@ class NemotronDuplexConfig:
     @property
     def eos_token_id(self) -> int:
         return self.nano.eos_token_id
+
+    @classmethod
+    def from_pretrained(cls, ckpt_dir: str) -> NemotronDuplexConfig:
+        """Build from the checkpoint's ``config.json`` (NeMo VoiceChat layout).
+
+        Only the stages whose components read from config are populated here;
+        the rest fall back to dataclass defaults. Extend as modules migrate to
+        config-driven construction.
+        """
+        import json
+        import os
+
+        with open(os.path.join(ckpt_dir, "config.json")) as f:
+            raw = json.load(f)
+        cfg = cls()
+
+        cc = raw["model"]["speech_generation"]["model"]["codec_config"]
+        cfg.codec = CodecConfig(
+            base_hidden_size=cc["base_hidden_size"],
+            channel_mult=tuple(cc["channel_mult"]),
+            codebook_size=cc["codebook_size"],
+            groups=cc["groups"],
+            hop_length=cc["hop_length"],
+            kernel_size=cc["kernel_size"],
+            latent_size=cc["latent_size"],
+            n_fft=cc["n_fft"],
+            num_blocks=cc["num_blocks"],
+            num_quantizers=cc["num_quantizers"],
+            rates=tuple(cc["rates"]),
+            wav_to_token_ratio=cc["wav_to_token_ratio"],
+        )
+
+        ri = raw["_rnnt_merge_info"]
+        dc, jc = ri["decoder_config"], ri["joint_config"]
+        cfg.rnnt = RnntConfig(
+            pred_hidden=dc["prednet"]["pred_hidden"],
+            pred_rnn_layers=dc["prednet"]["pred_rnn_layers"],
+            encoder_hidden=jc["jointnet"]["encoder_hidden"],
+            joint_hidden=jc["jointnet"]["joint_hidden"],
+            vocab_size=dc["vocab_size"],
+            activation=jc["jointnet"]["activation"],
+        )
+        return cfg

--- a/mstar/model/nemotron_duplex/config.py
+++ b/mstar/model/nemotron_duplex/config.py
@@ -152,6 +152,11 @@ class EarTTSConfig:
     inference_guidance_scale: float = 0.5     # classifier-free guidance weight
     inference_noise_scale: float = 0.8        # MoG latent noise (z = mu + exp(logs)*eps*ns)
     inference_top_p: float = 0.8              # nucleus filter on the mixture logits
+    # The MoG/MaskGIT sampler is stochastic (noise + Gumbel). Draw it from a
+    # dedicated seeded generator (the reference does ``torch.manual_seed(0)`` before
+    # generation) so audio is reproducible AND does not land on rare collapse-to-
+    # constant-code RNG states that an uncontrolled global RNG occasionally hits.
+    inference_seed: int = 0
 
     sample_rate: int = 22050
 

--- a/mstar/model/nemotron_duplex/config.py
+++ b/mstar/model/nemotron_duplex/config.py
@@ -299,6 +299,21 @@ class NemotronDuplexConfig:
     ignore_eos: bool = False
     max_new_tokens: int = 2048
 
+    # --- duplex fusion (AddFusion, parameter-free) + special tokens ---
+    # Per-channel weights (config.json -> model.stt.model.duplex_*_channel_weight).
+    # fuse_method is absent -> AddFusion: agent_text*w + user_audio*w + function*w.
+    agent_text_weight: float = 1.0
+    user_audio_weight: float = 1.0
+    function_weight: float = 2.0
+    use_function_head: bool = True
+    predict_user_text: bool = False
+    # Text-channel special tokens. TODO(verify) against the nano tokenizer
+    # (base repo ships only rnnt_tokenizer/; the text tokenizer is in the Spark
+    # nano/ folder). Defaults are the nano config's bos/eos/pad.
+    text_pad_id: int = 0
+    text_bos_id: int = 1
+    text_eos_id: int = 12
+
     # convenience passthroughs used by the Model glue
     @property
     def vocab_size(self) -> int:
@@ -390,4 +405,11 @@ class NemotronDuplexConfig:
             window_stride=pre["window_stride"],
             n_mels=pre["features"],
         )
+
+        sm = raw["model"]["stt"]["model"]
+        cfg.agent_text_weight = sm.get("duplex_text_channel_weight", cfg.agent_text_weight)
+        cfg.user_audio_weight = sm.get("duplex_user_channel_weight", cfg.user_audio_weight)
+        cfg.function_weight = sm.get("duplex_function_channel_weight", cfg.function_weight)
+        cfg.use_function_head = sm.get("use_function_head", cfg.use_function_head)
+        cfg.predict_user_text = sm.get("predict_user_text", cfg.predict_user_text)
         return cfg

--- a/mstar/model/nemotron_duplex/config.py
+++ b/mstar/model/nemotron_duplex/config.py
@@ -334,12 +334,16 @@ class NemotronDuplexConfig:
     function_weight: float = 2.0
     use_function_head: bool = True
     predict_user_text: bool = False
-    # Text-channel special tokens. TODO(verify) against the nano tokenizer
-    # (base repo ships only rnnt_tokenizer/; the text tokenizer is in the Spark
-    # nano/ folder). Defaults are the nano config's bos/eos/pad.
-    text_pad_id: int = 0
+    # Text-channel special tokens, per the checkpoint config.json
+    # (model.speech_generation.model): bos_token=<s> (1), eos_token=</s> (2),
+    # pad_token=<SPECIAL_12> (12). The pad token is the frequent between-word /
+    # turn-taking "pad-pair" frame; ``inference_force_speech_silence_on_eos``
+    # must silence ONLY the true EOS (2), NOT the pad frames (12) — else the
+    # talker is forced silent between words and the spoken reply truncates after
+    # a few words (verified via ASR).
+    text_pad_id: int = 12
     text_bos_id: int = 1
-    text_eos_id: int = 12
+    text_eos_id: int = 2
 
     # convenience passthroughs used by the Model glue
     @property

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -91,6 +91,157 @@ def _sample_text_token(
     return sampled
 
 
+class _StreamOutput:
+    """One streaming step's agent output: an int16 PCM audio chunk and/or a text delta."""
+
+    __slots__ = ("audio", "text")
+
+    def __init__(self, audio: bytes | None = None, text: str | None = None):
+        self.audio = audio
+        self.text = text
+
+
+class DuplexStream:
+    """Online (streaming) duplex inference session — the Phase-B/C path.
+
+    Audio is fed in chunks via ``append_audio``; each new ~80 ms perception frame
+    runs one duplex step (fuse -> nano cached-decode step -> sample text/function
+    -> talker frame -> codec frame) and yields agent audio + text deltas. The
+    nano attention-KV + Mamba conv/ssm state and the talker KV state persist
+    across the whole stream (O(1) per frame). Perception is re-encoded over a
+    growing buffer each chunk — correct because the Conformer is causal
+    (att_context [70,0]); a true streaming Conformer cache is a later perf item.
+
+    Produces the SAME result as ``offline_inference`` on the concatenated audio.
+    """
+
+    def __init__(self, model, device: str, voice: str, temperature: float, top_p: float, repetition_penalty: float):
+        self.m = model
+        self.cfg = model.config
+        self.device = device
+        self.voice = voice
+        self.temperature = temperature
+        self.top_p = top_p
+        self.repetition_penalty = repetition_penalty
+        self.special_ids = {self.cfg.text_pad_id, self.cfg.text_bos_id, self.cfg.text_eos_id}
+
+        self.perception = model.get_submodule("conformer_encoder", device=device).perception
+        self.nano = model.get_submodule("nano_llm", device=device).language_model
+        self.talker = model.get_submodule("eartts_talker", device=device).talker
+        self.codec = model.get_submodule("audio_codec", device=device).codec
+
+        # talker char-vocab conditioning maps (built once)
+        tok = model._talker_tokenizer()
+        from mstar.model.nemotron_duplex.components.eartts_talker import build_char_vocab, subword_to_char_ids
+        cv = build_char_vocab(tok)
+        self._s2c, _ = subword_to_char_ids(tok, cv)
+        self._char_pad = len(cv)
+
+        self.reset()
+
+    def reset(self):
+        self._wav = torch.zeros(0)
+        self._processed = 0                    # perception frames already stepped
+        self._nano_cache = None                # nano decode cache (B.1)
+        self._gen_text = []                    # sampled agent text tokens (all frames)
+        self._prev_func = self.cfg.text_pad_id
+        self._talker_state = None
+        self._prev_codes = None
+        self._codes_hist = None                # (1, n, num_q) accumulated RVQ codes
+        self._emitted = 0                      # waveform samples already emitted
+        self._t = 0
+
+    def append_audio(self, pcm_int16: bytes) -> list[_StreamOutput]:
+        chunk = torch.frombuffer(bytearray(pcm_int16), dtype=torch.int16).float() / 32768.0
+        self._wav = torch.cat([self._wav, chunk])
+        return self._step_new_frames()
+
+    def flush(self) -> list[_StreamOutput]:
+        return self._step_new_frames()
+
+    @torch.no_grad()
+    def _step_new_frames(self) -> list[_StreamOutput]:
+        if self._wav.numel() < self.cfg.stt.hop_length:
+            return []
+        sig = self._wav.unsqueeze(0).to(self.device)
+        lens = torch.tensor([self._wav.shape[0]], device=self.device)
+        audio_embeds, _ = self.perception(sig, lens)   # (1, T, H) — causal, re-encoded
+        T = audio_embeds.shape[1]
+        nano, cfg = self.nano, self.cfg
+        embed_tokens = nano.embed_tokens
+        outs: list[_StreamOutput] = []
+
+        for t in range(self._processed, T):
+            prev_text = cfg.text_bos_id if t == 0 else self._gen_text[t - 1]
+            agent_emb = embed_tokens(torch.tensor([prev_text], device=self.device))
+            func_emb = embed_tokens(torch.tensor([self._prev_func], device=self.device))
+            fused = agent_emb * cfg.agent_text_weight + audio_embeds[0, t].unsqueeze(0) * cfg.user_audio_weight
+            if cfg.use_function_head:
+                fused = fused + func_emb * cfg.function_weight   # (1, H) == (L=1, H)
+
+            hidden = self._nano_hidden(fused)           # (1, H)
+            text_logits = nano.lm_head(hidden)          # (1, vocab)
+            func_logits = nano.function_head(hidden)
+            gt = torch.tensor(self._gen_text, device=self.device).view(1, -1)
+            text_tok = int(_sample_text_token(
+                text_logits, gt, len(self._gen_text), self.temperature, self.top_p,
+                self.repetition_penalty, special_ids=self.special_ids,
+            )[0])
+            self._gen_text.append(text_tok)
+            self._prev_func = int(func_logits.argmax(-1)[0])
+
+            outs.append(self._talker_codec_frame(text_tok))
+            self._t += 1
+        self._processed = T
+        return outs
+
+    def _nano_hidden(self, fused: torch.Tensor) -> torch.Tensor:
+        """One nano step with persistent cache (B.1 cached decode; re-prefill fallback)."""
+        if hasattr(self.nano.llm, "decode_step") and hasattr(self.nano.llm, "prefill"):
+            if self._nano_cache is None:
+                h, self._nano_cache = self.nano.llm.prefill(fused)
+                return h[-1:]
+            return self.nano.llm.decode_step(fused, self._nano_cache)
+        # Fallback (pre-B.1): accumulate fused embeds and re-prefill (O(T^2)).
+        self._fused_hist = fused if self._nano_cache is None else torch.cat([self._nano_cache, fused], 0)
+        self._nano_cache = self._fused_hist
+        return self.nano.llm.offline_forward(self._fused_hist)[-1:]
+
+    def _talker_codec_frame(self, text_tok: int) -> _StreamOutput:
+        talker, cfg = self.talker, self.cfg
+        if self._talker_state is None:
+            self._talker_state = talker.init_state(
+                1, speaker=self.voice, device=self.device,
+                subword_id_to_char_ids=self._s2c, char_pad_idx=self._char_pad,
+                text_pad_id=cfg.text_pad_id, text_eos_id=cfg.text_eos_id,
+                speech_pad_id=cfg.eartts.codebook_size,
+            )
+            self._prev_codes = self._talker_state.get("prev_codes")
+            if self._prev_codes is None:
+                self._prev_codes = talker.initial_prev_codes(1, device=self.device)
+        cur = torch.tensor([[text_tok]], device=self.device)
+        mask = torch.ones_like(cur, dtype=torch.bool)
+        cond = talker.text_conditioning(cur, mask, self._s2c, self._char_pad)
+        codes, self._talker_state = talker.infer_codes_one_step(
+            self._talker_state, cur, cur, self._prev_codes, cond=cond,
+            text_eos_id=cfg.text_eos_id, temperature=self.temperature,
+        )
+        self._prev_codes = codes
+        # Codec has a multi-frame (causal) receptive field, so decode the full code
+        # history and emit only the newly-produced tail (matches offline decode).
+        frame = codes.unsqueeze(1)                                      # (1, 1, num_q)
+        self._codes_hist = frame if self._codes_hist is None else torch.cat([self._codes_hist, frame], dim=1)
+        with torch.autocast(device_type="cuda", enabled=False):
+            audio, _ = self.codec.decode(
+                self._codes_hist, torch.tensor([self._codes_hist.shape[1]], device=self.device),
+            )                                                          # (1, 1, samples)
+        wav = audio.squeeze(1)[0]                                       # (samples,)
+        new = wav[self._emitted:]
+        self._emitted = wav.shape[0]
+        pcm = (new.clamp(-1, 1) * 32767).to(torch.int16).cpu().numpy().tobytes()
+        return _StreamOutput(audio=pcm, text=self.m.tokenizer.decode([text_tok]))
+
+
 def _resolve_local_hf_snapshot(repo_id: str, cache_dir: str | None = None) -> str:
     from huggingface_hub import snapshot_download
 
@@ -331,6 +482,22 @@ class NemotronDuplexModel(Model):
         return self.config.eartts.sample_rate
 
     # -------------------------------------------------------------------
+    # Online (streaming) duplex inference — Phase B/C.
+    # -------------------------------------------------------------------
+
+    def prepare_streaming(self, device: str = "cuda"):
+        """Warm (build + load) all four submodules so streaming starts promptly."""
+        for node in ("conformer_encoder", "nano_llm", "eartts_talker", "audio_codec"):
+            self.get_submodule(node, device=device)
+
+    def create_stream(
+        self, device: str = "cuda", voice: str = "Aria",
+        temperature: float = 0.0, top_p: float = 1.0, repetition_penalty: float = 1.0,
+    ) -> DuplexStream:
+        """Open an online duplex streaming session (see ``DuplexStream``)."""
+        return DuplexStream(self, device, voice, temperature, top_p, repetition_penalty)
+
+    # -------------------------------------------------------------------
     # Standalone offline inference (Phase A — mirrors the reference
     # NemotronVoiceChat.offline_inference; bypasses the M* serving engine).
     # -------------------------------------------------------------------
@@ -480,8 +647,9 @@ class NemotronDuplexModel(Model):
         text_stream = gen_text[:, prompt_len:]                 # (1, T') agent text per frame
 
         gen_codes = talker.generate_codes(
-            text_stream, self._talker_tokenizer(),
-            speaker="Aria", temperature=temperature, text_eos_id=self.config.text_eos_id,
+            text_stream, self._talker_tokenizer(), speaker="Aria", temperature=temperature,
+            text_eos_id=self.config.text_eos_id, text_pad_id=self.config.text_pad_id,
+            speech_pad_id=self.config.eartts.codebook_size,   # speech-pad frame == all codebook_size
         )                                                       # (1, T', num_q)
         code_len = torch.tensor([gen_codes.shape[1]], device=device)
         with torch.autocast(device_type="cuda", enabled=False):

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -115,7 +115,8 @@ class DuplexStream:
     Produces the SAME result as ``offline_inference`` on the concatenated audio.
     """
 
-    def __init__(self, model, device: str, voice: str, temperature: float, top_p: float, repetition_penalty: float):
+    def __init__(self, model, device: str, voice: str, temperature: float, top_p: float,
+                 repetition_penalty: float, prompt_tokens: torch.Tensor | None = None):
         self.m = model
         self.cfg = model.config
         self.device = device
@@ -124,6 +125,9 @@ class DuplexStream:
         self.top_p = top_p
         self.repetition_penalty = repetition_penalty
         self.special_ids = {self.cfg.text_pad_id, self.cfg.text_bos_id, self.cfg.text_eos_id}
+        # System-prompt tokens (fed via the audio channel, gen_text held at PAD,
+        # exactly as offline_inference prepends the prompt). Primes the nano cache.
+        self.prompt_tokens = None if prompt_tokens is None else prompt_tokens.to(device).view(-1)
 
         self.perception = model.get_submodule("conformer_encoder", device=device).perception
         self.nano = model.get_submodule("nano_llm", device=device).language_model
@@ -150,6 +154,28 @@ class DuplexStream:
         self._codes_hist = None                # (1, n, num_q) accumulated RVQ codes
         self._emitted = 0                      # waveform samples already emitted
         self._t = 0
+        self._prime_prompt()                   # feed the system prompt (if any) first
+
+    @torch.no_grad()
+    def _prime_prompt(self):
+        """Prime the nano cache with the system prompt, mirroring how
+        ``_infer_one`` prepends ``prompt_emb`` to the audio channel and holds
+        ``gen_text`` at PAD across the prompt region (no sampling, no talker).
+        Frame 0's agent channel is BOS; later prompt frames use PAD."""
+        if self.prompt_tokens is None or self.prompt_tokens.numel() == 0:
+            return
+        nano, cfg = self.nano, self.cfg
+        embed_tokens = nano.embed_tokens
+        prompt_emb = embed_tokens(self.prompt_tokens)          # (P, H)
+        for i in range(prompt_emb.shape[0]):
+            prev_text = cfg.text_bos_id if i == 0 else cfg.text_pad_id
+            agent_emb = embed_tokens(torch.tensor([prev_text], device=self.device))
+            func_emb = embed_tokens(torch.tensor([cfg.text_pad_id], device=self.device))
+            fused = agent_emb * cfg.agent_text_weight + prompt_emb[i].unsqueeze(0) * cfg.user_audio_weight
+            if cfg.use_function_head:
+                fused = fused + func_emb * cfg.function_weight
+            self._nano_hidden(fused)                           # primes cache; no sampling
+            self._gen_text.append(cfg.text_pad_id)             # prompt region held at PAD
 
     def append_audio(self, pcm_int16: bytes) -> list[_StreamOutput]:
         chunk = torch.frombuffer(bytearray(pcm_int16), dtype=torch.int16).float() / 32768.0
@@ -172,7 +198,10 @@ class DuplexStream:
         outs: list[_StreamOutput] = []
 
         for t in range(self._processed, T):
-            prev_text = cfg.text_bos_id if t == 0 else self._gen_text[t - 1]
+            # Global position — with a primed system prompt, gen_text already holds
+            # `prompt_len` PADs, so the first audio frame's prev is the last prompt
+            # PAD (not BOS). BOS applies only at true global frame 0 (no prompt).
+            prev_text = cfg.text_bos_id if len(self._gen_text) == 0 else self._gen_text[-1]
             agent_emb = embed_tokens(torch.tensor([prev_text], device=self.device))
             func_emb = embed_tokens(torch.tensor([self._prev_func], device=self.device))
             fused = agent_emb * cfg.agent_text_weight + audio_embeds[0, t].unsqueeze(0) * cfg.user_audio_weight
@@ -490,12 +519,29 @@ class NemotronDuplexModel(Model):
         for node in ("conformer_encoder", "nano_llm", "eartts_talker", "audio_codec"):
             self.get_submodule(node, device=device)
 
+    def encode_prompt(self, system_prompt: str, device: str = "cuda") -> torch.Tensor | None:
+        """Tokenize a system prompt to nano text-token ids: ``[bos] + ids + [eos]``
+        (mirrors the reference ``encode_system_prompt``). Returns ``(1, P)`` or None."""
+        if not system_prompt or not system_prompt.strip():
+            return None
+        tok = self.tokenizer
+        ids = tok.encode(system_prompt, add_special_tokens=False)
+        ids = [tok.bos_token_id] + ids + [tok.eos_token_id]
+        return torch.tensor(ids, dtype=torch.long, device=device).unsqueeze(0)
+
     def create_stream(
         self, device: str = "cuda", voice: str = "Aria",
         temperature: float = 0.0, top_p: float = 1.0, repetition_penalty: float = 1.0,
+        prompt_tokens: torch.Tensor | None = None, system_prompt: str | None = None,
     ) -> DuplexStream:
-        """Open an online duplex streaming session (see ``DuplexStream``)."""
-        return DuplexStream(self, device, voice, temperature, top_p, repetition_penalty)
+        """Open an online duplex streaming session (see ``DuplexStream``).
+
+        A system prompt may be passed either pre-tokenized (``prompt_tokens``,
+        ``(1, P)`` nano text ids) or as raw text (``system_prompt``); it primes
+        the nano cache before any audio, exactly as offline prepends it."""
+        if prompt_tokens is None and system_prompt is not None:
+            prompt_tokens = self.encode_prompt(system_prompt, device=device)
+        return DuplexStream(self, device, voice, temperature, top_p, repetition_penalty, prompt_tokens)
 
     # -------------------------------------------------------------------
     # Standalone offline inference (Phase A — mirrors the reference

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -855,7 +855,13 @@ class NemotronDuplexModel(Model):
         with torch.device("meta"):
             talker = EarTTSTalker(cfg.eartts)
         talker = self._build_and_load(talker, device, autocast_dtype, local_dir)
-        return EarTTSTalkerSubmodule(talker=talker, config=self.config)
+        from mstar.model.nemotron_duplex.components.eartts_talker import build_char_vocab, subword_to_char_ids
+        tok = self._talker_tokenizer()
+        cv = build_char_vocab(tok)
+        s2c, _ = subword_to_char_ids(tok, cv)
+        return EarTTSTalkerSubmodule(
+            talker=talker, config=self.config, subword_to_char=s2c, char_pad_idx=len(cv),
+        )
 
     def _create_codec_submodule(
         self, device: str, autocast_dtype: torch.dtype | None = None,

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -65,15 +65,29 @@ class NemotronDuplexModel(Model):
 
     @property
     def tokenizer(self):
-        # TODO(verify): confirm the text tokenizer source. The Spark repo ships
-        # it under ``nano/``; the base repo ships only ``rnnt_tokenizer/`` (the
-        # ASR head). Loaded lazily so dummy-mode tests never touch the network.
+        # The text tokenizer lives in the Spark repo's ``nano/`` folder (the base
+        # repo ships only ``rnnt_tokenizer/``). 131072-token vocab; 256 single-
+        # char tokens -> the talker's char vocab. Loaded lazily.
         if self._tokenizer is None:
+            import os
+
+            from huggingface_hub import hf_hub_download
             from transformers import AutoTokenizer
 
-            src = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
-            self._tokenizer = AutoTokenizer.from_pretrained(src, trust_remote_code=True)
+            repo = "pipecat-ai/NVIDIA-NemotronLabs-VoiceChat-11B-Spark"
+            local_dir = None
+            for f in ("nano/tokenizer.json", "nano/tokenizer_config.json", "nano/special_tokens_map.json"):
+                local_dir = os.path.dirname(hf_hub_download(repo, f, cache_dir=self.cache_dir))
+            self._tokenizer = AutoTokenizer.from_pretrained(local_dir, trust_remote_code=True)
         return self._tokenizer
+
+    def _talker_tokenizer(self):
+        """Adapter exposing the NeMo-tokenizer interface (``.tokenizer.vocab`` /
+        ``.vocab``) the talker's char-vocab builder expects, over the HF tokenizer."""
+        import types
+
+        v = self.tokenizer.get_vocab()
+        return types.SimpleNamespace(tokenizer=types.SimpleNamespace(vocab=v), vocab=v)
 
     # -------------------------------------------------------------------
     # KV cache config — nano_llm (attention layers only) + eartts_talker
@@ -364,29 +378,16 @@ class NemotronDuplexModel(Model):
         return result
 
     def _decode_audio_path(self, gen_text, prompt_len, device, temperature):
-        """Talker (autoregressive RVQ codes) -> codec (waveform). Talker sampling
-        loop is being finalised in EarTTSTalker.infer_codes_one_step."""
+        """Talker (autoregressive RVQ codes with char-vocab text conditioning) ->
+        codec (waveform)."""
         talker = self.get_submodule("eartts_talker", device=device).talker
         codec = self.get_submodule("audio_codec", device=device).codec
         text_stream = gen_text[:, prompt_len:]                 # (1, T') agent text per frame
-        num_q = self.config.eartts.num_quantizers
 
-        if not hasattr(talker, "infer_codes_one_step"):
-            return {}  # talker sampling loop not yet available
-
-        state = talker.init_state(batch_size=text_stream.shape[0], device=device)
-        codes = []
-        prev_codes = None
-        prev_subword = text_stream[:, 0:1]
-        for t in range(text_stream.shape[1]):
-            cur_subword = text_stream[:, t : t + 1]
-            frame_codes, state = talker.infer_codes_one_step(
-                state, cur_subword, prev_subword, prev_codes, temperature=temperature,
-            )
-            codes.append(frame_codes)
-            prev_codes, prev_subword = frame_codes, cur_subword
-        gen_codes = torch.stack(codes, dim=1)                  # (1, T', num_q)
-        assert gen_codes.shape[-1] == num_q
+        gen_codes = talker.generate_codes(
+            text_stream, self._talker_tokenizer(),
+            speaker="Aria", temperature=temperature, text_eos_id=self.config.text_eos_id,
+        )                                                       # (1, T', num_q)
         code_len = torch.tensor([gen_codes.shape[1]], device=device)
         with torch.autocast(device_type="cuda", enabled=False):
             audio, audio_len = codec.decode(gen_codes, code_len)

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -315,32 +315,76 @@ class NemotronDuplexModel(Model):
     ) -> NodeSubmodule | None:
         if node_name == "nano_llm":
             return self._create_nano_submodule(device, autocast_dtype=autocast_dtype)
-        # Audio nodes: Phase 4/5 — dummy mode (None) keeps the text path runnable.
-        if node_name in ("conformer_encoder", "eartts_talker", "audio_codec"):
-            logger.warning("Submodule %s not implemented yet (Phase 4/5) — dummy mode.", node_name)
-            return None
+        if node_name == "conformer_encoder":
+            return self._create_conformer_submodule(device, autocast_dtype=autocast_dtype)
+        if node_name == "eartts_talker":
+            return self._create_talker_submodule(device, autocast_dtype=autocast_dtype)
+        if node_name == "audio_codec":
+            return self._create_codec_submodule(device, autocast_dtype=autocast_dtype)
         return None
+
+    def _build_and_load(self, module: torch.nn.Module, device: str, autocast_dtype, local_dir: str):
+        """meta-build -> cast -> materialize -> load the module's checkpoint subtree.
+
+        Each component's ``load_weights`` streams the single composite
+        ``model.safetensors`` and keeps only its own subtree (verified: every
+        checkpoint tensor maps to exactly one component param).
+        """
+        from mstar.model.loader import load_weights
+
+        if autocast_dtype is not None:
+            module = module.to(autocast_dtype)
+        module.to_empty(device=device)
+        load_weights(module, local_dir, device=device)
+        return module.eval()
 
     def _create_nano_submodule(
         self, device: str, autocast_dtype: torch.dtype | None = None,
     ) -> NodeSubmodule:
-        from mstar.model.loader import load_weights
         from mstar.model.nemotron_duplex.components.nemotron_h import NemotronHForCausalLM
         from mstar.model.nemotron_duplex.submodules import NemotronHLLMSubmodule
 
         local_dir = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
-
         with torch.device("meta"):
             language_model = NemotronHForCausalLM(self.config.nano)
-        if autocast_dtype is not None:
-            language_model = language_model.to(autocast_dtype)
-        language_model.to_empty(device=device)
-
-        # TODO(verify): the base checkpoint is a single composite ``model.safetensors``;
-        # confirm the weight-name prefix for the nano stage (e.g. ``nano.`` /
-        # ``model.``) and extend the component's name_remapper accordingly before
-        # this load succeeds.
-        load_weights(language_model, local_dir, device=device)
-        language_model.eval()
-
+        language_model = self._build_and_load(language_model, device, autocast_dtype, local_dir)
         return NemotronHLLMSubmodule(language_model=language_model, config=self.config)
+
+    def _create_conformer_submodule(
+        self, device: str, autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule:
+        from mstar.model.nemotron_duplex.components.conformer import Perception
+        from mstar.model.nemotron_duplex.components.rnnt import RnntDecoder, RnntJoint
+        from mstar.model.nemotron_duplex.submodules import ConformerEncoderSubmodule
+
+        local_dir = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
+        with torch.device("meta"):
+            perception, rnnt_dec, rnnt_joint = Perception(), RnntDecoder(), RnntJoint()
+        perception = self._build_and_load(perception, device, autocast_dtype, local_dir)
+        rnnt_dec = self._build_and_load(rnnt_dec, device, autocast_dtype, local_dir)
+        rnnt_joint = self._build_and_load(rnnt_joint, device, autocast_dtype, local_dir)
+        return ConformerEncoderSubmodule(perception, rnnt_dec, rnnt_joint, config=self.config)
+
+    def _create_talker_submodule(
+        self, device: str, autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule:
+        from mstar.model.nemotron_duplex.components.eartts_talker import EarTTSTalker
+        from mstar.model.nemotron_duplex.submodules import EarTTSTalkerSubmodule
+
+        local_dir = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
+        with torch.device("meta"):
+            talker = EarTTSTalker(self.config.eartts)
+        talker = self._build_and_load(talker, device, autocast_dtype, local_dir)
+        return EarTTSTalkerSubmodule(talker=talker, config=self.config)
+
+    def _create_codec_submodule(
+        self, device: str, autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule:
+        from mstar.model.nemotron_duplex.components.audio_codec import AudioCodec
+        from mstar.model.nemotron_duplex.submodules import AudioCodecDecoderSubmodule
+
+        local_dir = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
+        with torch.device("meta"):
+            codec = AudioCodec()
+        codec = self._build_and_load(codec, device, autocast_dtype, local_dir)
+        return AudioCodecDecoderSubmodule(codec=codec, config=self.config)

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -525,6 +525,12 @@ class NemotronDuplexModel(Model):
             wav = tensors.get("audio_inputs") or tensors.get("audio_features")
             if wav:
                 out["audio_features"] = wav
+        # Seed the first decode frame's fed-back tokens (BOS / PAD): the decode-loop
+        # node requires prev_text + prev_func, but frame 0 has no prior sampled token,
+        # so without a seed it never becomes ready (the hang). [UNVERIFIED — pending a
+        # live GPU run; see E5_RESUME.md.]
+        out["prev_text"] = [torch.tensor([self.config.text_bos_id], dtype=torch.long)]
+        out["prev_func"] = [torch.tensor([self.config.text_pad_id], dtype=torch.long)]
         return out
 
     def load_audio(self, filepath: str, device: str):
@@ -532,6 +538,7 @@ class NemotronDuplexModel(Model):
         torchcodec, whose native libs aren't always available). Returns the same
         ``TensorAndMetadata`` shape the data worker expects."""
         import soundfile as sf
+
         from mstar.model.base import TensorAndMetadata
 
         data, sr = sf.read(filepath, dtype="float32")
@@ -592,6 +599,14 @@ class NemotronDuplexModel(Model):
                 e = GraphEdge(next_node="nano_llm", name="text_inputs")
                 e.tensor_info = input_signals.get("text_inputs", [])
                 edges = [e]
+            else:
+                # Audio-only: start the decode loop directly, seeding frame 0's fed-back
+                # prev_text / prev_func so the node's input_names are satisfied on the
+                # first iteration (later iterations get them from the loop-back edges).
+                for name in ("prev_text", "prev_func"):
+                    e = GraphEdge(next_node="nano_llm", name=name)
+                    e.tensor_info = input_signals.get(name, [])
+                    edges.append(e)
             return ForwardPassArgs(
                 full_metadata=self._meta(input_modalities, output_modalities, walk, has_prompt),
                 inputs=edges, unpersist_tensors=sum([e.tensor_info for e in edges], start=[]),

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -1,21 +1,31 @@
 """NemotronDuplexModel — NVIDIA NemotronLabs VoiceChat-11B in M*.
 
-A half-duplex speech-to-speech model with three stages:
+A full-duplex speech-to-speech model with three stages:
 
     conformer_encoder (STATELESS) — 16 kHz speech → fused embeds + RNN-T transcript
     nano_llm          (KV_CACHE)  — Nemotron-H hybrid Mamba-2/attn/MLP backbone (9B)
     eartts_talker     (KV_CACHE)  — Gemma3 talker → 31-codebook RVQ codes
     audio_codec       (STATELESS) — RVQ codes → 22.05 kHz PCM
 
-Input:  text prompt + user speech.  Output: agent text + agent speech +
-streaming user transcription.
+Full-duplex: the model consumes user speech continuously and emits agent text +
+agent speech as it generates, frame-synchronously in one backbone, so it handles
+natural turn-taking and barge-in/interruptions.
 
-PHASING (agreed): this draft wires the **text path** end-to-end
-(``prefill_text`` → ``decode``) so the Nemotron-H backbone can be brought up and
-verified against the HF reference first. The audio nodes are declared and their
-submodules stubbed; the full duplex graph + async partitions (encoder →
-nano_llm → talker → codec, with ``StreamingGraphEdge`` fan-out of transcript /
-text / audio) is the Phase 6 extension sketched in ``_duplex_design`` below.
+Input:  optional system prompt + user speech.  Output: agent text + agent speech
+(+ streaming user transcription, RNN-T channel implemented but not yet wired).
+
+INFERENCE PATHS (all live, verified vs the NeMo reference):
+    * ``offline_inference`` — batched offline S2S (frame-synchronous perception →
+      AddFusion → nano no-cache re-prefill → sample → talker RVQ → codec).
+    * ``create_stream`` / ``DuplexStream`` — online streaming duplex with a
+      persistent nano cache (attn KV + Mamba conv/ssm state) and per-frame talker;
+      matches the offline text path and vocalizes with CFG + noise sampling.
+    * ``realtime_api`` — OpenAI Realtime-API WebSocket server over ``DuplexStream``.
+
+The M*-serving-engine graph path (``prefill_text`` → ``decode`` walk graphs, async
+partitions with ``StreamingGraphEdge`` fan-out of transcript / text / audio) is
+sketched in ``_duplex_design`` below and is the remaining engine-integration work;
+the standalone paths above are what run today.
 
 Contract methods crib from ``mstar/model/orpheus/orpheus_model.py`` (single
 streaming LLM+codec) and ``mstar/model/qwen3_omni/qwen3_omni_model.py`` (omni,
@@ -183,10 +193,12 @@ class DuplexStream:
         return self._step_new_frames()
 
     def flush(self) -> list[_StreamOutput]:
-        return self._step_new_frames()
+        # End of input: no more audio will arrive, so the held-back trailing frames
+        # are now final — consume them too (matches offline's zero-padded tail).
+        return self._step_new_frames(final=True)
 
     @torch.no_grad()
-    def _step_new_frames(self) -> list[_StreamOutput]:
+    def _step_new_frames(self, final: bool = False) -> list[_StreamOutput]:
         if self._wav.numel() < self.cfg.stt.hop_length:
             return []
         sig = self._wav.unsqueeze(0).to(self.device)
@@ -197,7 +209,12 @@ class DuplexStream:
         embed_tokens = nano.embed_tokens
         outs: list[_StreamOutput] = []
 
-        for t in range(self._processed, T):
+        # Hold back the encoder's right-context lookahead frames: the newest
+        # `streaming_lookahead_frames` are not yet final (they change as more audio
+        # arrives), so consuming them now would permanently diverge from offline.
+        # At `final` (flush) there is no future audio, so consume everything.
+        limit = T if final else max(self._processed, T - cfg.stt.streaming_lookahead_frames)
+        for t in range(self._processed, limit):
             # Global position — with a primed system prompt, gen_text already holds
             # `prompt_len` PADs, so the first audio frame's prev is the last prompt
             # PAD (not BOS). BOS applies only at true global frame 0 (no prompt).
@@ -221,7 +238,7 @@ class DuplexStream:
 
             outs.append(self._talker_codec_frame(text_tok))
             self._t += 1
-        self._processed = T
+        self._processed = limit   # held-back frames stay unconsumed until finalized
         return outs
 
     def _nano_hidden(self, fused: torch.Tensor) -> torch.Tensor:
@@ -254,6 +271,10 @@ class DuplexStream:
         codes, self._talker_state = talker.infer_codes_one_step(
             self._talker_state, cur, cur, self._prev_codes, cond=cond,
             text_eos_id=cfg.text_eos_id, temperature=self.temperature,
+            num_iter=cfg.eartts.inference_num_iter,
+            guidance_scale=cfg.eartts.inference_guidance_scale,
+            noise_scale=cfg.eartts.inference_noise_scale,
+            top_p=cfg.eartts.inference_top_p,
         )
         self._prev_codes = codes
         # Codec has a multi-frame (causal) receptive field, so decode the full code

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -323,6 +323,20 @@ class NemotronDuplexModel(Model):
             return self._create_codec_submodule(device, autocast_dtype=autocast_dtype)
         return None
 
+    def _json_config(self, local_dir: str) -> NemotronDuplexConfig:
+        """Config populated from the checkpoint's ``config.json`` (cached).
+
+        Falls back to dataclass defaults if the file is absent (e.g. when
+        ``local_dir`` is an unresolved repo id).
+        """
+        if getattr(self, "_json_config_cache", None) is None:
+            try:
+                self._json_config_cache = NemotronDuplexConfig.from_pretrained(local_dir)
+            except (FileNotFoundError, KeyError) as e:
+                logger.warning("Could not read config.json (%s); using config defaults.", e)
+                self._json_config_cache = self.config
+        return self._json_config_cache
+
     def _build_and_load(self, module: torch.nn.Module, device: str, autocast_dtype, local_dir: str):
         """meta-build -> cast -> materialize -> load the module's checkpoint subtree.
 
@@ -358,8 +372,10 @@ class NemotronDuplexModel(Model):
         from mstar.model.nemotron_duplex.submodules import ConformerEncoderSubmodule
 
         local_dir = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
+        cfg = self._json_config(local_dir)
         with torch.device("meta"):
-            perception, rnnt_dec, rnnt_joint = Perception(), RnntDecoder(), RnntJoint()
+            perception = Perception()
+            rnnt_dec, rnnt_joint = RnntDecoder(cfg.rnnt), RnntJoint(cfg.rnnt)
         perception = self._build_and_load(perception, device, autocast_dtype, local_dir)
         rnnt_dec = self._build_and_load(rnnt_dec, device, autocast_dtype, local_dir)
         rnnt_joint = self._build_and_load(rnnt_joint, device, autocast_dtype, local_dir)
@@ -384,7 +400,8 @@ class NemotronDuplexModel(Model):
         from mstar.model.nemotron_duplex.submodules import AudioCodecDecoderSubmodule
 
         local_dir = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
+        cfg = self._json_config(local_dir)
         with torch.device("meta"):
-            codec = AudioCodec()
+            codec = AudioCodec(cfg.codec)
         codec = self._build_and_load(codec, device, autocast_dtype, local_dir)
         return AudioCodecDecoderSubmodule(codec=codec, config=self.config)

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -374,7 +374,7 @@ class NemotronDuplexModel(Model):
         local_dir = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
         cfg = self._json_config(local_dir)
         with torch.device("meta"):
-            perception = Perception()
+            perception = Perception(cfg.stt)
             rnnt_dec, rnnt_joint = RnntDecoder(cfg.rnnt), RnntJoint(cfg.rnnt)
         perception = self._build_and_load(perception, device, autocast_dtype, local_dir)
         rnnt_dec = self._build_and_load(rnnt_dec, device, autocast_dtype, local_dir)
@@ -388,8 +388,9 @@ class NemotronDuplexModel(Model):
         from mstar.model.nemotron_duplex.submodules import EarTTSTalkerSubmodule
 
         local_dir = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
+        cfg = self._json_config(local_dir)
         with torch.device("meta"):
-            talker = EarTTSTalker(self.config.eartts)
+            talker = EarTTSTalker(cfg.eartts)
         talker = self._build_and_load(talker, device, autocast_dtype, local_dir)
         return EarTTSTalkerSubmodule(talker=talker, config=self.config)
 

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -268,6 +268,131 @@ class NemotronDuplexModel(Model):
         return self.config.eartts.sample_rate
 
     # -------------------------------------------------------------------
+    # Standalone offline inference (Phase A — mirrors the reference
+    # NemotronVoiceChat.offline_inference; bypasses the M* serving engine).
+    # -------------------------------------------------------------------
+
+    @torch.no_grad()
+    def offline_inference(
+        self,
+        input_signal: torch.Tensor,       # (1, num_samples) 16 kHz mono
+        input_signal_lens: torch.Tensor,  # (1,)
+        prompt_tokens: torch.Tensor | None = None,  # (1, P) text token ids
+        device: str = "cuda",
+        temperature: float = 0.0,
+        decode_audio: bool = True,
+    ) -> dict:
+        """Duplex speech-to-speech offline inference (batch size 1, fp32, greedy).
+
+        Frame-synchronous loop mirroring the reference: perception -> per-frame
+        [AddFusion(prev agent text, audio, prev function) -> nano step -> sample
+        text/function] -> talker emits RVQ codes -> codec -> waveform.
+
+        The nano uses the reference's Nemotron no-cache path: full re-prefill over
+        [0:t+1] each frame (reuses the verified ``offline_forward``).
+
+        Returns ``{tokens_text, tokens_function, tokens_audio, audio, audio_len}``.
+        TODO: talker sampling loop (``EarTTSTalker.infer_codes_one_step``) and the
+        text tokenizer (for detokenised ``text``) are being finalised; this method
+        returns token ids and — once those land — audio. Verify vs the NeMo ref.
+        """
+        cfg = self.config
+        # --- build the component modules (loads real weights) ---
+        conf_sub = self.get_submodule("conformer_encoder", device=device)
+        nano_sub = self.get_submodule("nano_llm", device=device)
+        perception = conf_sub.perception
+        nano = nano_sub.language_model
+        embed_tokens = nano.embed_tokens
+
+        # --- perception: audio -> per-frame embeddings (B, T, H) ---
+        audio_embeds, lengths = perception(input_signal.to(device), input_signal_lens.to(device))
+        B, T, H = audio_embeds.shape
+
+        # --- prepend the system prompt embeddings, if any ---
+        prompt_len = 0
+        if prompt_tokens is not None and prompt_tokens.numel() > 0:
+            prompt_len = prompt_tokens.shape[1]
+            prompt_emb = embed_tokens(prompt_tokens.to(device))            # (1, P, H)
+            audio_embeds = torch.cat([prompt_emb, audio_embeds], dim=1)    # (1, P+T, H)
+            T = audio_embeds.shape[1]
+
+        gen_text = torch.full((B, T), cfg.text_pad_id, device=device, dtype=torch.long)
+        gen_function = torch.full((B, T), cfg.text_pad_id, device=device, dtype=torch.long)
+        input_embeds = torch.zeros_like(audio_embeds)
+
+        def fuse(agent_emb, audio_emb, function_emb):
+            out = agent_emb * cfg.agent_text_weight + audio_emb * cfg.user_audio_weight
+            if cfg.use_function_head:
+                out = out + function_emb * cfg.function_weight
+            return out
+
+        def nano_step(seq_embeds):
+            # seq_embeds: (L, H) fused embeddings for frames [0:t+1]; returns the
+            # last position's text + function logits (non-cache re-prefill).
+            hidden = nano.llm.offline_forward(seq_embeds)      # (L, H)
+            last = hidden[-1:]                                  # (1, H)
+            return nano.lm_head(last)[0], nano.function_head(last)[0]
+
+        # frame 0: agent channel is BOS
+        bos_emb = embed_tokens(torch.tensor([cfg.text_bos_id], device=device))  # (1, H)
+        input_embeds[:, 0] = fuse(bos_emb, audio_embeds[:, 0], embed_tokens(gen_function[:, 0]))
+        text_logits, function_logits = nano_step(input_embeds[0, :1])
+        if prompt_len == 0:
+            gen_text[:, 0] = text_logits.argmax(-1)
+            gen_function[:, 0] = function_logits.argmax(-1)
+
+        for t in range(1, T):
+            agent_emb = embed_tokens(gen_text[:, t - 1])
+            function_emb = embed_tokens(gen_function[:, t - 1])
+            input_embeds[:, t] = fuse(agent_emb, audio_embeds[:, t], function_emb)
+            if t < prompt_len:
+                continue  # prompt region: teacher-forced, no sampling
+            text_logits, function_logits = nano_step(input_embeds[0, : t + 1])
+            # greedy (temperature==0). TODO: top-p / repetition-penalty sampling.
+            gen_text[:, t] = text_logits.argmax(-1)
+            gen_function[:, t] = function_logits.argmax(-1)
+
+        result = {
+            "tokens_text": gen_text,
+            "tokens_function": gen_function,
+            "prompt_len": prompt_len,
+        }
+
+        # --- audio-out: talker -> RVQ codes -> codec -> waveform ---
+        if decode_audio:
+            result.update(self._decode_audio_path(gen_text, prompt_len, device, temperature))
+        return result
+
+    def _decode_audio_path(self, gen_text, prompt_len, device, temperature):
+        """Talker (autoregressive RVQ codes) -> codec (waveform). Talker sampling
+        loop is being finalised in EarTTSTalker.infer_codes_one_step."""
+        talker = self.get_submodule("eartts_talker", device=device).talker
+        codec = self.get_submodule("audio_codec", device=device).codec
+        text_stream = gen_text[:, prompt_len:]                 # (1, T') agent text per frame
+        num_q = self.config.eartts.num_quantizers
+
+        if not hasattr(talker, "infer_codes_one_step"):
+            return {}  # talker sampling loop not yet available
+
+        state = talker.init_state(batch_size=text_stream.shape[0], device=device)
+        codes = []
+        prev_codes = None
+        prev_subword = text_stream[:, 0:1]
+        for t in range(text_stream.shape[1]):
+            cur_subword = text_stream[:, t : t + 1]
+            frame_codes, state = talker.infer_codes_one_step(
+                state, cur_subword, prev_subword, prev_codes, temperature=temperature,
+            )
+            codes.append(frame_codes)
+            prev_codes, prev_subword = frame_codes, cur_subword
+        gen_codes = torch.stack(codes, dim=1)                  # (1, T', num_q)
+        assert gen_codes.shape[-1] == num_q
+        code_len = torch.tensor([gen_codes.shape[1]], device=device)
+        with torch.autocast(device_type="cuda", enabled=False):
+            audio, audio_len = codec.decode(gen_codes, code_len)
+        return {"tokens_audio": gen_codes, "audio": audio.squeeze(1), "audio_len": audio_len}
+
+    # -------------------------------------------------------------------
     # Postprocess
     # -------------------------------------------------------------------
 

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -27,6 +27,7 @@ import logging
 from pathlib import Path
 
 import torch
+import torch.nn.functional as F
 
 from mstar.communication.tensors import NameToTensorList
 from mstar.conductor.request_info import CurrentForwardConductorMetadata
@@ -40,6 +41,54 @@ from mstar.model.submodule_base import NodeSubmodule
 from mstar.utils.sampling import SamplingConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _sample_text_token(
+    logits: torch.Tensor,          # (B, vocab)
+    generated: torch.Tensor,       # (B, T) tokens so far
+    step: int,
+    temperature: float = 0.0,
+    top_p: float = 1.0,
+    repetition_penalty: float = 1.0,
+    presence_penalty: float = 0.0,
+    special_ids: set | None = None,
+) -> torch.Tensor:
+    """Text-channel sampler — exact port of the reference ``_sample_text_token``.
+
+    Greedy when ``temperature==0``. Order: repetition/presence penalty ->
+    temperature -> top-p -> softmax + multinomial. If a row's argmax is a
+    special id, that row stays greedy. Function/ASR channels use plain argmax.
+    """
+    special_ids = special_ids or set()
+    if temperature == 0.0:
+        return logits.argmax(dim=-1)
+    sampled = logits.argmax(dim=-1).clone()
+    for b in range(logits.shape[0]):
+        if logits[b].argmax().item() in special_ids:
+            continue
+        lg = logits[b].clone()
+        if (repetition_penalty != 1.0 or presence_penalty != 0.0) and step > 0:
+            prev = generated[b, :step].unique()
+            if special_ids:
+                st = torch.tensor(list(special_ids), device=prev.device)
+                prev = prev[~torch.isin(prev, st)]
+            for tok in prev:
+                tid = tok.item()
+                if repetition_penalty != 1.0:
+                    lg[tid] = lg[tid] / repetition_penalty if lg[tid] > 0 else lg[tid] * repetition_penalty
+                if presence_penalty != 0.0:
+                    lg[tid] -= presence_penalty
+        if temperature != 1.0:
+            lg = lg / temperature
+        if top_p < 1.0:
+            s_lg, s_idx = torch.sort(lg, descending=True)
+            cum = torch.cumsum(torch.softmax(s_lg, dim=-1), dim=-1)
+            rm = cum > top_p
+            rm[1:] = rm[:-1].clone()
+            rm[0] = False
+            lg[s_idx[rm]] = float("-inf")
+        sampled[b] = torch.multinomial(torch.softmax(lg, dim=-1), num_samples=1).item()
+    return sampled
 
 
 def _resolve_local_hf_snapshot(repo_id: str, cache_dir: str | None = None) -> str:
@@ -289,28 +338,49 @@ class NemotronDuplexModel(Model):
     @torch.no_grad()
     def offline_inference(
         self,
-        input_signal: torch.Tensor,       # (1, num_samples) 16 kHz mono
-        input_signal_lens: torch.Tensor,  # (1,)
-        prompt_tokens: torch.Tensor | None = None,  # (1, P) text token ids
+        input_signal: torch.Tensor,       # (B, num_samples) 16 kHz mono
+        input_signal_lens: torch.Tensor,  # (B,)
+        prompt_tokens: torch.Tensor | None = None,      # (B, P) text token ids, or None
+        prompt_token_lens: torch.Tensor | None = None,  # (B,)
         device: str = "cuda",
         temperature: float = 0.0,
+        top_p: float = 1.0,
+        repetition_penalty: float = 1.0,
         decode_audio: bool = True,
     ) -> dict:
-        """Duplex speech-to-speech offline inference (batch size 1, fp32, greedy).
+        """Duplex speech-to-speech offline inference (fp32).
 
         Frame-synchronous loop mirroring the reference: perception -> per-frame
-        [AddFusion(prev agent text, audio, prev function) -> nano step -> sample
-        text/function] -> talker emits RVQ codes -> codec -> waveform.
+        [AddFusion(prev agent text, audio, prev function) -> nano no-cache re-prefill
+        step -> sample text/function] -> talker RVQ codes -> codec -> waveform.
 
-        The nano uses the reference's Nemotron no-cache path: full re-prefill over
-        [0:t+1] each frame (reuses the verified ``offline_forward``).
-
-        Returns ``{tokens_text, tokens_function, tokens_audio, audio, audio_len}``.
-        TODO: talker sampling loop (``EarTTSTalker.infer_codes_one_step``) and the
-        text tokenizer (for detokenised ``text``) are being finalised; this method
-        returns token ids and — once those land — audio. Verify vs the NeMo ref.
+        Batched via a per-utterance loop — correct results for B>1; true continuous
+        batching is the Phase-B engine path. Greedy when temperature==0, else
+        temperature/top-p/repetition-penalty on the text channel (function/ASR
+        channels are always greedy). Returns
+        ``{tokens_text, tokens_function, tokens_audio, audio, audio_len, text}``.
         """
+        B = input_signal.shape[0]
+        outs = []
+        for b in range(B):
+            p = None
+            if prompt_tokens is not None:
+                pl = int(prompt_token_lens[b]) if prompt_token_lens is not None else prompt_tokens.shape[1]
+                p = prompt_tokens[b : b + 1, :pl]
+            outs.append(self._infer_one(
+                input_signal[b : b + 1], input_signal_lens[b : b + 1], p, device,
+                temperature, top_p, repetition_penalty, decode_audio,
+            ))
+        return self._collate(outs, decode_audio)
+
+    @torch.no_grad()
+    def _infer_one(
+        self, input_signal, input_signal_lens, prompt_tokens, device,
+        temperature, top_p, repetition_penalty, decode_audio,
+    ) -> dict:
+        """Single-utterance (B==1) duplex inference; see ``offline_inference``."""
         cfg = self.config
+        special_ids = {cfg.text_pad_id, cfg.text_bos_id, cfg.text_eos_id}
         # --- build the component modules (loads real weights) ---
         conf_sub = self.get_submodule("conformer_encoder", device=device)
         nano_sub = self.get_submodule("nano_llm", device=device)
@@ -345,14 +415,19 @@ class NemotronDuplexModel(Model):
             # last position's text + function logits (non-cache re-prefill).
             hidden = nano.llm.offline_forward(seq_embeds)      # (L, H)
             last = hidden[-1:]                                  # (1, H)
-            return nano.lm_head(last)[0], nano.function_head(last)[0]
+            return nano.lm_head(last), nano.function_head(last)  # (1, vocab) each
+
+        def sample_text(text_logits, step):
+            return _sample_text_token(
+                text_logits, gen_text, step, temperature, top_p, repetition_penalty, special_ids=special_ids,
+            )
 
         # frame 0: agent channel is BOS
         bos_emb = embed_tokens(torch.tensor([cfg.text_bos_id], device=device))  # (1, H)
         input_embeds[:, 0] = fuse(bos_emb, audio_embeds[:, 0], embed_tokens(gen_function[:, 0]))
         text_logits, function_logits = nano_step(input_embeds[0, :1])
         if prompt_len == 0:
-            gen_text[:, 0] = text_logits.argmax(-1)
+            gen_text[:, 0] = sample_text(text_logits, 0)
             gen_function[:, 0] = function_logits.argmax(-1)
 
         for t in range(1, T):
@@ -362,8 +437,7 @@ class NemotronDuplexModel(Model):
             if t < prompt_len:
                 continue  # prompt region: teacher-forced, no sampling
             text_logits, function_logits = nano_step(input_embeds[0, : t + 1])
-            # greedy (temperature==0). TODO: top-p / repetition-penalty sampling.
-            gen_text[:, t] = text_logits.argmax(-1)
+            gen_text[:, t] = sample_text(text_logits, t)
             gen_function[:, t] = function_logits.argmax(-1)
 
         result = {
@@ -371,11 +445,32 @@ class NemotronDuplexModel(Model):
             "tokens_function": gen_function,
             "prompt_len": prompt_len,
         }
-
-        # --- audio-out: talker -> RVQ codes -> codec -> waveform ---
         if decode_audio:
             result.update(self._decode_audio_path(gen_text, prompt_len, device, temperature))
         return result
+
+    def _collate(self, outs: list[dict], decode_audio: bool) -> dict:
+        """Pad + stack per-utterance results into batched tensors."""
+        pad_id = self.config.text_pad_id
+
+        def pad_last(x, n, value=0):
+            return F.pad(x, (0, n - x.shape[1]), value=value) if x.shape[1] < n else x
+
+        tmax = max(o["tokens_text"].shape[1] for o in outs)
+        res = {
+            "tokens_text": torch.cat([pad_last(o["tokens_text"], tmax, pad_id) for o in outs], dim=0),
+            "tokens_function": torch.cat([pad_last(o["tokens_function"], tmax, pad_id) for o in outs], dim=0),
+            "text": [self.tokenizer.decode(o["tokens_text"][0].tolist()) for o in outs],
+        }
+        if decode_audio and outs and "audio" in outs[0]:
+            cmax = max(o["tokens_audio"].shape[1] for o in outs)
+            res["tokens_audio"] = torch.cat(
+                [F.pad(o["tokens_audio"], (0, 0, 0, cmax - o["tokens_audio"].shape[1])) for o in outs], dim=0,
+            )
+            amax = max(o["audio"].shape[1] for o in outs)
+            res["audio"] = torch.cat([pad_last(o["audio"], amax) for o in outs], dim=0)
+            res["audio_len"] = torch.cat([o["audio_len"] for o in outs], dim=0)
+        return res
 
     def _decode_audio_path(self, gen_text, prompt_len, device, temperature):
         """Talker (autoregressive RVQ codes with char-vocab text conditioning) ->

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -48,7 +48,7 @@ from mstar.graph.special_destinations import EMIT_TO_CLIENT, EMPTY_DESTINATION
 from mstar.model.base import ForwardPassArgs, Model
 from mstar.model.nemotron_duplex.config import NemotronDuplexConfig
 from mstar.model.submodule_base import NodeSubmodule
-from mstar.streaming.chunk_policy import FixedChunkPolicy, LeftContextChunkPolicy
+from mstar.streaming.chunk_policy import FixedChunkPolicy
 from mstar.streaming.topology import Connection, PartitionTopology, StreamingGraphEdge
 from mstar.utils.sampling import SamplingConfig
 
@@ -482,16 +482,28 @@ class NemotronDuplexModel(Model):
     def get_partition_topology(self) -> PartitionTopology:
         eartts = self.config.eartts
         return PartitionTopology(partitions=["Encoder", "LLM", "Talker", "Codec"], connections=[
-            # one audio frame per nano decode step
+            # one audio frame per nano decode step. continue_after_done=False:
+            # the duplex nano text loop is 1:1 with audio frames, so when the
+            # encoder's frames are exhausted the decode loop must terminate
+            # (the final empty chunk carries is_final). continue_after_done is
+            # only for the LLM→Talker leg, where the talker keeps going past
+            # the last text token.
             Connection(from_partition="Encoder", to_partition="LLM", edge_name="audio_frame",
-                       chunk_policy_factory=lambda: FixedChunkPolicy(chunk_size=1, continue_after_done=True)),
-            # one agent token per talker step
+                       chunk_policy_factory=lambda: FixedChunkPolicy(chunk_size=1, continue_after_done=False)),
+            # one agent token per talker step. continue_after_done=False: the
+            # duplex talker emits exactly one RVQ frame per agent-text token
+            # (T tokens → T frames), so when the LLM's token stream ends the
+            # talker loop terminates via its final chunk (unlike qwen3_omni,
+            # whose talker outlives the thinker and self-stops on codec EOS).
             Connection(from_partition="LLM", to_partition="Talker", edge_name="new_token",
-                       chunk_policy_factory=lambda: FixedChunkPolicy(chunk_size=1, continue_after_done=True)),
-            # codec needs left context for its causal receptive field
+                       chunk_policy_factory=lambda: FixedChunkPolicy(chunk_size=1, continue_after_done=False)),
+            # Non-overlapping chunks of NEW codec frames; the codec keeps its
+            # own left-context (AudioCodecDecoderSubmodule), so the stream must
+            # NOT re-deliver overlap (a LeftContextChunkPolicy here re-emits the
+            # overlap every chunk and balloons the audio, and is anyway
+            # ill-defined when chunk < left_context).
             Connection(from_partition="Talker", to_partition="Codec", edge_name="codec_tokens",
-                       chunk_policy_factory=lambda: LeftContextChunkPolicy(
-                           chunk=eartts.codec_chunk_frames, left_context=eartts.codec_left_context_frames)),
+                       chunk_policy_factory=lambda: FixedChunkPolicy(chunk_size=eartts.codec_chunk_frames)),
         ])
 
     def get_aux_sampling_configs(self, node_name: str, model_kwargs: dict | None = None) -> dict:
@@ -525,10 +537,11 @@ class NemotronDuplexModel(Model):
             wav = tensors.get("audio_inputs") or tensors.get("audio_features")
             if wav:
                 out["audio_features"] = wav
-        # Seed the first decode frame's fed-back tokens (BOS / PAD): the decode-loop
-        # node requires prev_text + prev_func, but frame 0 has no prior sampled token,
-        # so without a seed it never becomes ready (the hang). [UNVERIFIED — pending a
-        # live GPU run; see E5_RESUME.md.]
+        # Seed the decode loop's iteration-0 fed-back tokens (agent-text BOS,
+        # function PAD). The frame-synchronous nano step lists prev_text /
+        # prev_func as inputs, so without these the readiness gate never fires
+        # on the first frame (no loop-back exists yet) and the decode loop
+        # hangs. Later iterations overwrite them via the loop-back edges.
         out["prev_text"] = [torch.tensor([self.config.text_bos_id], dtype=torch.long)]
         out["prev_func"] = [torch.tensor([self.config.text_pad_id], dtype=torch.long)]
         return out
@@ -579,8 +592,6 @@ class NemotronDuplexModel(Model):
         model_kwargs: dict | None = None,
     ) -> ForwardPassArgs:
         audio_out = "audio" in output_modalities
-        logger.warning("NDTRACE initial_fpa partition=%s signals=%s audio_out=%s",
-                       partition_name, list(input_signals.keys()), audio_out)
 
         if partition_name == "Encoder":
             edge = GraphEdge(next_node="conformer_encoder", name="audio_features")
@@ -600,9 +611,10 @@ class NemotronDuplexModel(Model):
                 e.tensor_info = input_signals.get("text_inputs", [])
                 edges = [e]
             else:
-                # Audio-only: start the decode loop directly, seeding frame 0's fed-back
-                # prev_text / prev_func so the node's input_names are satisfied on the
-                # first iteration (later iterations get them from the loop-back edges).
+                # No system prompt: jump straight into the frame-synchronous
+                # decode loop. Seed iteration-0's fed-back tokens (BOS / PAD)
+                # so the node is ready before any loop-back exists; the audio
+                # frames then self-trigger it via the StreamBuffer.
                 for name in ("prev_text", "prev_func"):
                     e = GraphEdge(next_node="nano_llm", name=name)
                     e.tensor_info = input_signals.get(name, [])
@@ -628,8 +640,6 @@ class NemotronDuplexModel(Model):
         incoming_connections=None,
     ) -> ForwardPassArgs:
         m = partition_metadata
-        logger.warning("NDTRACE partition_fpa partition=%s walk=%s is_prefill=%s",
-                       partition_name, m.graph_walk, m.is_prefill)
 
         if partition_name == "Encoder":                    # runs once, then done producing
             return ForwardPassArgs(full_metadata=m, inputs=[], unpersist_tensors=[], request_done=True)

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -519,9 +519,29 @@ class NemotronDuplexModel(Model):
         if prompt:
             ids = self.tokenizer(prompt, return_tensors="pt").input_ids[0].to(torch.long)
             out["text_inputs"] = [ids]
-        if tensors and "audio_features" in tensors:
-            out["audio_features"] = tensors["audio_features"]
+        # The data worker loads audio files under ``audio_inputs`` (f"{modality}_inputs");
+        # expose them as ``audio_features`` — the conformer_encoder node's input.
+        if tensors:
+            wav = tensors.get("audio_inputs") or tensors.get("audio_features")
+            if wav:
+                out["audio_features"] = wav
         return out
+
+    def load_audio(self, filepath: str, device: str):
+        """Decode an uploaded audio file to 16 kHz mono via soundfile (the base uses
+        torchcodec, whose native libs aren't always available). Returns the same
+        ``TensorAndMetadata`` shape the data worker expects."""
+        import soundfile as sf
+        from mstar.model.base import TensorAndMetadata
+
+        data, sr = sf.read(filepath, dtype="float32")
+        audio = torch.from_numpy(data)
+        if audio.dim() == 2:                       # stereo -> mono
+            audio = audio.mean(dim=-1)
+        if sr != 16000:
+            import torchaudio.functional as AF
+            audio = AF.resample(audio, sr, 16000)
+        return TensorAndMetadata(data=audio, metadata=dict(sample_rate=16000, num_channels=1))
 
     # -------------------------------------------------------------------
     # Forward-pass-args state machines — one per async partition
@@ -552,6 +572,8 @@ class NemotronDuplexModel(Model):
         model_kwargs: dict | None = None,
     ) -> ForwardPassArgs:
         audio_out = "audio" in output_modalities
+        logger.warning("NDTRACE initial_fpa partition=%s signals=%s audio_out=%s",
+                       partition_name, list(input_signals.keys()), audio_out)
 
         if partition_name == "Encoder":
             edge = GraphEdge(next_node="conformer_encoder", name="audio_features")
@@ -591,6 +613,8 @@ class NemotronDuplexModel(Model):
         incoming_connections=None,
     ) -> ForwardPassArgs:
         m = partition_metadata
+        logger.warning("NDTRACE partition_fpa partition=%s walk=%s is_prefill=%s",
+                       partition_name, m.graph_walk, m.is_prefill)
 
         if partition_name == "Encoder":                    # runs once, then done producing
             return ForwardPassArgs(full_metadata=m, inputs=[], unpersist_tensors=[], request_done=True)

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -513,18 +513,35 @@ class NemotronDuplexModel(Model):
         tensors: NameToTensorList | None = None,
         **kwargs,
     ) -> NameToTensorList:
-        # Phase 4: when audio is in ``input_modalities``, run the conformer
-        # encoder path to derive ``combined_embeds`` from ``audio_inputs``.
-        if "audio" in input_modalities:
-            raise NotImplementedError("Audio input (conformer encoder) — Phase 4.")
-        if prompt is None:
-            return {}
-        ids = self.tokenizer(prompt, return_tensors="pt").input_ids[0].to(torch.long)
-        return {"text_inputs": [ids]}
+        # Duplex request: raw user audio (-> Encoder partition) plus an optional
+        # system-prompt text that primes the nano cache (prefill_text).
+        out: NameToTensorList = {}
+        if prompt:
+            ids = self.tokenizer(prompt, return_tensors="pt").input_ids[0].to(torch.long)
+            out["text_inputs"] = [ids]
+        if tensors and "audio_features" in tensors:
+            out["audio_features"] = tensors["audio_features"]
+        return out
 
     # -------------------------------------------------------------------
-    # Forward-pass-args state machine (single "default" partition, text path)
+    # Forward-pass-args state machines — one per async partition
+    # (Encoder -> LLM -> Talker -> Codec), mirroring qwen3_omni.
     # -------------------------------------------------------------------
+
+    def _meta(self, imod, omod, walk, is_prefill):
+        return CurrentForwardConductorMetadata(
+            input_modalities=imod, output_modalities=omod, graph_walk=walk, is_prefill=is_prefill,
+        )
+
+    @staticmethod
+    def _stream_exhausted(incoming_connections, edge_name: str) -> bool:
+        """A consumer partition is done once its upstream producer is finished and
+        every streamed token has been consumed."""
+        for c in incoming_connections or []:
+            if getattr(c, "edge_name", None) == edge_name:
+                return bool(getattr(c, "producer_done", False)) and \
+                    getattr(c, "consumed_count", 0) >= getattr(c, "token_count", 0)
+        return False
 
     def get_initial_forward_pass_args(
         self,
@@ -534,21 +551,37 @@ class NemotronDuplexModel(Model):
         input_signals: dict[str, list[TensorPointerInfo]],
         model_kwargs: dict | None = None,
     ) -> ForwardPassArgs:
-        full_metadata = CurrentForwardConductorMetadata(
-            input_modalities=input_modalities,
-            output_modalities=output_modalities,
-            graph_walk="prefill_text",
-            is_prefill=True,
-        )
-        graph_edge = GraphEdge(next_node="nano_llm", name="text_inputs")
-        graph_edge.tensor_info = input_signals.get("text_inputs", [])
-        inputs = [graph_edge]
-        return ForwardPassArgs(
-            full_metadata=full_metadata,
-            inputs=inputs,
-            unpersist_tensors=sum([inp.tensor_info for inp in inputs], start=[]),
-            step_metadata={"is_prefill": True},
-        )
+        audio_out = "audio" in output_modalities
+
+        if partition_name == "Encoder":
+            edge = GraphEdge(next_node="conformer_encoder", name="audio_features")
+            edge.tensor_info = input_signals.get("audio_features", [])
+            return ForwardPassArgs(
+                full_metadata=self._meta(input_modalities, output_modalities, "encode", True),
+                inputs=[edge], unpersist_tensors=list(edge.tensor_info), step_metadata={},
+            )
+        if partition_name == "LLM":
+            # System prompt (if any) primes the cache first; else jump straight into
+            # the frame-synchronous decode loop, self-triggered by the audio stream.
+            has_prompt = bool(input_signals.get("text_inputs"))
+            walk = "prefill_text" if has_prompt else "decode"
+            edges = []
+            if has_prompt:
+                e = GraphEdge(next_node="nano_llm", name="text_inputs")
+                e.tensor_info = input_signals.get("text_inputs", [])
+                edges = [e]
+            return ForwardPassArgs(
+                full_metadata=self._meta(input_modalities, output_modalities, walk, has_prompt),
+                inputs=edges, unpersist_tensors=sum([e.tensor_info for e in edges], start=[]),
+                step_metadata={"is_prefill": has_prompt},
+            )
+        if partition_name in ("Talker", "Codec"):
+            walk = "talker_decode" if partition_name == "Talker" else "codec_chunk"
+            return ForwardPassArgs(
+                full_metadata=self._meta(input_modalities, output_modalities, walk, False),
+                inputs=[], unpersist_tensors=[], request_done=not audio_out,
+            )
+        raise ValueError(f"Unknown partition: {partition_name!r}")
 
     def get_partition_forward_pass_args(
         self,
@@ -557,29 +590,34 @@ class NemotronDuplexModel(Model):
         persist_signals: dict[str, list[TensorPointerInfo]],
         incoming_connections=None,
     ) -> ForwardPassArgs:
-        metadata = partition_metadata
-        request_done = False
-        if metadata.is_prefill:
-            metadata.is_prefill = False
-            metadata.graph_walk = "decode"
-        elif metadata.graph_walk == "decode":
-            request_done = True
-            metadata.kwargs["decode_finished"] = True
+        m = partition_metadata
 
-        if request_done:
+        if partition_name == "Encoder":                    # runs once, then done producing
+            return ForwardPassArgs(full_metadata=m, inputs=[], unpersist_tensors=[], request_done=True)
+
+        if partition_name == "LLM":
+            if m.is_prefill:                               # prefill_text -> decode
+                m.is_prefill = False
+                m.graph_walk = "decode"
+            done = self._stream_exhausted(incoming_connections, "audio_frame")
+            edges = []
+            for name in ("prev_text", "prev_func"):        # fed-back tokens for AddFusion
+                e = GraphEdge(next_node="nano_llm", name=name)
+                e.tensor_info = persist_signals.get(name, [])
+                edges.append(e)
             return ForwardPassArgs(
-                full_metadata=metadata, inputs=[], unpersist_tensors=[], request_done=True,
+                full_metadata=m, inputs=edges,
+                unpersist_tensors=sum([e.tensor_info for e in edges], start=[]),
+                request_done=done, step_metadata={"is_prefill": False},
             )
 
-        graph_edge = GraphEdge(next_node="nano_llm", name="text_inputs")
-        graph_edge.tensor_info = persist_signals.get("new_token", [])
-        inputs = [graph_edge]
-        return ForwardPassArgs(
-            full_metadata=metadata,
-            inputs=inputs,
-            unpersist_tensors=sum([inp.tensor_info for inp in inputs], start=[]),
-            step_metadata={"is_prefill": metadata.is_prefill},
-        )
+        if partition_name in ("Talker", "Codec"):          # self-triggered by the upstream stream
+            stream = "new_token" if partition_name == "Talker" else "codec_tokens"
+            return ForwardPassArgs(
+                full_metadata=m, inputs=[], unpersist_tensors=[],
+                request_done=self._stream_exhausted(incoming_connections, stream),
+            )
+        raise ValueError(f"Unknown partition: {partition_name!r}")
 
     # -------------------------------------------------------------------
     # Sampling

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -40,7 +40,7 @@ import torch
 import torch.nn.functional as F
 
 from mstar.communication.tensors import NameToTensorList
-from mstar.conductor.request_info import CurrentForwardConductorMetadata
+from mstar.conductor.request_info import CurrentForwardConductorMetadata, PartitionDefinition
 from mstar.engine.base import EngineType
 from mstar.engine.kv_cache_engine import KVCacheConfig
 from mstar.graph.base import GraphEdge, GraphNode, GraphSection, Loop, TensorPointerInfo
@@ -48,6 +48,8 @@ from mstar.graph.special_destinations import EMIT_TO_CLIENT, EMPTY_DESTINATION
 from mstar.model.base import ForwardPassArgs, Model
 from mstar.model.nemotron_duplex.config import NemotronDuplexConfig
 from mstar.model.submodule_base import NodeSubmodule
+from mstar.streaming.chunk_policy import FixedChunkPolicy, LeftContextChunkPolicy
+from mstar.streaming.topology import Connection, PartitionTopology, StreamingGraphEdge
 from mstar.utils.sampling import SamplingConfig
 
 logger = logging.getLogger(__name__)
@@ -388,58 +390,116 @@ class NemotronDuplexModel(Model):
     # -------------------------------------------------------------------
 
     def get_graph_walk_graphs(self) -> dict[str, GraphSection]:
+        """Full-duplex S2S pipeline as four async partitions (frame-synchronous):
+
+            Encoder --[audio_frame, FixedChunk(1)]--> LLM
+            LLM     --[new_token,   FixedChunk(1)]--> Talker
+            Talker  --[codec_tokens, LeftContext ]--> Codec
+
+        The LLM (nano) is a frame-driven decode loop: each iteration fuses one
+        streamed audio frame with the fed-back previous agent-text/function tokens
+        (AddFusion), samples the next agent text (main) + function (aux) token, emits
+        the text to the client, streams it to the talker, and feeds both back. An
+        optional system-prompt ``prefill_text`` primes the nano cache first.
+        """
+        # Encoder: audio chunk -> per-frame embeds, streamed one frame per LLM step.
+        encode = GraphNode(
+            name="conformer_encoder",
+            input_names=["audio_features"],
+            outputs=[StreamingGraphEdge(next_node="nano_llm", name="audio_frame", target_partition="LLM")],
+        )
+        # LLM: optional bulk system-prompt prefill (primes cache; persists the carry-in
+        # prev_text / prev_func), then the frame-synchronous decode loop.
         prefill_text = GraphNode(
             name="nano_llm",
             input_names=["text_inputs"],
             outputs=[
-                GraphEdge(
-                    next_node=EMPTY_DESTINATION,
-                    name="new_token",
-                    conductor_new_token=True,
-                    persist=True,
-                ),
+                GraphEdge(next_node=EMPTY_DESTINATION, name="prev_text", persist=True),
+                GraphEdge(next_node=EMPTY_DESTINATION, name="prev_func", persist=True),
             ],
         )
         decode = Loop(
             name="decode_loop",
             section=GraphNode(
                 name="nano_llm",
-                input_names=["text_inputs"],
+                input_names=["audio_frame", "prev_text", "prev_func"],
+                consumes_stream=True,
                 outputs=[
-                    GraphEdge(next_node="nano_llm", name="text_inputs"),
-                    GraphEdge(
-                        next_node=EMIT_TO_CLIENT,
-                        name="new_token",
-                        output_modality="text",
-                        conductor_new_token=True,
-                    ),
+                    GraphEdge(next_node=EMIT_TO_CLIENT, name="new_token",
+                              output_modality="text", conductor_new_token=True),
+                    GraphEdge(next_node="nano_llm", name="prev_text"),   # fed-back agent text
+                    GraphEdge(next_node="nano_llm", name="prev_func"),   # fed-back function
+                    StreamingGraphEdge(next_node="eartts_talker", name="new_token",
+                                       target_partition="Talker"),
                 ],
             ),
             max_iters=self.get_max_output_tokens(),
             outputs=[],
         )
-        return dict(prefill_text=prefill_text, decode=decode)
+        # Talker: each streamed agent token -> RVQ codes, streamed to the codec.
+        talker_decode = Loop(
+            name="talker_decode_loop",
+            section=GraphNode(
+                name="eartts_talker",
+                input_names=["new_token"],
+                consumes_stream=True,
+                outputs=[StreamingGraphEdge(next_node="audio_codec", name="codec_tokens",
+                                            target_partition="Codec")],
+            ),
+            max_iters=self.get_max_output_tokens(),
+            outputs=[],
+        )
+        # Codec: code window -> 22.05 kHz PCM chunk -> client.
+        codec_chunk = GraphNode(
+            name="audio_codec",
+            input_names=["codec_tokens"],
+            consumes_stream=True,
+            outputs=[GraphEdge(next_node=EMIT_TO_CLIENT, name="audio_chunk", output_modality="audio")],
+        )
+        return dict(encode=encode, prefill_text=prefill_text, decode=decode,
+                    talker_decode=talker_decode, codec_chunk=codec_chunk)
 
-    @staticmethod
-    def _duplex_design() -> str:
-        """Phase 6 target (documentation only).
+    def get_partitions(self) -> list[PartitionDefinition]:
+        return [
+            PartitionDefinition(
+                name="Encoder", graph_walks={"encode"}, initial_walk="encode",
+                producer_partitions=[],
+            ),
+            PartitionDefinition(
+                name="LLM", graph_walks={"prefill_text", "decode"}, initial_walk="prefill_text",
+                producer_partitions=["Encoder"],
+            ),
+            PartitionDefinition(
+                name="Talker", graph_walks={"talker_decode"}, initial_walk="talker_decode",
+                producer_partitions=["LLM"],
+            ),
+            PartitionDefinition(
+                name="Codec", graph_walks={"codec_chunk"}, initial_walk="codec_chunk",
+                producer_partitions=["Talker"],
+            ),
+        ]
 
-        Nodes/partitions:
-            ENC  partition: conformer_encoder  (prefill_audio) — emits
-                 ``combined_embeds`` -> nano_llm and streaming ``transcript_token``
-                 -> EMIT_TO_CLIENT (modality "text").
-            LLM  partition: nano_llm (prefill_text | prefill_audio | decode) —
-                 streams ``new_token`` (agent text) to the client and a talker
-                 conditioning signal to the TTS partition via StreamingGraphEdge.
-            TTS  partition: eartts_talker (tts_decode Loop) -> audio_codec
-                 (codec_chunk) -> EMIT_TO_CLIENT (modality "audio"), with a
-                 SlidingWindowChunkPolicy on the talker->codec connection
-                 (Orpheus pattern) for low-latency 22.05 kHz output.
+    def get_partition_topology(self) -> PartitionTopology:
+        eartts = self.config.eartts
+        return PartitionTopology(partitions=["Encoder", "LLM", "Talker", "Codec"], connections=[
+            # one audio frame per nano decode step
+            Connection(from_partition="Encoder", to_partition="LLM", edge_name="audio_frame",
+                       chunk_policy_factory=lambda: FixedChunkPolicy(chunk_size=1, continue_after_done=True)),
+            # one agent token per talker step
+            Connection(from_partition="LLM", to_partition="Talker", edge_name="new_token",
+                       chunk_policy_factory=lambda: FixedChunkPolicy(chunk_size=1, continue_after_done=True)),
+            # codec needs left context for its causal receptive field
+            Connection(from_partition="Talker", to_partition="Codec", edge_name="codec_tokens",
+                       chunk_policy_factory=lambda: LeftContextChunkPolicy(
+                           chunk=eartts.codec_chunk_frames, left_context=eartts.codec_left_context_frames)),
+        ])
 
-        Requires overriding get_partition_topology / get_partitions and routing
-        cross-partition tensors with StreamingGraphEdge (target_partition=...).
-        """
-        return "see docstring"
+    def get_aux_sampling_configs(self, node_name: str, model_kwargs: dict | None = None) -> dict:
+        # The nano samples a second (function) token per frame alongside agent text;
+        # it is fed back into the next frame's AddFusion. Greedy (like the reference).
+        if node_name == "nano_llm":
+            return {"function": SamplingConfig(temperature=0.0)}
+        return {}
 
     # -------------------------------------------------------------------
     # Prompt processing

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -164,6 +164,10 @@ class DuplexStream:
         self._codes_hist = None                # (1, n, num_q) accumulated RVQ codes
         self._emitted = 0                      # waveform samples already emitted
         self._t = 0
+        # Dedicated seeded RNG for the talker's stochastic MoG sampling — keeps the
+        # audio reproducible and off the rare collapse-to-constant-code states an
+        # uncontrolled global RNG hits (mirrors the reference's manual_seed).
+        self._talker_gen = torch.Generator(device=self.device).manual_seed(self.cfg.eartts.inference_seed)
         self._prime_prompt()                   # feed the system prompt (if any) first
 
     @torch.no_grad()
@@ -275,6 +279,7 @@ class DuplexStream:
             guidance_scale=cfg.eartts.inference_guidance_scale,
             noise_scale=cfg.eartts.inference_noise_scale,
             top_p=cfg.eartts.inference_top_p,
+            generator=self._talker_gen,
         )
         self._prev_codes = codes
         # Codec has a multi-frame (causal) receptive field, so decode the full code
@@ -713,10 +718,12 @@ class NemotronDuplexModel(Model):
         codec = self.get_submodule("audio_codec", device=device).codec
         text_stream = gen_text[:, prompt_len:]                 # (1, T') agent text per frame
 
+        gen = torch.Generator(device=device).manual_seed(self.config.eartts.inference_seed)
         gen_codes = talker.generate_codes(
             text_stream, self._talker_tokenizer(), speaker="Aria", temperature=temperature,
             text_eos_id=self.config.text_eos_id, text_pad_id=self.config.text_pad_id,
             speech_pad_id=self.config.eartts.codebook_size,   # speech-pad frame == all codebook_size
+            generator=gen,
         )                                                       # (1, T', num_q)
         code_len = torch.tensor([gen_codes.shape[1]], device=device)
         with torch.autocast(device_type="cuda", enabled=False):

--- a/mstar/model/nemotron_duplex/nemotron_duplex_model.py
+++ b/mstar/model/nemotron_duplex/nemotron_duplex_model.py
@@ -1,0 +1,346 @@
+"""NemotronDuplexModel — NVIDIA NemotronLabs VoiceChat-11B in M*.
+
+A half-duplex speech-to-speech model with three stages:
+
+    conformer_encoder (STATELESS) — 16 kHz speech → fused embeds + RNN-T transcript
+    nano_llm          (KV_CACHE)  — Nemotron-H hybrid Mamba-2/attn/MLP backbone (9B)
+    eartts_talker     (KV_CACHE)  — Gemma3 talker → 31-codebook RVQ codes
+    audio_codec       (STATELESS) — RVQ codes → 22.05 kHz PCM
+
+Input:  text prompt + user speech.  Output: agent text + agent speech +
+streaming user transcription.
+
+PHASING (agreed): this draft wires the **text path** end-to-end
+(``prefill_text`` → ``decode``) so the Nemotron-H backbone can be brought up and
+verified against the HF reference first. The audio nodes are declared and their
+submodules stubbed; the full duplex graph + async partitions (encoder →
+nano_llm → talker → codec, with ``StreamingGraphEdge`` fan-out of transcript /
+text / audio) is the Phase 6 extension sketched in ``_duplex_design`` below.
+
+Contract methods crib from ``mstar/model/orpheus/orpheus_model.py`` (single
+streaming LLM+codec) and ``mstar/model/qwen3_omni/qwen3_omni_model.py`` (omni,
+multi-KV, aux sampling, async partitions).
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import torch
+
+from mstar.communication.tensors import NameToTensorList
+from mstar.conductor.request_info import CurrentForwardConductorMetadata
+from mstar.engine.base import EngineType
+from mstar.engine.kv_cache_engine import KVCacheConfig
+from mstar.graph.base import GraphEdge, GraphNode, GraphSection, Loop, TensorPointerInfo
+from mstar.graph.special_destinations import EMIT_TO_CLIENT, EMPTY_DESTINATION
+from mstar.model.base import ForwardPassArgs, Model
+from mstar.model.nemotron_duplex.config import NemotronDuplexConfig
+from mstar.model.submodule_base import NodeSubmodule
+from mstar.utils.sampling import SamplingConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_local_hf_snapshot(repo_id: str, cache_dir: str | None = None) -> str:
+    from huggingface_hub import snapshot_download
+
+    try:
+        local_dir = snapshot_download(repo_id=repo_id, cache_dir=cache_dir, local_files_only=False)
+    except Exception as e:  # noqa: BLE001 - fall back to the raw id, mirrors Orpheus
+        logger.warning("Error downloading %s from huggingface: %s", repo_id, e)
+        return repo_id
+    return str(Path(local_dir))
+
+
+class NemotronDuplexModel(Model):
+    """NVIDIA NemotronLabs VoiceChat-11B (duplex S2S)."""
+
+    def __init__(self, model_path_hf: str, cache_dir: str | None = None, **kwargs):
+        self.model_path_hf = model_path_hf
+        self.cache_dir = cache_dir
+        self.config = NemotronDuplexConfig()
+        self._tokenizer = None  # lazy — not needed in dummy mode
+        self._submodule_cache: dict[str, NodeSubmodule | None] = {}
+
+    @property
+    def tokenizer(self):
+        # TODO(verify): confirm the text tokenizer source. The Spark repo ships
+        # it under ``nano/``; the base repo ships only ``rnnt_tokenizer/`` (the
+        # ASR head). Loaded lazily so dummy-mode tests never touch the network.
+        if self._tokenizer is None:
+            from transformers import AutoTokenizer
+
+            src = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
+            self._tokenizer = AutoTokenizer.from_pretrained(src, trust_remote_code=True)
+        return self._tokenizer
+
+    # -------------------------------------------------------------------
+    # KV cache config — nano_llm (attention layers only) + eartts_talker
+    # -------------------------------------------------------------------
+
+    def get_kv_cache_config(self) -> list[KVCacheConfig]:
+        nano = self.config.nano
+        eartts = self.config.eartts
+        return [
+            KVCacheConfig(
+                # Only the ``*`` (attention) layers hold a KV cache; the Mamba
+                # and MLP layers do not. The submodule maps global layer -> this
+                # dense attention index.
+                num_layers=nano.num_attention_layers,
+                num_kv_heads=nano.num_key_value_heads,
+                head_dim=nano.head_dim,
+                max_seq_len=nano.max_position_embeddings,
+                num_qo_heads=nano.num_attention_heads,
+                nodes=["nano_llm"],
+            ),
+            # Phase 5 — declared now so layout is stable; only used once the
+            # talker submodule is implemented.
+            KVCacheConfig(
+                num_layers=eartts.num_hidden_layers,
+                num_kv_heads=eartts.num_key_value_heads,
+                head_dim=eartts.head_dim,
+                max_seq_len=nano.max_position_embeddings,
+                num_qo_heads=eartts.num_attention_heads,
+                nodes=["eartts_talker"],
+            ),
+        ]
+
+    def get_node_engine_types(self) -> dict[str, EngineType]:
+        return {
+            "conformer_encoder": EngineType.STATELESS,  # Phase 4
+            "nano_llm": EngineType.KV_CACHE,            # implemented (text path)
+            "eartts_talker": EngineType.KV_CACHE,        # Phase 5
+            "audio_codec": EngineType.STATELESS,        # Phase 5
+        }
+
+    # -------------------------------------------------------------------
+    # Graph walks. Text path is live; audio walks are Phase 6 (see design note).
+    # -------------------------------------------------------------------
+
+    def get_graph_walk_graphs(self) -> dict[str, GraphSection]:
+        prefill_text = GraphNode(
+            name="nano_llm",
+            input_names=["text_inputs"],
+            outputs=[
+                GraphEdge(
+                    next_node=EMPTY_DESTINATION,
+                    name="new_token",
+                    conductor_new_token=True,
+                    persist=True,
+                ),
+            ],
+        )
+        decode = Loop(
+            name="decode_loop",
+            section=GraphNode(
+                name="nano_llm",
+                input_names=["text_inputs"],
+                outputs=[
+                    GraphEdge(next_node="nano_llm", name="text_inputs"),
+                    GraphEdge(
+                        next_node=EMIT_TO_CLIENT,
+                        name="new_token",
+                        output_modality="text",
+                        conductor_new_token=True,
+                    ),
+                ],
+            ),
+            max_iters=self.get_max_output_tokens(),
+            outputs=[],
+        )
+        return dict(prefill_text=prefill_text, decode=decode)
+
+    @staticmethod
+    def _duplex_design() -> str:
+        """Phase 6 target (documentation only).
+
+        Nodes/partitions:
+            ENC  partition: conformer_encoder  (prefill_audio) — emits
+                 ``combined_embeds`` -> nano_llm and streaming ``transcript_token``
+                 -> EMIT_TO_CLIENT (modality "text").
+            LLM  partition: nano_llm (prefill_text | prefill_audio | decode) —
+                 streams ``new_token`` (agent text) to the client and a talker
+                 conditioning signal to the TTS partition via StreamingGraphEdge.
+            TTS  partition: eartts_talker (tts_decode Loop) -> audio_codec
+                 (codec_chunk) -> EMIT_TO_CLIENT (modality "audio"), with a
+                 SlidingWindowChunkPolicy on the talker->codec connection
+                 (Orpheus pattern) for low-latency 22.05 kHz output.
+
+        Requires overriding get_partition_topology / get_partitions and routing
+        cross-partition tensors with StreamingGraphEdge (target_partition=...).
+        """
+        return "see docstring"
+
+    # -------------------------------------------------------------------
+    # Prompt processing
+    # -------------------------------------------------------------------
+
+    def process_prompt(
+        self,
+        prompt: str | None,
+        input_modalities: list[str],
+        output_modalities: list[str],
+        tensors: NameToTensorList | None = None,
+        **kwargs,
+    ) -> NameToTensorList:
+        # Phase 4: when audio is in ``input_modalities``, run the conformer
+        # encoder path to derive ``combined_embeds`` from ``audio_inputs``.
+        if "audio" in input_modalities:
+            raise NotImplementedError("Audio input (conformer encoder) — Phase 4.")
+        if prompt is None:
+            return {}
+        ids = self.tokenizer(prompt, return_tensors="pt").input_ids[0].to(torch.long)
+        return {"text_inputs": [ids]}
+
+    # -------------------------------------------------------------------
+    # Forward-pass-args state machine (single "default" partition, text path)
+    # -------------------------------------------------------------------
+
+    def get_initial_forward_pass_args(
+        self,
+        partition_name: str,
+        input_modalities: list[str],
+        output_modalities: list[str],
+        input_signals: dict[str, list[TensorPointerInfo]],
+        model_kwargs: dict | None = None,
+    ) -> ForwardPassArgs:
+        full_metadata = CurrentForwardConductorMetadata(
+            input_modalities=input_modalities,
+            output_modalities=output_modalities,
+            graph_walk="prefill_text",
+            is_prefill=True,
+        )
+        graph_edge = GraphEdge(next_node="nano_llm", name="text_inputs")
+        graph_edge.tensor_info = input_signals.get("text_inputs", [])
+        inputs = [graph_edge]
+        return ForwardPassArgs(
+            full_metadata=full_metadata,
+            inputs=inputs,
+            unpersist_tensors=sum([inp.tensor_info for inp in inputs], start=[]),
+            step_metadata={"is_prefill": True},
+        )
+
+    def get_partition_forward_pass_args(
+        self,
+        partition_name: str,
+        partition_metadata: CurrentForwardConductorMetadata,
+        persist_signals: dict[str, list[TensorPointerInfo]],
+        incoming_connections=None,
+    ) -> ForwardPassArgs:
+        metadata = partition_metadata
+        request_done = False
+        if metadata.is_prefill:
+            metadata.is_prefill = False
+            metadata.graph_walk = "decode"
+        elif metadata.graph_walk == "decode":
+            request_done = True
+            metadata.kwargs["decode_finished"] = True
+
+        if request_done:
+            return ForwardPassArgs(
+                full_metadata=metadata, inputs=[], unpersist_tensors=[], request_done=True,
+            )
+
+        graph_edge = GraphEdge(next_node="nano_llm", name="text_inputs")
+        graph_edge.tensor_info = persist_signals.get("new_token", [])
+        inputs = [graph_edge]
+        return ForwardPassArgs(
+            full_metadata=metadata,
+            inputs=inputs,
+            unpersist_tensors=sum([inp.tensor_info for inp in inputs], start=[]),
+            step_metadata={"is_prefill": metadata.is_prefill},
+        )
+
+    # -------------------------------------------------------------------
+    # Sampling
+    # -------------------------------------------------------------------
+
+    def get_sampling_config(self, node_name: str, model_kwargs: dict | None = None) -> SamplingConfig | None:
+        if node_name != "nano_llm":
+            return None  # eartts_talker sampling: Phase 5 (+ get_aux_sampling_configs)
+        model_kwargs = model_kwargs or {}
+        keys = ["temperature", "top_p", "repetition_penalty", "ignore_eos"]
+        params = {k: model_kwargs.get(k, getattr(self.config, k)) for k in keys}
+        return SamplingConfig(vocab_size=self.config.vocab_size, **params)
+
+    def get_output_sample_rate(self, modality: str = "audio") -> int:
+        return self.config.eartts.sample_rate
+
+    # -------------------------------------------------------------------
+    # Postprocess
+    # -------------------------------------------------------------------
+
+    def postprocess(self, output: torch.Tensor, modality: str, **kwargs) -> bytes:
+        if modality == "text":
+            token_ids = output.tolist() if output.dim() else [int(output)]
+            return self.tokenizer.decode(token_ids).encode("utf-8")
+        if modality == "audio":
+            if output.numel() == 0:
+                return b""
+            return output.cpu().numpy().tobytes()
+        raise ValueError(f"Unsupported modality for NemotronDuplex: {modality!r}")
+
+    # -------------------------------------------------------------------
+    # Sharding — nano_llm attention/MLP are TP-eligible (Phase 10).
+    # -------------------------------------------------------------------
+
+    def get_default_sharding_config(self):
+        from mstar.distributed.base import ShardingConfig
+
+        # TODO(Phase 10): Mamba layers need head-sharded state; declare TP only
+        # after the components are built from the distributed linears.
+        return ShardingConfig(groups=[], tp_enabled_nodes=set(), shard_dim={})
+
+    # -------------------------------------------------------------------
+    # Submodule loading
+    # -------------------------------------------------------------------
+
+    def get_submodule(
+        self,
+        node_name: str,
+        device: str = "cpu",
+        tp_group=None,
+        autocast_dtype: torch.dtype | None = None,
+        **kwargs,
+    ) -> NodeSubmodule | None:
+        if node_name in self._submodule_cache:
+            return self._submodule_cache[node_name]
+        submodule = self._create_submodule(node_name, device, autocast_dtype=autocast_dtype)
+        self._submodule_cache[node_name] = submodule
+        return submodule
+
+    def _create_submodule(
+        self, node_name: str, device: str, autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule | None:
+        if node_name == "nano_llm":
+            return self._create_nano_submodule(device, autocast_dtype=autocast_dtype)
+        # Audio nodes: Phase 4/5 — dummy mode (None) keeps the text path runnable.
+        if node_name in ("conformer_encoder", "eartts_talker", "audio_codec"):
+            logger.warning("Submodule %s not implemented yet (Phase 4/5) — dummy mode.", node_name)
+            return None
+        return None
+
+    def _create_nano_submodule(
+        self, device: str, autocast_dtype: torch.dtype | None = None,
+    ) -> NodeSubmodule:
+        from mstar.model.loader import load_weights
+        from mstar.model.nemotron_duplex.components.nemotron_h import NemotronHForCausalLM
+        from mstar.model.nemotron_duplex.submodules import NemotronHLLMSubmodule
+
+        local_dir = _resolve_local_hf_snapshot(self.model_path_hf, cache_dir=self.cache_dir)
+
+        with torch.device("meta"):
+            language_model = NemotronHForCausalLM(self.config.nano)
+        if autocast_dtype is not None:
+            language_model = language_model.to(autocast_dtype)
+        language_model.to_empty(device=device)
+
+        # TODO(verify): the base checkpoint is a single composite ``model.safetensors``;
+        # confirm the weight-name prefix for the nano stage (e.g. ``nano.`` /
+        # ``model.``) and extend the component's name_remapper accordingly before
+        # this load succeeds.
+        load_weights(language_model, local_dir, device=device)
+        language_model.eval()
+
+        return NemotronHLLMSubmodule(language_model=language_model, config=self.config)

--- a/mstar/model/nemotron_duplex/realtime_api.py
+++ b/mstar/model/nemotron_duplex/realtime_api.py
@@ -1,0 +1,157 @@
+"""OpenAI Realtime-API-compatible WebSocket server for the Nemotron VoiceChat
+duplex model (Phase C).
+
+This is a thin protocol layer over the model's *streaming* duplex inference
+(Phase B / ``NemotronDuplexModel.create_stream``). It speaks a subset of the
+OpenAI Realtime API events so existing Realtime clients can talk to it:
+
+  client -> server:
+    - session.update                      (config: voice, output/ input formats)
+    - input_audio_buffer.append           (base64 PCM16 mono @ input_sample_rate)
+    - input_audio_buffer.commit / clear
+    - response.create / response.cancel
+
+  server -> client:
+    - session.created / session.updated
+    - response.created
+    - response.audio.delta                (base64 PCM16 @ 24k -> here 22.05k)
+    - response.audio_transcript.delta     (agent text, streamed)
+    - response.audio.done / response.done
+    - error
+
+The model is *full-duplex*: it consumes user audio continuously and emits agent
+audio+text as it generates, so we run in a server-VAD-like continuous mode —
+every appended audio chunk is fed to the stream and any generated agent
+audio/transcript is pushed back as deltas. Turn boundaries (barge-in / end of
+utterance) come from the model's own RNN-T turn signals when available.
+
+Run: ``python -m mstar.model.nemotron_duplex.realtime_api --host 0.0.0.0 --port 8000``
+(requires ``fastapi`` + ``uvicorn``). The heavy model streaming lives in the
+model; this file only does event framing.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+# 80 ms/frame; the model emits agent audio at the codec sample rate (22.05 kHz).
+DEFAULT_INPUT_SR = 16000
+DEFAULT_OUTPUT_SR = 22050
+
+
+class RealtimeConnection:
+    """Per-WebSocket session: bridges Realtime events to a model duplex stream.
+
+    ``stream`` is a ``DuplexStream`` from ``NemotronDuplexModel.create_stream``
+    (Phase B), exposing:
+        - ``append_audio(pcm_int16_bytes) -> list[Output]`` where each ``Output``
+          has ``.audio`` (int16 bytes @ output_sr) and/or ``.text`` (str delta),
+        - ``reset()``.
+    """
+
+    def __init__(self, model, send_json, send_defaults: dict | None = None):
+        self.model = model
+        self.send_json = send_json                 # async callable(dict)
+        self.cfg = {
+            "voice": "Aria",
+            "input_audio_format": "pcm16",
+            "output_audio_format": "pcm16",
+            "input_sample_rate": DEFAULT_INPUT_SR,
+            "output_sample_rate": DEFAULT_OUTPUT_SR,
+            "temperature": 0.0,
+            **(send_defaults or {}),
+        }
+        self.stream = None
+        self._response_open = False
+
+    async def start(self):
+        self.stream = self.model.create_stream(
+            voice=self.cfg["voice"], temperature=self.cfg["temperature"],
+        )
+        await self.send_json({"type": "session.created", "session": self.cfg})
+
+    async def handle(self, event: dict):
+        et = event.get("type")
+        if et == "session.update":
+            self.cfg.update(event.get("session", {}))
+            await self.send_json({"type": "session.updated", "session": self.cfg})
+        elif et == "input_audio_buffer.append":
+            pcm = base64.b64decode(event["audio"])
+            await self._consume(self.stream.append_audio(pcm))
+        elif et == "input_audio_buffer.commit":
+            await self._consume(self.stream.flush())
+            await self._finish_response()
+        elif et == "input_audio_buffer.clear":
+            self.stream.reset()
+        elif et == "response.cancel":
+            self.stream.reset()
+            await self._finish_response()
+        elif et in ("response.create", "session.close"):
+            pass  # continuous mode: responses stream as audio arrives
+        else:
+            await self.send_json({"type": "error", "error": {"message": f"unhandled event {et!r}"}})
+
+    async def _consume(self, outputs):
+        """Push generated agent audio/text deltas from a stream step."""
+        for out in outputs or ():
+            if not self._response_open:
+                self._response_open = True
+                await self.send_json({"type": "response.created"})
+            if getattr(out, "text", None):
+                await self.send_json({"type": "response.audio_transcript.delta", "delta": out.text})
+            if getattr(out, "audio", None):
+                await self.send_json({
+                    "type": "response.audio.delta",
+                    "delta": base64.b64encode(out.audio).decode("ascii"),
+                })
+
+    async def _finish_response(self):
+        if self._response_open:
+            await self.send_json({"type": "response.audio.done"})
+            await self.send_json({"type": "response.done"})
+            self._response_open = False
+
+
+def build_app(model):
+    """Build a FastAPI app exposing ``/v1/realtime`` for the given loaded model."""
+    from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+    app = FastAPI()
+
+    @app.websocket("/v1/realtime")
+    async def realtime(ws: WebSocket):
+        await ws.accept()
+        conn = RealtimeConnection(model, ws.send_json)
+        await conn.start()
+        try:
+            while True:
+                conn_event = await ws.receive_text()
+                await conn.handle(json.loads(conn_event))
+        except WebSocketDisconnect:
+            logger.info("realtime client disconnected")
+
+    return app
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Nemotron VoiceChat OpenAI-Realtime server")
+    ap.add_argument("--model", default="nemotron_duplex")
+    ap.add_argument("--host", default="0.0.0.0")
+    ap.add_argument("--port", type=int, default=8000)
+    ap.add_argument("--device", default="cuda")
+    args = ap.parse_args()
+
+    import uvicorn
+
+    from mstar.model.registry import HF_MODELS, get_model_class
+    model = get_model_class(args.model)(**HF_MODELS[args.model])
+    model.prepare_streaming(device=args.device)  # warm the submodules (Phase B)
+    uvicorn.run(build_app(model), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/mstar/model/nemotron_duplex/realtime_api.py
+++ b/mstar/model/nemotron_duplex/realtime_api.py
@@ -67,28 +67,49 @@ class RealtimeConnection:
         }
         self.stream = None
         self._response_open = False
+        self._consumed_audio = False           # any user audio fed yet?
 
-    async def start(self):
+    def _open_stream(self):
+        """(Re)create the duplex stream, priming the current system prompt."""
         self.stream = self.model.create_stream(
             voice=self.cfg["voice"], temperature=self.cfg["temperature"],
+            system_prompt=self.cfg.get("instructions"),
         )
+        self._consumed_audio = False
+
+    async def start(self):
+        self._open_stream()
         await self.send_json({"type": "session.created", "session": self.cfg})
 
     async def handle(self, event: dict):
         et = event.get("type")
         if et == "session.update":
+            prev = (self.cfg.get("instructions"), self.cfg.get("voice"), self.cfg.get("temperature"))
             self.cfg.update(event.get("session", {}))
+            now = (self.cfg.get("instructions"), self.cfg.get("voice"), self.cfg.get("temperature"))
+            # The system prompt / voice must be primed before audio; if it changed
+            # and nothing has been fed yet, rebuild the stream. Changing it mid-turn
+            # is not supported (would need a fresh turn) — warn instead of silently
+            # dropping it.
+            if now != prev:
+                if not self._consumed_audio:
+                    self._open_stream()
+                else:
+                    await self.send_json({"type": "error", "error": {"message":
+                        "session.update to instructions/voice/temperature after audio "
+                        "started is applied on the next input_audio_buffer.clear"}})
             await self.send_json({"type": "session.updated", "session": self.cfg})
         elif et == "input_audio_buffer.append":
             pcm = base64.b64decode(event["audio"])
+            self._consumed_audio = True
             await self._consume(self.stream.append_audio(pcm))
         elif et == "input_audio_buffer.commit":
             await self._consume(self.stream.flush())
             await self._finish_response()
         elif et == "input_audio_buffer.clear":
-            self.stream.reset()
+            self._open_stream()  # fresh turn — re-prime the current system prompt
         elif et == "response.cancel":
-            self.stream.reset()
+            self._open_stream()
             await self._finish_response()
         elif et in ("response.create", "session.close"):
             pass  # continuous mode: responses stream as audio arrives

--- a/mstar/model/nemotron_duplex/submodules.py
+++ b/mstar/model/nemotron_duplex/submodules.py
@@ -78,6 +78,7 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
         pos_info: dict[str, PositionInfo] = {},  # noqa: B006 - matches base signature
         **kwargs,
     ) -> ARNodeInputs:
+        logger.warning("NDTRACE nano.prepare_inputs walk=%s keys=%s", graph_walk, list(inputs.keys()))
         # Frame-synchronous decode: AddFusion of one streamed audio frame with the
         # fed-back previous agent-text + function tokens (the duplex input per frame).
         if "audio_frame" in inputs:
@@ -263,10 +264,12 @@ class ConformerEncoderSubmodule(NodeSubmodule):
 
     def forward(self, graph_walk, engine_inputs, wav=None, lens=None, **kwargs) -> NameToTensorList:
         # audio -> per-frame LLM-space embeddings (T, H). These are the *user-audio*
-        # channel; the nano node fuses them per frame with its own fed-back previous
-        # text/function tokens (AddFusion) before stepping — see the decode walk.
+        # channel; streamed as ``audio_frame`` (the LLM decode edge name) and sliced
+        # one frame per nano step by the FixedChunkPolicy, where the nano node fuses
+        # each with its fed-back previous text/function tokens (AddFusion).
         audio_embeds, _ = self.perception(wav, lens)                  # (1, T, H)
-        return {"audio_embeds": [audio_embeds[0]]}                    # (T, H)
+        logger.warning("NDTRACE encoder.forward: produced audio_frame T=%d", audio_embeds.shape[1])
+        return {"audio_frame": [audio_embeds[0]]}                     # (T, H)
 
 
 class EarTTSTalkerSubmodule(ARNodeSubmodule):

--- a/mstar/model/nemotron_duplex/submodules.py
+++ b/mstar/model/nemotron_duplex/submodules.py
@@ -59,11 +59,14 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
         self.lm_head = language_model.lm_head
         self.config = config
 
-    def _mamba_state(self, graph_walk: str, engine_inputs: ModelInputsFromEngine) -> MambaStateAccessor:
+    def _mamba_state(
+        self, graph_walk: str, engine_inputs: ModelInputsFromEngine, seq_lens: list | None = None,
+    ) -> MambaStateAccessor:
         return MambaStateAccessor(
             request_states=engine_inputs.per_request_states or {},
             request_ids=list(engine_inputs.request_ids),
             is_prefill=graph_walk in PREFILL_WALKS,
+            seq_lens=seq_lens,
         )
 
     def prepare_inputs(
@@ -95,12 +98,17 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
         # apply no positional encoding).
         cache_manager.plan_attention(seq_lens=seq_lens, is_causal=True, label="main")
 
-        out: dict[str, torch.Tensor | Any] = {}
+        out: dict[str, torch.Tensor | Any] = {"seq_lens": seq_lens}
         if inputs[0].input_embeds is not None:
             out["input_embeds"] = torch.cat([inp.input_embeds for inp in inputs], dim=0)
         else:
             out["input_ids"] = torch.cat([inp.input_ids for inp in inputs], dim=0)
         return out
+
+    def can_batch(self, batch, model_inputs) -> bool:
+        # Eager (disable_torch_compile) batched decode/prefill: attention batches via
+        # the paged-KV pool, Mamba conv/ssm state via the per-request MambaStateAccessor.
+        return len(model_inputs) > 1
 
     def forward(
         self,
@@ -108,6 +116,7 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
         engine_inputs: ModelInputsFromEngine,
         input_ids: torch.Tensor | None = None,
         input_embeds: torch.Tensor | None = None,
+        seq_lens: list | None = None,
         **kwargs,
     ) -> NameToTensorList:
         cache_handle = engine_inputs.cache_manager
@@ -116,10 +125,40 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
         hidden = self.language_model(
             input_embeds,
             cache_handle=cache_handle,
-            mamba_state=self._mamba_state(graph_walk, engine_inputs),
+            mamba_state=self._mamba_state(graph_walk, engine_inputs, seq_lens),
         )
         logits = self.lm_head(hidden[-1:])
         return {"logits": [logits]}
+
+    def forward_batched(
+        self,
+        graph_walk: str,
+        engine_inputs: ModelInputsFromEngine,
+        input_ids: torch.Tensor | None = None,
+        input_embeds: torch.Tensor | None = None,
+        seq_lens: list | None = None,
+        **kwargs,
+    ) -> dict[str, NameToTensorList]:
+        """One fused forward advancing every request in the batch. Attention uses the
+        planned paged-KV layout; Mamba conv/ssm state is stepped per request from the
+        packed rows (see ``Mamba2Mixer.forward`` / ``MambaStateAccessor``). Per-request
+        next-token logits are read at each request's last packed position."""
+        import itertools
+
+        cache_handle = engine_inputs.cache_manager
+        if input_embeds is None:
+            input_embeds = self.embeddings(input_ids)
+        hidden = self.language_model(
+            input_embeds,
+            cache_handle=cache_handle,
+            mamba_state=self._mamba_state(graph_walk, engine_inputs, seq_lens),
+        )
+        ends = list(itertools.accumulate(seq_lens))          # last index+1 per request
+        result: dict[str, NameToTensorList] = {}
+        for i, rid in enumerate(engine_inputs.request_ids):
+            last = hidden[ends[i] - 1: ends[i]]              # (1, H) request i's last token
+            result[rid] = {"logits": [self.lm_head(last)]}
+        return result
 
     def postprocess(
         self,

--- a/mstar/model/nemotron_duplex/submodules.py
+++ b/mstar/model/nemotron_duplex/submodules.py
@@ -245,19 +245,79 @@ class EarTTSTalkerSubmodule(ARNodeSubmodule):
     loaded (verified); forward is Phase 5 (audio-out).
     """
 
-    def __init__(self, talker: nn.Module, config: NemotronDuplexConfig):
+    # Eager: the MoG/MaskGIT/CFG sampling is internal (not the engine's categorical
+    # sampler), and the talker keeps its own KV + CFG-uncond state per request in
+    # PerRequestState — not compile/capture-safe, like the nano's Mamba state.
+    disable_torch_compile = True
+
+    def __init__(self, talker: nn.Module, config: NemotronDuplexConfig,
+                 subword_to_char: dict | None = None, char_pad_idx: int | None = None):
         super().__init__()
         self.talker = talker
         self.config = config
+        self._s2c = subword_to_char
+        self._char_pad = char_pad_idx
+
+    def _step(self, state, text_tok: int, device, generator):
+        """One talker frame: agent text token -> ``num_quantizers`` RVQ codes.
+        ``state`` is the per-request talker state (``None`` warms up from the speaker
+        prompt). Returns ``(codes (num_q,), new_state)``. Same math as
+        DuplexStream._talker_codec_frame (the verified streaming path)."""
+        cfg, talker = self.config, self.talker
+        if state is None:
+            state = talker.init_state(
+                1, speaker="Aria", device=device,
+                subword_id_to_char_ids=self._s2c, char_pad_idx=self._char_pad,
+                text_pad_id=cfg.text_pad_id, text_eos_id=cfg.text_eos_id,
+                speech_pad_id=cfg.eartts.codebook_size,
+            )
+            prev = state.get("prev_codes")
+            state["_prev_codes"] = prev if prev is not None else talker.initial_prev_codes(1, device=device)
+        cur = torch.tensor([[text_tok]], device=device)
+        cond = talker.text_conditioning(cur, torch.ones_like(cur, dtype=torch.bool), self._s2c, self._char_pad)
+        codes, new_state = talker.infer_codes_one_step(
+            state, cur, cur, state["_prev_codes"], cond=cond, text_eos_id=cfg.text_eos_id,
+            num_iter=cfg.eartts.inference_num_iter, guidance_scale=cfg.eartts.inference_guidance_scale,
+            noise_scale=cfg.eartts.inference_noise_scale, top_p=cfg.eartts.inference_top_p,
+            generator=generator,
+        )
+        new_state["_prev_codes"] = codes
+        return codes.squeeze(0), new_state
+
+    def _request_step(self, st, text_tok: int, device) -> torch.Tensor:
+        """Advance one request (state carried in its PerRequestState) -> codes."""
+        state = st.get("talker_state")
+        gen = st.get("talker_gen")
+        if gen is None:
+            gen = torch.Generator(device=device).manual_seed(self.config.eartts.inference_seed)
+            st.add("talker_gen", gen)
+        codes, state = self._step(state, text_tok, device, gen)
+        st.add("talker_state", state)
+        return codes
 
     def prepare_inputs(self, graph_walk, fwd_info, inputs, seen_token_mask=None, pos_info={}, **kwargs):  # noqa: B006
-        raise NotImplementedError("EarTTSTalkerSubmodule.forward — Phase 5 (audio-out).")
+        tok = inputs["agent_token"][0]
+        return ARNodeInputs(input_ids=tok.reshape(1), input_seq_len=1)
 
     def preprocess(self, graph_walk, engine_inputs, inputs):
-        raise NotImplementedError("EarTTSTalkerSubmodule.forward — Phase 5 (audio-out).")
+        return {"tokens": [int(inp.input_ids.reshape(-1)[0].item()) for inp in inputs]}
 
-    def forward(self, graph_walk, engine_inputs, **kwargs) -> NameToTensorList:
-        raise NotImplementedError("EarTTSTalkerSubmodule.forward — Phase 5 (audio-out).")
+    def can_batch(self, batch, model_inputs) -> bool:
+        return len(model_inputs) > 1
+
+    def forward(self, graph_walk, engine_inputs, tokens=None, **kwargs) -> NameToTensorList:
+        rid = engine_inputs.request_ids[0]
+        st = engine_inputs.per_request_states[rid]
+        codes = self._request_step(st, tokens[0], self.talker.embed_code.weight.device)
+        return {"codec_tokens": [codes]}
+
+    def forward_batched(self, graph_walk, engine_inputs, tokens=None, **kwargs) -> dict[str, NameToTensorList]:
+        dev = self.talker.embed_code.weight.device
+        out: dict[str, NameToTensorList] = {}
+        for i, rid in enumerate(engine_inputs.request_ids):
+            codes = self._request_step(engine_inputs.per_request_states[rid], tokens[i], dev)
+            out[rid] = {"codec_tokens": [codes]}
+        return out
 
 
 class AudioCodecDecoderSubmodule(NodeSubmodule):

--- a/mstar/model/nemotron_duplex/submodules.py
+++ b/mstar/model/nemotron_duplex/submodules.py
@@ -216,11 +216,24 @@ class ConformerEncoderSubmodule(NodeSubmodule):
         self.rnnt_joint = rnnt_joint
         self.config = config
 
-    def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs):
-        raise NotImplementedError("ConformerEncoderSubmodule.forward — Phase 4 (audio-in).")
+    def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs) -> NodeInputs:
+        # ``audio_features`` is the raw 16 kHz mono waveform for this chunk; the
+        # Fast-Conformer perception does mel + subsampling + encoder internally.
+        wav = inputs["audio_features"][0]
+        if wav.dim() == 1:
+            wav = wav.unsqueeze(0)                                     # (1, N)
+        if "audio_seqlens" in inputs:
+            lens = inputs["audio_seqlens"][0].to(wav.device)
+        else:
+            lens = torch.tensor([wav.shape[-1]], device=wav.device)
+        return NodeInputs(tensor_inputs={"wav": wav, "lens": lens})
 
-    def forward(self, graph_walk, engine_inputs, **kwargs) -> NameToTensorList:
-        raise NotImplementedError("ConformerEncoderSubmodule.forward — Phase 4 (audio-in).")
+    def forward(self, graph_walk, engine_inputs, wav=None, lens=None, **kwargs) -> NameToTensorList:
+        # audio -> per-frame LLM-space embeddings (T, H). These are the *user-audio*
+        # channel; the nano node fuses them per frame with its own fed-back previous
+        # text/function tokens (AddFusion) before stepping — see the decode walk.
+        audio_embeds, _ = self.perception(wav, lens)                  # (1, T, H)
+        return {"audio_embeds": [audio_embeds[0]]}                    # (T, H)
 
 
 class EarTTSTalkerSubmodule(ARNodeSubmodule):

--- a/mstar/model/nemotron_duplex/submodules.py
+++ b/mstar/model/nemotron_duplex/submodules.py
@@ -31,6 +31,7 @@ from mstar.model.submodule_base import (
     ARNodeInputs,
     ARNodeSubmodule,
     ModelInputsFromEngine,
+    NodeInputs,
     NodeSubmodule,
 )
 
@@ -260,8 +261,25 @@ class AudioCodecDecoderSubmodule(NodeSubmodule):
     def get_stateless_flavor(self) -> str:
         return "audio_codec"
 
-    def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs):
-        raise NotImplementedError("AudioCodecDecoderSubmodule.forward — Phase 5 (audio-out).")
+    def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs) -> NodeInputs:
+        # ``codec_tokens`` is the streamed RVQ code window (T, num_q) — under a
+        # LeftContextChunkPolicy it carries `left_context` prior frames + the new
+        # `chunk` frames; we decode the whole window and emit only the new tail so
+        # the causal codec has enough left context (mirrors the standalone
+        # DuplexStream "decode history, emit tail" and Orpheus/Qwen streaming codec).
+        codes = inputs["codec_tokens"][0]
+        n_new = int(inputs["codec_tokens"][1].item()) if len(inputs["codec_tokens"]) > 1 else codes.shape[-2]
+        return NodeInputs(tensor_inputs={"codes": codes}, kwargs={"n_new": n_new})
 
-    def forward(self, graph_walk, engine_inputs, **kwargs) -> NameToTensorList:
-        raise NotImplementedError("AudioCodecDecoderSubmodule.forward — Phase 5 (audio-out).")
+    def forward(self, graph_walk, engine_inputs, codes=None, n_new=None, **kwargs) -> NameToTensorList:
+        if codes.dim() == 2:
+            codes = codes.unsqueeze(0)                                  # (1, T, num_q)
+        T = codes.shape[1]
+        code_len = torch.tensor([T], device=codes.device)
+        with torch.autocast(device_type="cuda", enabled=False):
+            audio, _ = self.codec.decode(codes.long(), code_len)        # (1, 1, samples)
+        wav = audio.squeeze(1)[0]                                       # (samples,)
+        if n_new is not None and n_new < T:                            # emit only the new tail
+            spf = wav.shape[0] // T
+            wav = wav[-n_new * spf:]
+        return {"audio_chunk": [(wav.clamp(-1, 1) * 32767).to(torch.int16)]}

--- a/mstar/model/nemotron_duplex/submodules.py
+++ b/mstar/model/nemotron_duplex/submodules.py
@@ -162,28 +162,34 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
 class ConformerEncoderSubmodule(NodeSubmodule):
     """Fast-Conformer streaming STT encoder (audio in → fused embeds + transcript).
 
-    STATELESS node. Produces ``combined_embeds`` for the nano LLM and a
-    streaming ``transcript_token`` (RNN-T) emitted to the client.
+    STATELESS node. Holds the perception stack plus the RNN-T decoder/joint —
+    all three checkpoint subtrees are loaded (weight loading verified). Produces
+    ``combined_embeds`` for the nano LLM and a streaming ``transcript_token``.
+    Forward is Phase 4 (audio-in).
     """
 
-    def __init__(self, encoder: nn.Module, config: NemotronDuplexConfig):
+    def __init__(self, perception: nn.Module, rnnt_decoder: nn.Module, rnnt_joint: nn.Module,
+                 config: NemotronDuplexConfig):
         super().__init__()
-        self.encoder = encoder
+        self.perception = perception
+        self.rnnt_decoder = rnnt_decoder
+        self.rnnt_joint = rnnt_joint
         self.config = config
 
     def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs):
-        raise NotImplementedError("ConformerEncoderSubmodule — Phase 4 (audio-in).")
+        raise NotImplementedError("ConformerEncoderSubmodule.forward — Phase 4 (audio-in).")
 
     def forward(self, graph_walk, engine_inputs, **kwargs) -> NameToTensorList:
-        raise NotImplementedError("ConformerEncoderSubmodule — Phase 4 (audio-in).")
+        raise NotImplementedError("ConformerEncoderSubmodule.forward — Phase 4 (audio-in).")
 
 
 class EarTTSTalkerSubmodule(ARNodeSubmodule):
     """Gemma3-text talker: nano hidden/text → RVQ codec codes (autoregressive).
 
     KV_CACHE node. Emits ``num_quantizers`` codebooks per frame; the extra
-    codebooks (1..N-1) sample from a ``code_predictor`` aux sampling config
-    (see Model.get_aux_sampling_configs), mirroring Qwen3-Omni's Talker.
+    codebooks sample from a ``code_predictor`` aux config (see
+    Model.get_aux_sampling_configs), mirroring Qwen3-Omni's Talker. Weights
+    loaded (verified); forward is Phase 5 (audio-out).
     """
 
     def __init__(self, talker: nn.Module, config: NemotronDuplexConfig):
@@ -192,17 +198,20 @@ class EarTTSTalkerSubmodule(ARNodeSubmodule):
         self.config = config
 
     def prepare_inputs(self, graph_walk, fwd_info, inputs, seen_token_mask=None, pos_info={}, **kwargs):  # noqa: B006
-        raise NotImplementedError("EarTTSTalkerSubmodule — Phase 5 (audio-out).")
+        raise NotImplementedError("EarTTSTalkerSubmodule.forward — Phase 5 (audio-out).")
 
     def preprocess(self, graph_walk, engine_inputs, inputs):
-        raise NotImplementedError("EarTTSTalkerSubmodule — Phase 5 (audio-out).")
+        raise NotImplementedError("EarTTSTalkerSubmodule.forward — Phase 5 (audio-out).")
 
     def forward(self, graph_walk, engine_inputs, **kwargs) -> NameToTensorList:
-        raise NotImplementedError("EarTTSTalkerSubmodule — Phase 5 (audio-out).")
+        raise NotImplementedError("EarTTSTalkerSubmodule.forward — Phase 5 (audio-out).")
 
 
 class AudioCodecDecoderSubmodule(NodeSubmodule):
-    """RVQ codec decoder: talker codes → 22.05 kHz PCM (sliding-window stream)."""
+    """RVQ codec decoder: talker codes → 22.05 kHz PCM (sliding-window stream).
+
+    Weights loaded (verified); forward is Phase 5 (audio-out).
+    """
 
     def __init__(self, codec: nn.Module, config: NemotronDuplexConfig):
         super().__init__()
@@ -213,7 +222,7 @@ class AudioCodecDecoderSubmodule(NodeSubmodule):
         return "audio_codec"
 
     def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs):
-        raise NotImplementedError("AudioCodecDecoderSubmodule — Phase 5 (audio-out).")
+        raise NotImplementedError("AudioCodecDecoderSubmodule.forward — Phase 5 (audio-out).")
 
     def forward(self, graph_walk, engine_inputs, **kwargs) -> NameToTensorList:
-        raise NotImplementedError("AudioCodecDecoderSubmodule — Phase 5 (audio-out).")
+        raise NotImplementedError("AudioCodecDecoderSubmodule.forward — Phase 5 (audio-out).")

--- a/mstar/model/nemotron_duplex/submodules.py
+++ b/mstar/model/nemotron_duplex/submodules.py
@@ -78,7 +78,6 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
         pos_info: dict[str, PositionInfo] = {},  # noqa: B006 - matches base signature
         **kwargs,
     ) -> ARNodeInputs:
-        logger.warning("NDTRACE nano.prepare_inputs walk=%s keys=%s", graph_walk, list(inputs.keys()))
         # Frame-synchronous decode: AddFusion of one streamed audio frame with the
         # fed-back previous agent-text + function tokens (the duplex input per frame).
         if "audio_frame" in inputs:
@@ -92,9 +91,7 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
 
     def _fuse_frame(self, inputs: NameToTensorList) -> ARNodeInputs:
         cfg = self.config
-        audio = inputs["audio_frame"][0]
-        audio = audio.unsqueeze(0) if audio.dim() == 1 else audio          # (1, H)
-        dev = audio.device
+        dev = self.embeddings.weight.device
 
         def _tok(name, default):
             if name in inputs and inputs[name]:
@@ -103,7 +100,15 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
 
         prev_text = _tok("prev_text", cfg.text_bos_id)                     # carry-in BOS
         prev_func = _tok("prev_func", cfg.text_pad_id)
-        fused = self.embeddings(prev_text) * cfg.agent_text_weight + audio * cfg.user_audio_weight
+        fused = self.embeddings(prev_text) * cfg.agent_text_weight
+        # ``audio_frame`` is normally this frame's encoder embedding; the terminal
+        # stream chunk (producer_done race) can arrive empty — run a no-audio step
+        # (the decode loop stops this iteration via the final-stream-chunk signal).
+        af = inputs.get("audio_frame") or []
+        if af:
+            audio = af[0]
+            audio = audio.unsqueeze(0) if audio.dim() == 1 else audio      # (1, H)
+            fused = fused + audio.to(dev) * cfg.user_audio_weight
         if cfg.use_function_head:
             fused = fused + self.embeddings(prev_func) * cfg.function_weight
         return ARNodeInputs(input_embeds=fused, input_seq_len=1)
@@ -212,17 +217,17 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
         request_info: CurrentForwardPassInfo,
         outputs: dict[str, list[torch.Tensor]],
     ) -> set[str]:
-        if "new_token" not in outputs:
-            return set()
-        token = outputs["new_token"][0].item()
-        ignore_eos = request_info.sampling_config["nano_llm"].ignore_eos
+        # Frame-synchronous duplex: the nano emits exactly one agent-text token
+        # per audio frame, and text EOS (eos_token_id) is a NORMAL per-frame
+        # token (silence / agent-turn boundary), NOT end-of-generation. The
+        # decode loop therefore terminates when the audio_frame stream is
+        # exhausted (the final chunk carries is_final), NOT on EOS. Only the
+        # max-tokens backstop force-stops here.
         at_max = (
             request_info.dynamic_loop_iter_counts.get("decode_loop", 0) + 1
             >= request_info.max_tokens
         )
-        if (not ignore_eos and token == self.config.eos_token_id) or at_max:
-            return {"decode_loop"}
-        return set()
+        return {"decode_loop"} if at_max else set()
 
     def cleanup_request(self, request_id: str):
         # Drop this request's Mamba conv/ssm state (base clears request_states).
@@ -241,6 +246,13 @@ class ConformerEncoderSubmodule(NodeSubmodule):
     ``combined_embeds`` for the nano LLM and a streaming ``transcript_token``.
     Forward is Phase 4 (audio-in).
     """
+
+    # Run eager: the Fast-Conformer forward is variable-length (per-utterance
+    # audio), so torch.compile recompiles per shape, and the inductor/triton
+    # backend in this env raises ``cuda_utils has no attribute PyKernelArg`` on
+    # some shapes. The encoder runs once per request (not a hot decode loop), so
+    # eager is fine for correctness; revisit under the E6 perf pass.
+    disable_torch_compile = True
 
     def __init__(self, perception: nn.Module, rnnt_decoder: nn.Module, rnnt_joint: nn.Module,
                  config: NemotronDuplexConfig):
@@ -268,8 +280,11 @@ class ConformerEncoderSubmodule(NodeSubmodule):
         # one frame per nano step by the FixedChunkPolicy, where the nano node fuses
         # each with its fed-back previous text/function tokens (AddFusion).
         audio_embeds, _ = self.perception(wav, lens)                  # (1, T, H)
-        logger.warning("NDTRACE encoder.forward: produced audio_frame T=%d", audio_embeds.shape[1])
-        return {"audio_frame": [audio_embeds[0]]}                     # (T, H)
+        # Emit each frame as its own stream item so the LLM partition's
+        # FixedChunkPolicy(chunk=1) releases exactly one frame per nano decode
+        # step. Returning a single (T, H) tensor would be ONE stream item (the
+        # whole utterance), which the chunk policy could not slice per frame.
+        return {"audio_frame": list(audio_embeds[0])}                # T × (H,)
 
 
 class EarTTSTalkerSubmodule(ARNodeSubmodule):
@@ -332,7 +347,9 @@ class EarTTSTalkerSubmodule(ARNodeSubmodule):
         return codes
 
     def prepare_inputs(self, graph_walk, fwd_info, inputs, seen_token_mask=None, pos_info={}, **kwargs):  # noqa: B006
-        tok = inputs["agent_token"][0]
+        # The LLM streams the sampled agent text token under the edge name
+        # "new_token" (see the decode Loop's StreamingGraphEdge → eartts_talker).
+        tok = inputs["new_token"][0]
         return ARNodeInputs(input_ids=tok.reshape(1), input_seq_len=1)
 
     def preprocess(self, graph_walk, engine_inputs, inputs):
@@ -357,38 +374,58 @@ class EarTTSTalkerSubmodule(ARNodeSubmodule):
 
 
 class AudioCodecDecoderSubmodule(NodeSubmodule):
-    """RVQ codec decoder: talker codes → 22.05 kHz PCM (sliding-window stream).
+    """RVQ codec decoder: talker codes → 22.05 kHz PCM (streaming, left-context).
 
-    Weights loaded (verified); forward is Phase 5 (audio-out).
+    The codec is causal with a multi-frame receptive field, so decoding each
+    chunk in isolation clicks at the boundaries. Instead we keep a per-request
+    rolling context of the previous ``codec_left_context_frames`` code frames,
+    prepend it to each chunk of NEW frames, decode ``context + new``, and emit
+    ONLY the new frames' audio (trimming the context's samples). This is the
+    same "decode with left context, emit the new tail" math as the verified
+    standalone ``DuplexStream._talker_codec_frame`` / offline decode, but O(1)
+    per chunk instead of re-decoding the whole history.
     """
+
+    # Per-request context is a plain dict keyed by request id (like the nano /
+    # talker Option-A state) — not compile/capture-safe, so run eager.
+    disable_torch_compile = True
 
     def __init__(self, codec: nn.Module, config: NemotronDuplexConfig):
         super().__init__()
         self.codec = codec
         self.config = config
+        self._ctx: dict[str, torch.Tensor] = {}  # rid -> last left_context code frames (Lc, num_q)
 
     def get_stateless_flavor(self) -> str:
         return "audio_codec"
 
     def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs) -> NodeInputs:
-        # ``codec_tokens`` is the streamed RVQ code window (T, num_q) — under a
-        # LeftContextChunkPolicy it carries `left_context` prior frames + the new
-        # `chunk` frames; we decode the whole window and emit only the new tail so
-        # the causal codec has enough left context (mirrors the standalone
-        # DuplexStream "decode history, emit tail" and Orpheus/Qwen streaming codec).
+        # ``codec_tokens`` is this chunk's NEW RVQ frames (T_new, num_q); the
+        # Talker→Codec connection uses a non-overlapping FixedChunkPolicy, so
+        # left context is supplied here from per-request state, not the stream.
         codes = inputs["codec_tokens"][0]
-        n_new = int(inputs["codec_tokens"][1].item()) if len(inputs["codec_tokens"]) > 1 else codes.shape[-2]
-        return NodeInputs(tensor_inputs={"codes": codes}, kwargs={"n_new": n_new})
+        return NodeInputs(tensor_inputs={"codes": codes})
 
-    def forward(self, graph_walk, engine_inputs, codes=None, n_new=None, **kwargs) -> NameToTensorList:
-        if codes.dim() == 2:
-            codes = codes.unsqueeze(0)                                  # (1, T, num_q)
-        T = codes.shape[1]
-        code_len = torch.tensor([T], device=codes.device)
+    def forward(self, graph_walk, engine_inputs, codes=None, **kwargs) -> NameToTensorList:
+        rid = engine_inputs.request_ids[0]
+        lc = self.config.eartts.codec_left_context_frames
+        if codes.dim() == 3:
+            codes = codes[0]                                            # (T_new, num_q)
+        elif codes.dim() == 1:
+            codes = codes.unsqueeze(0)                                  # single frame -> (1, num_q)
+        prev = self._ctx.get(rid)                                       # (n_ctx, num_q) or None
+        n_ctx = 0 if prev is None else prev.shape[0]
+        full = codes if prev is None else torch.cat([prev, codes], dim=0)
+        Tf = full.shape[0]
+        code_len = torch.tensor([Tf], device=full.device)
         with torch.autocast(device_type="cuda", enabled=False):
-            audio, _ = self.codec.decode(codes.long(), code_len)        # (1, 1, samples)
+            audio, _ = self.codec.decode(full.long().unsqueeze(0), code_len)  # (1, 1, samples)
         wav = audio.squeeze(1)[0]                                       # (samples,)
-        if n_new is not None and n_new < T:                            # emit only the new tail
-            spf = wav.shape[0] // T
-            wav = wav[-n_new * spf:]
-        return {"audio_chunk": [(wav.clamp(-1, 1) * 32767).to(torch.int16)]}
+        spf = wav.shape[0] // Tf                                        # samples per frame
+        new_wav = wav[n_ctx * spf:]                                     # emit only the new frames
+        self._ctx[rid] = full[-lc:].detach()                           # roll the context forward
+        return {"audio_chunk": [(new_wav.clamp(-1, 1) * 32767).to(torch.int16)]}
+
+    def cleanup_request(self, request_id: str):
+        self._ctx.pop(request_id, None)
+        super().cleanup_request(request_id)

--- a/mstar/model/nemotron_duplex/submodules.py
+++ b/mstar/model/nemotron_duplex/submodules.py
@@ -1,0 +1,219 @@
+"""NodeSubmodules for NVIDIA NemotronLabs VoiceChat-11B (duplex).
+
+Nodes:
+    nano_llm         (KV_CACHE)  — Nemotron-H hybrid backbone      [implemented]
+    conformer_encoder(STATELESS) — Fast-Conformer STT + RNN-T head [Phase 4 stub]
+    eartts_talker    (KV_CACHE)  — Gemma3 talker → RVQ codes        [Phase 5 stub]
+    audio_codec      (STATELESS) — RVQ codec → 22.05 kHz waveform   [Phase 5 stub]
+
+Per the agreed phasing, the ``nano_llm`` text path is drafted first; the audio
+stages carry correct interfaces + TODOs and are only wired once the LLM matches
+the HF reference numerically.
+
+Correctness note for ``nano_llm``: it runs eager (``disable_torch_compile``)
+because Option-A Mamba state lives in ``per_request_states`` (None during
+CUDA-graph capture). Batching + CUDA graphs come with the Option-B SSM pool.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+from torch import nn
+
+from mstar.communication.tensors import NameToTensorList
+from mstar.conductor.request_info import CurrentForwardPassInfo
+from mstar.engine.kv_store import PositionInfo
+from mstar.model.nemotron_duplex.components.nemotron_h import MambaStateAccessor
+from mstar.model.nemotron_duplex.config import NemotronDuplexConfig
+from mstar.model.submodule_base import (
+    ARNodeInputs,
+    ARNodeSubmodule,
+    ModelInputsFromEngine,
+    NodeSubmodule,
+)
+
+logger = logging.getLogger(__name__)
+
+# Walks in which the nano LLM is (re)starting its recurrent state.
+PREFILL_WALKS = {"prefill_text", "prefill_audio"}
+
+
+class NemotronHLLMSubmodule(ARNodeSubmodule):
+    """Nemotron-H backbone node.
+
+    ``prefill_*`` embeds the prompt (or consumes fused ``combined_embeds`` from
+    the encoder) and fills the attention KV cache + seeds Mamba state; ``decode``
+    single-steps. Sampling is the engine's; EOS handling is in ``check_stop``.
+    """
+
+    # Option-A Mamba state is a Python-dict lookup keyed by request id — not
+    # compile-/capture-safe. Keep this node eager until the Option-B pool lands.
+    disable_torch_compile = True
+
+    def __init__(self, language_model: nn.Module, config: NemotronDuplexConfig):
+        super().__init__()
+        self.language_model = language_model
+        self.embeddings = language_model.embeddings
+        self.lm_head = language_model.lm_head
+        self.config = config
+
+    def _mamba_state(self, graph_walk: str, engine_inputs: ModelInputsFromEngine) -> MambaStateAccessor:
+        return MambaStateAccessor(
+            request_states=engine_inputs.per_request_states or {},
+            request_ids=list(engine_inputs.request_ids),
+            is_prefill=graph_walk in PREFILL_WALKS,
+        )
+
+    def prepare_inputs(
+        self,
+        graph_walk: str,
+        fwd_info: CurrentForwardPassInfo,
+        inputs: NameToTensorList,
+        pos_info: dict[str, PositionInfo] = {},  # noqa: B006 - matches base signature
+        **kwargs,
+    ) -> ARNodeInputs:
+        # ``combined_embeds`` (fused audio+text) takes precedence over token ids
+        # on the voicechat audio path; the text path supplies ``text_inputs``.
+        if "combined_embeds" in inputs:
+            emb = inputs["combined_embeds"][0]
+            return ARNodeInputs(input_embeds=emb, input_seq_len=emb.shape[0])
+        ids = inputs["text_inputs"][0]
+        return ARNodeInputs(input_ids=ids, input_seq_len=ids.shape[0])
+
+    def preprocess(
+        self,
+        graph_walk: str,
+        engine_inputs: ModelInputsFromEngine,
+        inputs: list[ARNodeInputs],
+    ) -> dict[str, torch.Tensor | Any]:
+        cache_manager = engine_inputs.cache_manager
+        seq_lens = [inp.input_seq_len for inp in inputs]
+        cache_manager.set_active_label("main")
+        # NoPE: plan attention only — no plan_rope (Nemotron-H attention layers
+        # apply no positional encoding).
+        cache_manager.plan_attention(seq_lens=seq_lens, is_causal=True, label="main")
+
+        out: dict[str, torch.Tensor | Any] = {}
+        if inputs[0].input_embeds is not None:
+            out["input_embeds"] = torch.cat([inp.input_embeds for inp in inputs], dim=0)
+        else:
+            out["input_ids"] = torch.cat([inp.input_ids for inp in inputs], dim=0)
+        return out
+
+    def forward(
+        self,
+        graph_walk: str,
+        engine_inputs: ModelInputsFromEngine,
+        input_ids: torch.Tensor | None = None,
+        input_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> NameToTensorList:
+        cache_handle = engine_inputs.cache_manager
+        if input_embeds is None:
+            input_embeds = self.embeddings(input_ids)
+        hidden = self.language_model(
+            input_embeds,
+            cache_handle=cache_handle,
+            mamba_state=self._mamba_state(graph_walk, engine_inputs),
+        )
+        logits = self.lm_head(hidden[-1:])
+        return {"logits": [logits]}
+
+    def postprocess(
+        self,
+        request_id: str,
+        request_info: CurrentForwardPassInfo,
+        outputs: dict[str, list[torch.Tensor]],
+        **kwargs,
+    ):
+        # Rebind the sampled token for loop-back routing (metadata only).
+        if "new_token" in outputs:
+            outputs["text_inputs"] = outputs["new_token"]
+
+    def check_stop(
+        self,
+        request_id: str,
+        request_info: CurrentForwardPassInfo,
+        outputs: dict[str, list[torch.Tensor]],
+    ) -> set[str]:
+        if "new_token" not in outputs:
+            return set()
+        token = outputs["new_token"][0].item()
+        ignore_eos = request_info.sampling_config["nano_llm"].ignore_eos
+        at_max = (
+            request_info.dynamic_loop_iter_counts.get("decode_loop", 0) + 1
+            >= request_info.max_tokens
+        )
+        if (not ignore_eos and token == self.config.eos_token_id) or at_max:
+            return {"decode_loop"}
+        return set()
+
+    def cleanup_request(self, request_id: str):
+        # Drop this request's Mamba conv/ssm state (base clears request_states).
+        super().cleanup_request(request_id)
+
+
+# ---------------------------------------------------------------------------
+# Audio stages — Phase 4/5 stubs (interfaces fixed; internals TODO)
+# ---------------------------------------------------------------------------
+
+class ConformerEncoderSubmodule(NodeSubmodule):
+    """Fast-Conformer streaming STT encoder (audio in → fused embeds + transcript).
+
+    STATELESS node. Produces ``combined_embeds`` for the nano LLM and a
+    streaming ``transcript_token`` (RNN-T) emitted to the client.
+    """
+
+    def __init__(self, encoder: nn.Module, config: NemotronDuplexConfig):
+        super().__init__()
+        self.encoder = encoder
+        self.config = config
+
+    def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs):
+        raise NotImplementedError("ConformerEncoderSubmodule — Phase 4 (audio-in).")
+
+    def forward(self, graph_walk, engine_inputs, **kwargs) -> NameToTensorList:
+        raise NotImplementedError("ConformerEncoderSubmodule — Phase 4 (audio-in).")
+
+
+class EarTTSTalkerSubmodule(ARNodeSubmodule):
+    """Gemma3-text talker: nano hidden/text → RVQ codec codes (autoregressive).
+
+    KV_CACHE node. Emits ``num_quantizers`` codebooks per frame; the extra
+    codebooks (1..N-1) sample from a ``code_predictor`` aux sampling config
+    (see Model.get_aux_sampling_configs), mirroring Qwen3-Omni's Talker.
+    """
+
+    def __init__(self, talker: nn.Module, config: NemotronDuplexConfig):
+        super().__init__()
+        self.talker = talker
+        self.config = config
+
+    def prepare_inputs(self, graph_walk, fwd_info, inputs, seen_token_mask=None, pos_info={}, **kwargs):  # noqa: B006
+        raise NotImplementedError("EarTTSTalkerSubmodule — Phase 5 (audio-out).")
+
+    def preprocess(self, graph_walk, engine_inputs, inputs):
+        raise NotImplementedError("EarTTSTalkerSubmodule — Phase 5 (audio-out).")
+
+    def forward(self, graph_walk, engine_inputs, **kwargs) -> NameToTensorList:
+        raise NotImplementedError("EarTTSTalkerSubmodule — Phase 5 (audio-out).")
+
+
+class AudioCodecDecoderSubmodule(NodeSubmodule):
+    """RVQ codec decoder: talker codes → 22.05 kHz PCM (sliding-window stream)."""
+
+    def __init__(self, codec: nn.Module, config: NemotronDuplexConfig):
+        super().__init__()
+        self.codec = codec
+        self.config = config
+
+    def get_stateless_flavor(self) -> str:
+        return "audio_codec"
+
+    def prepare_inputs(self, graph_walk, fwd_info, inputs, **kwargs):
+        raise NotImplementedError("AudioCodecDecoderSubmodule — Phase 5 (audio-out).")
+
+    def forward(self, graph_walk, engine_inputs, **kwargs) -> NameToTensorList:
+        raise NotImplementedError("AudioCodecDecoderSubmodule — Phase 5 (audio-out).")

--- a/mstar/model/nemotron_duplex/submodules.py
+++ b/mstar/model/nemotron_duplex/submodules.py
@@ -78,13 +78,34 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
         pos_info: dict[str, PositionInfo] = {},  # noqa: B006 - matches base signature
         **kwargs,
     ) -> ARNodeInputs:
-        # ``combined_embeds`` (fused audio+text) takes precedence over token ids
-        # on the voicechat audio path; the text path supplies ``text_inputs``.
+        # Frame-synchronous decode: AddFusion of one streamed audio frame with the
+        # fed-back previous agent-text + function tokens (the duplex input per frame).
+        if "audio_frame" in inputs:
+            return self._fuse_frame(inputs)
+        # ``combined_embeds`` (pre-fused) or ``text_inputs`` (system-prompt prefill).
         if "combined_embeds" in inputs:
             emb = inputs["combined_embeds"][0]
             return ARNodeInputs(input_embeds=emb, input_seq_len=emb.shape[0])
         ids = inputs["text_inputs"][0]
         return ARNodeInputs(input_ids=ids, input_seq_len=ids.shape[0])
+
+    def _fuse_frame(self, inputs: NameToTensorList) -> ARNodeInputs:
+        cfg = self.config
+        audio = inputs["audio_frame"][0]
+        audio = audio.unsqueeze(0) if audio.dim() == 1 else audio          # (1, H)
+        dev = audio.device
+
+        def _tok(name, default):
+            if name in inputs and inputs[name]:
+                return inputs[name][0].reshape(-1)[:1].to(dev)
+            return torch.tensor([default], device=dev, dtype=torch.long)
+
+        prev_text = _tok("prev_text", cfg.text_bos_id)                     # carry-in BOS
+        prev_func = _tok("prev_func", cfg.text_pad_id)
+        fused = self.embeddings(prev_text) * cfg.agent_text_weight + audio * cfg.user_audio_weight
+        if cfg.use_function_head:
+            fused = fused + self.embeddings(prev_func) * cfg.function_weight
+        return ARNodeInputs(input_embeds=fused, input_seq_len=1)
 
     def preprocess(
         self,
@@ -128,8 +149,17 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
             cache_handle=cache_handle,
             mamba_state=self._mamba_state(graph_walk, engine_inputs, seq_lens),
         )
-        logits = self.lm_head(hidden[-1:])
-        return {"logits": [logits]}
+        return self._token_outputs(graph_walk, hidden[-1:], engine_inputs, engine_inputs.request_ids[0])
+
+    def _token_outputs(self, graph_walk, last_hidden, engine_inputs, rid) -> NameToTensorList:
+        """Text logits (engine samples -> new_token) plus, on the frame-synchronous
+        decode walk, the greedily-sampled function token (aux channel) that is fed
+        back into the next frame's AddFusion."""
+        out: NameToTensorList = {"logits": [self.lm_head(last_hidden)]}
+        if graph_walk == "decode" and self.config.use_function_head:
+            func_logits = self.language_model.function_head(last_hidden)
+            out["new_func"] = [engine_inputs.sampler.sample_aux("function", [rid], func_logits)]
+        return out
 
     def forward_batched(
         self,
@@ -158,7 +188,7 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
         result: dict[str, NameToTensorList] = {}
         for i, rid in enumerate(engine_inputs.request_ids):
             last = hidden[ends[i] - 1: ends[i]]              # (1, H) request i's last token
-            result[rid] = {"logits": [self.lm_head(last)]}
+            result[rid] = self._token_outputs(graph_walk, last, engine_inputs, rid)
         return result
 
     def postprocess(
@@ -168,9 +198,12 @@ class NemotronHLLMSubmodule(ARNodeSubmodule):
         outputs: dict[str, list[torch.Tensor]],
         **kwargs,
     ):
-        # Rebind the sampled token for loop-back routing (metadata only).
+        # Feed the sampled agent-text + function tokens back into the next frame's
+        # AddFusion (the decode-loop loop-back edges prev_text / prev_func).
         if "new_token" in outputs:
-            outputs["text_inputs"] = outputs["new_token"]
+            outputs["prev_text"] = outputs["new_token"]
+        if "new_func" in outputs:
+            outputs["prev_func"] = outputs["new_func"]
 
     def check_stop(
         self,

--- a/mstar/model/registry.py
+++ b/mstar/model/registry.py
@@ -2,6 +2,7 @@ from mstar.model.bagel.bagel_model import BagelModel
 from mstar.model.base import Model
 from mstar.model.cosmos3.cosmos3_model import Cosmos3Model
 from mstar.model.higgs_audio.higgs_audio_model import HiggsAudioModel
+from mstar.model.nemotron_duplex.nemotron_duplex_model import NemotronDuplexModel
 from mstar.model.orpheus.orpheus_model import OrpheusModel
 from mstar.model.pi05.pi05_model import Pi05Model
 from mstar.model.qwen3_omni.qwen3_omni_model import Qwen3OmniModel
@@ -16,6 +17,7 @@ MODEL_REGISTRY: dict[str, type[Model]] = {
     "cosmos3_droid": Cosmos3Model,
     "cosmos3_super": Cosmos3Model,
     "higgs_audio": HiggsAudioModel,
+    "nemotron_duplex": NemotronDuplexModel,
     "orpheus": OrpheusModel,
     "pi05": Pi05Model,
     "qwen3_omni": Qwen3OmniModel,
@@ -42,6 +44,11 @@ HF_MODELS: dict[str, dict] = {
     # Higgs-Audio v3 STT: Whisper-style audio tower + Qwen3-1.7B LLM.
     # (The v2 checkpoints are TTS/generation models, not ASR.)
     "higgs_audio": {"model_path_hf": "bosonai/higgs-audio-v3-stt"},
+    # NVIDIA NemotronLabs VoiceChat-11B: half-duplex S2S — Fast-Conformer STT
+    # encoder + Nemotron-H hybrid Mamba-2/attn/MLP backbone (9B) + EarTTS
+    # (Gemma3 talker + RVQ codec). Base checkpoint is a single composite
+    # ``model.safetensors`` (unquantized); the Spark repo is the GPTQ variant.
+    "nemotron_duplex": {"model_path_hf": "nvidia/NVIDIA-NemotronLabs-VoiceChat-11B"},
     "orpheus": {"model_path_hf": "canopylabs/orpheus-3b-0.1-ft"},
     # Pi0.5 PyTorch port published by lerobot — single safetensors blob
     # (~14 GB). mstar/model/pi05/weight_loader.py handles the lerobot->mstar

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -337,14 +337,19 @@ class Worker:
             conn.edge_name for conn in self._my_consumer_connections
         }
 
-        # Build consumer node cache: edge_name -> next_node name
+        # Build consumer node cache: edge_name -> consuming node name.
+        # Recurse via get_nodes() so consumers nested inside a Loop / Sequential /
+        # Parallel are found too (a bare ``hasattr(section, 'input_names')`` only
+        # matches a walk that is itself a single top-level GraphNode, missing e.g.
+        # a decode Loop whose inner node consumes the streamed edge).
         self._consumer_node_cache: dict[str, str] = {}
         if self._my_consumer_connections and model:
             walks = model.get_graph_walk_graphs()
             for conn in self._my_consumer_connections:
                 for section in walks.values():
-                    if hasattr(section, 'input_names') and conn.edge_name in section.input_names:
-                        self._consumer_node_cache[conn.edge_name] = section.name
+                    for node in section.get_nodes().values():
+                        if conn.edge_name in node.input_names:
+                            self._consumer_node_cache[conn.edge_name] = node.name
 
     def _get_node_names_for_partition(self, partition_name: str, model: Model) -> list[str]:
         """Get the node names that belong to a partition."""
@@ -355,8 +360,14 @@ class Worker:
                 nodes = set()
                 for walk_name in pdef.graph_walks:
                     section = walks.get(walk_name)
-                    if section and hasattr(section, 'name'):
-                        nodes.add(section.name)
+                    if section is not None:
+                        # Recurse into the section so nodes nested in a Loop /
+                        # Sequential / Parallel are included — a bare
+                        # ``section.name`` would return the Loop's name (e.g.
+                        # "talker_decode_loop"), not the consuming node
+                        # ("eartts_talker"), so its StreamBuffer would never
+                        # be created (KeyError when routing the streamed edge).
+                        nodes.update(section.get_nodes().keys())
                 return list(nodes)
         return []
 
@@ -1716,6 +1727,22 @@ class Worker:
         engine = self.engine_manager.get_engine(batch_N.node_name)
         cpu_output = self._prematerialize_for_check_stop(output)
         stop_result = engine.check_stop_for_batch(batch_N.node_batch, cpu_output)
+
+        # Stream-terminated loop: a stream-consuming node inside a loop has no
+        # internal stop signal (unlike a self-EOS loop), so when it consumes the
+        # terminal chunk (_final_stream_chunk → final_stream_rids) end its
+        # enclosing loop. Without this the loop would spin to max_iters and the
+        # partition would never report done.
+        for rid in batch_N.node_batch.final_stream_rids:
+            try:
+                nested = self.worker_graphs_manager.get_nested_loop_idxs_for_node(
+                    rid, batch_N.partition, batch_N.node_name
+                )
+            except (KeyError, AttributeError):
+                continue
+            if nested.loop_name_order:
+                stop_result.stops.setdefault(rid, set()).add(nested.loop_name_order[-1])
+
         if stop_result.failed_requests:
             # A rid whose stop check raised has no trustworthy stop decision:
             # routing it would either run its loop forever or end it early.

--- a/test/modular/test_nemotron_duplex_model.py
+++ b/test/modular/test_nemotron_duplex_model.py
@@ -7,9 +7,12 @@ so a dangling edge name or unresolved partition fails loudly here.
 """
 from pathlib import Path
 
+import torch
+
 from mstar.engine.base import EngineType
 from mstar.model.nemotron_duplex.config import NemotronDuplexConfig
 from mstar.model.nemotron_duplex.nemotron_duplex_model import NemotronDuplexModel
+from mstar.streaming.chunk_policy import FixedChunkPolicy
 
 CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "nemotron_duplex.yaml"
 
@@ -90,3 +93,54 @@ def test_duplex_llm_prefill_to_decode_transition():
     fpa = model.get_partition_forward_pass_args("LLM", meta, {})
     assert fpa.full_metadata.graph_walk == "decode"
     assert fpa.full_metadata.is_prefill is False
+
+
+# --- regression tests for the E5 full-duplex serving fixes ------------------
+
+
+def test_duplex_stream_connection_policies():
+    """The duplex loops are 1:1 stream-driven and terminate on stream end:
+    Encoder→LLM and LLM→Talker release one item per step with
+    continue_after_done=False (else the loops would spin past their input);
+    Talker→Codec releases NON-overlapping chunks of ``codec_chunk_frames`` (the
+    codec keeps its own left-context, so re-delivering overlap balloons the
+    audio ~window/chunk×)."""
+    model = _make_model()
+    conns = {c.edge_name: c.chunk_policy_factory()
+             for c in model.get_partition_topology().connections}
+
+    for edge in ("audio_frame", "new_token"):
+        pol = conns[edge]
+        assert isinstance(pol, FixedChunkPolicy)
+        assert pol.next_chunk_size(10) == 1
+        assert pol.continue_after_producer_done() is False
+
+    codec = conns["codec_tokens"]
+    assert isinstance(codec, FixedChunkPolicy)
+    assert codec.next_chunk_size(100) == model.config.eartts.codec_chunk_frames
+    assert codec.continue_after_producer_done() is False
+
+
+def test_duplex_process_prompt_seeds_frame0_feedback():
+    """The frame-0 decode step lists prev_text / prev_func as inputs but has no
+    prior sampled token; process_prompt must seed them (BOS / PAD) or the decode
+    loop never becomes ready (the original hang)."""
+    model = _make_model()
+    out = model.process_prompt(
+        None, ["audio"], ["audio", "text"],
+        tensors={"audio_inputs": [torch.zeros(16000)]},
+    )
+    assert "audio_features" in out
+    assert int(out["prev_text"][0].item()) == model.config.text_bos_id
+    assert int(out["prev_func"][0].item()) == model.config.text_pad_id
+
+
+def test_duplex_no_prompt_seeds_initial_decode_inputs():
+    """Audio-only start (no system prompt): the LLM partition jumps straight to
+    the decode loop and its initial inputs carry the seeded prev_text / prev_func
+    so iteration 0's readiness gate fires."""
+    model = _make_model()
+    sig = {"audio_features": ["a"], "prev_text": ["pt"], "prev_func": ["pf"]}
+    fpa = model.get_initial_forward_pass_args("LLM", ["audio"], ["audio"], sig)
+    assert fpa.full_metadata.graph_walk == "decode"
+    assert {e.name for e in fpa.inputs} == {"prev_text", "prev_func"}

--- a/test/modular/test_nemotron_duplex_model.py
+++ b/test/modular/test_nemotron_duplex_model.py
@@ -1,0 +1,92 @@
+"""Structural tests for the Nemotron-Duplex M* engine integration: the four-partition
+full-duplex walk graphs, topology, aux sampling, and forward-pass-args routing.
+
+These validate everything the engine needs to *wire* the model (no weights / GPU):
+``get_worker_graphs`` resolves every edge route + cross-partition streaming connection,
+so a dangling edge name or unresolved partition fails loudly here.
+"""
+from pathlib import Path
+
+from mstar.engine.base import EngineType
+from mstar.model.nemotron_duplex.config import NemotronDuplexConfig
+from mstar.model.nemotron_duplex.nemotron_duplex_model import NemotronDuplexModel
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "configs" / "nemotron_duplex.yaml"
+
+WALKS = {"encode", "prefill_text", "decode", "talker_decode", "codec_chunk"}
+
+
+def _make_model() -> NemotronDuplexModel:
+    model = object.__new__(NemotronDuplexModel)
+    model.config = NemotronDuplexConfig()
+    model._submodule_cache = {}
+    return model
+
+
+def test_duplex_declares_all_walks():
+    assert set(_make_model().get_graph_walk_graphs()) == WALKS
+
+
+def test_duplex_engine_types():
+    assert _make_model().get_node_engine_types() == {
+        "conformer_encoder": EngineType.STATELESS,
+        "nano_llm": EngineType.KV_CACHE,
+        "eartts_talker": EngineType.KV_CACHE,
+        "audio_codec": EngineType.STATELESS,
+    }
+
+
+def test_duplex_partition_producer_chain():
+    parts = {p.name: p for p in _make_model().get_partitions()}
+    assert set(parts) == {"Encoder", "LLM", "Talker", "Codec"}
+    assert parts["Encoder"].producer_partitions == []
+    assert parts["LLM"].producer_partitions == ["Encoder"]
+    assert parts["Talker"].producer_partitions == ["LLM"]
+    assert parts["Codec"].producer_partitions == ["Talker"]
+
+
+def test_duplex_topology_routes():
+    conns = {(c.from_partition, c.to_partition, c.edge_name)
+             for c in _make_model().get_partition_topology().connections}
+    assert conns == {
+        ("Encoder", "LLM", "audio_frame"),
+        ("LLM", "Talker", "new_token"),
+        ("Talker", "Codec", "codec_tokens"),
+    }
+
+
+def test_duplex_nano_has_function_aux_channel():
+    assert "function" in _make_model().get_aux_sampling_configs("nano_llm")
+    assert _make_model().get_aux_sampling_configs("audio_codec") == {}
+
+
+def test_duplex_worker_graphs_derive_all_walks():
+    model = _make_model()
+    worker_graphs = model.get_worker_graphs(str(CONFIG_PATH))
+    by_walk = {next(iter(wg.graph_walks)): wg for wg in worker_graphs}
+    assert set(by_walk) == WALKS
+    assert by_walk["decode"].consumes_stream is True
+    assert by_walk["codec_chunk"].consumes_stream is True
+
+
+def test_duplex_initial_partition_routing():
+    model = _make_model()
+    sig = {"audio_features": ["a"], "text_inputs": ["t"]}
+    expected = {"Encoder": "encode", "LLM": "prefill_text",
+                "Talker": "talker_decode", "Codec": "codec_chunk"}
+    for pname, walk in expected.items():
+        fpa = model.get_initial_forward_pass_args(pname, ["audio"], ["audio", "text"], sig)
+        assert fpa.full_metadata.graph_walk == walk
+    # no system prompt -> LLM starts straight in the decode loop
+    fpa = model.get_initial_forward_pass_args("LLM", ["audio"], ["audio"], {"audio_features": ["a"]})
+    assert fpa.full_metadata.graph_walk == "decode"
+    # audio not requested -> streaming output partitions are immediately done
+    assert model.get_initial_forward_pass_args("Codec", ["audio"], ["text"], sig).request_done
+
+
+def test_duplex_llm_prefill_to_decode_transition():
+    model = _make_model()
+    meta = model._meta(["audio"], ["audio"], "prefill_text", True)
+    fpa = model.get_partition_forward_pass_args("LLM", meta, {})
+    assert fpa.full_metadata.graph_walk == "decode"
+    assert fpa.full_metadata.is_prefill is False

--- a/test/modular/test_nemotron_duplex_submodules.py
+++ b/test/modular/test_nemotron_duplex_submodules.py
@@ -1,0 +1,118 @@
+"""CPU unit tests for the Nemotron-Duplex NodeSubmodules — the per-node compute
+wrappers — using lightweight fakes (no real weights / GPU).
+
+Regression coverage for the E5 serving fixes:
+  * nano ``check_stop`` must NOT stop on EOS (a normal per-frame token in duplex);
+  * nano ``_fuse_frame`` must tolerate the empty terminal ``audio_frame`` chunk;
+  * the codec keeps a per-request left-context and emits ONLY the new frames
+    (a stateless full-window emit balloons the audio ~window/chunk×).
+"""
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from mstar.model.nemotron_duplex.config import NemotronDuplexConfig
+from mstar.model.nemotron_duplex.submodules import (
+    AudioCodecDecoderSubmodule,
+    NemotronHLLMSubmodule,
+)
+
+
+def _make_nano() -> NemotronHLLMSubmodule:
+    cfg = NemotronDuplexConfig()
+    lm = nn.Module()
+    lm.embeddings = nn.Embedding(64, 8)   # covers the special ids (bos/pad/eos)
+    lm.lm_head = nn.Linear(8, 64)
+    lm.function_head = nn.Linear(8, 64)
+    return NemotronHLLMSubmodule(language_model=lm, config=cfg)
+
+
+def _fwd_info(iters: int, max_tokens: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        dynamic_loop_iter_counts={"decode_loop": iters}, max_tokens=max_tokens,
+    )
+
+
+def test_nano_check_stop_ignores_eos():
+    """Text EOS is a normal per-frame token in duplex; the decode loop ends on
+    audio-frame stream exhaustion, NOT on EOS — so check_stop must not stop on it."""
+    nano = _make_nano()
+    eos = {"new_token": [torch.tensor([nano.config.eos_token_id])]}
+    assert nano.check_stop("r", _fwd_info(0, 2048), eos) == set()
+
+
+def test_nano_check_stop_hits_max_tokens():
+    nano = _make_nano()
+    out = {"new_token": [torch.tensor([5])]}
+    assert nano.check_stop("r", _fwd_info(max_tokens=8, iters=7), out) == {"decode_loop"}
+
+
+def test_nano_fuse_frame_handles_empty_audio_frame():
+    """The terminal audio_frame stream chunk (producer_done race) arrives with the
+    key present but an empty tensor list; _fuse_frame must run a no-audio step
+    instead of IndexError-ing on ``inputs["audio_frame"][0]``."""
+    nano = _make_nano()
+    empty = nano.prepare_inputs("decode", None, {"audio_frame": []})
+    assert empty.input_embeds is not None
+    assert empty.input_embeds.shape == (1, 8) and empty.input_seq_len == 1
+
+
+def test_nano_fuse_frame_adds_audio_when_present():
+    nano = _make_nano()
+    got = nano.prepare_inputs("decode", None, {"audio_frame": [torch.ones(8)]})
+    assert got.input_embeds.shape == (1, 8)
+    # with a nonzero audio frame the fused embed differs from the no-audio (empty) step
+    no_audio = nano.prepare_inputs("decode", None, {"audio_frame": []})
+    assert not torch.allclose(got.input_embeds, no_audio.input_embeds)
+
+
+class _FakeCodec(nn.Module):
+    """Stand-in vocoder: emits SPF samples per code frame (value = frame index),
+    so a chunk's emitted length and content are checkable."""
+
+    SPF = 16
+
+    def decode(self, codes, code_len):
+        tf = codes.shape[1]
+        wav = torch.repeat_interleave(torch.arange(tf, dtype=torch.float32) / 1000.0, self.SPF)
+        return wav.view(1, 1, -1), torch.tensor([tf * self.SPF])
+
+
+def _make_codec() -> AudioCodecDecoderSubmodule:
+    return AudioCodecDecoderSubmodule(codec=_FakeCodec(), config=NemotronDuplexConfig())
+
+
+def _run_codec(codec, rid, n_frames):
+    codes = torch.zeros(n_frames, 4, dtype=torch.long)
+    eng = SimpleNamespace(request_ids=[rid])
+    return codec.forward("codec_chunk", eng, codes=codes)["audio_chunk"][0]
+
+
+def test_codec_emits_only_new_frames_with_left_context():
+    """First chunk emits all its frames; later chunks decode context+new but
+    emit ONLY the new frames — so a 5+5 frame stream yields 10 frames of audio,
+    not 5+10 (the overlap-re-emission balloon)."""
+    codec = _make_codec()
+    spf = _FakeCodec.SPF
+    a = _run_codec(codec, "r", 5)
+    assert a.shape[0] == 5 * spf                       # first chunk: all 5 frames
+    b = _run_codec(codec, "r", 5)
+    assert b.shape[0] == 5 * spf                       # second chunk: only the 5 NEW frames
+    # context rolled forward, capped at codec_left_context_frames
+    assert codec._ctx["r"].shape[0] == min(10, codec.config.eartts.codec_left_context_frames)
+
+
+def test_codec_cleanup_clears_per_request_context():
+    codec = _make_codec()
+    _run_codec(codec, "r", 5)
+    assert "r" in codec._ctx
+    codec.cleanup_request("r")
+    assert "r" not in codec._ctx
+
+
+def test_codec_requests_are_isolated():
+    codec = _make_codec()
+    _run_codec(codec, "a", 5)
+    _run_codec(codec, "b", 3)
+    assert codec._ctx["a"].shape[0] == 5 and codec._ctx["b"].shape[0] == 3

--- a/test/modular/test_streaming_loop_rearm.py
+++ b/test/modular/test_streaming_loop_rearm.py
@@ -1,0 +1,49 @@
+"""A Loop whose inner node's inputs are ALL streaming (no loop-back) must have
+that node re-armed into ``ready_for_streaming`` on every iteration.
+
+Loop-back nodes are re-armed implicitly by their re-injected inputs; a
+pure-streaming node has nothing to re-inject, so without an explicit re-arm it
+falls out of ``ready_for_streaming`` after the first chunk and the loop stalls
+(the Nemotron-Duplex talker / codec stream-consuming loops). This exercises the
+generic ``Loop._advance_one_iter`` → ``WorkerGraphStateRegistry.rearm_streaming``
+path, independent of any model.
+"""
+from mstar.graph.base import GraphEdge, GraphNode, Loop
+from mstar.graph.graph_io import WorkerGraphIO
+
+
+def _pure_streaming_loop() -> WorkerGraphIO:
+    node = GraphNode(
+        name="consumer",
+        input_names={"chunk"},
+        outputs=[GraphEdge(next_node="downstream", name="out")],
+    )
+    node._register_streaming({"chunk"})            # input_names == streaming_inputs
+    # _external_inputs empty: mimic _divide_into_worker_graphs, which filters the
+    # streaming input out of the loop's re-injected external inputs.
+    loop = Loop(
+        name="consumer_loop", section=node, max_iters=8, outputs=[],
+        _external_inputs=set(), _loop_back_inputs=set(),
+    )
+    return WorkerGraphIO(loop)
+
+
+def test_pure_streaming_loop_node_rearmed_each_iteration():
+    wg = _pure_streaming_loop()
+
+    # Starts ready-for-streaming (all inputs streaming).
+    assert "consumer" in wg.ready_for_streaming
+
+    # Consume one streamed chunk -> node becomes fully ready and is dropped from
+    # the streaming-ready set.
+    assert wg.ingest_input(GraphEdge(next_node="consumer", name="chunk"))
+    assert "consumer" not in wg.ready_for_streaming
+    assert "consumer" in wg.ready_node_names
+
+    # Finish the iteration -> loop advances -> node re-armed for the next chunk.
+    wg.mark_node_complete("consumer")
+    assert "consumer" in wg.ready_for_streaming
+
+    # And it advanced rather than finishing (max_iters not reached).
+    assert wg.loops["consumer_loop"].curr_iter == 1
+    assert wg.loops["consumer_loop"].is_done is False

--- a/test/nemotron_duplex/.sample.env
+++ b/test/nemotron_duplex/.sample.env
@@ -1,0 +1,23 @@
+# mstar nemotron_duplex (VoiceChat-11B) test config — copy to .env and edit:
+#   cp test/nemotron_duplex/.sample.env test/nemotron_duplex/.env
+
+# --- User identity (used for temp paths) ---
+WHO=yourname
+
+# --- GPU devices (comma-separated) ---
+# Single-GPU layout (configs/nemotron_duplex.yaml) needs one GPU: DEVICES=0
+# Disaggregated layout (configs/nemotron_duplex_disagg.yaml) needs three: DEVICES=0,1,2
+DEVICES=0
+
+# --- Server host/port ---
+HOST=127.0.0.1
+PORT=8019
+
+# --- Weight cache directory (HF snapshots land here) ---
+NEMOTRON_DUPLEX_CACHE_DIR=/mnt/storage/$WHO/mstar/nemotron_duplex/
+
+# --- Tensor transfer protocol (SHM is the safe single-node default) ---
+TENSOR_PROTOCOL=SHM
+
+# --- TCP loopback device (only used when TENSOR_PROTOCOL=TCP) ---
+TCP_DEVICE=0.0.0.0.0

--- a/test/nemotron_duplex/README.md
+++ b/test/nemotron_duplex/README.md
@@ -73,12 +73,15 @@ Behavior to expect / verify:
 - The agent stays silent while the user talks and starts replying a few frames
   after; with a longer `--silence` it will emit **more reply text** (it does not
   wait for the user — it fills silence with plausible follow-up turns).
-- The reply **audio is sparse** — the talker/codec voices only a fraction of the
-  dense text (e.g. ~1.5 s voiced per reply). This matches the standalone
-  `offline_inference` reference, so it's a model/reference characteristic, not a
-  serving-engine bug. (The transport is fixed-buffer input + streamed output; the
-  engine has no incremental-audio-input path — that lives in the model's
-  standalone `realtime_api.py` over `DuplexStream`.)
+- The reply is voiced as **real, intelligible speech**. On a long-context input
+  (a full ~53 s user channel) the agent produces a coherent multi-turn reply with
+  ~13 s of voiced audio (ASR-verifiable, e.g. "Hello! How can I help you today? …
+  a quick peanut butter cookie recipe … bake at three hundred fifty degrees …").
+  Very dense late sentences in a long reply can still thin out (the talker emits
+  ~1 code-frame per text token and the nano packs words densely) — a minor
+  remaining model-reimplementation tail, not a serving-engine bug. (The transport
+  is fixed-buffer input + streamed output; the engine has no incremental-audio-input
+  path — that lives in the model's standalone `realtime_api.py` over `DuplexStream`.)
 
 `--text-only` returns the agent text in seconds; full audio is slower.
 
@@ -96,8 +99,9 @@ python test/nemotron_duplex/webui.py --mstar-url http://127.0.0.1:8019 --port 85
 ```
 
 The mic needs a secure context (works on `http://localhost` / `127.0.0.1`; for
-remote access put it behind HTTPS). Same caveat as above applies — the agent
-replies with full text but only a short voiced burst of audio.
+remote access put it behind HTTPS). The agent replies with full text and voiced
+speech; on very dense late sentences of a long reply the audio can thin out (see
+the streaming-request note above).
 
 ## Validate against the oracle
 

--- a/test/nemotron_duplex/README.md
+++ b/test/nemotron_duplex/README.md
@@ -36,14 +36,14 @@ bash test/nemotron_duplex/launch_server.sh disagg   # 3-GPU pipeline (nemotron_d
 ```
 
 Both layouts produce identical text + audio. The first request compiles kernels
-(cold, ~90 s); the talker is eager MaskGIT (~2 s/frame), so prefer short clips.
+(cold, ~90 s); once warm the pipeline runs ~0.1 s/frame.
 
-Send a request. With no `--audio`, a clean **user-only** input is prepared from
-the base VoiceChat-11B demo `turn_taking.wav` — those demo wavs are 2-channel
-recordings of the whole conversation (user left, agent right), so we take the
-user channel, isolate the first user turn, and append silence for the reply. On
-the default clip the agent answers *"Oh, I love cooking! How about this chocolate
-chip cookie recipe? …"*.
+### One-shot request (`duplex_request.py`)
+
+With no `--audio`, a clean **user-only** input is prepared from the base
+VoiceChat-11B demo `turn_taking.wav` — those demo wavs are 2-channel recordings
+of the whole conversation (user left, agent right), so we take the user channel,
+isolate the first user turn, and append silence for the reply.
 
 ```bash
 cd test/nemotron_duplex
@@ -53,10 +53,34 @@ python duplex_request.py --text-only                     # skip talker/codec (fa
 python duplex_request.py -n 3                             # 3 concurrent (batching)
 ```
 
-Your own `--audio` should be **user speech only** (mono), with a few seconds of
-trailing silence — the model is frame-synchronous and replies in the frames
-*after* you stop talking. `--text-only` returns the transcript-style agent text
-in seconds; full audio takes a few minutes (the talker is eager MaskGIT).
+Your own `--audio` should be **user speech only** (mono), with trailing silence —
+the model is frame-synchronous and replies in the frames *after* you stop talking.
+
+### Duplex / streaming request (`duplex_stream_request.py`)
+
+Sends the user utterance followed by a window of no-sound frames (the "keep
+talking after the user stops" case) and consumes the reply as it streams back,
+reporting the turn boundary and how much of the reply was actually voiced:
+
+```bash
+cd test/nemotron_duplex
+python duplex_stream_request.py                          # 30 s reply window
+python duplex_stream_request.py --silence 15 --output agent.wav
+python duplex_stream_request.py --audio user.wav --silence 20
+```
+
+Behavior to expect / verify:
+- The agent stays silent while the user talks and starts replying a few frames
+  after; with a longer `--silence` it will emit **more reply text** (it does not
+  wait for the user — it fills silence with plausible follow-up turns).
+- The reply **audio is sparse** — the talker/codec voices only a fraction of the
+  dense text (e.g. ~1.5 s voiced per reply). This matches the standalone
+  `offline_inference` reference, so it's a model/reference characteristic, not a
+  serving-engine bug. (The transport is fixed-buffer input + streamed output; the
+  engine has no incremental-audio-input path — that lives in the model's
+  standalone `realtime_api.py` over `DuplexStream`.)
+
+`--text-only` returns the agent text in seconds; full audio is slower.
 
 ## Validate against the oracle
 

--- a/test/nemotron_duplex/README.md
+++ b/test/nemotron_duplex/README.md
@@ -82,6 +82,23 @@ Behavior to expect / verify:
 
 `--text-only` returns the agent text in seconds; full audio is slower.
 
+### Browser UI (`webui.py`)
+
+A tiny local web app to talk to the model from a browser (record from the mic or
+upload a wav). It's a small proxy: the page posts audio to it, it resamples to
+16 kHz mono, appends the silence reply window, forwards to the model server with
+streaming, and streams the agent's text + audio back to play.
+
+```bash
+# with the model server already running (e.g. on :8019):
+python test/nemotron_duplex/webui.py --mstar-url http://127.0.0.1:8019 --port 8500
+# then open http://127.0.0.1:8500/
+```
+
+The mic needs a secure context (works on `http://localhost` / `127.0.0.1`; for
+remote access put it behind HTTPS). Same caveat as above applies — the agent
+replies with full text but only a short voiced burst of audio.
+
 ## Validate against the oracle
 
 `offline_inference` is the verified ground truth (100% text-token match vs the

--- a/test/nemotron_duplex/README.md
+++ b/test/nemotron_duplex/README.md
@@ -38,14 +38,16 @@ bash test/nemotron_duplex/launch_server.sh disagg   # 3-GPU pipeline (nemotron_d
 Both layouts produce identical text + audio. The first request compiles kernels
 (cold, ~90 s); the talker is eager MaskGIT (~2 s/frame), so prefer short clips.
 
-Send a request (the base VoiceChat-11B HF repo ships `turn_taking.wav`,
-`interruptions.wav`, `tool_call.wav`):
+Send a request. With no `--audio`, a sample input is auto-resolved from the base
+VoiceChat-11B HF repo (which ships `turn_taking.wav`, `interruptions.wav`,
+`tool_call.wav`):
 
 ```bash
 cd test/nemotron_duplex
+python duplex_request.py                                 # default sample -> agent_out.wav
 python duplex_request.py --audio /path/to/user.wav --output agent.wav
-python duplex_request.py --audio /path/to/user.wav --text-only          # skip talker/codec
-python duplex_request.py --audio /path/to/user.wav -n 3                  # 3 concurrent (batching)
+python duplex_request.py --text-only                     # skip talker/codec
+python duplex_request.py -n 3                             # 3 concurrent (batching)
 ```
 
 ## Validate against the oracle

--- a/test/nemotron_duplex/README.md
+++ b/test/nemotron_duplex/README.md
@@ -1,0 +1,60 @@
+# Nemotron-Duplex (VoiceChat-11B) — serving tests
+
+Full-duplex speech-to-speech: user speech in → agent **text + agent speech** out,
+through the M* engine (`conformer_encoder` → `nano_llm` → `eartts_talker` →
+`audio_codec`).
+
+## CPU unit tests (CI, no GPU / weights)
+
+Run from the repo root:
+
+```bash
+pytest test/modular/test_nemotron_duplex_model.py \
+       test/modular/test_nemotron_duplex_submodules.py \
+       test/modular/test_streaming_loop_rearm.py
+```
+
+- `test_nemotron_duplex_model.py` — walk graphs, partitions, streaming topology,
+  chunk policies, frame-0 seeding, forward-pass-args routing.
+- `test_nemotron_duplex_submodules.py` — nano `check_stop` (EOS is not a stop),
+  `_fuse_frame` empty-terminal-chunk guard, stateful codec (left-context + emit
+  only new frames).
+- `test_streaming_loop_rearm.py` — generic: a pure-streaming loop node is
+  re-armed each iteration (the talker/codec loops rely on this).
+
+## End-to-end serving (GPU + real weights)
+
+```bash
+cp test/nemotron_duplex/.sample.env test/nemotron_duplex/.env   # then edit it
+```
+
+Launch the server (run from the repo root):
+
+```bash
+bash test/nemotron_duplex/launch_server.sh          # single-GPU  (configs/nemotron_duplex.yaml)
+bash test/nemotron_duplex/launch_server.sh disagg   # 3-GPU pipeline (nemotron_duplex_disagg.yaml)
+```
+
+Both layouts produce identical text + audio. The first request compiles kernels
+(cold, ~90 s); the talker is eager MaskGIT (~2 s/frame), so prefer short clips.
+
+Send a request (the base VoiceChat-11B HF repo ships `turn_taking.wav`,
+`interruptions.wav`, `tool_call.wav`):
+
+```bash
+cd test/nemotron_duplex
+python duplex_request.py --audio /path/to/user.wav --output agent.wav
+python duplex_request.py --audio /path/to/user.wav --text-only          # skip talker/codec
+python duplex_request.py --audio /path/to/user.wav -n 3                  # 3 concurrent (batching)
+```
+
+## Validate against the oracle
+
+`offline_inference` is the verified ground truth (100% text-token match vs the
+NeMo reference). The engine's text must match it token-for-token; audio is
+seeded-stochastic (compare duration / RMS, not samples). Run the oracle on a GPU
+the server is **not** using:
+
+```bash
+CUDA_VISIBLE_DEVICES=<free-gpu> python test/nemotron_duplex/oracle_compare.py --audio /path/to/user.wav
+```

--- a/test/nemotron_duplex/README.md
+++ b/test/nemotron_duplex/README.md
@@ -38,17 +38,25 @@ bash test/nemotron_duplex/launch_server.sh disagg   # 3-GPU pipeline (nemotron_d
 Both layouts produce identical text + audio. The first request compiles kernels
 (cold, ~90 s); the talker is eager MaskGIT (~2 s/frame), so prefer short clips.
 
-Send a request. With no `--audio`, a sample input is auto-resolved from the base
-VoiceChat-11B HF repo (which ships `turn_taking.wav`, `interruptions.wav`,
-`tool_call.wav`):
+Send a request. With no `--audio`, a clean **user-only** input is prepared from
+the base VoiceChat-11B demo `turn_taking.wav` — those demo wavs are 2-channel
+recordings of the whole conversation (user left, agent right), so we take the
+user channel, isolate the first user turn, and append silence for the reply. On
+the default clip the agent answers *"Oh, I love cooking! How about this chocolate
+chip cookie recipe? …"*.
 
 ```bash
 cd test/nemotron_duplex
-python duplex_request.py                                 # default sample -> agent_out.wav
+python duplex_request.py                                 # default user clip -> agent_out.wav
 python duplex_request.py --audio /path/to/user.wav --output agent.wav
-python duplex_request.py --text-only                     # skip talker/codec
+python duplex_request.py --text-only                     # skip talker/codec (fast)
 python duplex_request.py -n 3                             # 3 concurrent (batching)
 ```
+
+Your own `--audio` should be **user speech only** (mono), with a few seconds of
+trailing silence — the model is frame-synchronous and replies in the frames
+*after* you stop talking. `--text-only` returns the transcript-style agent text
+in seconds; full audio takes a few minutes (the talker is eager MaskGIT).
 
 ## Validate against the oracle
 

--- a/test/nemotron_duplex/_audio_prep.py
+++ b/test/nemotron_duplex/_audio_prep.py
@@ -1,0 +1,76 @@
+"""Prepare a clean USER-only 16 kHz-mono input clip from the VoiceChat-11B demo.
+
+The base repo's demo wavs (turn_taking.wav, ...) are 2-channel recordings of the
+WHOLE conversation (user on the left, agent on the right) meant for listening.
+For an INPUT we want the user side only, plus trailing silence for the reply
+(this is a frame-synchronous model: it answers in the frames *after* the user
+stops). We take the left channel, isolate the first user turn, append
+``trailing_s`` of silence, and resample to 16 kHz mono. Results are cached in the
+temp dir keyed by ``trailing_s``.
+"""
+import os
+import tempfile
+
+_DEMO_WAV = "turn_taking.wav"       # base VoiceChat-11B repo; L=user, R=agent
+
+
+def resolve_demo() -> str:
+    from huggingface_hub import hf_hub_download
+
+    from mstar.model.registry import HF_MODELS
+
+    repo = HF_MODELS["nemotron_duplex"]["model_path_hf"]
+    return hf_hub_download(repo, _DEMO_WAV, cache_dir=os.environ.get("NEMOTRON_DUPLEX_CACHE_DIR"))
+
+
+def first_user_turn(user, sr, trailing_s):
+    """First contiguous user utterance >= ~1.2 s (short gaps bridged), 0.3 s lead
+    pad, and ``trailing_s`` of trailing silence (zero-padded past EOF)."""
+    import numpy as np
+
+    w = int(sr * 0.1)                                  # 100 ms frames
+    n = len(user) // w
+    e = np.sqrt((user[: n * w].reshape(n, w) ** 2).mean(1))
+    act = e > e.max() * 0.08
+    for i in range(1, n - 3):                          # bridge <0.3 s gaps
+        if not act[i] and act[i - 1] and act[i : i + 3].any():
+            act[i] = True
+    runs, i = [], 0
+    while i < n:
+        if act[i]:
+            j = i
+            while j < n and act[j]:
+                j += 1
+            runs.append((i, j))
+            i = j
+        else:
+            i += 1
+    if not runs:
+        return user
+    s, ep = next((r for r in runs if (r[1] - r[0]) * 0.1 >= 1.2), runs[0])
+    a = max(0, s * w - int(sr * 0.3))
+    b = ep * w + int(sr * trailing_s)
+    clip = user[a : min(len(user), b)]
+    if b > len(user):
+        clip = np.concatenate([clip, np.zeros(b - len(user), dtype=clip.dtype)])
+    return clip
+
+
+def prepare_user_clip(trailing_s=6.0, target_sr=16000) -> str:
+    """Return a path to a cached 16 kHz-mono user-only clip with ``trailing_s`` of
+    trailing silence."""
+    out = os.path.join(tempfile.gettempdir(), f"nemotron_duplex_user_{int(round(trailing_s))}s.wav")
+    if os.path.exists(out):
+        return out
+    import soundfile as sf
+    import torch
+    import torchaudio.functional as AF
+
+    src = resolve_demo()
+    d, sr = sf.read(src, dtype="float32")
+    user = d[:, 0] if d.ndim == 2 else d               # left channel = user
+    clip = first_user_turn(user, sr, trailing_s)
+    if sr != target_sr:
+        clip = AF.resample(torch.from_numpy(clip.copy()), sr, target_sr).numpy()
+    sf.write(out, clip, target_sr)
+    return out

--- a/test/nemotron_duplex/_env.py
+++ b/test/nemotron_duplex/_env.py
@@ -1,0 +1,36 @@
+"""Load .env into os.environ so every script shares one config."""
+
+import os
+from pathlib import Path
+
+_loaded = False
+
+
+def load_env() -> None:
+    global _loaded
+    if _loaded:
+        return
+    _loaded = True
+
+    env_file = Path(__file__).parent / ".env"
+    if not env_file.exists():
+        env_file = Path(".env")
+        if not env_file.exists():
+            return  # fall back to existing env vars / defaults
+
+    with open(env_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            key, _, value = line.partition("=")
+            key, value = key.strip(), value.strip()
+            if key and key not in os.environ:
+                os.environ[key] = value
+
+
+def get_base_url() -> str:
+    load_env()
+    host = os.environ.get("HOST", "127.0.0.1")
+    port = os.environ.get("PORT", "8019")
+    return f"http://{host}:{port}"

--- a/test/nemotron_duplex/duplex_request.py
+++ b/test/nemotron_duplex/duplex_request.py
@@ -7,12 +7,16 @@ Usage:
     python test/nemotron_duplex/duplex_request.py --text-only
     python test/nemotron_duplex/duplex_request.py --output agent.wav -n 3
 
-With no --audio, a sample input is resolved from the base VoiceChat-11B HF repo,
-which ships turn_taking.wav / interruptions.wav / tool_call.wav.
+With no --audio, a clean USER-only input is prepared from the base VoiceChat-11B
+demo (``turn_taking.wav``). Those demo wavs are 2-channel recordings of the WHOLE
+conversation (user on the left, agent on the right) meant for listening — feeding
+them as-is would let the model hear its own side, so we take the left (user)
+channel, isolate the first user turn, and resample to 16 kHz mono.
 """
 import argparse
 import os
 import sys
+import tempfile
 import threading
 import time
 
@@ -20,13 +24,52 @@ from _env import get_base_url, load_env
 
 from mstar.client.client import MStarClient
 
-# Sample inputs bundled in the base VoiceChat-11B HF repo, in preference order.
-_SAMPLE_WAVS = ("turn_taking.wav", "interruptions.wav", "tool_call.wav")
+_DEMO_WAV = "turn_taking.wav"     # base VoiceChat-11B repo; L=user, R=agent
+_PREPARED = os.path.join(tempfile.gettempdir(), "nemotron_duplex_default_user_turn.wav")
+
+
+def _first_user_turn(user, sr, trailing_s=6.0):
+    """First contiguous user utterance >= ~1.2 s (short gaps bridged), with 0.3 s
+    lead pad and ``trailing_s`` of trailing silence.
+
+    The trailing silence matters: this is a frame-synchronous model that stays
+    silent (EOS) *while* the user is speaking and only produces its reply in the
+    frames *after* — so a clip cut off right at the question yields an all-silent
+    agent. The user (left) channel is naturally silent while the agent replies,
+    so extending into it (zero-padded if the file ends) gives the reply room."""
+    import numpy as np
+
+    w = int(sr * 0.1)                                  # 100 ms frames
+    n = len(user) // w
+    e = np.sqrt((user[: n * w].reshape(n, w) ** 2).mean(1))
+    act = e > e.max() * 0.08
+    for i in range(1, n - 3):                          # bridge <0.3 s gaps
+        if not act[i] and act[i - 1] and act[i : i + 3].any():
+            act[i] = True
+    runs, i = [], 0
+    while i < n:
+        if act[i]:
+            j = i
+            while j < n and act[j]:
+                j += 1
+            runs.append((i, j))
+            i = j
+        else:
+            i += 1
+    if not runs:
+        return user
+    s, ep = next((r for r in runs if (r[1] - r[0]) * 0.1 >= 1.2), runs[0])
+    a = max(0, s * w - int(sr * 0.3))
+    b = ep * w + int(sr * trailing_s)
+    clip = user[a : min(len(user), b)]
+    if b > len(user):                                  # pad reply room past EOF
+        clip = np.concatenate([clip, np.zeros(b - len(user), dtype=clip.dtype)])
+    return clip
 
 
 def default_audio() -> str:
-    """Resolve a bundled sample wav from the HF cache (downloads the small file
-    if the repo snapshot didn't already fetch it)."""
+    """Prepare (once) and return a clean 16 kHz-mono user-only clip from the
+    VoiceChat-11B demo. Falls back to the raw demo wav if audio libs are missing."""
     load_env()
     from huggingface_hub import hf_hub_download
 
@@ -34,16 +77,25 @@ def default_audio() -> str:
 
     repo = HF_MODELS["nemotron_duplex"]["model_path_hf"]
     cache_dir = os.environ.get("NEMOTRON_DUPLEX_CACHE_DIR")
-    last_err = None
-    for fname in _SAMPLE_WAVS:
-        try:
-            return hf_hub_download(repo, fname, cache_dir=cache_dir)
-        except Exception as e:  # noqa: BLE001 - try the next sample
-            last_err = e
-    raise SystemExit(
-        f"No --audio given and no sample wav could be resolved from {repo!r} "
-        f"(last error: {last_err}). Pass --audio /path/to/user.wav."
-    )
+    src = hf_hub_download(repo, _DEMO_WAV, cache_dir=cache_dir)
+
+    if os.path.exists(_PREPARED):
+        return _PREPARED
+    try:
+        import soundfile as sf
+        import torch
+        import torchaudio.functional as AF
+
+        d, sr = sf.read(src, dtype="float32")
+        user = d[:, 0] if d.ndim == 2 else d          # left channel = user
+        clip = _first_user_turn(user, sr)
+        clip16 = AF.resample(torch.from_numpy(clip.copy()), sr, 16000).numpy()
+        sf.write(_PREPARED, clip16, 16000)
+        print(f"prepared user-only input: {_PREPARED} ({len(clip16) / 16000:.1f}s @ 16 kHz)")
+        return _PREPARED
+    except Exception as e:  # noqa: BLE001 - degrade to the raw demo wav
+        print(f"warning: could not prepare user-only clip ({e}); using raw demo {src}")
+        return src
 
 
 def one_request(url: str, audio: str, modalities, temperature: float):

--- a/test/nemotron_duplex/duplex_request.py
+++ b/test/nemotron_duplex/duplex_request.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Nemotron-Duplex client: send user speech, get back agent text + agent speech.
+
+Usage:
+    python test/nemotron_duplex/duplex_request.py --audio user.wav
+    python test/nemotron_duplex/duplex_request.py --audio user.wav --text-only
+    python test/nemotron_duplex/duplex_request.py --audio user.wav --output agent.wav -n 3
+
+The base VoiceChat-11B HF repo ships sample inputs (turn_taking.wav,
+interruptions.wav, tool_call.wav) usable for --audio.
+"""
+import argparse
+import sys
+import threading
+import time
+
+from _env import get_base_url
+
+from mstar.client.client import MStarClient
+
+
+def one_request(url: str, audio: str, modalities, temperature: float):
+    c = MStarClient(url, timeout=600)
+    t0 = time.time()
+    r = c.generate(
+        audio=audio, input_modalities=("audio",),
+        output_modalities=modalities, temperature=temperature,
+    )
+    return r, time.time() - t0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--audio", required=True, help="path to a 16 kHz-ish mono wav of user speech")
+    ap.add_argument("--output", default="agent_out.wav", help="where to save agent speech")
+    ap.add_argument("--text-only", action="store_true", help="request text output only (skip the talker/codec)")
+    ap.add_argument("--temperature", type=float, default=0.0)
+    ap.add_argument("-n", "--concurrency", type=int, default=1, help="fire N identical requests concurrently")
+    args = ap.parse_args()
+
+    url = get_base_url()
+    modalities = ("text",) if args.text_only else ("text", "audio")
+    print(f"POST {url}/generate  audio={args.audio}  out={modalities}  n={args.concurrency}")
+
+    results: dict[int, tuple] = {}
+
+    def worker(i):
+        results[i] = one_request(url, args.audio, modalities, args.temperature)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(args.concurrency)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    texts = [results[i][0].text for i in range(args.concurrency)]
+    for i in range(args.concurrency):
+        r, dt = results[i]
+        n_audio = len(r.audio) if getattr(r, "audio", None) is not None else 0
+        print(f"  req{i}: {dt:.1f}s  text_len={len(r.text or '')}  audio_samples={n_audio}")
+
+    if args.concurrency > 1:
+        print(f"  all identical: {all(t == texts[0] for t in texts)}")
+
+    r0 = results[0][0]
+    print("\n=== agent text ===")
+    print(r0.text)
+    if getattr(r0, "audio", None) is not None and len(r0.audio):
+        r0.audio.to_wav(args.output)
+        dur = len(r0.audio) / (r0.audio.sample_rate or 22050)
+        print(f"\nsaved {args.output}  ({dur:.2f}s @ {r0.audio.sample_rate} Hz)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/nemotron_duplex/duplex_request.py
+++ b/test/nemotron_duplex/duplex_request.py
@@ -2,21 +2,48 @@
 """Nemotron-Duplex client: send user speech, get back agent text + agent speech.
 
 Usage:
+    python test/nemotron_duplex/duplex_request.py                     # default sample input
     python test/nemotron_duplex/duplex_request.py --audio user.wav
-    python test/nemotron_duplex/duplex_request.py --audio user.wav --text-only
-    python test/nemotron_duplex/duplex_request.py --audio user.wav --output agent.wav -n 3
+    python test/nemotron_duplex/duplex_request.py --text-only
+    python test/nemotron_duplex/duplex_request.py --output agent.wav -n 3
 
-The base VoiceChat-11B HF repo ships sample inputs (turn_taking.wav,
-interruptions.wav, tool_call.wav) usable for --audio.
+With no --audio, a sample input is resolved from the base VoiceChat-11B HF repo,
+which ships turn_taking.wav / interruptions.wav / tool_call.wav.
 """
 import argparse
+import os
 import sys
 import threading
 import time
 
-from _env import get_base_url
+from _env import get_base_url, load_env
 
 from mstar.client.client import MStarClient
+
+# Sample inputs bundled in the base VoiceChat-11B HF repo, in preference order.
+_SAMPLE_WAVS = ("turn_taking.wav", "interruptions.wav", "tool_call.wav")
+
+
+def default_audio() -> str:
+    """Resolve a bundled sample wav from the HF cache (downloads the small file
+    if the repo snapshot didn't already fetch it)."""
+    load_env()
+    from huggingface_hub import hf_hub_download
+
+    from mstar.model.registry import HF_MODELS
+
+    repo = HF_MODELS["nemotron_duplex"]["model_path_hf"]
+    cache_dir = os.environ.get("NEMOTRON_DUPLEX_CACHE_DIR")
+    last_err = None
+    for fname in _SAMPLE_WAVS:
+        try:
+            return hf_hub_download(repo, fname, cache_dir=cache_dir)
+        except Exception as e:  # noqa: BLE001 - try the next sample
+            last_err = e
+    raise SystemExit(
+        f"No --audio given and no sample wav could be resolved from {repo!r} "
+        f"(last error: {last_err}). Pass --audio /path/to/user.wav."
+    )
 
 
 def one_request(url: str, audio: str, modalities, temperature: float):
@@ -31,21 +58,23 @@ def one_request(url: str, audio: str, modalities, temperature: float):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--audio", required=True, help="path to a 16 kHz-ish mono wav of user speech")
+    ap.add_argument("--audio", default=None,
+                    help="path to a mono wav of user speech (default: a bundled VoiceChat-11B sample)")
     ap.add_argument("--output", default="agent_out.wav", help="where to save agent speech")
     ap.add_argument("--text-only", action="store_true", help="request text output only (skip the talker/codec)")
     ap.add_argument("--temperature", type=float, default=0.0)
     ap.add_argument("-n", "--concurrency", type=int, default=1, help="fire N identical requests concurrently")
     args = ap.parse_args()
 
+    audio = args.audio or default_audio()
     url = get_base_url()
     modalities = ("text",) if args.text_only else ("text", "audio")
-    print(f"POST {url}/generate  audio={args.audio}  out={modalities}  n={args.concurrency}")
+    print(f"POST {url}/generate  audio={audio}  out={modalities}  n={args.concurrency}")
 
     results: dict[int, tuple] = {}
 
     def worker(i):
-        results[i] = one_request(url, args.audio, modalities, args.temperature)
+        results[i] = one_request(url, audio, modalities, args.temperature)
 
     threads = [threading.Thread(target=worker, args=(i,)) for i in range(args.concurrency)]
     for t in threads:

--- a/test/nemotron_duplex/duplex_request.py
+++ b/test/nemotron_duplex/duplex_request.py
@@ -14,88 +14,26 @@ them as-is would let the model hear its own side, so we take the left (user)
 channel, isolate the first user turn, and resample to 16 kHz mono.
 """
 import argparse
-import os
 import sys
-import tempfile
 import threading
 import time
 
+from _audio_prep import prepare_user_clip, resolve_demo
 from _env import get_base_url, load_env
 
 from mstar.client.client import MStarClient
 
-_DEMO_WAV = "turn_taking.wav"     # base VoiceChat-11B repo; L=user, R=agent
-_PREPARED = os.path.join(tempfile.gettempdir(), "nemotron_duplex_default_user_turn.wav")
-
-
-def _first_user_turn(user, sr, trailing_s=6.0):
-    """First contiguous user utterance >= ~1.2 s (short gaps bridged), with 0.3 s
-    lead pad and ``trailing_s`` of trailing silence.
-
-    The trailing silence matters: this is a frame-synchronous model that stays
-    silent (EOS) *while* the user is speaking and only produces its reply in the
-    frames *after* — so a clip cut off right at the question yields an all-silent
-    agent. The user (left) channel is naturally silent while the agent replies,
-    so extending into it (zero-padded if the file ends) gives the reply room."""
-    import numpy as np
-
-    w = int(sr * 0.1)                                  # 100 ms frames
-    n = len(user) // w
-    e = np.sqrt((user[: n * w].reshape(n, w) ** 2).mean(1))
-    act = e > e.max() * 0.08
-    for i in range(1, n - 3):                          # bridge <0.3 s gaps
-        if not act[i] and act[i - 1] and act[i : i + 3].any():
-            act[i] = True
-    runs, i = [], 0
-    while i < n:
-        if act[i]:
-            j = i
-            while j < n and act[j]:
-                j += 1
-            runs.append((i, j))
-            i = j
-        else:
-            i += 1
-    if not runs:
-        return user
-    s, ep = next((r for r in runs if (r[1] - r[0]) * 0.1 >= 1.2), runs[0])
-    a = max(0, s * w - int(sr * 0.3))
-    b = ep * w + int(sr * trailing_s)
-    clip = user[a : min(len(user), b)]
-    if b > len(user):                                  # pad reply room past EOF
-        clip = np.concatenate([clip, np.zeros(b - len(user), dtype=clip.dtype)])
-    return clip
-
 
 def default_audio() -> str:
-    """Prepare (once) and return a clean 16 kHz-mono user-only clip from the
-    VoiceChat-11B demo. Falls back to the raw demo wav if audio libs are missing."""
+    """A clean 16 kHz-mono user-only clip from the VoiceChat-11B demo (with 6 s of
+    trailing silence for the reply). Falls back to the raw demo wav if audio libs
+    are missing."""
     load_env()
-    from huggingface_hub import hf_hub_download
-
-    from mstar.model.registry import HF_MODELS
-
-    repo = HF_MODELS["nemotron_duplex"]["model_path_hf"]
-    cache_dir = os.environ.get("NEMOTRON_DUPLEX_CACHE_DIR")
-    src = hf_hub_download(repo, _DEMO_WAV, cache_dir=cache_dir)
-
-    if os.path.exists(_PREPARED):
-        return _PREPARED
     try:
-        import soundfile as sf
-        import torch
-        import torchaudio.functional as AF
-
-        d, sr = sf.read(src, dtype="float32")
-        user = d[:, 0] if d.ndim == 2 else d          # left channel = user
-        clip = _first_user_turn(user, sr)
-        clip16 = AF.resample(torch.from_numpy(clip.copy()), sr, 16000).numpy()
-        sf.write(_PREPARED, clip16, 16000)
-        print(f"prepared user-only input: {_PREPARED} ({len(clip16) / 16000:.1f}s @ 16 kHz)")
-        return _PREPARED
+        return prepare_user_clip(trailing_s=6.0)
     except Exception as e:  # noqa: BLE001 - degrade to the raw demo wav
-        print(f"warning: could not prepare user-only clip ({e}); using raw demo {src}")
-        return src
+        print(f"warning: could not prepare user-only clip ({e}); using raw demo")
+        return resolve_demo()
 
 
 def one_request(url: str, audio: str, modalities, temperature: float):

--- a/test/nemotron_duplex/duplex_stream_request.py
+++ b/test/nemotron_duplex/duplex_stream_request.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Duplex-style streaming test for the Nemotron-Duplex server.
+
+Sends one user utterance followed by trailing silence — i.e. "keep sending
+no-sound frames after the user stops" — and consumes the agent's reply as it
+streams back, frame by frame. This exercises the server's full-duplex behavior:
+the model should stay silent while the user talks, start replying in the frames
+after, speak its turn, and return to silence. We detect that turn boundary and
+report it (and stop reading once the agent is done, which cancels the rest of
+the request server-side).
+
+    python test/nemotron_duplex/duplex_stream_request.py                 # 30 s reply window
+    python test/nemotron_duplex/duplex_stream_request.py --silence 15 --output agent.wav
+    python test/nemotron_duplex/duplex_stream_request.py --audio user.wav --silence 20
+
+Note on the transport: the M* engine's /generate takes a fixed audio buffer and
+streams the OUTPUT back (there is no incremental-audio-input / WebSocket path in
+the engine — that lives in the model's standalone realtime_api.py). So the
+"silence until the agent finishes" is a fixed pre-padded window (``--silence``,
+the cap the user asked for); the realtime part is the streamed reply we watch.
+"""
+import argparse
+import sys
+import time
+import wave
+
+from _audio_prep import prepare_user_clip
+from _env import get_base_url, load_env
+
+from mstar.client.client import MStarClient
+from mstar.client.types import AudioChunk, TextChunk
+
+FRAME_S = 0.08                       # model frame period (~12.5 Hz)
+_SILENCE_RMS = 100                   # int16 RMS below this = a silent (non-speech) frame
+
+
+def _is_special(txt: str) -> bool:
+    t = txt.strip()
+    return t == "" or t.startswith("<SPECIAL") or t in ("</s>", "<s>", "<pad>", "<unk>")
+
+
+def _rms_int16(pcm: bytes) -> float:
+    import numpy as np
+
+    if not pcm:
+        return 0.0
+    a = np.frombuffer(pcm, dtype="<i2").astype("float32")
+    return float((a ** 2).mean() ** 0.5) if a.size else 0.0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--audio", default=None, help="user speech wav (default: prepared VoiceChat-11B sample)")
+    ap.add_argument("--silence", type=float, default=30.0,
+                    help="seconds of no-sound frames to send after the user stops (reply window / cap)")
+    ap.add_argument("--finish-silence", type=float, default=1.6,
+                    help="stop once the agent has been silent this long after speaking")
+    ap.add_argument("--output", default="agent_out.wav", help="where to save the agent's speech")
+    ap.add_argument("--temperature", type=float, default=0.0)
+    args = ap.parse_args()
+
+    load_env()
+    audio = args.audio or prepare_user_clip(trailing_s=args.silence)
+    url = get_base_url()
+    print(f"POST {url}/generate (stream)  audio={audio}  reply-window={args.silence:.0f}s")
+    print("watching the agent's turn (frame ~= 80 ms):\n")
+
+    c = MStarClient(url, timeout=600)
+    gen = c.generate(
+        audio=audio, input_modalities=("audio",),
+        output_modalities=("text", "audio"), temperature=args.temperature, stream=True,
+    )
+
+    pcm = bytearray()
+    transcript = []
+    sr = 22050
+    text_frames = 0                  # agent text tokens seen (frames)
+    audio_secs = 0.0                 # seconds of agent audio received
+    audible_secs = 0.0               # seconds of that audio that is actually voiced
+    first_audible = None
+    last_audible = 0.0
+    text_started = None              # time of first non-special text token
+    text_quiet = 0.0                 # seconds of consecutive EOS/special text
+    audio_quiet = 0.0                # seconds of consecutive silent audio
+    finished_reason = "reply window ended"
+    t0 = time.time()
+
+    try:
+        for ev in gen:
+            if isinstance(ev, TextChunk):
+                text_frames += 1
+                if _is_special(ev.text):
+                    text_quiet += FRAME_S
+                else:
+                    text_quiet = 0.0
+                    transcript.append(ev.text)
+                    if text_started is None:
+                        text_started = (text_frames - 1) * FRAME_S
+                        print(f"[{text_started:5.1f}s] agent starts replying")
+                    sys.stdout.write(ev.text)
+                    sys.stdout.flush()
+            elif isinstance(ev, AudioChunk):
+                pcm += ev.pcm
+                sr = ev.sample_rate or sr
+                dur = (len(ev.pcm) // 2) / (sr or 1)
+                audio_secs += dur
+                if _rms_int16(ev.pcm) >= _SILENCE_RMS:
+                    audio_quiet = 0.0
+                    audible_secs += dur
+                    if first_audible is None:
+                        first_audible = audio_secs - dur
+                    last_audible = audio_secs
+                else:
+                    audio_quiet += dur
+            # Turn is done only after we've actually HEARD the agent (first_audible)
+            # and BOTH channels have since gone quiet. The audio pipeline lags the
+            # text badly, so gating on text (or on audio before the reply streams)
+            # would truncate the spoken reply. If the agent never pauses we run to
+            # the --silence cap; if it never voices audio we also run to the cap.
+            if (first_audible is not None and text_quiet >= args.finish_silence
+                    and audio_quiet >= args.finish_silence):
+                finished_reason = "agent finished (text + audio returned to silence)"
+                break
+    except KeyboardInterrupt:
+        finished_reason = "interrupted"
+    finally:
+        gen.close()   # closing the stream cancels the remaining request server-side
+
+    # --- report ---
+    print("\n")
+    print(f"=== duplex turn summary ({finished_reason}) ===")
+    print(f"  wall time         : {time.time() - t0:.1f}s")
+    print(f"  interaction       : ~{text_frames * FRAME_S:.1f}s ({text_frames} input frames)")
+    if text_started is None:
+        print("  agent reply text  : NONE (all silence) — try more --silence / a different --audio")
+    else:
+        print(f"  agent reply text  : {''.join(transcript)!r}")
+    if first_audible is not None:
+        print(f"  audible speech    : {first_audible:.1f}s -> {last_audible:.1f}s span, "
+              f"{audible_secs:.1f}s voiced of {audio_secs:.1f}s audio")
+    else:
+        print(f"  audible speech    : none ({audio_secs:.1f}s of audio, all below threshold)")
+    if pcm:
+        with wave.open(args.output, "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(sr)
+            w.writeframes(bytes(pcm))
+        print(f"  saved audio       : {args.output} ({len(pcm) // 2 / sr:.1f}s @ {sr} Hz)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/nemotron_duplex/launch_server.sh
+++ b/test/nemotron_duplex/launch_server.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Launch the Nemotron-Duplex (VoiceChat-11B) full-duplex server.
+#
+#   ./launch_server.sh              # single-GPU layout (configs/nemotron_duplex.yaml)
+#   ./launch_server.sh disagg       # 3-GPU disaggregated layout (nemotron_duplex_disagg.yaml)
+#
+# Both layouts serve the same text + audio; disagg puts each stream-consuming
+# loop (Encoder+LLM / Talker / Codec) on its own GPU/worker thread.
+
+if [ -f "./.env" ]; then
+    source "./.env"
+elif [ -f "$(dirname "$0")/.env" ]; then
+    source "$(dirname "$0")/.env"
+else
+    echo "Error: no .env found. Run: cp test/nemotron_duplex/.sample.env test/nemotron_duplex/.env and edit it."
+    exit 1
+fi
+
+export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+
+CONFIG=configs/nemotron_duplex.yaml
+if [ "$1" == "disagg" ]; then
+    CONFIG=configs/nemotron_duplex_disagg.yaml
+fi
+echo "Serving $CONFIG on GPUs=$DEVICES port=$PORT"
+
+CACHE_ARG=""
+if [[ -n "$NEMOTRON_DUPLEX_CACHE_DIR" ]]; then
+    CACHE_ARG="--cache-dir $NEMOTRON_DUPLEX_CACHE_DIR"
+fi
+
+CUDA_VISIBLE_DEVICES=$DEVICES python mstar/api_server/entrypoint.py \
+    --config $CONFIG --host ${HOST:-127.0.0.1} --port $PORT \
+    $CACHE_ARG \
+    --socket-path-prefix /tmp/mstar_${WHO}/ \
+    --upload-dir /tmp/mstar_uploads_${WHO}/ \
+    --tensor-comm-protocol ${TENSOR_PROTOCOL:-SHM} \
+    --tcp-transfer-device ${TCP_DEVICE:-0.0.0.0.0}

--- a/test/nemotron_duplex/oracle_compare.py
+++ b/test/nemotron_duplex/oracle_compare.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Ground-truth oracle for validating the Nemotron-Duplex engine path.
+
+Runs the standalone ``offline_inference`` (verified against the NeMo reference)
+on a wav and prints the agent text tokens + audio stats. The M* engine's
+``/generate`` output (see duplex_request.py) must match the text token-for-token
+(audio is seeded-stochastic, so compare length / RMS, not samples).
+
+    python test/nemotron_duplex/oracle_compare.py --audio user.wav
+
+Loads real weights → needs a GPU (put it on a GPU the server is NOT using) and
+the VoiceChat-11B checkpoint in the HF cache. Note: offline_inference is O(T^2)
+in the number of audio frames, so prefer short clips (< a few seconds).
+"""
+import argparse
+import os
+import sys
+
+import torch
+
+from mstar.model.nemotron_duplex.nemotron_duplex_model import NemotronDuplexModel
+from mstar.model.registry import HF_MODELS
+
+
+def load_wav_16k_mono(path: str) -> torch.Tensor:
+    import soundfile as sf
+
+    data, sr = sf.read(path, dtype="float32")
+    a = torch.from_numpy(data)
+    if a.dim() == 2:
+        a = a.mean(dim=-1)
+    if sr != 16000:
+        import torchaudio.functional as AF
+
+        a = AF.resample(a, sr, 16000)
+    return a
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--audio", required=True)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--cache-dir", default=os.environ.get("NEMOTRON_DUPLEX_CACHE_DIR"))
+    ap.add_argument("--no-audio", action="store_true", help="skip talker+codec (text tokens only, faster)")
+    args = ap.parse_args()
+
+    model = NemotronDuplexModel(
+        model_path_hf=HF_MODELS["nemotron_duplex"]["model_path_hf"], cache_dir=args.cache_dir,
+    )
+    wav = load_wav_16k_mono(args.audio).to(args.device)
+    out = model.offline_inference(
+        wav.unsqueeze(0), torch.tensor([wav.shape[0]], device=args.device),
+        device=args.device, temperature=0.0, decode_audio=not args.no_audio,
+    )
+    toks = out["tokens_text"][0].tolist()
+    print("=== ORACLE (offline_inference) ===")
+    print(f"frames/text_tokens: {len(toks)}")
+    print(f"text: {out['text'][0]!r}")
+    print(f"first tokens: {toks[:40]}")
+    if "audio" in out:
+        n = int(out["audio_len"][0].item())
+        a = out["audio"][0, :n].float()
+        print(f"audio: {n} samples ({n / model.config.eartts.sample_rate:.2f}s @ "
+              f"{model.config.eartts.sample_rate} Hz) rms={a.pow(2).mean().sqrt():.4f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/nemotron_duplex/webui.py
+++ b/test/nemotron_duplex/webui.py
@@ -41,8 +41,8 @@ PAGE = """<!doctype html>
 </style></head><body>
 <h1>Nemotron-Duplex — voice chat</h1>
 <p class="muted">Speak a short question (or upload a wav), then the agent replies. The reply window
-appends silence so the agent has frames to answer in. Note: the model voices only a short burst per
-reply — see the README.</p>
+appends silence so the agent has frames to answer in. The agent replies with text and voiced
+speech; very dense late sentences of a long reply may thin out.</p>
 <div class="row">
  <button id="rec">● Record</button>
  <input type="file" id="file" accept="audio/*">

--- a/test/nemotron_duplex/webui.py
+++ b/test/nemotron_duplex/webui.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Minimal browser UI to talk to a running Nemotron-Duplex (VoiceChat-11B) server.
+
+    # 1) start the model server (see README / launch_server.sh), e.g. on :8019
+    # 2) start this UI proxy and open the printed URL:
+    python test/nemotron_duplex/webui.py
+    python test/nemotron_duplex/webui.py --mstar-url http://127.0.0.1:8019 --port 8500
+
+Record from the mic (or upload a wav) in the browser; this tiny proxy resamples
+to 16 kHz mono, appends a silence "reply window" (the model is frame-synchronous
+and replies in the frames AFTER you stop talking), forwards to the model server's
+/generate with streaming, and streams the agent's text + audio back to the page.
+
+Browser <-> this proxy is same-origin (no CORS); the proxy <-> model server is a
+plain server-to-server call. getUserMedia needs a secure context, which includes
+http://localhost / http://127.0.0.1 — for remote access put this behind HTTPS.
+"""
+import argparse
+import base64
+import io
+import json
+import sys
+
+from _env import load_env
+
+from mstar.client.client import MStarClient
+from mstar.client.types import AudioChunk, TextChunk
+
+MSTAR_URL = "http://127.0.0.1:8019"
+
+PAGE = """<!doctype html>
+<html><head><meta charset="utf-8"><title>Nemotron-Duplex chat</title>
+<style>
+ body{font-family:system-ui,sans-serif;max-width:760px;margin:2rem auto;padding:0 1rem;color:#111}
+ h1{font-size:1.3rem} .row{display:flex;gap:.75rem;align-items:center;flex-wrap:wrap;margin:.6rem 0}
+ button{padding:.5rem 1rem;border-radius:.5rem;border:1px solid #ccc;background:#f6f6f6;cursor:pointer;font-size:1rem}
+ button.rec{background:#e23;color:#fff;border-color:#e23} button:disabled{opacity:.5;cursor:default}
+ #status{color:#555;min-height:1.4em} #transcript{white-space:pre-wrap;background:#fafafa;border:1px solid #eee;
+  border-radius:.5rem;padding:.8rem;min-height:3rem;margin:.6rem 0} .muted{color:#888;font-size:.85rem}
+ audio{width:100%;margin-top:.4rem}
+</style></head><body>
+<h1>Nemotron-Duplex — voice chat</h1>
+<p class="muted">Speak a short question (or upload a wav), then the agent replies. The reply window
+appends silence so the agent has frames to answer in. Note: the model voices only a short burst per
+reply — see the README.</p>
+<div class="row">
+ <button id="rec">● Record</button>
+ <input type="file" id="file" accept="audio/*">
+ <label>reply window <input type="range" id="win" min="5" max="30" value="20"><span id="winv">20</span>s</label>
+ <label><input type="checkbox" id="textonly"> text only</label>
+</div>
+<div id="status">idle</div>
+<div id="transcript"></div>
+<audio id="player" controls></audio>
+<script>
+const $=id=>document.getElementById(id);
+$("win").oninput=()=>$("winv").textContent=$("win").value;
+let ctx,stream,proc,chunks=[],recording=false;
+
+async function startRec(){
+  stream=await navigator.mediaDevices.getUserMedia({audio:true});
+  ctx=new (window.AudioContext||window.webkitAudioContext)();
+  const src=ctx.createMediaStreamSource(stream);
+  proc=ctx.createScriptProcessor(4096,1,1);
+  chunks=[];
+  proc.onaudioprocess=e=>chunks.push(new Float32Array(e.inputBuffer.getChannelData(0)));
+  src.connect(proc); proc.connect(ctx.destination);
+  recording=true; $("rec").textContent="■ Stop"; $("rec").classList.add("rec"); $("status").textContent="recording…";
+}
+async function stopRec(){
+  recording=false; $("rec").textContent="● Record"; $("rec").classList.remove("rec");
+  proc.disconnect(); stream.getTracks().forEach(t=>t.stop());
+  const rate=ctx.sampleRate; await ctx.close();
+  let n=chunks.reduce((a,c)=>a+c.length,0), buf=new Float32Array(n), o=0;
+  for(const c of chunks){buf.set(c,o);o+=c.length;}
+  send(encodeWav(buf,rate));
+}
+$("rec").onclick=()=>recording?stopRec():startRec();
+$("file").onchange=e=>{const f=e.target.files[0]; if(f) send(f);};
+
+function encodeWav(samples,rate){
+  const b=new ArrayBuffer(44+samples.length*2), v=new DataView(b);
+  const ws=(o,s)=>{for(let i=0;i<s.length;i++)v.setUint8(o+i,s.charCodeAt(i));};
+  ws(0,"RIFF");v.setUint32(4,36+samples.length*2,true);ws(8,"WAVE");ws(12,"fmt ");
+  v.setUint32(16,16,true);v.setUint16(20,1,true);v.setUint16(22,1,true);
+  v.setUint32(24,rate,true);v.setUint32(28,rate*2,true);v.setUint16(32,2,true);v.setUint16(34,16,true);
+  ws(36,"data");v.setUint32(40,samples.length*2,true);
+  let o=44;
+  for(let i=0;i<samples.length;i++){let s=Math.max(-1,Math.min(1,samples[i]));v.setInt16(o,s*0x7fff,true);o+=2;}
+  return new Blob([b],{type:"audio/wav"});
+}
+function wavFromPcm(bytes,rate){
+  const b=new ArrayBuffer(44+bytes.length), v=new DataView(b);
+  const ws=(o,s)=>{for(let i=0;i<s.length;i++)v.setUint8(o+i,s.charCodeAt(i));};
+  ws(0,"RIFF");v.setUint32(4,36+bytes.length,true);ws(8,"WAVE");ws(12,"fmt ");
+  v.setUint32(16,16,true);v.setUint16(20,1,true);v.setUint16(22,1,true);
+  v.setUint32(24,rate,true);v.setUint32(28,rate*2,true);v.setUint16(32,2,true);v.setUint16(34,16,true);
+  ws(36,"data");v.setUint32(40,bytes.length,true);
+  new Uint8Array(b,44).set(bytes);
+  return new Blob([b],{type:"audio/wav"});
+}
+async function send(blob){
+  $("transcript").textContent=""; $("player").removeAttribute("src");
+  $("status").textContent="sending…"; $("rec").disabled=true; $("file").disabled=true;
+  const fd=new FormData();
+  fd.append("audio",blob,"input.wav"); fd.append("reply_window",$("win").value);
+  fd.append("text_only",$("textonly").checked?"true":"false");
+  let pcmParts=[], sr=22050, spoke=false;
+  try{
+    const resp=await fetch("/chat",{method:"POST",body:fd});
+    const rd=resp.body.getReader(), dec=new TextDecoder(); let carry="";
+    while(true){
+      const {value,done}=await rd.read(); if(done)break;
+      carry+=dec.decode(value,{stream:true});
+      let parts=carry.split("\\n\\n"); carry=parts.pop();
+      for(const p of parts){
+        const line=p.split("\\n").find(l=>l.startsWith("data:")); if(!line)continue;
+        const ev=JSON.parse(line.slice(5));
+        if(ev.type==="text"){ if(ev.text && !ev.special){ $("transcript").textContent+=ev.text; spoke=true; } }
+        else if(ev.type==="audio"){ sr=ev.sr; const bin=atob(ev.pcm); const u=new Uint8Array(bin.length);
+          for(let i=0;i<bin.length;i++)u[i]=bin.charCodeAt(i);
+          pcmParts.push(u); $("status").textContent="agent replying…"; }
+        else if(ev.type==="done"){ $("status").textContent="done"; }
+        else if(ev.type==="error"){ $("status").textContent="error: "+ev.msg; }
+      }
+    }
+    if(pcmParts.length){
+      let n=pcmParts.reduce((a,c)=>a+c.length,0), all=new Uint8Array(n), o=0;
+      for(const c of pcmParts){all.set(c,o);o+=c.length;}
+      $("player").src=URL.createObjectURL(wavFromPcm(all,sr)); $("player").play().catch(()=>{});
+    }
+    if(!spoke && !pcmParts.length) $("status").textContent="no reply (try a longer reply window)";
+  }catch(e){ $("status").textContent="error: "+e; }
+  $("rec").disabled=false; $("file").disabled=false;
+}
+</script></body></html>"""
+
+
+def _prep_16k_mono_silence(wav_bytes: bytes, reply_window_s: float) -> bytes:
+    import numpy as np
+    import soundfile as sf
+    import torch
+    import torchaudio.functional as AF
+
+    d, sr = sf.read(io.BytesIO(wav_bytes), dtype="float32")
+    if d.ndim == 2:
+        d = d.mean(axis=1)
+    t = torch.from_numpy(np.ascontiguousarray(d))
+    if sr != 16000:
+        t = AF.resample(t, sr, 16000)
+    out = torch.cat([t, torch.zeros(int(16000 * reply_window_s))]).numpy()
+    buf = io.BytesIO()
+    sf.write(buf, out, 16000, format="WAV", subtype="PCM_16")
+    return buf.getvalue()
+
+
+def _is_special(txt: str) -> bool:
+    t = txt.strip()
+    return t == "" or t.startswith("<SPECIAL") or t in ("</s>", "<s>", "<pad>", "<unk>")
+
+
+def build_app():
+    from fastapi import FastAPI, Form, UploadFile
+    from fastapi.responses import HTMLResponse, StreamingResponse
+
+    app = FastAPI()
+
+    @app.get("/")
+    def index():
+        return HTMLResponse(PAGE)
+
+    @app.post("/chat")
+    async def chat(audio: UploadFile, reply_window: float = Form(20.0), text_only: str = Form("false")):
+        raw = await audio.read()
+
+        def sse(obj):
+            return f"data: {json.dumps(obj)}\n\n"
+
+        def stream():
+            try:
+                wav16 = _prep_16k_mono_silence(raw, reply_window)
+            except Exception as e:  # noqa: BLE001
+                yield sse({"type": "error", "msg": f"audio prep failed: {e}"})
+                return
+            mods = ("text",) if text_only == "true" else ("text", "audio")
+            try:
+                c = MStarClient(MSTAR_URL, timeout=600)
+                for ev in c.generate(
+                    audio=[("input.wav", wav16)], input_modalities=("audio",),
+                    output_modalities=mods, temperature=0.0, stream=True,
+                ):
+                    if isinstance(ev, TextChunk):
+                        yield sse({"type": "text", "text": ev.text, "special": _is_special(ev.text)})
+                    elif isinstance(ev, AudioChunk):
+                        yield sse({"type": "audio", "sr": ev.sample_rate,
+                                   "pcm": base64.b64encode(ev.pcm).decode()})
+                yield sse({"type": "done"})
+            except Exception as e:  # noqa: BLE001
+                yield sse({"type": "error", "msg": str(e)})
+
+        return StreamingResponse(stream(), media_type="text/event-stream")
+
+    return app
+
+
+def main():
+    global MSTAR_URL
+    load_env()
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mstar-url", default=MSTAR_URL, help="running model server base URL")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=8500)
+    args = ap.parse_args()
+    MSTAR_URL = args.mstar_url
+
+    import uvicorn
+
+    print(f"Nemotron-Duplex web UI -> model server {MSTAR_URL}")
+    print(f"open http://{args.host}:{args.port}/  (mic needs localhost or HTTPS)")
+    uvicorn.run(build_app(), host=args.host, port=args.port, log_level="warning")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> **Status: DRAFT / WIP** — do not merge yet. Standalone + engine integration are implemented and verified; the one remaining item is a live end-to-end batched run through the deployed serving stack (GPU workers).

Addresses #186.

## What this adds

Support for **NVIDIA NemotronLabs VoiceChat-11B** — a full-duplex speech-to-speech voice-chat model — under `mstar/model/nemotron_duplex/`, both as standalone inference paths and as a batched M\* serving-engine integration.

| Stage | Engine | Role |
|---|---|---|
| `conformer_encoder` | STATELESS | 16 kHz speech → per-frame embeds (+ RNN-T transcript) |
| `nano_llm` | KV_CACHE (+ batched Mamba) | Nemotron-H hybrid Mamba-2 / attention / MLP backbone (9B) |
| `eartts_talker` | KV_CACHE | Gemma3 talker → 31-codebook RVQ codes (MoG + MaskGIT + CFG) |
| `audio_codec` | STATELESS | RVQ codes → 22.05 kHz PCM |

## Standalone paths (verified vs the live NeMo reference)

- **Offline** `offline_inference` — batched frame-synchronous S2S; text 100% token-match, audio verified.
- **Online** `create_stream` / `DuplexStream` — streaming duplex, persistent nano cache (attn KV + rolling Mamba conv/ssm), matches offline.
- **OpenAI Realtime API** (`realtime_api.py`) — WebSocket server; system-prompt via `instructions`.
- Audio fixes found by generating real speech: classifier-free guidance + noise + top-p sampling (talker was collapsing to silence), 1-frame Conformer lookahead holdback (streaming/offline parity), and a seeded talker RNG (a rare collapse-to-constant-code cut off the agent mid-utterance).

## M\* serving-engine integration (new — the E1–E4 commits)

- **True batched inference (E1):** the hybrid backbone's Mamba conv/ssm state is now per-request-batchable — B>1 requests advance in one fused SSD step (`Mamba2Mixer` + `MambaStateAccessor`); the `nano_llm` node gains `can_batch`/`forward_batched`. Verified: batched decode == per-request standalone (max|Δ| 8.5e-4); offline unchanged (100%). (Attention already batches via the paged-KV pool.)
- **Node forwards (E2/E3):** `conformer_encoder`, `audio_codec` (bit-exact vs standalone), `eartts_talker` (bit-exact codes; internal MoG/CFG sampling, per-request KV + CFG-uncond state). All four `NotImplementedError` stubs removed.
- **Walk graphs (E4):** four async partitions (Encoder→LLM→Talker→Codec) with `StreamingGraphEdge` + chunk policies; the nano decode loop is frame-synchronous (fuses one streamed audio frame with the fed-back previous agent-text + function tokens); `function` aux sampling channel; multi-partition forward-pass-args driver.
- **Verified:** `get_worker_graphs` derives all five walks; 8 structural CI tests (`test/modular/test_nemotron_duplex_model.py`); the **Conductor derives + launches the worker topology** from the walks.

## Not done yet

- **Live end-to-end batched serving run** through deployed GPU workers (conductor + workers + KV pool executing a real batched request with weights loaded) — everything the engine consumes is defined and validated up to the Conductor's launch plan; this is the deployment-scale validation.
- CUDA-graph capture for the Mamba/talker state (currently eager, Option-A per-request state; Option-B fixed-buffer pool is the perf follow-up).
- RNN-T user-transcript emission as a Realtime event.

## Notes

- Audio generation is stochastic by design (noise + Gumbel), seeded for reproducibility; text is deterministic.
- Developed/verified in a conda env against a runnable NeMo reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
