### PR TITLE
comm: non-blocking sends to break the worker<->conductor PUSH/PULL deadlock

### DIFF
--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -452,7 +452,12 @@ class Benchmark:
         # max_concurrency don't bottleneck on aiohttp's default 100/host limit.
         connector_limit = max(100, (self.config.max_concurrency or 1) + 10)
         async with aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=300),
+            # Per-request inactivity budget, NOT a whole-session deadline: a
+            # sweep runs many requests (sequentially, in offline mode) on one
+            # session, so a ``total`` deadline expires mid-sweep and
+            # spuriously fails every remaining request. ``sock_read`` resets
+            # on each streamed chunk, so a healthy request never trips it.
+            timeout=aiohttp.ClientTimeout(total=None, sock_read=120),
             connector=aiohttp.TCPConnector(limit=connector_limit),
             read_bufsize=5 * 2**20,  # 1MB read buffer
         ) as session:

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -28,6 +28,20 @@ Communication
      - constructor's protocol
      - Overrides the communicator protocol (``IPC`` or ``TCP``) for a
        process, e.g. to run entities on separate hosts.
+   * - ``MSTAR_ZMQ_SNDHWM``
+     - ``100000``
+     - Send high-water mark (messages) on each PUSH socket of the pyzmq
+       communicator. Above it, ``send`` queues in-process instead of
+       handing the message to zmq — it never blocks, because a blocking
+       send stalls the caller's own drain loop and can deadlock the
+       worker↔conductor PUSH/PULL cycle. Raise it to absorb larger bursts
+       inside zmq; lower it to shift buffering into the process.
+   * - ``MSTAR_ZMQ_BACKLOG_WARN``
+     - ``10000``
+     - Per-peer in-process backlog (messages) that logs a warning naming
+       the peer. The queue is unbounded by design, so this is the signal
+       that a peer has stopped draining and memory is growing. One
+       warning per stall; it re-arms once that peer's queue drains.
    * - ``MSTAR_ZMQ_TCP_HOST``
      - ``127.0.0.1``
      - Host used to build peer endpoints when the protocol is ``TCP``.

--- a/mstar/communication/communicator.py
+++ b/mstar/communication/communicator.py
@@ -21,6 +21,15 @@ _SNDHWM = int(os.getenv("MSTAR_ZMQ_SNDHWM", "100000"))
 #: (possibly indefinite) wait for its queued messages.
 _BACKLOG_POLL_SLICE_MS = 50
 
+#: Backlog size (messages, per peer) that warrants a warning. The in-process
+#: queue is deliberately unbounded — bounding it would reintroduce the blocking
+#: (or start dropping control messages, which corrupts the mesh) — so a peer
+#: that has stopped draining for good grows it until the process runs out of
+#: memory. The threshold turns that silent growth into a diagnosable signal
+#: naming the peer. Well above any healthy transient: normal bursts drain
+#: within a poll or two, so crossing this means a peer is genuinely wedged.
+_BACKLOG_WARN_AT = int(os.getenv("MSTAR_ZMQ_BACKLOG_WARN", "10000"))
+
 #: The ``mstar_rust`` extension version this tree expects (the vendored
 #: ``rust/`` crate's version). Under ``MSTAR_RUST_ZMQ=AUTO`` a mismatching
 #: install - e.g. a stale wheel after an upgrade - takes over the mesh
@@ -107,6 +116,10 @@ class ZMQCommunicator(BaseCommunicator):
         # and both peers can end up waiting on each other. With local
         # queueing, a momentarily full peer never stops us servicing our PULL.
         self.outbound: dict[str, deque] = {}
+        # Peers already warned about an oversized backlog. Cleared when that
+        # peer's queue drains, so a peer that wedges again warns again while a
+        # single stall stays one line.
+        self._backlog_warned: set[str] = set()
         self.my_id = my_id
         self.ipc_socket_path_prefix = ipc_socket_path_prefix
 
@@ -186,9 +199,27 @@ class ZMQCommunicator(BaseCommunicator):
                 except zmq.Again:
                     break  # peer still full; retry on a later flush
                 queued.popleft()
+            if not queued:
+                # Drained: re-arm the warning so a later stall is reported.
+                self._backlog_warned.discard(eid)
 
     def _has_backlog(self) -> bool:
         return any(self.outbound.values())
+
+    def _warn_if_backlog_large(self, entity_id: str) -> None:
+        """Warn once per stall when a peer's queue passes the threshold."""
+        if entity_id in self._backlog_warned:
+            return
+        depth = len(self.outbound[entity_id])
+        if depth < _BACKLOG_WARN_AT:
+            return
+        self._backlog_warned.add(entity_id)
+        logger.warning(
+            "%s has %d messages queued for %s: the peer has not been draining. "
+            "The queue is unbounded, so it will grow until %s recovers "
+            "(threshold: MSTAR_ZMQ_BACKLOG_WARN).",
+            self.my_id, depth, entity_id, entity_id,
+        )
 
     def send(self, entity_id: str, msg):
         # TODO: maybe serialize to JSON instead if more efficient
@@ -204,6 +235,7 @@ class ZMQCommunicator(BaseCommunicator):
             # Still non-empty -> the peer is full; queue this one behind it
             # rather than block (blocking is what deadlocks the cycle).
             queued.append(msg)
+            self._warn_if_backlog_large(entity_id)
             return
         try:
             sock.send_pyobj(msg, flags=zmq.NOBLOCK)
@@ -215,6 +247,7 @@ class ZMQCommunicator(BaseCommunicator):
                 "%s deferring send to %s (peer buffer full, %d queued)",
                 self.my_id, entity_id, len(self.outbound[entity_id]),
             )
+            self._warn_if_backlog_large(entity_id)
 
     def get_all_new_messages(self, blocking=False, timeout_s=None) -> list:
         # Opportunistically push out anything we previously had to queue.

--- a/mstar/communication/communicator.py
+++ b/mstar/communication/communicator.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from abc import ABC, abstractmethod
+from collections import deque
 from enum import Enum
 
 import zmq
@@ -8,6 +9,17 @@ import zmq
 from mstar.communication.event import EventWakeup
 
 logger = logging.getLogger(__name__)
+
+#: PUSH socket send high-water-mark. ZMQ's default (1000 messages) is small
+#: for the bursty control traffic between worker / conductor / api_server, so
+#: raising it lets the kernel + zmq absorb a burst before we have to queue
+#: in-process. Overridable for tuning.
+_SNDHWM = int(os.getenv("MSTAR_ZMQ_SNDHWM", "100000"))
+
+#: Cap on a blocking receive slice while an outbound backlog is pending, so a
+#: peer that drains while we are parked in ``poll`` doesn't wait a whole
+#: (possibly indefinite) wait for its queued messages.
+_BACKLOG_POLL_SLICE_MS = 50
 
 #: The ``mstar_rust`` extension version this tree expects (the vendored
 #: ``rust/`` crate's version). Under ``MSTAR_RUST_ZMQ=AUTO`` a mismatching
@@ -85,6 +97,16 @@ class ZMQCommunicator(BaseCommunicator):
         # TODO: maybe only open sockets as we need them, and close sockets
         # when we no longer need them
         self.push_sockets: dict[str, zmq.SyncSocket] = {}
+        # Per-peer in-process backlog of messages that could not be handed to
+        # zmq immediately (the peer's receive buffer is full). Drained
+        # opportunistically by ``_flush_outbound`` before each send and on
+        # every poll. This is what makes ``send`` non-blocking, and that is
+        # what breaks the worker<->conductor PUSH/PULL deadlock: the two form
+        # a cycle where each drains its PULL in the same loop that issues its
+        # PUSH sends, so a blocking send stalls the sender's own drain loop
+        # and both peers can end up waiting on each other. With local
+        # queueing, a momentarily full peer never stops us servicing our PULL.
+        self.outbound: dict[str, deque] = {}
         self.my_id = my_id
         self.ipc_socket_path_prefix = ipc_socket_path_prefix
 
@@ -100,9 +122,7 @@ class ZMQCommunicator(BaseCommunicator):
         for id in push_ids:
             if id == my_id:
                 continue
-            self.push_sockets[id] = self.context.socket(zmq.PUSH)
-            self.push_sockets[id].connect(self._endpoint(id))
-            self.push_sockets[id].setsockopt(zmq.LINGER, 0)
+            self._socket_for(id)
         self.poller = zmq.Poller()
         self.poller.register(self.pull_socket, zmq.POLLIN)
         self.event = None
@@ -112,6 +132,9 @@ class ZMQCommunicator(BaseCommunicator):
         self.event = event
 
     def wait_for_work(self, timeout_ms=50):
+        # Idle poll point: push out anything we previously had to queue, so a
+        # backlog drains even when no new send() calls are happening.
+        self._flush_outbound()
         events = dict(self.poller.poll(timeout=timeout_ms))
         if self.event.fd in events:
             self.event.drain()
@@ -123,6 +146,7 @@ class ZMQCommunicator(BaseCommunicator):
         a wakeup ends the poll early with False (the event is drained,
         exactly as in ``wait_for_work``). Mirrors the Rust communicator's
         method so call sites work against either transport."""
+        self._flush_outbound()
         events = dict(self.poller.poll(timeout=timeout_ms))
         if self.event is not None and self.event.fd in events:
             self.event.drain()
@@ -131,20 +155,70 @@ class ZMQCommunicator(BaseCommunicator):
     # def get_session_id(self) -> str:
     #     return self.session_id
 
+    def _socket_for(self, entity_id: str) -> "zmq.SyncSocket":
+        """This peer's PUSH socket, created on first use."""
+        sock = self.push_sockets.get(entity_id)
+        if sock is None:
+            sock = self.context.socket(zmq.PUSH)
+            sock.setsockopt(zmq.SNDHWM, _SNDHWM)
+            sock.connect(self._endpoint(entity_id))
+            sock.setsockopt(zmq.LINGER, 0)
+            self.push_sockets[entity_id] = sock
+        return sock
+
+    def _flush_outbound(self, entity_id: str | None = None) -> None:
+        """Hand queued messages to zmq, as many as it will take.
+
+        Non-blocking: stops at the first message that would block (the peer is
+        still full) and leaves it plus the rest queued, so FIFO order per peer
+        is preserved. Called before each send and on every poll, so a backlog
+        drains as soon as the peer has room.
+        """
+        ids = [entity_id] if entity_id is not None else list(self.outbound.keys())
+        for eid in ids:
+            queued = self.outbound.get(eid)
+            if not queued:
+                continue
+            sock = self._socket_for(eid)
+            while queued:
+                try:
+                    sock.send_pyobj(queued[0], flags=zmq.NOBLOCK)
+                except zmq.Again:
+                    break  # peer still full; retry on a later flush
+                queued.popleft()
+
+    def _has_backlog(self) -> bool:
+        return any(self.outbound.values())
+
     def send(self, entity_id: str, msg):
         # TODO: maybe serialize to JSON instead if more efficient
         logger.debug(
             "%s to send a message %s to entity %s",
             self.my_id, str(msg), entity_id
         )
-        if entity_id not in self.push_sockets:
-            sock = self.context.socket(zmq.PUSH)
-            sock.connect(self._endpoint(entity_id))
-            sock.setsockopt(zmq.LINGER, 0)
-            self.push_sockets[entity_id] = sock
-        self.push_sockets[entity_id].send_pyobj(msg)
+        sock = self._socket_for(entity_id)
+        # Drain this peer's prior backlog first so ordering is preserved.
+        self._flush_outbound(entity_id)
+        queued = self.outbound.get(entity_id)
+        if queued:
+            # Still non-empty -> the peer is full; queue this one behind it
+            # rather than block (blocking is what deadlocks the cycle).
+            queued.append(msg)
+            return
+        try:
+            sock.send_pyobj(msg, flags=zmq.NOBLOCK)
+        except zmq.Again:
+            # The peer's receive buffer is full. Queue locally and move on;
+            # delivery happens on a later flush once the peer drains.
+            self.outbound.setdefault(entity_id, deque()).append(msg)
+            logger.debug(
+                "%s deferring send to %s (peer buffer full, %d queued)",
+                self.my_id, entity_id, len(self.outbound[entity_id]),
+            )
 
     def get_all_new_messages(self, blocking=False, timeout_s=None) -> list:
+        # Opportunistically push out anything we previously had to queue.
+        self._flush_outbound()
         messages = []
         if blocking:
             # Wait until the pull socket is readable before draining. A
@@ -153,9 +227,17 @@ class ZMQCommunicator(BaseCommunicator):
             # future can interrupt a blocking receive. `timeout_s` bounds
             # the wait (None = indefinitely); on expiry, drain what's there.
             timeout_ms = None if timeout_s is None else int(timeout_s * 1000)
+            if self._has_backlog():
+                # Don't park past the next flush attempt: the peer may drain
+                # while we wait, and nothing else would retry the backlog.
+                timeout_ms = (
+                    _BACKLOG_POLL_SLICE_MS if timeout_ms is None
+                    else min(timeout_ms, _BACKLOG_POLL_SLICE_MS)
+                )
             events = dict(self.poller.poll(timeout=timeout_ms))
             if self.event is not None and self.event.fd in events:
                 self.event.drain()
+            self._flush_outbound()
         while True:
             try:
                 # zmq.NOBLOCK means zmq doesn't wait for a new message to be

--- a/test/modular/test_communicator_backpressure.py
+++ b/test/modular/test_communicator_backpressure.py
@@ -122,3 +122,55 @@ def test_poll_points_flush_the_backlog(socket_dir, monkeypatch):
 def test_sndhwm_is_env_overridable():
     """Deployments tune the burst headroom without a code change."""
     assert comm._SNDHWM == int(os.getenv("MSTAR_ZMQ_SNDHWM", "100000"))
+
+
+def test_large_backlog_warns_once_and_rearms(socket_dir, monkeypatch, caplog):
+    """An unbounded queue must not grow silently.
+
+    Bounding it isn't an option (that reinstates the blocking, or drops control
+    messages), so a wedged peer is reported instead: one warning naming the
+    peer, and a fresh one if it wedges again after recovering.
+    """
+    monkeypatch.setattr(comm, "_SNDHWM", 10)
+    monkeypatch.setattr(comm, "_BACKLOG_WARN_AT", 50)
+
+    sender = comm.ZMQCommunicator(
+        "sender", ["peer"], protocol=CommProtocol.IPC,
+        ipc_socket_path_prefix=socket_dir,
+    )
+    with caplog.at_level("WARNING", logger=comm.__name__):
+        for i in range(400):
+            sender.send("peer", {"i": i, "pad": "x" * 5_000})
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1, "expected exactly one warning per stall"
+        assert "peer" in warnings[0].getMessage()
+
+        # Drain, then wedge it again: the second stall gets its own warning.
+        receiver = comm.ZMQCommunicator(
+            "peer", [], protocol=CommProtocol.IPC,
+            ipc_socket_path_prefix=socket_dir,
+        )
+        deadline = time.monotonic() + 30
+        while sender.outbound.get("peer") and time.monotonic() < deadline:
+            sender._flush_outbound()
+            receiver.get_all_new_messages()
+            time.sleep(0.01)
+        assert not sender.outbound.get("peer"), "backlog never drained"
+        assert "peer" not in sender._backlog_warned, "warning not re-armed"
+
+
+def test_small_backlog_does_not_warn(socket_dir, monkeypatch, caplog):
+    """A transient overflow is normal — it must stay quiet."""
+    monkeypatch.setattr(comm, "_SNDHWM", 10)
+    monkeypatch.setattr(comm, "_BACKLOG_WARN_AT", 10_000)
+
+    sender = comm.ZMQCommunicator(
+        "sender", ["peer"], protocol=CommProtocol.IPC,
+        ipc_socket_path_prefix=socket_dir,
+    )
+    with caplog.at_level("WARNING", logger=comm.__name__):
+        for i in range(400):
+            sender.send("peer", {"i": i, "pad": "x" * 5_000})
+    assert sender.outbound.get("peer"), "test needs an actual backlog"
+    assert not [r for r in caplog.records if r.levelname == "WARNING"]

--- a/test/modular/test_communicator_backpressure.py
+++ b/test/modular/test_communicator_backpressure.py
@@ -1,0 +1,124 @@
+"""Regression tests for ZMQCommunicator non-blocking send / backpressure.
+
+The worker<->conductor topology is a PUSH/PULL cycle: each drains its PULL in
+the same loop that issues PUSH sends. If a PUSH blocked when the peer's receive
+buffer filled, the caller would stop draining its own PULL, so two peers could
+each block sending to the other while neither drained — a deadlock observed
+under concurrent omni serving load.
+
+The fix makes send() non-blocking: when a peer is full, the message is queued
+in-process and flushed opportunistically. These tests pin that behavior: send
+never blocks, and queued messages deliver in FIFO order with no loss once the
+peer drains.
+"""
+import os
+import shutil
+import tempfile
+import time
+
+import pytest
+
+import mstar.communication.communicator as comm
+from mstar.communication.communicator import CommProtocol, ZMQCommunicator
+
+
+@pytest.fixture
+def socket_dir():
+    """A private IPC socket namespace, removed with the test.
+
+    Per-test rather than per-pid: two tests sharing a prefix share endpoints,
+    so one test's undelivered backlog would land in the other's receiver.
+    """
+    path = tempfile.mkdtemp(prefix="mstar_bptest_")
+    yield path + "/"
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def test_send_does_not_block_without_receiver(socket_dir):
+    """No peer is bound, so nothing is ever consumed — send must still return.
+
+    This is the deadlock's shape in miniature: with a blocking send, the caller
+    parks here forever instead of getting back to its own receive loop. The
+    count has to exceed zmq's default 1000-message HWM, or the messages fit in
+    the socket's own queue and even a blocking send returns.
+    """
+    sender = ZMQCommunicator(
+        "sender", ["peer"], protocol=CommProtocol.IPC,
+        ipc_socket_path_prefix=socket_dir,
+    )
+    start = time.monotonic()
+    for i in range(3000):
+        sender.send("peer", {"i": i, "pad": "x" * 10_000})
+    assert time.monotonic() - start < 5.0, "send blocked with no receiver"
+
+
+def test_overflow_queues_locally_then_delivers_in_order(socket_dir, monkeypatch):
+    """Overflow goes to the in-process queue and still arrives, in order."""
+    # Force a tiny HWM so the zmq.Again -> local-queue path triggers
+    # deterministically. _SNDHWM is read at import time and applied when the
+    # socket is created, so patch the module constant before constructing.
+    monkeypatch.setattr(comm, "_SNDHWM", 10)
+
+    sender = ZMQCommunicator(
+        "sender", ["peer"], protocol=CommProtocol.IPC,
+        ipc_socket_path_prefix=socket_dir,
+    )
+    n = 200
+    start = time.monotonic()
+    for i in range(n):
+        sender.send("peer", {"i": i, "pad": "x" * 5_000})
+    assert time.monotonic() - start < 5.0, "send blocked on overflow"
+    assert sender.outbound.get("peer"), "expected messages to queue in-process"
+
+    receiver = ZMQCommunicator(
+        "peer", [], protocol=CommProtocol.IPC,
+        ipc_socket_path_prefix=socket_dir,
+    )
+    got = []
+    deadline = time.monotonic() + 30
+    while len(got) < n and time.monotonic() < deadline:
+        sender._flush_outbound()
+        got += receiver.get_all_new_messages()
+        time.sleep(0.01)
+
+    assert len(got) == n, f"lost messages: {len(got)}/{n}"
+    assert [m["i"] for m in got] == list(range(n)), "FIFO order broken"
+    assert not sender.outbound.get("peer"), "backlog not fully drained"
+
+
+def test_poll_points_flush_the_backlog(socket_dir, monkeypatch):
+    """A backlog drains from the receive path alone — no further send() needed.
+
+    That is what unblocks a stalled peer in production: the loop that stopped
+    sending is still polling, and each poll retries the queue.
+    """
+    monkeypatch.setattr(comm, "_SNDHWM", 10)
+
+    sender = ZMQCommunicator(
+        "sender", ["peer"], protocol=CommProtocol.IPC,
+        ipc_socket_path_prefix=socket_dir,
+    )
+    n = 100
+    for i in range(n):
+        sender.send("peer", {"i": i, "pad": "x" * 5_000})
+    assert sender.outbound.get("peer"), "expected messages to queue in-process"
+
+    receiver = ZMQCommunicator(
+        "peer", [], protocol=CommProtocol.IPC,
+        ipc_socket_path_prefix=socket_dir,
+    )
+    got = []
+    deadline = time.monotonic() + 30
+    while len(got) < n and time.monotonic() < deadline:
+        # The sender only ever polls its own inbox here.
+        sender.get_all_new_messages()
+        got += receiver.get_all_new_messages()
+        time.sleep(0.01)
+
+    assert [m["i"] for m in got] == list(range(n))
+    assert not sender.outbound.get("peer"), "backlog not fully drained"
+
+
+def test_sndhwm_is_env_overridable():
+    """Deployments tune the burst headroom without a code change."""
+    assert comm._SNDHWM == int(os.getenv("MSTAR_ZMQ_SNDHWM", "100000"))

--- a/test/modular/test_communicator_deadlock.py
+++ b/test/modular/test_communicator_deadlock.py
@@ -35,6 +35,10 @@ import pytest
 # small via the env var below; RCVHWM stays at its 1000-message default, so the
 # burst has to comfortably exceed that.
 _TEST_SNDHWM = "50"
+# Over the pinned capacity (SNDHWM 50 + the receiver's 1000 RCVHWM) with room
+# to spare, and also over the *default* capacity (1000 + 1000) — so the same
+# reproduction works against a tree that predates MSTAR_ZMQ_SNDHWM, which is
+# how this test was checked to actually discriminate.
 _BURST = 3000
 _PAYLOAD = "x" * 1024
 
@@ -42,17 +46,24 @@ _PAYLOAD = "x" * 1024
 #: The peers park within ~0.2s of the barrier, so this only has to outlast
 #: process startup.
 _DEADLOCK_WINDOW_S = 5.0
-#: Budget for the fixed variant (it completes in ~1s). Generous: it fails only
-#: on a real hang.
+#: The peers' own budget for finishing (they complete in ~1s). Generous: it
+#: trips only on a real hang.
 _COMPLETION_BUDGET_S = 60.0
+#: The parent waits longer than the peers do, so a peer that gives up reports
+#: *where* it stopped (exit code + reason file) instead of being killed mid-way
+#: and looking like a deadlock.
+_PARENT_BUDGET_S = _COMPLETION_BUDGET_S + 20.0
 
 
-def _peer(my_id: str, peer_id: str, prefix: str, legacy: bool, barrier) -> None:
+def _peer(
+    my_id: str, peer_id: str, prefix: str, legacy: bool,
+    barrier, my_done, peer_done,
+) -> None:
     """One side of the cycle. Marker files report how far it got.
 
     Sequence: bind -> barrier -> send a burst at the peer -> drain until the
-    peer's burst has fully arrived -> ``fin`` handshake. The deadlock lands
-    between the barrier and ``<id>.burst_done``.
+    peer's burst has fully arrived -> keep draining until the peer is done
+    too. The deadlock lands between the barrier and ``<id>.burst_done``.
     """
     import mstar.communication.communicator as comm
     from mstar.communication.communicator import CommProtocol, ZMQCommunicator
@@ -96,20 +107,26 @@ def _peer(my_id: str, peer_id: str, prefix: str, legacy: bool, barrier) -> None:
         )
         time.sleep(0.001)
     if seen != _BURST:
-        raise SystemExit(f"{my_id}: received {seen}/{_BURST}")
-
-    # Don't exit while the peer still needs us: LINGER is 0, so anything left
-    # in our socket (or our backlog) dies with the process.
-    conn.send(peer_id, {"kind": "fin"})
-    peer_done = False
-    deadline = time.monotonic() + _COMPLETION_BUDGET_S
-    while not peer_done and time.monotonic() < deadline:
-        peer_done = any(
-            m.get("kind") == "fin" for m in conn.get_all_new_messages()
+        (marker / f"{my_id}.stalled").write_text(
+            f"received {seen}/{_BURST} bursts"
         )
+        raise SystemExit(1)
+
+    # Receiving everything is not the end: this peer's own backlog only moves
+    # while it keeps polling (the flush hangs off the receive path), and LINGER
+    # is 0 so whatever is still queued dies with the process. So keep polling
+    # until the peer reports it has everything — which is what the production
+    # loops do anyway. Out-of-band events, not a "fin" message: an in-band
+    # handshake has the same problem it is trying to solve, since a fin queued
+    # behind 1500 burst messages never arrives.
+    my_done.set()
+    deadline = time.monotonic() + _COMPLETION_BUDGET_S
+    while not peer_done.is_set() and time.monotonic() < deadline:
+        conn.get_all_new_messages()  # flushes our backlog toward the peer
         time.sleep(0.001)
-    if not peer_done:
-        raise SystemExit(f"{my_id}: peer never finished")
+    if not peer_done.is_set():
+        (marker / f"{my_id}.stalled").write_text("peer never finished receiving")
+        raise SystemExit(1)
     (marker / f"{my_id}.done").touch()
 
 
@@ -129,12 +146,15 @@ def _run_cycle(root: Path, legacy: bool, wait_s: float) -> list[mp.Process]:
     os.makedirs(prefix, exist_ok=True)
     ctx = mp.get_context("spawn")
     barrier = ctx.Barrier(2)
+    done_a, done_b = ctx.Event(), ctx.Event()
     peers = [
         ctx.Process(
-            target=_peer, args=("peer_a", "peer_b", prefix, legacy, barrier),
+            target=_peer,
+            args=("peer_a", "peer_b", prefix, legacy, barrier, done_a, done_b),
         ),
         ctx.Process(
-            target=_peer, args=("peer_b", "peer_a", prefix, legacy, barrier),
+            target=_peer,
+            args=("peer_b", "peer_a", prefix, legacy, barrier, done_b, done_a),
         ),
     ]
     for p in peers:
@@ -176,14 +196,16 @@ def test_blocking_send_deadlocks_the_cycle(cycle_env):
 
 def test_non_blocking_send_completes_the_cycle(cycle_env):
     """The same cycle on the shipped send: both peers finish and deliver."""
-    peers = _run_cycle(cycle_env, legacy=False, wait_s=_COMPLETION_BUDGET_S)
+    peers = _run_cycle(cycle_env, legacy=False, wait_s=_PARENT_BUDGET_S)
     try:
+        stalls = {
+            f.name: f.read_text() for f in cycle_env.glob("*.stalled")
+        }
         assert not [p for p in peers if p.is_alive()], (
-            "cycle deadlocked with the non-blocking send"
+            f"cycle deadlocked with the non-blocking send; peer reports: {stalls}"
         )
         assert [p.exitcode for p in peers] == [0, 0], (
-            f"peers exited {[p.exitcode for p in peers]} "
-            "(non-zero = burst not fully received)"
+            f"peers exited {[p.exitcode for p in peers]}; reports: {stalls}"
         )
         for name in ("peer_a", "peer_b"):
             assert (cycle_env / f"{name}.burst_done").exists()

--- a/test/modular/test_communicator_deadlock.py
+++ b/test/modular/test_communicator_deadlock.py
@@ -1,0 +1,192 @@
+"""End-to-end proof that the PUSH/PULL cycle deadlock is real, and fixed.
+
+``test_communicator_backpressure.py`` pins the *primitive* (send doesn't block).
+This file reproduces the actual failure: two processes wired into a PUSH/PULL
+cycle — the worker<->conductor shape, where each peer drains its PULL in the
+same loop that issues its PUSH sends.
+
+Both variants run the identical peer program; only ``send`` differs:
+
+* ``legacy`` — the pre-fix blocking ``send_pyobj``. Each peer fills the other's
+  queue before either reaches its drain loop, so both park in ``send`` and
+  neither ever drains. Deadlock: neither peer finishes its send burst.
+* ``current`` — the shipped non-blocking ``send``. Overflow is queued
+  in-process and flushed from the drain loop, so both bursts finish and
+  everything is delivered.
+
+CPU-only and a few seconds; no GPU, no model, no server. That matters because
+the original incident was only ever reproduced under live multi-request serving
+load, which CI cannot run.
+"""
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+# The peers have to overflow the transport, and the capacity they must overflow
+# is SNDHWM (the sender's queue) + RCVHWM (the receiver's, serviced by zmq's own
+# IO thread whether or not the app drains) + kernel buffers. SNDHWM is pinned
+# small via the env var below; RCVHWM stays at its 1000-message default, so the
+# burst has to comfortably exceed that.
+_TEST_SNDHWM = "50"
+_BURST = 3000
+_PAYLOAD = "x" * 1024
+
+#: How long to let the deadlocking variant run before calling it deadlocked.
+#: The peers park within ~0.2s of the barrier, so this only has to outlast
+#: process startup.
+_DEADLOCK_WINDOW_S = 5.0
+#: Budget for the fixed variant (it completes in ~1s). Generous: it fails only
+#: on a real hang.
+_COMPLETION_BUDGET_S = 60.0
+
+
+def _peer(my_id: str, peer_id: str, prefix: str, legacy: bool, barrier) -> None:
+    """One side of the cycle. Marker files report how far it got.
+
+    Sequence: bind -> barrier -> send a burst at the peer -> drain until the
+    peer's burst has fully arrived -> ``fin`` handshake. The deadlock lands
+    between the barrier and ``<id>.burst_done``.
+    """
+    import mstar.communication.communicator as comm
+    from mstar.communication.communicator import CommProtocol, ZMQCommunicator
+
+    if legacy:
+        # The pre-fix send: blocking, no local queue. Socket setup is shared
+        # with the current implementation (so SNDHWM is pinned identically in
+        # both variants) — the blocking call is the only difference under test.
+        def _blocking_send(self, entity_id, msg):
+            self._socket_for(entity_id).send_pyobj(msg)
+
+        comm.ZMQCommunicator.send = _blocking_send
+
+    marker = Path(prefix).parent
+    conn = ZMQCommunicator(
+        my_id, [peer_id], protocol=CommProtocol.IPC,
+        ipc_socket_path_prefix=prefix,
+    )
+
+    # Both PULL sockets are bound before any burst starts, and both bursts
+    # start together. Without the barrier the peers stagger: whoever starts
+    # first drains the other's messages while the other is still setting up,
+    # and the cycle never closes. A barrier (not a message handshake) keeps the
+    # drain loops untouched until the burst.
+    barrier.wait(timeout=30)
+    (marker / f"{my_id}.started").touch()
+
+    # The cycle: a send burst issued BEFORE this peer drains anything. With a
+    # blocking send both peers stop here, each waiting on the other.
+    for i in range(_BURST):
+        conn.send(peer_id, {"kind": "burst", "i": i, "pad": _PAYLOAD})
+    (marker / f"{my_id}.burst_done").touch()
+
+    seen = 0
+    deadline = time.monotonic() + _COMPLETION_BUDGET_S
+    while seen < _BURST and time.monotonic() < deadline:
+        # Also flushes this peer's own backlog — the property that lets a
+        # stalled cycle recover with no further send() calls.
+        seen += sum(
+            1 for m in conn.get_all_new_messages() if m.get("kind") == "burst"
+        )
+        time.sleep(0.001)
+    if seen != _BURST:
+        raise SystemExit(f"{my_id}: received {seen}/{_BURST}")
+
+    # Don't exit while the peer still needs us: LINGER is 0, so anything left
+    # in our socket (or our backlog) dies with the process.
+    conn.send(peer_id, {"kind": "fin"})
+    peer_done = False
+    deadline = time.monotonic() + _COMPLETION_BUDGET_S
+    while not peer_done and time.monotonic() < deadline:
+        peer_done = any(
+            m.get("kind") == "fin" for m in conn.get_all_new_messages()
+        )
+        time.sleep(0.001)
+    if not peer_done:
+        raise SystemExit(f"{my_id}: peer never finished")
+    (marker / f"{my_id}.done").touch()
+
+
+@pytest.fixture
+def cycle_env(monkeypatch):
+    """Private socket dir + a small SNDHWM, inherited by the spawned peers."""
+    root = tempfile.mkdtemp(prefix="mstar_cycle_")
+    monkeypatch.setenv("MSTAR_ZMQ_SNDHWM", _TEST_SNDHWM)
+    # ``spawn`` re-imports in the child, so the env var is read there; the
+    # parent never builds a communicator.
+    yield Path(root)
+    shutil.rmtree(root, ignore_errors=True)
+
+
+def _run_cycle(root: Path, legacy: bool, wait_s: float) -> list[mp.Process]:
+    prefix = str(root / "sock") + "/"
+    os.makedirs(prefix, exist_ok=True)
+    ctx = mp.get_context("spawn")
+    barrier = ctx.Barrier(2)
+    peers = [
+        ctx.Process(
+            target=_peer, args=("peer_a", "peer_b", prefix, legacy, barrier),
+        ),
+        ctx.Process(
+            target=_peer, args=("peer_b", "peer_a", prefix, legacy, barrier),
+        ),
+    ]
+    for p in peers:
+        p.start()
+    deadline = time.monotonic() + wait_s
+    for p in peers:
+        p.join(timeout=max(0.0, deadline - time.monotonic()))
+    return peers
+
+
+def _cleanup(peers: list[mp.Process]) -> None:
+    for p in peers:
+        if p.is_alive():
+            p.terminate()
+    for p in peers:
+        p.join(timeout=5)
+        if p.is_alive():
+            p.kill()
+            p.join(timeout=5)
+
+
+def test_blocking_send_deadlocks_the_cycle(cycle_env):
+    """The negative control: with the pre-fix blocking send, the cycle wedges.
+
+    Without this, the fix has no evidence it prevents anything — the failure it
+    targets was only ever seen on a GPU box under live serving load.
+    """
+    peers = _run_cycle(cycle_env, legacy=True, wait_s=_DEADLOCK_WINDOW_S)
+    try:
+        assert (cycle_env / "peer_a.started").exists(), "peers never started"
+        assert (cycle_env / "peer_b.started").exists(), "peers never started"
+        # The deadlock's signature: both up, both stuck mid-burst.
+        assert not (cycle_env / "peer_a.burst_done").exists()
+        assert not (cycle_env / "peer_b.burst_done").exists()
+        assert all(p.is_alive() for p in peers), "expected both peers wedged"
+    finally:
+        _cleanup(peers)
+
+
+def test_non_blocking_send_completes_the_cycle(cycle_env):
+    """The same cycle on the shipped send: both peers finish and deliver."""
+    peers = _run_cycle(cycle_env, legacy=False, wait_s=_COMPLETION_BUDGET_S)
+    try:
+        assert not [p for p in peers if p.is_alive()], (
+            "cycle deadlocked with the non-blocking send"
+        )
+        assert [p.exitcode for p in peers] == [0, 0], (
+            f"peers exited {[p.exitcode for p in peers]} "
+            "(non-zero = burst not fully received)"
+        )
+        for name in ("peer_a", "peer_b"):
+            assert (cycle_env / f"{name}.burst_done").exists()
+            assert (cycle_env / f"{name}.done").exists()
+    finally:
+        _cleanup(peers)


### PR DESCRIPTION
## What does this PR do?

Makes `ZMQCommunicator.send` non-blocking so a peer that has stopped draining can't stall the sender's own receive loop.

Worker and conductor form a PUSH/PULL cycle: each drains its PULL in the same loop that issues its PUSH sends. With a blocking `send_pyobj`, a peer whose queue filled blocked the sender, which then stopped draining its own PULL — both ends wait on each other, the server stalls at 0% GPU util and requests hang. Originally hit under concurrent omni serving load; py-spy showed the worker parked in zmq send inside `_send_outputs`.

**What actually fills the queue.** ZMQ's HWM is a *message count* (default 1000), not a byte budget, and the control mesh carries pointers and scheduling metadata — tensors ride Mooncake/SHM, not ZMQ. So the trigger is message fan-out × concurrency ÷ the peer's drain rate: streaming output (one `result_tensors` per chunk), multi-node graphs and TP-group broadcasts raise the numerator; a long forward, weight loading or graph capture drops the denominator. Nothing about it requires large payloads.

Now: raise SNDHWM off the default 1000 (`MSTAR_ZMQ_SNDHWM`), send with `zmq.NOBLOCK`, and on `zmq.Again` queue into a per-peer in-process deque. The backlog is flushed before each send and at every poll point (`wait_for_work`, `poll_for_messages`, `get_all_new_messages`) so it drains from the receive path alone — that is what frees an end that has stopped sending. Per-peer FIFO and delivery are preserved: a flush stops at the first message zmq won't take and leaves the rest behind it. A blocking receive with a pending backlog caps its poll slice so the retry isn't parked behind an indefinite wait.

The queue is deliberately **unbounded** — bounding it would reinstate the blocking, or drop control messages and corrupt the mesh — so a peer that wedges for good grows it until the process OOMs. That is now reported: one warning naming the peer past `MSTAR_ZMQ_BACKLOG_WARN` (default 10000), re-armed when the queue drains.

**Scope:** the pyzmq `ZMQCommunicator`. The Rust transport (`RustZMQCommunicator`, used when `mstar_rust` is installed under the default `MSTAR_RUST_ZMQ=AUTO`) still sends blocking — `rust/src/communicator.rs` drops the peer-map lock so an HWM-blocked send stalls only that peer, but the calling thread still parks, so the cycle stays reachable there. It needs the same treatment in the crate (separate PR); `MSTAR_RUST_ZMQ=0` selects this path meanwhile.

Also widens the benchmark client's session timeout from a whole-session `total=300` (expires mid-sweep and fails every remaining request) to a per-request `sock_read=120`.

## How was it tested?

- **`test/modular/test_communicator_deadlock.py` — the deadlock itself, in two processes.** Same peer program under both send implementations: with the pre-fix blocking send both peers park mid-burst and neither drains (asserted as a deadlock); with the shipped send both bursts finish, 3000 messages are delivered each way, both peers exit 0 in ~1s. CPU-only, ~6s, no GPU/model/server — the original incident was only reproducible under live serving load, so there was no CI-visible evidence before this.
- **Verified it discriminates:** with `mstar/communication/communicator.py` reverted to `origin/main`, the cycle test hangs both peers and fails on its budget; with the fix it passes in ~1s.
- **Flakiness:** an earlier revision was flaky under load; two shutdown races were found and fixed (see the last commit). Final version ran 8x while three full `test/modular` runs hammered the box — no failures.
- `test/modular/test_communicator_backpressure.py` — 6 unit tests: send with no receiver past the default HWM, overflow → local queue → in-order delivery, backlog drained by the receive path alone, warn-once + re-arm, quiet below threshold, env override.
- `pytest test/modular` — failure set unchanged vs `main`.

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
