### PR TITLE
[1/3] Extend device support from CUDA-only by using torch.accelerator in worker runtime

### DIFF
--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -233,6 +233,9 @@ class Conductor:
 
         with open(model_config_file, "r") as f:
             self.model_config = yaml.safe_load(f)
+        accelerator = torch.accelerator.current_accelerator(check_available=True)
+        self.device_type = accelerator.type if accelerator is not None else "cpu"
+        logger.info("Detected worker device type: %s", self.device_type)
         self.max_concurrent_requests: int = self.model_config.get(
             "max_concurrent_requests", None
         )
@@ -439,7 +442,10 @@ class Conductor:
                     "model": self.model,
                     "enable_nvtx": self.enable_nvtx,
                     "enable_prof": self.enable_prof,
-                    "device": f"cuda:{rank}",
+                    "device": (
+                        f"{self.device_type}:{rank}"
+                        if self.device_type != "cpu" else "cpu"
+                    ),
                     "log_level": self.log_level,
                     "tensor_comm_protocol": self.tensor_comm_protocol,
                     "tcp_transfer_device": self.tcp_transfer_device

--- a/mstar/distributed/communication.py
+++ b/mstar/distributed/communication.py
@@ -192,6 +192,7 @@ class WorkerParallelGroups:
     # projections).
     node_to_tp_group: dict[str, CommGroup] = field(default_factory=dict)
     node_to_sp_group: dict[str, CommGroup] = field(default_factory=dict)
+    _device: torch.device | None = field(default=None, init=False, repr=False)
 
     def add(self, node: str, comm_group: CommGroup):
         # disallow colocation of multiple comm groups on the same node
@@ -213,6 +214,7 @@ class WorkerParallelGroups:
 
     def init_dist(
         self, init_method="tcp://127.0.0.1:29500",
+        device: torch.device | None = None,
     ):
         """Initialize the NCCL world group and per-node parallel subgroups.
 
@@ -229,15 +231,20 @@ class WorkerParallelGroups:
         every rank — members keep the returned handle, non-members
         discard it.
         """
-        torch.cuda.set_device(self.global_rank)
+        device = device or torch.device("cuda", self.global_rank)
+        self._device = device
+        if device.type != "cpu":
+            torch.accelerator.set_device_index(device)
+        backend = dist.get_default_backend_for_device(device.type)
         if not self.any_parallelism:
             return
 
         dist.init_process_group(
-            backend="nccl",
+            backend=backend,
             init_method=init_method,
             world_size=self.num_workers,
             rank=self.global_rank,
+            device_id=device,
         )
 
         # One subgroup per distinct rank tuple across BOTH mesh axes —
@@ -302,7 +309,10 @@ class WorkerParallelGroups:
         """
         if not self.any_parallelism:
             return
-        dist.barrier()
+        if not dist.is_initialized():
+            return
+        fence = torch.ones(1, dtype=torch.int32, device=self._device)
+        dist.all_reduce(fence)
 
 
 class GlobalParallelConfig:
@@ -372,4 +382,3 @@ class GlobalParallelConfig:
                         self.per_worker_config[worker_ids[rank]].add_sp(
                             node, self.sp_comm_groups[key]
                         )
-

--- a/mstar/distributed/communication.py
+++ b/mstar/distributed/communication.py
@@ -309,10 +309,7 @@ class WorkerParallelGroups:
         """
         if not self.any_parallelism:
             return
-        if not dist.is_initialized():
-            return
-        fence = torch.ones(1, dtype=torch.int32, device=self._device)
-        dist.all_reduce(fence)
+        dist.barrier()
 
 
 class GlobalParallelConfig:

--- a/mstar/engine/kv_store.py
+++ b/mstar/engine/kv_store.py
@@ -446,6 +446,26 @@ class CudaIpcKVTransferEngine(KVTransferEngine):
         self._executor.shutdown(wait=True)
 
 
+class LocalOnlyKVTransferEngine(KVTransferEngine):
+    """KV cache that remains local to its worker."""
+
+    def read_batched_async(
+        self, remote_kv_info, read_info: list[KVReadInfo]
+    ) -> Future | None:
+        if read_info:
+            raise RuntimeError(
+                "Cross-worker KV migration is unavailable for this accelerator. "
+                "Use a colocated worker graph or a remote transfer engine."
+            )
+        return None
+
+    def get_kv_transfer_info(self) -> None:
+        return None
+
+    def shutdown(self):
+        pass
+
+
 @dataclass
 class CrossAttnPool:
     """One physical cross-attention KV pool (possibly shared by several
@@ -492,7 +512,10 @@ class PagedAllocationManager:
         elif isinstance(
             transfer_engine_info.transfer_engine, LocalTransferEngine
         ):
-            self._kv_transfer_engine = CudaIpcKVTransferEngine(kv_cache)
+            if kv_cache.device.type == "cuda":
+                self._kv_transfer_engine = CudaIpcKVTransferEngine(kv_cache)
+            else:
+                self._kv_transfer_engine = LocalOnlyKVTransferEngine()
         else:
             raise ValueError(f"Unsupported transfer engine type: {type(transfer_engine_info.transfer_engine)}")
 
@@ -728,4 +751,3 @@ class PagedAllocationManager:
                 state.seq_len = seq_len
                 state.position_id_start = pos_id
         cpu_pool.sync()
-

--- a/mstar/engine/stateless_engine.py
+++ b/mstar/engine/stateless_engine.py
@@ -332,7 +332,7 @@ class StatelessEngine(BaseEngine):
         if dtype is not None:
             return _ComposedContext(
                 torch.amp.autocast(
-                    "cuda", enabled=True, dtype=dtype
+                    self.device.type, enabled=True, dtype=dtype
                 ),
                 torch.no_grad(),
             )

--- a/mstar/model/registry.py
+++ b/mstar/model/registry.py
@@ -1,29 +1,21 @@
-from mstar.model.bagel.bagel_model import BagelModel
-from mstar.model.base import Model
-from mstar.model.cosmos3.cosmos3_model import Cosmos3Model
-from mstar.model.higgs_audio.higgs_audio_model import HiggsAudioModel
-from mstar.model.orpheus.orpheus_model import OrpheusModel
-from mstar.model.pi05.pi05_model import Pi05Model
-from mstar.model.qwen3_omni.qwen3_omni_model import Qwen3OmniModel
-from mstar.model.qwen3_tts.qwen3_tts_model import Qwen3TTSModel
-from mstar.model.vjepa2.vjepa2_model import VJepa2ACModel, VJepa2Model
-from mstar.model.wan22.wan22_model import Wan22Model
-from mstar.model.whisper.whisper_model import WhisperModel
+from importlib import import_module
 
-MODEL_REGISTRY: dict[str, type[Model]] = {
-    "bagel": BagelModel,
-    "cosmos3": Cosmos3Model,
-    "cosmos3_droid": Cosmos3Model,
-    "cosmos3_super": Cosmos3Model,
-    "higgs_audio": HiggsAudioModel,
-    "orpheus": OrpheusModel,
-    "pi05": Pi05Model,
-    "qwen3_omni": Qwen3OmniModel,
-    "qwen3_tts": Qwen3TTSModel,
-    "vjepa2": VJepa2Model,
-    "vjepa2_ac": VJepa2ACModel,
-    "wan22": Wan22Model,
-    "whisper_large": WhisperModel,
+from mstar.model.base import Model
+
+MODEL_REGISTRY: dict[str, tuple[str, str]] = {
+    "bagel": ("mstar.model.bagel.bagel_model", "BagelModel"),
+    "cosmos3": ("mstar.model.cosmos3.cosmos3_model", "Cosmos3Model"),
+    "cosmos3_droid": ("mstar.model.cosmos3.cosmos3_model", "Cosmos3Model"),
+    "cosmos3_super": ("mstar.model.cosmos3.cosmos3_model", "Cosmos3Model"),
+    "higgs_audio": ("mstar.model.higgs_audio.higgs_audio_model", "HiggsAudioModel"),
+    "orpheus": ("mstar.model.orpheus.orpheus_model", "OrpheusModel"),
+    "pi05": ("mstar.model.pi05.pi05_model", "Pi05Model"),
+    "qwen3_omni": ("mstar.model.qwen3_omni.qwen3_omni_model", "Qwen3OmniModel"),
+    "qwen3_tts": ("mstar.model.qwen3_tts.qwen3_tts_model", "Qwen3TTSModel"),
+    "vjepa2": ("mstar.model.vjepa2.vjepa2_model", "VJepa2Model"),
+    "vjepa2_ac": ("mstar.model.vjepa2.vjepa2_model", "VJepa2ACModel"),
+    "wan22": ("mstar.model.wan22.wan22_model", "Wan22Model"),
+    "whisper_large": ("mstar.model.whisper.whisper_model", "WhisperModel"),
 }
 
 HF_MODELS: dict[str, dict] = {
@@ -71,4 +63,5 @@ HF_MODELS: dict[str, dict] = {
 def get_model_class(name: str) -> type[Model]:
     if name not in MODEL_REGISTRY:
         raise KeyError(f"Unknown model name: {name!r}. Available: {list(MODEL_REGISTRY.keys())}")
-    return MODEL_REGISTRY[name]
+    module_name, class_name = MODEL_REGISTRY[name]
+    return getattr(import_module(module_name), class_name)

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -143,8 +143,8 @@ class Worker:
         self.enable_prof = enable_prof
         self.profile_info = WorkerProfileInfo()
 
-        if self.device.type == "cuda" and self.device.index is not None:
-            torch.cuda.set_device(self.device)
+        if self.device.type != "cpu" and self.device.index is not None:
+            torch.accelerator.set_device_index(self.device)
 
         # ``dist_init_method`` is normally provided by the conductor — it
         # picks a free TCP port at startup so multiple ``mstar`` runs on
@@ -155,7 +155,10 @@ class Worker:
             dist_init_method = f"tcp://{hostname}:29500"
 
         self.parallel_groups = parallel_groups
-        self.parallel_groups.init_dist(init_method=dist_init_method)
+        self.parallel_groups.init_dist(
+            init_method=dist_init_method,
+            device=self.device,
+        )
 
         # Build node_to_partition mapping from model's partitions and graph walks
         node_to_partition: dict[str, str] = {}
@@ -1162,7 +1165,7 @@ class Worker:
         engine.reset_pre_plan_for_batch(spec_node_batch)
 
     def _init_cuda_executor_thread(self) -> None:
-        """Pin this executor thread to the worker's CUDA device.
+        """Pin this executor thread to the worker's accelerator device.
 
         The CUDA current device is per-thread and defaults to 0. PyTorch
         ops carry per-tensor device guards, but raw Triton launches and
@@ -1171,8 +1174,8 @@ class Worker:
         lives on a non-zero device, work issued from an unpinned thread
         lands on device 0's stream, unordered with the real compute.
         """
-        if self.device.type == "cuda" and self.device.index is not None:
-            torch.cuda.set_device(self.device)
+        if self.device.type != "cpu" and self.device.index is not None:
+            torch.accelerator.set_device_index(self.device)
 
     def _execute_on_gpu_thread(
         self,
@@ -1221,10 +1224,15 @@ class Worker:
                 synchronize=False,
             )
         try:
+            execution_stream = (
+                torch.accelerator.current_stream(self.device)
+                if self.device.type != "cpu"
+                else None
+            )
             output = engine.execute_with_max_batch_size(node_batch)
-            if torch.cuda.is_available():
-                event = torch.cuda.Event()
-                event.record(torch.cuda.default_stream(self.device))
+            if execution_stream is not None:
+                event = torch.Event()
+                event.record(execution_stream)
                 output.completion_event = event
             return output
         finally:
@@ -1689,7 +1697,7 @@ class Worker:
 
         # Wait for batch N's completion event before proceeding
         # TODO: may need to refine this based on how it affects performance?
-        if torch.cuda.is_available() and batch_N.batch.node_objects:
+        if self.device.type != "cpu" and batch_N.batch.node_objects:
             if output.completion_event is not None:
                 if self.enable_nvtx:
                     range_push("worker.postprocess.completion_event_sync", synchronize=False)
@@ -1697,7 +1705,7 @@ class Worker:
                 if self.enable_nvtx:
                     range_pop(synchronize=False)
             else:
-                torch.cuda.default_stream().synchronize()
+                torch.accelerator.synchronize(self.device)
 
         if self.enable_prof:
             batch_N.node_batch.exec_timings.fwd_end = time.perf_counter()
@@ -2595,4 +2603,3 @@ class Worker:
                 _set_pending(None)
                 consecutive_spec_steps = 0
                 sleep(0.01)
-


### PR DESCRIPTION
## Extend device support from CUDA-only by using torch.accelerator in worker runtime

- use `torch.accelerator` for worker device, stream, event, and synchronization handling
- select distributed backends by device rather than hard coding NCCL
- support local-only KV caches transport for non-CUDA devices
- lazily import model implementations to avoid unrelated CUDA-only initialization

## How was it tested?
Tested bagel serving success on Intel GPU
### command
```
# server
mstar serve bagel \
  --config configs/bagel_xpu_tp4.yaml \
  --tensor-comm-protocol SHM \
  --host 127.0.0.1 \
  --port 8010 \
  --log-level INFO

# client
curl -sS --max-time 1800 \
  -o bagel-image-response-kernel.json \
  -w 'HTTP %{http_code}\nTurn-around: %{time_total}s\nResponse bytes: %{size_download}\n' \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "bagel",
    "prompt": "A red sports car parked beside a mountain lake at sunrise",
    "n": 1,
    "size": "1024x1024"
  }' \
  http://127.0.0.1:8010/v1/images/generations
```
### Output
<img width="818" height="819" alt="1" src="https://github.com/user-attachments/assets/7d99a71e-74db-4bd4-985f-38e23a6df28e" />

## Checklist
- [x] `ruff check .` passes