### PR TITLE
distributed: make the per-step TP barrier optional (MSTAR_TP_STEP_BARRIER)

### DIFF
--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -98,6 +98,27 @@ Communication
      - Under ``--log-stats``: how often the arena logs its occupancy /
        fragmentation snapshot (segments, free bytes, largest contiguous
        free block, pinned bytes).
+
+Distributed (TP / SP)
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 14 58
+
+   * - Variable
+     - Default
+     - Meaning
+   * - ``MSTAR_TP_STEP_BARRIER``
+     - ``1``
+     - Per-step ``tp_group.barrier()`` at the engine's execute entry
+       (``KVCacheEngine.execute_forward``, ``StatelessEngine.execute_batch``).
+       On NCCL this is a dummy all-reduce plus a current-stream synchronize,
+       so the host blocks until the previous step has drained. ``0`` skips
+       it: the forward's own collectives keep ranks in lockstep, and step
+       N+1 can be enqueued behind step N. Capture-time barriers in
+       ``cuda_graph_runner`` are unaffected.
+
 Serving (Rust frontend)
 -----------------------
 

--- a/mstar/distributed/communication.py
+++ b/mstar/distributed/communication.py
@@ -1,8 +1,23 @@
+import os
 from dataclasses import dataclass, field
 from typing import Any
 
 import torch
 import torch.distributed as dist
+
+# Per-step TP barrier at the engine's execute entry (KVCacheEngine.execute_forward,
+# StatelessEngine.execute_batch). "1" (default) keeps it. With the NCCL backend
+# dist.barrier() is a dummy all-reduce followed by a current-stream synchronize,
+# so the host blocks until everything already enqueued (the previous step)
+# drains: it forbids enqueueing step N+1 behind N — which is exactly what
+# async scheduling needs. The forward's own NCCL collectives keep
+# ranks in lockstep without it; capture-time barriers (cuda_graph_runner) are
+# separate and unaffected. Flag-gated, default unchanged: measure, then decide.
+TP_STEP_BARRIER_ENV = "MSTAR_TP_STEP_BARRIER"
+
+
+def step_barrier_enabled() -> bool:
+    return os.environ.get(TP_STEP_BARRIER_ENV, "1").strip() not in ("0", "false", "no", "off")
 
 
 class CommGroup:
@@ -61,6 +76,15 @@ class CommGroup:
 
     def barrier(self):
         if self.world_size == 1:
+            return
+        dist.barrier(group=self.device_group)
+
+    def step_barrier(self):
+        """The per-step barrier at the engine's execute entry. Same as
+        ``barrier()`` unless ``MSTAR_TP_STEP_BARRIER=0`` (see the env note at the
+        top of this module). Read per call: the flag is a launch-time setting and
+        the lookup is ~100 ns against a ~100 us barrier."""
+        if self.world_size == 1 or not step_barrier_enabled():
             return
         dist.barrier(group=self.device_group)
 

--- a/mstar/engine/kv_cache_engine.py
+++ b/mstar/engine/kv_cache_engine.py
@@ -1013,7 +1013,7 @@ class KVCacheEngine(BaseEngine):
         if not batch.request_ids:
             return NodeOutput(per_request_output_tensors={})
 
-        submod_mgmt.tp_group.barrier()
+        submod_mgmt.tp_group.step_barrier()
 
         if self._can_use_cuda_graph(batch, node_inputs):
             if self.enable_nvtx:

--- a/mstar/engine/stateless_engine.py
+++ b/mstar/engine/stateless_engine.py
@@ -238,7 +238,7 @@ class StatelessEngine(BaseEngine):
                 f"engine.{self.config.name}.{batch.node_name}."
                 f"{batch.graph_walk}.bs{len(batch.request_ids)}"
             )
-        self.parallel_groups.get_tp_config_for_node(batch.node_name).barrier()
+        self.parallel_groups.get_tp_config_for_node(batch.node_name).step_barrier()
         submodule = self.submodules.get(batch.node_name)
         per_submodule_dtype = submodule.get_autocast_dtype() if submodule is not None else None
         try:

--- a/test/modular/test_comm_step_barrier.py
+++ b/test/modular/test_comm_step_barrier.py
@@ -1,0 +1,47 @@
+"""MSTAR_TP_STEP_BARRIER gates the per-step engine barrier, nothing else.
+
+The flag exists because dist.barrier() on the NCCL backend ends in a
+current-stream synchronize: it blocks the host until the previous step drains,
+which forbids the N+1-behind-N enqueue that TP-async scheduling needs. Default
+must stay "1" (unchanged behaviour); "0" must skip ONLY ``step_barrier`` — the
+plain ``barrier()`` used at capture time is untouched either way.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from mstar.distributed import communication as comm
+
+
+def _group(world_size: int) -> comm.CommGroup:
+    return comm.CommGroup(my_global_rank=0, my_group_rank=0, group_members=list(range(world_size)))
+
+
+@pytest.mark.parametrize("value,expect_call", [(None, True), ("1", True), ("0", False), ("off", False)])
+def test_step_barrier_honours_flag(monkeypatch, value, expect_call):
+    if value is None:
+        monkeypatch.delenv(comm.TP_STEP_BARRIER_ENV, raising=False)
+    else:
+        monkeypatch.setenv(comm.TP_STEP_BARRIER_ENV, value)
+    g = _group(2)
+    with patch.object(comm.dist, "barrier") as barrier:
+        g.step_barrier()
+    assert barrier.called is expect_call
+
+
+def test_plain_barrier_ignores_flag(monkeypatch):
+    monkeypatch.setenv(comm.TP_STEP_BARRIER_ENV, "0")
+    g = _group(2)
+    with patch.object(comm.dist, "barrier") as barrier:
+        g.barrier()
+    assert barrier.called
+
+
+def test_trivial_group_never_barriers(monkeypatch):
+    monkeypatch.delenv(comm.TP_STEP_BARRIER_ENV, raising=False)
+    g = _group(1)
+    with patch.object(comm.dist, "barrier") as barrier:
+        g.step_barrier()
+        g.barrier()
+    assert not barrier.called


### PR DESCRIPTION
Every engine step starts with `tp_group.barrier()` (`KVCacheEngine.execute_forward`, `StatelessEngine.execute_batch`). On NCCL that's an all-reduce + stream sync, so the host waits for the previous step to fully drain before it can do anything for the next one. That kills any chance of queueing step N+1 behind N, and at bs=1 decode the whole host side of the step becomes GPU idle time.

The forward's own collectives already keep the ranks in lockstep, the barrier isn't doing anything for correctness. The v1 engine on `resource_pools_2` doesn't have it either.

This puts it behind `MSTAR_TP_STEP_BARRIER` (default 1, nothing changes). `CommGroup.step_barrier()` checks the flag, `barrier()` doesn't, so the capture-time barriers in `cuda_graph_runner.py` are untouched. Added to `docs/environment_variables.rst`.

Not posting perf numbers yet, it depends on the config and I want a clean A/B. Will add as a comment.

Tested: `test/modular/test_comm_step_barrier.py` (6 tests). Ran with `=0` on a GLM-5.2 TP8 serve with async scheduling on, no hang, same output as with the barrier.
