### PR TITLE
worker: async scheduling for TP nodes (MSTAR_TP_ASYNC_SCHED)

### DIFF
--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -158,3 +158,50 @@ uses ``soundfile`` / ``ffmpeg``), so two surfaces degrade:
   the audio is dropped and a warning is logged. Do not set ``generate_sound`` on
   the Rust frontend (it spends compute on a track the client won't receive), or
   run the Python frontend for sound video.
+
+Worker scheduling
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 14 58
+
+   * - Variable
+     - Default
+     - Meaning
+   * - ``MSTAR_TP_ASYNC_SCHED``
+     - ``0``
+     - Async scheduling for lockstep-parallel (TP / SP) nodes. ``1``: the
+       instance leader speculates step N+1 of the parallel node during
+       forward N (the existing single-worker speculation machinery, gate
+       opened) and broadcasts it at once as a speculative
+       ``ScheduleTPNode``; followers rebuild the identical batch during
+       their own forward N and every rank submits N+1 the moment N
+       completes. Removes the per-step serial build/plan from the group's
+       critical path. Voids (allocation failure, per-rid failure, a
+       continuing request without loop-back output) are derived by each
+       rank from replicated state, never signalled. A comma-separated
+       list of node names (``thinker,talker``) enables it for those
+       parallel nodes only. ``0``: the serial path — leader schedules
+       after N, followers rebuild after the broadcast. Set it identically
+       on every rank of an instance: the workers compare it at startup and
+       refuse to start on a mismatch. Leave ``MSTAR_ENGINE_STEP_SYNC`` at
+       ``0`` with it: that throttle holds the GPU thread until step N drains,
+       which serialises the very overlap this flag buys.
+   * - ``MSTAR_PRE_PLAN_SPEC``
+     - ``1``
+     - Pre-plan the speculative batch's attention on a dedicated thread
+       while the previous replay runs. ``0`` plans inline on the GPU
+       thread.
+   * - ``MSTAR_MAX_CONSECUTIVE_SPEC_STEPS``
+     - ``1024``
+     - Cap on back-to-back speculative steps before the leader yields to
+       other ready work.
+   * - ``MSTAR_SPEC_PEEK_FOR_FAIRNESS``
+     - ``1``
+     - Yield the speculation chain only when another (node, walk) is
+       actually ready right now; ``0`` uses the consecutive-step cap alone.
+   * - ``MSTAR_PHASE_TIMING``
+     - ``0``
+     - ``N > 0``: every N iterations log per-phase p50/p95/mean of the
+       worker main loop (speculate, await_gpu, submit_spec, ...).

--- a/mstar/model/qwen3_omni/submodules.py
+++ b/mstar/model/qwen3_omni/submodules.py
@@ -394,10 +394,10 @@ class ThinkerSubmodule(ARNodeSubmodule):
             # Next MRoPE position for all 3 components: read from the
             # stream's position counter (advanced by the runner's commit
             # of each declared step).
-            pos_ids = torch.tensor(
-                [[start_pos], [start_pos], [start_pos]],
-                dtype=torch.float,
-                device=device,
+            # Fill kernel, not ``torch.tensor(..., device=cuda)``: a pageable H2D
+            # syncs the stream, stalling prepare(N+1) until step N drains.
+            pos_ids = torch.full(
+                (3, 1), float(start_pos), dtype=torch.float, device=device,
             )  # (3, 1)
 
             return ARNodeInputs(

--- a/mstar/utils/containers.py
+++ b/mstar/utils/containers.py
@@ -1,0 +1,44 @@
+"""Small generic containers with no engine or worker knowledge"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Hashable, Iterator
+from typing import Generic, TypeVar
+
+T = TypeVar("T", bound=Hashable)
+
+
+class RecentSet(Generic[T]):
+    """Set of the ``maxlen`` most recently added items: O(1) add / ``in``, FIFO
+    eviction. Readding a present item is a no-op (age not refreshed)."""
+
+    __slots__ = ("_items", "_order", "maxlen")
+
+    def __init__(self, maxlen: int) -> None:
+        if maxlen < 1:
+            raise ValueError(f"maxlen must be >= 1, got {maxlen}")
+        self.maxlen = maxlen
+        self._items: set[T] = set()
+        self._order: deque[T] = deque()
+
+    def add(self, item: T) -> None:
+        if item in self._items:
+            return
+        self._items.add(item)
+        self._order.append(item)
+        if len(self._order) > self.maxlen:
+            self._items.discard(self._order.popleft())
+
+    def __contains__(self, item: object) -> bool:
+        return item in self._items
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self) -> Iterator[T]:
+        """Oldest to newest."""
+        return iter(self._order)
+
+    def __repr__(self) -> str:
+        return f"RecentSet(maxlen={self.maxlen}, items={list(self._order)!r})"

--- a/mstar/utils/ipc_format.py
+++ b/mstar/utils/ipc_format.py
@@ -37,6 +37,7 @@ class WorkerMessageType(Enum):
     TENSOR_RECEIVED = "tensor_received"
     SCHEDULE_TP = "schedule_tp"
     STOP_LOOPS = "stop_loops"
+    TP_NO_SPEC = "tp_no_spec"
 
 
 @dataclass
@@ -93,6 +94,16 @@ class ScheduleTPNode(MessageBody):
     node_name: str
     graph_walk: str
     request_ids: list[str]
+    speculative: bool = False
+    spec_seq: int = -1
+    spec_from_seq: int = -1
+
+
+@dataclass
+class TPNoSpeculation(MessageBody):
+    node_name: str
+    graph_walk: str
+    spec_from_seq: int
 
 @dataclass
 class WorkerMessage:

--- a/mstar/worker/micro_scheduler.py
+++ b/mstar/worker/micro_scheduler.py
@@ -223,16 +223,9 @@ class MicroScheduler:
 
     def _try_schedule_tp_follow(
         self, worker_graphs_manager: WorkerGraphsManager,
-        target_node_name: str | None = None,
-        target_graph_walk: str | None = None,
         exclude_target: tuple[str, str] | None = None,
     ) -> ScheduledBatch | None:
         if len(self.tp_batches_pending_schedule) == 0:
-            return
-        # A popped ScheduleTPNode has no re-queue path and must be submitted
-        # unconditionally. Targeted calls (the speculation fresh-rid merge) may
-        # reject what they are handed, so never serve them from this FIFO.
-        if target_node_name is not None or target_graph_walk is not None:
             return
         first_tp_node: ScheduleTPNode = self.tp_batches_pending_schedule[0]
         if exclude_target is not None and \
@@ -316,12 +309,12 @@ class MicroScheduler:
         # Rank 0 already committed to this batch and will sit on the collective
         # inside the forward until every follower joins it, so a follower that
         # skipped the batch because one of its rids failed locally would hang
-        # the whole TP group.
-        tp_follow_batch = self._try_schedule_tp_follow(
-            worker_graphs_manager,
-            target_node_name=target_node_name,
-            target_graph_walk=target_graph_walk,
-            exclude_target=exclude_target,
+        # the whole TP group. A popped ScheduleTPNode ha sno re-queue path
+        # and must be submitted unconditionally. So that a targeted call,
+        # (the speculation fresh-rid merge, which may reject what it is
+        # handed) is never served from the FIFO.
+        tp_follow_batch = None if target is not None else self._try_schedule_tp_follow(
+            worker_graphs_manager, exclude_target=exclude_target,
         )
         if tp_follow_batch is None:
             self.num_consec_tp_follower_batches = 0

--- a/mstar/worker/micro_scheduler.py
+++ b/mstar/worker/micro_scheduler.py
@@ -36,6 +36,9 @@ class ScheduledBatch:
     node_objects: dict[str,GraphNode]
     # request_id -> worker_graph_id (for push-back on OOM)
     request_to_worker_graph: dict[str, str] = None
+    # ``ScheduleTPNode.spec_seq`` this batch came off the TP-follow FIFO with,
+    # -1 otherwise. ``split_off_first`` / ``merge`` only ever see -1.
+    tp_seq: int = -1
 
     def merge(self, other: "ScheduledBatch") -> None:
         """Fold ``other``'s requests in, ours first — they have waited longer."""
@@ -171,6 +174,53 @@ class MicroScheduler:
     ):
         self.tp_batches_pending_schedule.append(message)
 
+    # TP-follow FIFO accessors for the follower's async path (head only).
+
+    def peek_tp_follow(self) -> ScheduleTPNode | None:
+        if not self.tp_batches_pending_schedule:
+            return None
+        return self.tp_batches_pending_schedule[0]
+
+    def pop_tp_follow_head(self) -> ScheduleTPNode:
+        return self.tp_batches_pending_schedule.popleft()
+
+    def pop_ready_rids(
+        self, worker_graphs_manager: WorkerGraphsManager,
+        node_name: str, graph_walk: str, request_ids: list[str],
+    ) -> tuple[dict[str, GraphNode], dict[str, str]] | None:
+        """Pop ``node_name`` for exactly ``request_ids``, all or none.
+        Checked for every rid before anything is popped, so the caller
+        retries later for a partially ready set."""
+        if not request_ids:
+            return {}, {}
+        node_partition = worker_graphs_manager.get_partition_for_node(node_name)
+        wgid = worker_graphs_manager.get_worker_graph_id_for_node(
+            request_ids[0], node_name, graph_walk=graph_walk,
+        )
+        queue = worker_graphs_manager.queues[wgid]
+        for rid in request_ids:
+            # An unknown rid (removed on this rank) counts as not ready.
+            wg = queue.per_request_queues.get(rid)
+            if wg is None or node_name not in wg.ready_node_names:
+                return None
+            fwd_info = worker_graphs_manager.get_fwd_info(rid, node_partition)
+            # Engine-level readiness
+            if not self._check_ready(node_name, rid, fwd_info):
+                return None
+
+        node_objects: dict[str, GraphNode] = {}
+        request_to_worker_graph: dict[str, str] = {}
+        for rid in request_ids:
+            popped = queue.pop_ready_nodes(rid, [node_name])
+            if popped:
+                assert len(popped) == 1
+                node_objects[rid] = popped[0]
+                request_to_worker_graph[rid] = wgid
+
+        self.batch_number += 1
+        self.node_and_walk_to_last_batch_num[(node_name, graph_walk)] = self.batch_number
+        return node_objects, request_to_worker_graph
+
     def _try_schedule_tp_follow(
         self, worker_graphs_manager: WorkerGraphsManager,
         target_node_name: str | None = None,
@@ -179,15 +229,12 @@ class MicroScheduler:
     ) -> ScheduledBatch | None:
         if len(self.tp_batches_pending_schedule) == 0:
             return
+        # A popped ScheduleTPNode has no re-queue path and must be submitted
+        # unconditionally. Targeted calls (the speculation fresh-rid merge) may
+        # reject what they are handed, so never serve them from this FIFO.
+        if target_node_name is not None or target_graph_walk is not None:
+            return
         first_tp_node: ScheduleTPNode = self.tp_batches_pending_schedule[0]
-        # Respect the caller's filters: a targeted call (e.g. the speculation
-        # path asking for one specific node/walk) must not be handed a TP
-        # follower batch for some other node, or the caller will merge those
-        # node objects into a batch labeled with the target's name.
-        if target_node_name is not None and first_tp_node.node_name != target_node_name:
-            return
-        if target_graph_walk is not None and first_tp_node.graph_walk != target_graph_walk:
-            return
         if exclude_target is not None and \
                 (first_tp_node.node_name, first_tp_node.graph_walk) == exclude_target:
             return
@@ -197,40 +244,15 @@ class MicroScheduler:
                     (first_tp_node.node_name, first_tp_node.graph_walk)
                 ):
             return
-        # check if batch is ready
-        node_partition = worker_graphs_manager.get_partition_for_node(first_tp_node.node_name)
-        # Use the leader's graph walk, not this worker's current one: the
-        # follower may lag or lead the leader's partition state.
-        wgid = worker_graphs_manager.get_worker_graph_id_for_node(
-            first_tp_node.request_ids[0], first_tp_node.node_name,
-            graph_walk=first_tp_node.graph_walk,
+        # Check readiness for every rid to pop all-or-none. Use the
+        # leader's graph walk.
+        popped = self.pop_ready_rids(
+            worker_graphs_manager, first_tp_node.node_name,
+            first_tp_node.graph_walk, first_tp_node.request_ids,
         )
-        queue = worker_graphs_manager.queues[wgid]
-        for rid in first_tp_node.request_ids:
-            wg = queue.per_request_queues[rid]
-            if first_tp_node.node_name not in wg.ready_node_names:
-                return
-            fwd_info = worker_graphs_manager.get_fwd_info(rid, node_partition)
-            # check if the node is ready on the engine level
-            # (e.g., for AR, whether the kv cache is read in)
-            if not self._check_ready(first_tp_node.node_name, rid, fwd_info):
-                return
-
-        node_objects = {}
-        request_to_worker_graph = {}
-
-        # TODO: this code is also repeated below, should pull into a helper fn
-        for rid in first_tp_node.request_ids:
-            popped = queue.pop_ready_nodes(rid, [first_tp_node.node_name])
-            if popped:
-                assert len(popped) == 1
-                node_objects[rid] = popped[0]
-                request_to_worker_graph[rid] = wgid
-
-        self.batch_number += 1
-        self.node_and_walk_to_last_batch_num[(
-            first_tp_node.node_name, first_tp_node.graph_walk
-        )] = self.batch_number
+        if popped is None:
+            return
+        node_objects, request_to_worker_graph = popped
 
         self.tp_batches_pending_schedule.popleft()
 
@@ -239,6 +261,7 @@ class MicroScheduler:
             graph_walk=first_tp_node.graph_walk,
             node_objects=node_objects,
             request_to_worker_graph=request_to_worker_graph,
+            tp_seq=first_tp_node.spec_seq,
         )
 
 

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -6,6 +6,7 @@ import threading
 import time
 import time as _time
 from collections import defaultdict
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -24,12 +25,13 @@ from mstar.distributed.communication import WorkerParallelGroups
 from mstar.engine.engine import ExecutingBatch
 from mstar.engine.resources import AllocationFailed, StepContext
 from mstar.engine.resources.kv.transfer import TransferEngineInfo
-from mstar.graph.base import GraphEdge, GraphNode
+from mstar.graph.base import GraphEdge, GraphNode, SpeculativeNodeInfo
 from mstar.graph.graph_io import format_graph_edge_list
 from mstar.graph.loop_indices import NestedLoopIndices
 from mstar.model.base import Model, WorkerGraph
 from mstar.profile.worker import WorkerProfileInfo
 from mstar.streaming.stream_buffer import StreamBuffer
+from mstar.utils.containers import RecentSet
 from mstar.utils.ipc_format import (
     ConductorMessage,
     ConductorMessageType,
@@ -42,6 +44,7 @@ from mstar.utils.ipc_format import (
     SetupDone,
     StopLoops,
     TensorReceived,
+    TPNoSpeculation,
     UnpersistTensors,
     WorkerGraphsDone,
     WorkerMessage,
@@ -59,6 +62,17 @@ from mstar.worker.node_manager_utils import (
 logger = logging.getLogger(__name__)
 
 
+def _parse_tp_async_sched(raw: str) -> tuple[bool, frozenset[str] | None]:
+    """``MSTAR_TP_ASYNC_SCHED``: ``0``/empty off, ``1`` every parallel node,
+    or a comma-separated node list. Returns ``(enabled, nodes_or_None)``."""
+    raw = raw.strip()
+    if raw in ("", "0"):
+        return False, None
+    if raw == "1":
+        return True, None
+    return True, frozenset(n.strip() for n in raw.split(",") if n.strip())
+
+
 @dataclass
 class PendingBatch:
     batch: ScheduledBatch
@@ -69,6 +83,9 @@ class PendingBatch:
     future: Future
     speculative_new_iter: bool = False
     loop_name: str = None
+    # The leader's broadcast seq for this batch (``ScheduleTPNode.spec_seq``).
+    tp_seq: int = -1
+
 
 @dataclass
 class Speculation:
@@ -95,6 +112,9 @@ class Speculation:
     dropped: set[str] = field(default_factory=set)
 
     plan_future: Future | None = None
+    # TP async scheduling: the broadcast seq of this speculation (leader:
+    # assigned at broadcast; follower: the head's). PendingBatch.tp_seq on submit.
+    tp_seq: int = -1
 
 
 @dataclass(frozen=True)
@@ -270,6 +290,32 @@ class Worker:
             )
 
         self.is_tp_follower = len(self.parallel_nodes - self.parallel_leader_nodes) > 0
+
+        # TP async scheduling: the leader speculates N+1 during forward N and
+        # broadcasts it at once; followers rebuild it during their own N.
+        self.tp_async_sched, self.tp_async_nodes = _parse_tp_async_sched(
+            os.environ.get("MSTAR_TP_ASYNC_SCHED", "0")
+        )
+        # Leader: monotonic seq stamped on every ScheduleTPNode it sends.
+        self._tp_broadcast_seq = 0
+        # Follower: leader steps that will NOT be followed by a head; the
+        # leader said so (TPNoSpeculation) or this rank closed the step.
+        self._tp_nospec: RecentSet[int] = RecentSet(self._TP_NOSPEC_KEEP)
+        self._tp_leader_gap_warned = False
+        tp_async_on = sorted(n for n in self.parallel_nodes if self._tp_async_for(n))
+        if tp_async_on:
+            logger.info(
+                "Worker %s: TP async scheduling ON for %s (%s)",
+                worker_id, tp_async_on,
+                "follower" if self.is_tp_follower else "leader",
+            )
+        elif self.tp_async_sched and self.parallel_nodes:
+            logger.warning(
+                "Worker %s: MSTAR_TP_ASYNC_SCHED=%r names none of this worker's "
+                "parallel nodes %s; running the serial protocol",
+                worker_id, os.environ.get("MSTAR_TP_ASYNC_SCHED"),
+                sorted(self.parallel_nodes),
+            )
 
         self.scheduler = MicroScheduler(
             self.engine_manager,
@@ -601,7 +647,9 @@ class Worker:
             elif message.message_type == WorkerMessageType.STOP_LOOPS:
                 self._stop_loops(message.body)
             elif message.message_type == WorkerMessageType.SCHEDULE_TP:
-                self.scheduler.register_tp_follow(message.body)
+                self._register_tp_follow(message.body)
+            elif message.message_type == WorkerMessageType.TP_NO_SPEC:
+                self._register_tp_nospec(message.body)
 
     def _process_messages(self) -> None:
         self._process_message_list(self.communicator.get_all_new_messages())
@@ -857,11 +905,16 @@ class Worker:
         )
 
     def maybe_send_zmq_to_tp_followers(
-        self, node_batch: ExecutingBatch
-    ):
+        self, node_batch: ExecutingBatch,
+        *, speculative: bool = False, spec_from_seq: int = -1,
+    ) -> int:
+        """Broadcast this batch as a ``ScheduleTPNode``. Returns its seq, or
+        ``-1`` when this worker does not lead the node (nothing sent)."""
         if node_batch.node_name not in self.parallel_nodes or \
                 node_batch.node_name not in self.parallel_leader_nodes:
-            return
+            return -1
+        seq = self._tp_broadcast_seq
+        self._tp_broadcast_seq += 1
         # this worker is only a part of one TP group for this node,
         # so, we can just look at the sharding_config for the first
         # request to get the relevant workers
@@ -877,7 +930,33 @@ class Worker:
                     body=ScheduleTPNode(
                         node_name=node_batch.node_name,
                         graph_walk=node_batch.graph_walk,
-                        request_ids=node_batch.request_ids
+                        request_ids=list(node_batch.request_ids),  # tuple -> wire list
+                        speculative=speculative,
+                        spec_seq=seq,
+                        spec_from_seq=spec_from_seq,
+                    )
+                )
+            )
+        return seq
+
+    def _broadcast_tp_nospec(self, pending: PendingBatch) -> None:
+        """Tell followers no speculative head will follow step ``pending.tp_seq``,
+        so each step they await settles on exactly one of {head, marker}."""
+        # Not ``pending.node_batch.request_ids``: the GPU thread may be
+        # ``drop_rids``-ing that list right now (empty at B=1 on a veto).
+        sample_rid = next(iter(pending.batch.node_objects))
+        cfg = self.worker_graphs_manager.per_request_info[sample_rid]
+        workers = cfg.sharding_config.get_sharding_group(
+            pending.node_name, pending.graph_walk
+        )._workers[1:]
+        for worker in workers:
+            self.communicator.send(
+                worker, msg=WorkerMessage(
+                    message_type=WorkerMessageType.TP_NO_SPEC,
+                    body=TPNoSpeculation(
+                        node_name=pending.node_name,
+                        graph_walk=pending.graph_walk,
+                        spec_from_seq=pending.tp_seq,
                     )
                 )
             )
@@ -1261,8 +1340,9 @@ class Worker:
         function with the same ``batch_ids``; their local actions
         (push-back, hold) produce identical follower state.
 
-        ``KVCacheEngine._verify_tp_kv_symmetry`` fails fast at startup if
-        that invariant ever breaks.
+        ``KVCacheManager.post_warmup_validate`` fails fast at startup if
+        that invariant ever breaks. TP async scheduling leans on the same
+        symmetry: a follower voids a speculative head from its own verdict.
 
         v2 caveat: this function does not yet coordinate ``_last_active``
         / eviction-victim selection across TP ranks. Wall-clock LRU can
@@ -1310,10 +1390,52 @@ class Worker:
     def _can_speculate(self, batch: ScheduledBatch) -> bool:
         if any(
             not node.enable_async_scheduling for node in batch.node_objects.values()
-        ) or batch.node_name in self.parallel_nodes:
-            # disable speculation for lockstep-parallel nodes for now
+        ):
             return False
+        if batch.node_name in self.parallel_nodes:
+            # Only the leader initiates, only under TP async scheduling.
+            return (
+                self._tp_async_for(batch.node_name)
+                and batch.node_name in self.parallel_leader_nodes
+            )
         return True
+
+    def _tp_async_for(self, node_name: str) -> bool:
+        """TP async scheduling applies to this node (flag, narrowed by node list)."""
+        return self.tp_async_sched and (
+            self.tp_async_nodes is None or node_name in self.tp_async_nodes
+        )
+
+    def _is_tp_lead_pending(self, pending: PendingBatch) -> bool:
+        """``pending`` is a parallel batch this worker leads under TP async."""
+        return (
+            self._tp_async_for(pending.node_name)
+            and pending.node_name in self.parallel_nodes
+            and pending.node_name in self.parallel_leader_nodes
+        )
+
+    def _tp_lead_needs_marker(
+        self, pending: PendingBatch, speculation: Speculation | None,
+    ) -> bool:
+        """Leader owes followers a marker: no head went out for ``pending``
+        (nothing speculated, or a non-parallel target, never broadcast)."""
+        return self._is_tp_lead_pending(pending) and (
+            speculation is None or speculation.tp_seq < 0
+        )
+
+    def _is_tp_follow_pending(self, pending: PendingBatch) -> bool:
+        """``pending`` is a parallel batch this worker follows under TP async:
+        the leader will send a head or a marker for it. Mirrors ``_can_speculate``."""
+        return (
+            self._tp_async_for(pending.node_name)
+            and self.is_tp_follower
+            and pending.node_name in self.parallel_nodes
+            and pending.node_name not in self.parallel_leader_nodes
+            and all(
+                node.enable_async_scheduling
+                for node in pending.batch.node_objects.values()
+            )
+        )
 
     def _get_wgio_for_rid(self, batch: ScheduledBatch, rid: str):
         """Per-rid WorkerGraphIO for the wg that owns this rid in this batch.
@@ -1336,6 +1458,148 @@ class Worker:
             ]
         return tensors
 
+    def _prep_continuing_rid_for_spec(
+        self,
+        batch_N: ScheduledBatch,
+        batch_N_node: GraphNode,
+        rid: str,
+        spec_node_name: str,
+        speculating_same_node: bool,
+    ) -> tuple[GraphNode, str, NameToTensorList, list[GraphEdge], list[GraphEdge]] | None:
+        """Prepare one in-flight rid for the speculative batch: ingest its stream
+        chunks, check readiness, gather inputs. Returns ``(node, wg_id, inputs,
+        ingested_signals, ingested_next_iter)``, or ``None`` after rolling back."""
+        wgio = self._get_wgio_for_rid(batch_N, rid)
+        node = wgio.nodes[spec_node_name]
+
+        # temporarily set to prevent ingesting streaming inputs from re-adding the node to
+        # the ready queue
+        node._speculatively_scheduled = True
+        streaming_edges = self._poll_stream_buffers_for_speculation(
+            rid, spec_node_name
+        )
+        # Track which slot each ingest landed in so we can roll back if
+        # the readiness check below fails. ``ingest_input`` returns success
+        # without telling us which slot it used, so peek the slot state
+        # before the call.
+        ingested_into_ready_signals: list[GraphEdge] = []
+        ingested_into_ready_next_iter: list[GraphEdge] = []
+        for edge in streaming_edges:
+            already_in_ready_signals = (
+                edge.name in node.ready_signals.ready_names
+            )
+            if node.ingest_input(
+                edge, can_buffer=speculating_same_node
+            ):
+                if already_in_ready_signals:
+                    ingested_into_ready_next_iter.append(edge)
+                else:
+                    ingested_into_ready_signals.append(edge)
+            else:
+                self._return_speculative_streaming_edge(rid, edge)
+
+        # Check if the node is ready after ingesting the streaming edges
+        wgio.ingest_for_speculation(
+            batch_N_node.outputs, batch_N_node.name
+        )
+        fully_ready = node.is_ready_for_speculation(
+            check_next_iter=speculating_same_node,
+            allow_streaming=False
+        )
+        wgio.clear_speculative_inputs()
+        node._speculatively_scheduled = False # reset in case this rid gets dropped
+        if not fully_ready:
+            # Return the chunks we ingested to their StreamBuffers so a later
+            # scheduling of this node consumes them normally. Registry state
+            # was not touched (``_speculatively_scheduled=True`` above).
+            self._rollback_continuing_rid_prep(
+                rid, node, ingested_into_ready_signals, ingested_into_ready_next_iter,
+            )
+            return None
+
+        inputs = self._get_input_tensors(
+            rid, node, check_next_iter=speculating_same_node,
+        )
+        return (
+            node, wgio.wg_id, inputs,
+            ingested_into_ready_signals, ingested_into_ready_next_iter,
+        )
+
+    def _rollback_continuing_rid_prep(
+        self,
+        rid: str,
+        node: GraphNode,
+        ingested_into_ready_signals: list[GraphEdge],
+        ingested_into_ready_next_iter: list[GraphEdge],
+    ) -> None:
+        """Undo ``_prep_continuing_rid_for_spec``: pull the streaming chunks it
+        ingested back out of the node's ready slots and return them to their
+        StreamBuffers, so a future scheduling consumes them normally."""
+        for edge in ingested_into_ready_signals:
+            node.ready_signals.remove(edge.name)
+            self._return_speculative_streaming_edge(rid, edge)
+        for edge in ingested_into_ready_next_iter:
+            node.ready_next_iter.remove(edge.name)
+            self._return_speculative_streaming_edge(rid, edge)
+
+    def _assemble_speculation(
+        self,
+        pending: PendingBatch,
+        sample_node: GraphNode,
+        spec_node_info: SpeculativeNodeInfo,
+        node_objects: dict[str, GraphNode],
+        request_to_worker_graph: dict[str, str],
+        per_request_inputs: dict[str, NameToTensorList],
+        consumed_streaming_edges: dict[str, list[GraphEdge]],
+        continuing: list[str],
+        *,
+        is_same_node: bool,
+        tp_seq: int = -1,
+    ) -> Speculation:
+        """Package prepared rids (batch order) into the ``Speculation`` the main
+        loop runs. Leader and follower differ only in how they pick the rids."""
+        spec_node = spec_node_info.node_name
+        request_ids = list(node_objects)
+        spec_batch = ScheduledBatch(
+            node_name=spec_node,
+            graph_walk=pending.graph_walk,
+            node_objects=node_objects,
+            request_to_worker_graph=request_to_worker_graph,
+            tp_seq=tp_seq,
+        )
+        spec_node_batch = self._make_executing_batch(
+            node_name=spec_node,
+            graph_walk=pending.graph_walk,
+            request_ids=request_ids,
+            per_request_input_tensors=per_request_inputs,
+            per_request_info={
+                rid: self.worker_graphs_manager.get_fwd_info(rid, pending.partition)
+                for rid in request_ids
+            },
+            final_stream_rids={
+                rid for rid, edges in consumed_streaming_edges.items()
+                if any(e._final_stream_chunk for e in edges)
+            },
+        )
+        return Speculation(
+            scheduled_batch=spec_batch,
+            node_batch=spec_node_batch,
+            # Outputs of batch_N the spec batch consumes: every edge of
+            # sample_node whose destination is the spec node.
+            consumed_edges={
+                (edge.name, edge.next_node)
+                for edge in sample_node.outputs
+                if edge.next_node == spec_node
+            },
+            continuing_rids=set(continuing),
+            partition=pending.partition,
+            is_new_iter=spec_node_info.is_new_loop_iter,
+            is_same_node=is_same_node,
+            loop_name=spec_node_info.loop_name,
+            consumed_streaming_edges=consumed_streaming_edges,
+            tp_seq=tp_seq,
+        )
+
     def _try_speculate_next(
         self,
         pending: PendingBatch
@@ -1356,7 +1620,6 @@ class Worker:
             current speculation chain to drain before they can be scheduled.
         """
         batch_N = pending.batch
-        partition_N = pending.partition
         graph_walk = pending.graph_walk
 
         # sample node and RID to see which node we will be speculating
@@ -1374,9 +1637,10 @@ class Worker:
 
         # Filter out destinations that aren't speculation candidates.
         #
-        # * ``info.node_name in self.parallel_nodes`` — lockstep-parallel nodes
-        #   don't support speculation in v1 (the instance leader schedules;
-        #   followers can't initiate).
+        # * ``info.node_name in self.parallel_nodes`` — parallel nodes are
+        #   targets only under TP async, from the leader, as a same-node
+        #   loop-back (a follower rebuilds a head from its in-flight batch of
+        #   that node; for a transition into it there is none).
         # * ``not wgio.nodes[info.node_name].enable_async_scheduling`` — the
         #   destination node opts out of async scheduling. Mirrors the
         #   source-side check in ``_can_speculate``; without this, a
@@ -1385,7 +1649,14 @@ class Worker:
         #   then dropped per-rid further down.
         ready_for_spec = [
             info for info in ready_for_spec
-            if info.node_name not in self.parallel_nodes
+            if (
+                info.node_name not in self.parallel_nodes
+                or (
+                    self._tp_async_for(info.node_name)
+                    and info.node_name in self.parallel_leader_nodes
+                    and info.node_name == batch_N.node_name
+                )
+            )
             and wgio.nodes[info.node_name].enable_async_scheduling
         ]
 
@@ -1427,84 +1698,26 @@ class Worker:
                 # Room is spoken for by the backlog. Skipped before any
                 # streaming ingest, so there is nothing to roll back; this rid
                 # goes ready again the moment the in-flight batch lands.
+                # (Leader-only: followers run the composition they were sent.)
                 continue
 
-            # If the speculation is contingent on streaming edges, ingest the
-            # appropriate streaming edges
-            node = wgio.nodes[spec_node_info.node_name]
-
-            # temporarily set to prevent ingesting streaming inputs from re-adding the node to
-            # the ready queue
-            node._speculatively_scheduled = True
-            streaming_edges = self._poll_stream_buffers_for_speculation(
-                rid, spec_node_info.node_name
+            prep = self._prep_continuing_rid_for_spec(
+                batch_N, batch_N_node, rid, spec_node_info.node_name,
+                speculating_same_node,
             )
-            # Track which slot each ingest landed in so we can roll back if
-            # the readiness check below fails. ``ingest_input`` returns success
-            # without telling us which slot it used, so peek the slot state
-            # before the call.
-            ingested_into_ready_signals: list[GraphEdge] = []
-            ingested_into_ready_next_iter: list[GraphEdge] = []
-            for edge in streaming_edges:
-                already_in_ready_signals = (
-                    edge.name in node.ready_signals.ready_names
-                )
-                if node.ingest_input(
-                    edge, can_buffer=speculating_same_node
-                ):
-                    if already_in_ready_signals:
-                        ingested_into_ready_next_iter.append(edge)
-                    else:
-                        ingested_into_ready_signals.append(edge)
-                else:
-                    self._return_speculative_streaming_edge(rid, edge)
-
-            # Check if the node is ready after ingesting the streaming edges
-            wgio.ingest_for_speculation(
-                batch_N_node.outputs, batch_N_node.name
-            )
-            fully_ready = node.is_ready_for_speculation(
-                check_next_iter=speculating_same_node,
-                allow_streaming=False
-            )
-            wgio.clear_speculative_inputs()
-            node._speculatively_scheduled = False # reset in case this rid gets dropped
-            if not fully_ready:
-                # Roll back the streaming edges we just ingested so the
-                # chunks don't sit in the spec target's ready_signals /
-                # ready_next_iter unused. Return each chunk to its
-                # StreamBuffer's uningested cache so a future scheduling
-                # of this node consumes it normally. The registry's
-                # ``ready_names`` / ``ready_next_iter`` sets weren't
-                # touched (gated by ``_speculatively_scheduled=True``
-                # above), so no registry-state rollback is needed.
-                for edge in ingested_into_ready_signals:
-                    node.ready_signals.remove(edge.name)
-                    self._return_speculative_streaming_edge(rid, edge)
-                for edge in ingested_into_ready_next_iter:
-                    node.ready_next_iter.remove(edge.name)
-                    self._return_speculative_streaming_edge(rid, edge)
+            if prep is None:
                 continue
+            node, wg_id, inputs, into_signals, into_next_iter = prep
 
             # prepare speculative batch
             continuing.append(rid)
             new_node_objects[rid] = node
-            new_request_to_worker_graph[rid] = wgio.wg_id
-            per_request_inputs[rid] = self._get_input_tensors(
-                rid, node, check_next_iter=speculating_same_node,
-            )
-            consumed_streaming_edges[rid] = ingested_into_ready_next_iter + ingested_into_ready_signals
+            new_request_to_worker_graph[rid] = wg_id
+            per_request_inputs[rid] = inputs
+            consumed_streaming_edges[rid] = into_next_iter + into_signals
 
         if not continuing:
             return None
-
-        # Edges that the spec batch effectively "consumed" from batch_N's
-        # outputs: every output of sample_node whose destination is the spec node
-        consumed_edges: set[tuple[str, str]] = {
-            (edge.name, edge.next_node)
-            for edge in sample_node.outputs
-            if edge.next_node == spec_node_info.node_name
-        }
 
         # Merge in fresh rids whose spec-target node is ready right now
         # Speculation only consumes work compatible with the spec target. In
@@ -1530,17 +1743,8 @@ class Worker:
                     # in-flight step and shouldn't be in ready queues —
                     # but if it does, the in-flight rid wins.
                     #
-                    # KNOWN GAP (latent): if fresh_batch ever came from the
-                    # TP-follow path, ``_try_schedule_tp_follow`` has already
-                    # popped the leader's ScheduleTPNode. Pushing the node
-                    # back onto the ready queue does not undo that, and this
-                    # worker is a follower for that node so nothing will
-                    # reschedule it — the TP group stalls. Unreachable today
-                    # (spec targets exclude ``parallel_nodes``, so the
-                    # target_node_name filter never matches a TP batch), but
-                    # any future overlap needs the scheduler to re-queue the
-                    # message, or to defer the popleft until the caller
-                    # commits to the batch.
+                    # Never a TP-follow batch: targeted calls don't pop the
+                    # TP-follow FIFO (a rejected ScheduleTPNode can't re-queue).
                     wg_id = fresh_batch.request_to_worker_graph[rid]
                     self.worker_graphs_manager.queues[wg_id].push_back_node(rid, node)
                     continue
@@ -1553,42 +1757,12 @@ class Worker:
                     fresh_batch.request_to_worker_graph[rid]
                 )
 
-        spec_batch = ScheduledBatch(
-            node_name=spec_node_info.node_name,
-            graph_walk=batch_N.graph_walk,
-            node_objects=new_node_objects,
-            request_to_worker_graph=new_request_to_worker_graph,
-        )
-
-        request_ids = list(new_node_objects.keys())
-        spec_node_batch = self._make_executing_batch(
-            node_name=spec_node_info.node_name,
-            graph_walk=batch_N.graph_walk,
-            request_ids=request_ids,
-            per_request_input_tensors=per_request_inputs,
-            per_request_info={
-                rid: self.worker_graphs_manager.get_fwd_info(
-                    rid, partition_N
-                ) for rid in request_ids
-            },
-            final_stream_rids={
-                rid for rid, edges in consumed_streaming_edges.items()
-                if any(e._final_stream_chunk for e in edges)
-            },
-        )
-
-        logger.debug(f"Speculating: {spec_node_info.node_name} {spec_node_batch.request_ids}")
-
-        return Speculation(
-            scheduled_batch=spec_batch,
-            node_batch=spec_node_batch,
-            consumed_edges=consumed_edges,
-            continuing_rids=set(continuing),
-            partition=pending.partition,
-            is_new_iter=spec_node_info.is_new_loop_iter,
+        logger.debug(f"Speculating: {spec_node_info.node_name} {list(new_node_objects)}")
+        return self._assemble_speculation(
+            pending, sample_node, spec_node_info,
+            new_node_objects, new_request_to_worker_graph, per_request_inputs,
+            consumed_streaming_edges, continuing,
             is_same_node=speculating_same_node,
-            loop_name=spec_node_info.loop_name,
-            consumed_streaming_edges=consumed_streaming_edges
         )
 
     def _thread_outputs_to_speculative(
@@ -1638,6 +1812,211 @@ class Worker:
                 speculation.consumed_streaming_edges.pop(rid, None)
         speculation.continuing_rids = threaded_continuing
         speculation.dropped = dropped
+
+    # ------------------------------------------------------------------
+    # TP async scheduling — the follower side
+    # ------------------------------------------------------------------
+    # A follower whose in-flight batch N is a head's spec_from_seq rebuilds
+    # that head from replicated state during its own N. No commit / cancel:
+    # every post-N verdict is derived per rank. The leader always sends a head
+    # or a TPNoSpeculation marker per step, settled before N is post-processed.
+
+    def _try_follow_speculation(self, pending: PendingBatch) -> Speculation | None:
+        head = self.scheduler.peek_tp_follow()
+        if head is None or not head.speculative:
+            return None
+        if head.spec_from_seq != pending.tp_seq:
+            # From some other step: the serial path gets it in FIFO order.
+            return None
+        if head.node_name != pending.node_name or head.graph_walk != pending.graph_walk:
+            # Leaders only speculate same-node loop-backs; leave it serial.
+            logger.warning(
+                "Worker %s: speculative head %s/%s (seq %d) does not match its "
+                "parent batch %s/%s; leaving it for the serial path",
+                self.worker_id, head.node_name, head.graph_walk, head.spec_seq,
+                pending.node_name, pending.graph_walk,
+            )
+            return None
+
+        batch_N = pending.batch
+        rid0, sample_node = next(iter(batch_N.node_objects.items()))
+        if not sample_node.outputs:
+            return None
+        wgio = self._get_wgio_for_rid(batch_N, rid0)
+        ready_for_spec = wgio.ingest_for_speculation(
+            sample_node.outputs, sample_node.name
+        )
+        wgio.clear_speculative_inputs()
+        infos = [i for i in ready_for_spec if i.node_name == head.node_name]
+        if not infos:
+            return None
+        spec_node_info = infos[0]
+
+        continuing = [r for r in head.request_ids if r in batch_N.node_objects]
+        fresh = [r for r in head.request_ids if r not in batch_N.node_objects]
+
+        # The leader's list is the composition every rank runs: no local
+        # finished-rid skipping, no ``room_for_continuing`` cap here.
+        prepped: dict[str, tuple] = {}
+
+        def _rollback_all() -> None:
+            for r, (node, _wg, _inputs, into_sig, into_next) in prepped.items():
+                self._rollback_continuing_rid_prep(r, node, into_sig, into_next)
+
+        for rid in continuing:
+            prep = self._prep_continuing_rid_for_spec(
+                batch_N, batch_N.node_objects[rid], rid, head.node_name,
+                speculating_same_node=True,
+            )
+            if prep is None:
+                _rollback_all()
+                return None
+            prepped[rid] = prep
+
+        popped = self.scheduler.pop_ready_rids(
+            self.worker_graphs_manager, head.node_name, head.graph_walk, fresh,
+        )
+        if popped is None:
+            _rollback_all()
+            return None
+        fresh_nodes, fresh_wg = popped
+
+        new_node_objects: dict[str, GraphNode] = {}
+        new_request_to_worker_graph: dict[str, str] = {}
+        per_request_inputs: dict[str, NameToTensorList] = {}
+        consumed_streaming_edges: dict[str, list[GraphEdge]] = {}
+        for rid in head.request_ids:  # wire order == the leader's batch order
+            if rid in prepped:
+                node, wg_id, inputs, into_sig, into_next = prepped[rid]
+                consumed_streaming_edges[rid] = into_next + into_sig
+            else:
+                node = fresh_nodes[rid]
+                wg_id = fresh_wg[rid]
+                inputs = self._get_input_tensors(rid, node, check_next_iter=False)
+            new_node_objects[rid] = node
+            new_request_to_worker_graph[rid] = wg_id
+            per_request_inputs[rid] = inputs
+
+        # Committed: the serial path must not see the head any more.
+        self.scheduler.pop_tp_follow_head()
+        # Its rids count as in flight now, so a remove landing before submit is
+        # deferred like any other; ``_set_pending`` re-derives the set on submit.
+        self._in_flight_rids |= set(head.request_ids)
+        logger.debug(
+            "Follow-speculating: %s %s (seq %d from %d)",
+            head.node_name, head.request_ids, head.spec_seq, head.spec_from_seq,
+        )
+        return self._assemble_speculation(
+            pending, sample_node, spec_node_info,
+            new_node_objects, new_request_to_worker_graph, per_request_inputs,
+            consumed_streaming_edges, continuing,
+            is_same_node=True, tp_seq=head.spec_seq,
+        )
+
+    # How many "no speculative head from step s" seqs a follower remembers.
+    _TP_NOSPEC_KEEP = 1024
+
+    def _register_tp_nospec(self, message: TPNoSpeculation) -> None:
+        """The leader sends no head from its step ``spec_from_seq``."""
+        if self._tp_async_for(message.node_name):
+            self._tp_nospec.add(message.spec_from_seq)
+
+    def _register_tp_follow(self, message: ScheduleTPNode) -> None:
+        """Queue a ScheduleTPNode; drop a head for a step this rank closed."""
+        if not message.request_ids:
+            logger.warning(
+                "Worker %s: dropped empty ScheduleTPNode for %s/%s (seq %d)",
+                self.worker_id, message.node_name, message.graph_walk,
+                message.spec_seq,
+            )
+            return
+        if (
+            self._tp_async_for(message.node_name) and message.speculative
+            and message.spec_from_seq in self._tp_nospec
+        ):
+            logger.debug(
+                "Worker %s: dropped speculative head seq %d (parent %d closed)",
+                self.worker_id, message.spec_seq, message.spec_from_seq,
+            )
+            return
+        self.scheduler.register_tp_follow(message)
+
+    def _close_tp_follow_step(self, pending: PendingBatch) -> None:
+        """This step's forward raised (symmetrically on the leader, which never
+        submitted its head): drop a queued head from it, and any arriving later."""
+        self._tp_nospec.add(pending.tp_seq)
+        head = self.scheduler.peek_tp_follow()
+        if head is not None and head.speculative and head.spec_from_seq == pending.tp_seq:
+            self.scheduler.pop_tp_follow_head()
+
+    @staticmethod
+    def _step_voids_head(pending: PendingBatch) -> str | None:
+        """Why N's verdict voids a head built on it, or ``None``. Both fields are
+        final once N's future is done; the leader clears on exactly these two."""
+        if pending.node_batch.admit_error is not None:
+            return "admit_error"
+        if pending.node_batch.failed_requests:
+            return "failed rids"
+        return None
+
+    def _await_tp_follow_step(
+        self, pending: PendingBatch, arm: Callable[[Speculation], None],
+    ) -> tuple[dict[str, NameToTensorList] | None, Speculation | None]:
+        """Wait for step N and settle the leader's decision about N+1. Returns
+        ``(outputs or None, armed head or None)``. Once N is done this never
+        returns without a decision: going serial early strands the leader."""
+        s = pending.tp_seq
+        outputs: dict[str, NameToTensorList] | None = None
+        t_done = last_warn = 0.0
+        while True:
+            if outputs is None and pending.future.done():
+                outputs = pending.future.result()
+                t_done = last_warn = _time.perf_counter()
+            if s in self._tp_nospec:
+                return outputs, None
+            head = self.scheduler.peek_tp_follow()
+            if head is not None and head.speculative and head.spec_from_seq == s:
+                void = self._step_voids_head(pending) if outputs is not None else None
+                if void is not None:
+                    # The leader clears its speculation on this verdict too.
+                    self.scheduler.pop_tp_follow_head()
+                    logger.debug(
+                        "Worker %s: dropped speculative head seq %d (parent %d %s)",
+                        self.worker_id, head.spec_seq, s, void,
+                    )
+                    return outputs, None
+                spec = self._try_follow_speculation(pending)
+                if spec is not None:
+                    arm(spec)
+                    return outputs, spec
+                # Not buildable yet (fresh rid / stream chunk): poll and retry.
+            elif head is not None and head.spec_seq > s:
+                # Per-peer FIFO: a later message with no decision for s means
+                # none is coming (flag off on the leader). Go serial.
+                if not self._tp_leader_gap_warned:
+                    self._tp_leader_gap_warned = True
+                    logger.warning(
+                        "Worker %s: leader moved past step seq %d without a "
+                        "speculation decision (front: seq %d); treating as "
+                        "no-spec. Is MSTAR_TP_ASYNC_SCHED set on every rank?",
+                        self.worker_id, s, head.spec_seq,
+                    )
+                self._tp_nospec.add(s)
+                return outputs, None
+            self.communicator.wait_for_work(20)
+            self._process_messages()
+            self._check_ready_tensors()
+            self._poll_stream_buffers()
+            if outputs is not None:
+                now = _time.perf_counter()
+                if now - last_warn > 2.0:
+                    last_warn = now
+                    logger.warning(
+                        "Worker %s: still waiting for the leader's decision on "
+                        "step seq %d, %.1fs after it finished (head queued: %s)",
+                        self.worker_id, s, now - t_done,
+                        head is not None and head.spec_from_seq == s,
+                    )
 
     # ------------------------------------------------------------------
     # Postprocessing
@@ -2339,6 +2718,15 @@ class Worker:
                             _phase_record("speculate", _time.perf_counter() - _t0)
                         if self.enable_nvtx:
                             range_pop(synchronize=False)
+                        if speculation is not None:
+                            # Broadcast the head now, during forward N, so
+                            # followers build it during theirs (-1: not parallel).
+                            speculation.tp_seq = self.maybe_send_zmq_to_tp_followers(
+                                speculation.node_batch,
+                                speculative=True, spec_from_seq=pending.tp_seq,
+                            )
+                    if self._tp_lead_needs_marker(pending, speculation):
+                        self._broadcast_tp_nospec(pending)
                     if speculation is None:
                         yield_away_from_target = (
                             pending.node_name,
@@ -2364,30 +2752,53 @@ class Worker:
                                 is_yield_away=True
                             )
 
-                            # send messages to follower ranks if relevant
-                            self.maybe_send_zmq_to_tp_followers(node_batch)
-                    if speculation is not None and plan_executor is not None:
-                        # Hand N+1 to the plan thread NOW. It waits on N's
-                        # commit event, then reserves a slot and pre-plans —
-                        # while the main thread sits in await_gpu with the GIL
-                        # released and N's kernels are still running.
-                        speculation.plan_future = plan_executor.submit(
-                            self._preplan_spec, pending, speculation,
+                            # A leader stamps the seq it sends; a follower's
+                            # batch keeps the one it came off the FIFO with.
+                            ya_seq = self.maybe_send_zmq_to_tp_followers(node_batch)
+                            speculation.tp_seq = ya_seq if ya_seq >= 0 else batch.tp_seq
+
+                def _arm_speculation(spec: Speculation) -> None:
+                    # Hand N+1 to the plan thread NOW. It waits on N's
+                    # commit event, then reserves a slot and pre-plans —
+                    # while the main thread sits in await_gpu with the GIL
+                    # released and N's kernels are still running.
+                    if plan_executor is not None:
+                        spec.plan_future = plan_executor.submit(
+                            self._preplan_spec, pending, spec,
                         )
+
+                if speculation is not None:
+                    _arm_speculation(speculation)
 
                 # 3. If pending: await GPU(N), submit speculated GPU(N+1)
                 # asap, then post-process N (fast then slow) overlapping
                 # with GPU(N+1).
                 spec_pending = None
                 if pending is not None:
-                    if self.enable_nvtx:
-                        range_push("worker.await_gpu", synchronize=False)
-                    _t0 = _time.perf_counter() if phase_period else 0.0
-                    outputs: dict[str, NameToTensorList] = pending.future.result()
-                    if phase_period:
-                        _phase_record("await_gpu", _time.perf_counter() - _t0)
-                    if self.enable_nvtx:
-                        range_pop(synchronize=False)
+                    outputs: dict[str, NameToTensorList] | None = None
+                    if speculation is None and self._is_tp_follow_pending(pending):
+                        # Follower: watch for the head while N runs and settle
+                        # the leader's decision before N is post-processed.
+                        if self.enable_nvtx:
+                            range_push("worker.follow_await", synchronize=False)
+                        _t0 = _time.perf_counter() if phase_period else 0.0
+                        outputs, speculation = self._await_tp_follow_step(
+                            pending, _arm_speculation,
+                        )
+                        if phase_period:
+                            _phase_record("follow_await", _time.perf_counter() - _t0)
+                        if self.enable_nvtx:
+                            range_pop(synchronize=False)
+
+                    if outputs is None:
+                        if self.enable_nvtx:
+                            range_push("worker.await_gpu", synchronize=False)
+                        _t0 = _time.perf_counter() if phase_period else 0.0
+                        outputs = pending.future.result()
+                        if phase_period:
+                            _phase_record("await_gpu", _time.perf_counter() - _t0)
+                        if self.enable_nvtx:
+                            range_pop(synchronize=False)
 
                     # set node._speculatively_scheduled to false, since
                     # the node has just completed
@@ -2417,6 +2828,15 @@ class Worker:
                                 for rid, edges in speculation.consumed_streaming_edges.items():
                                     for edge in edges:
                                         self._return_speculative_streaming_edge(rid, edge)
+                                # Fresh rids are not re-readied by N's routing
+                                # the way continuing rids are: give them back.
+                                sb = speculation.scheduled_batch
+                                for rid, node in sb.node_objects.items():
+                                    if rid in speculation.continuing_rids:
+                                        continue
+                                    wg_id = sb.request_to_worker_graph.get(rid)
+                                    if wg_id is not None:
+                                        self.worker_graphs_manager.queues[wg_id].push_back_node(rid, node)
                                 speculation = None
 
                     if pending.node_batch.admit_error is not None:
@@ -2488,6 +2908,7 @@ class Worker:
                                 future=spec_future,
                                 speculative_new_iter=speculation.is_new_iter,
                                 loop_name=speculation.loop_name,
+                                tp_seq=speculation.tp_seq,
                             )
                         elif speculation.plan_future is not None:
                             # All continuing rids were dropped, so no spec
@@ -2559,8 +2980,10 @@ class Worker:
                 # Nothing speculated this batch, so prepare it here. The GPU
                 # thread then admits, plans and runs it inline; the slot is
                 # leased inside exec, once the token count is known.
-                # send messages to follower ranks if relevant
-                self.maybe_send_zmq_to_tp_followers(node_batch)
+                # A leader stamps the seq it sends; a follower's batch keeps
+                # the one it came off the FIFO with; everyone else -1.
+                broadcast_seq = self.maybe_send_zmq_to_tp_followers(node_batch)
+                fallthrough_tp_seq = broadcast_seq if broadcast_seq >= 0 else batch.tp_seq
 
                 future = gpu_executor.submit(
                     self._execute_on_gpu_thread, batch, node_batch, None,
@@ -2573,10 +2996,15 @@ class Worker:
                     node_name=batch.node_name,
                     partition=batch_partition,
                     graph_walk=batch.graph_walk,
-                    future=future
+                    future=future,
+                    tp_seq=fallthrough_tp_seq,
                 ))
             except Exception as e:
                 self._handle_main_loop_error(e, (pending, spec_pending), batch)
+                # Follower: a head from a step that raised must not sit at the
+                # FIFO front with failed rids.
+                if pending is not None and self._is_tp_follow_pending(pending):
+                    self._close_tp_follow_step(pending)
                 # Clear the in-flight step. Without this the next iteration
                 # calls .result() on the same completed-with-exception future
                 # and re-raises forever, wedging the worker on one bad batch.

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -1406,6 +1406,27 @@ class Worker:
             self.tp_async_nodes is None or node_name in self.tp_async_nodes
         )
 
+    def _verify_tp_async_sched_agrees(self) -> None:
+        """Refuse a per-rank flag mismatch at startup: a follower would wait for
+        a decision the leader never sends, or get a head it cannot build."""
+        for node in sorted(self.parallel_nodes):
+            local = torch.tensor(
+                [int(self._tp_async_for(node))], dtype=torch.int64, device=self.device,
+            )
+            for group in (
+                self.parallel_groups.get_tp_config_for_node(node),
+                self.parallel_groups.get_sp_config_for_node(node),
+            ):
+                if group.world_size == 1:
+                    continue
+                values = group.all_gather(local, dim=0).cpu().tolist()
+                if any(v != values[0] for v in values):
+                    raise RuntimeError(
+                        f"MSTAR_TP_ASYNC_SCHED disagrees across the ranks of {node!r} "
+                        f"(ranks {group.group_members}: async={values}); set it "
+                        "identically on every rank of the instance."
+                    )
+
     def _is_tp_lead_pending(self, pending: PendingBatch) -> bool:
         """``pending`` is a parallel batch this worker leads under TP async."""
         return (
@@ -2511,6 +2532,7 @@ class Worker:
         # reaches warmup at the same wall-clock instant, so subgroup
         # bootstrap completes within the retry budget.
         self.parallel_groups.barrier_all()
+        self._verify_tp_async_sched_agrees()
 
         # CUDA graph capture before entering the main loop
         self.engine_manager.warmup_all()

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -1828,9 +1828,9 @@ class Worker:
                 speculation.node_batch.per_request_info.pop(r, None)
                 speculation.scheduled_batch.request_to_worker_graph.pop(r, None)
                 speculation.scheduled_batch.node_objects.pop(r, None)
-                for edge in speculation.consumed_streaming_edges.get(rid, []):
-                    self._return_speculative_streaming_edge(rid, edge)
-                speculation.consumed_streaming_edges.pop(rid, None)
+                for edge in speculation.consumed_streaming_edges.get(r, []):
+                    self._return_speculative_streaming_edge(r, edge)
+                speculation.consumed_streaming_edges.pop(r, None)
         speculation.continuing_rids = threaded_continuing
         speculation.dropped = dropped
 

--- a/test/modular/test_recent_set.py
+++ b/test/modular/test_recent_set.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mstar.utils.containers import RecentSet  # noqa: E402
+
+
+def test_membership_and_len():
+    s = RecentSet(3)
+    assert len(s) == 0 and 1 not in s
+    s.add(1)
+    s.add(2)
+    assert 1 in s and 2 in s and 3 not in s
+    assert len(s) == 2
+
+
+def test_evicts_oldest_first_once_full():
+    s = RecentSet(3)
+    for i in range(5):
+        s.add(i)
+    assert list(s) == [2, 3, 4]
+    assert 0 not in s and 1 not in s
+    assert len(s) == 3
+
+
+def test_readding_is_a_noop_and_keeps_original_age():
+    s = RecentSet(2)
+    s.add("a")
+    s.add("b")
+    s.add("a")           # already present, thus no eviction or age refresh
+    assert list(s) == ["a", "b"]
+    s.add("c")           # evicts "a", it is still the oldest
+    assert list(s) == ["b", "c"]
+    assert "a" not in s
+
+
+def test_maxlen_must_be_positive():
+    with pytest.raises(ValueError):
+        RecentSet(0)

--- a/test/modular/test_speculation_dropped_rid_cleanup.py
+++ b/test/modular/test_speculation_dropped_rid_cleanup.py
@@ -1,0 +1,74 @@
+"""``_thread_outputs_to_speculative`` returns a dropped rid's streaming edges
+under the dropped rid.
+
+A rid is dropped from the spec batch when batch N produced no loop-back
+output for it. Its consumed streaming edges must go back to its own stream
+buffer, or the chunk is lost; a continuing rid's edges must stay consumed,
+or the chunk is fed twice. The cleanup loop runs over ``dropped`` — every
+line in it has to address the dropped rid, not whatever the threading loop
+above it left bound.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mstar.graph.base import GraphEdge  # noqa: E402
+from mstar.worker.worker import Speculation, Worker  # noqa: E402
+
+NODE = "decoder"
+
+
+def _edge(name: str) -> GraphEdge:
+    return GraphEdge(next_node=NODE, name=name, is_streaming=True)
+
+
+def _speculation(rids: list[str]) -> Speculation:
+    return Speculation(
+        scheduled_batch=SimpleNamespace(
+            request_to_worker_graph={r: "wg" for r in rids},
+            node_objects={r: object() for r in rids},
+        ),
+        node_batch=SimpleNamespace(
+            request_ids=list(rids),
+            per_request_input_tensors={r: {} for r in rids},
+            per_request_info={r: object() for r in rids},
+        ),
+        consumed_edges={("tok", NODE)},
+        continuing_rids=set(rids),
+        partition="p",
+        is_new_iter=True,
+        is_same_node=True,
+        consumed_streaming_edges={r: [_edge(f"audio_{r}")] for r in rids},
+    )
+
+
+def test_dropped_rid_gets_its_own_edges_back():
+    returned: list[tuple[str, str]] = []
+    worker = SimpleNamespace(
+        _return_speculative_streaming_edge=lambda rid, edge: returned.append((rid, edge.name)),
+    )
+    # The dropped rid goes first: the threading loop leaves its variable bound
+    # to the LAST rid it visited, so a cleanup that read that leftover would
+    # act on ``keep`` and look correct if ``drop`` happened to come last.
+    spec = _speculation(["drop", "keep"])
+    outputs_N = {"keep": {"tok": ["t"]}}  # nothing came back for ``drop``
+
+    Worker._thread_outputs_to_speculative(worker, spec, outputs_N)
+
+    assert spec.dropped == {"drop"}
+    assert spec.continuing_rids == {"keep"}
+    assert spec.node_batch.request_ids == ["keep"]
+    for table in (
+        spec.node_batch.per_request_input_tensors,
+        spec.node_batch.per_request_info,
+        spec.scheduled_batch.request_to_worker_graph,
+        spec.scheduled_batch.node_objects,
+    ):
+        assert set(table) == {"keep"}
+
+    # drop's chunk went back to drop's buffer; keep's stays consumed.
+    assert returned == [("drop", "audio_drop")]
+    assert set(spec.consumed_streaming_edges) == {"keep"}

--- a/test/modular/test_tp_async_follow_sched.py
+++ b/test/modular/test_tp_async_follow_sched.py
@@ -1,0 +1,187 @@
+"""TP async scheduling — the follower-side scheduler surface.
+
+What a follower needs beyond the serial TP-follow path, pinned here against
+the same fakes ``test_tp_follow_targeted_gate.py`` uses:
+
+``MicroScheduler.pop_ready_rids`` — pop a named rid set for a node
+*all-or-nothing*. The follower rebuilds the leader's speculative head from the
+ids on the wire; if any fresh rid is not ready locally yet, NOTHING may be
+popped (the caller retries once readiness has progressed). The FIFO accessors
+(peek / pop head) keep order and touch only the head. The serial
+``_try_schedule_tp_follow`` path now goes through the same pop and stamps the
+head's seq on the batch it returns.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mstar.engine.resources.step import FULL_ADMIT_NOT_READY, FULL_ADMIT_OK  # noqa: E402
+from mstar.graph.base import GraphNode  # noqa: E402
+from mstar.utils.ipc_format import ScheduleTPNode  # noqa: E402
+from mstar.worker.micro_scheduler import MicroScheduler  # noqa: E402
+
+NODE = "LLM"
+WALK = "decode"
+
+
+class _FakeEngine:
+    def __init__(self, not_ready=()):
+        self.not_ready = set(not_ready)
+
+    def check_ready(self, node_name, rid, fwd_info):
+        # Retryable not-ready only; a terminal AdmitRuntimeError is the
+        # scheduler's ``_check_ready`` business, pinned in test_micro_scheduler.
+        return FULL_ADMIT_NOT_READY if rid in self.not_ready else FULL_ADMIT_OK
+
+
+class _FakeEngineManager:
+    def __init__(self, engine):
+        self.engine = engine
+
+    def get_engine(self, node_name):
+        return self.engine
+
+
+class _FakeRequestGraph:
+    def __init__(self, ready_node_names):
+        self.ready_node_names = set(ready_node_names)
+
+
+class _FakeQueue:
+    def __init__(self, ready_rids, not_ready_rids=()):
+        self.per_request_queues = {
+            rid: _FakeRequestGraph({NODE}) for rid in ready_rids
+        }
+        for rid in not_ready_rids:
+            self.per_request_queues[rid] = _FakeRequestGraph(set())
+
+    def pop_ready_nodes(self, rid, node_names):
+        wg = self.per_request_queues[rid]
+        popped = [
+            GraphNode(name=name, input_names=set(), outputs=[])
+            for name in node_names if name in wg.ready_node_names
+        ]
+        wg.ready_node_names -= set(node_names)
+        return popped
+
+    def get_ready_node_names(self):
+        return {}
+
+
+class _FakeWorkerGraphsManager:
+    def __init__(self, queue):
+        self.queues = {"wg0": queue}
+        self.per_request_info = {}
+
+    def get_partition_for_node(self, node_name):
+        return "p0"
+
+    def get_worker_graph_id_for_node(self, rid, node_name, graph_walk=None):
+        return "wg0"
+
+    def get_fwd_info(self, rid, partition):
+        return None
+
+
+def _sched(engine=None):
+    return MicroScheduler(
+        engine_manager=_FakeEngineManager(engine or _FakeEngine()),
+        parallel_leader_nodes=set(),  # follower role
+    )
+
+
+def _head(rids, seq=5, from_seq=4):
+    return ScheduleTPNode(
+        node_name=NODE, graph_walk=WALK, request_ids=list(rids),
+        speculative=True, spec_seq=seq, spec_from_seq=from_seq,
+    )
+
+
+# ---------------------------------------------------------------- pop_ready_rids
+
+def test_pop_ready_rids_pops_exactly_the_named_set():
+    sched = _sched()
+    queue = _FakeQueue(["r0", "r1", "r2"])
+    manager = _FakeWorkerGraphsManager(queue)
+
+    popped = sched.pop_ready_rids(manager, NODE, WALK, ["r1", "r2"])
+    assert popped is not None
+    nodes, wg = popped
+    assert list(nodes) == ["r1", "r2"]  # wire order preserved
+    assert wg == {"r1": "wg0", "r2": "wg0"}
+    # r0 untouched, r1/r2 consumed
+    assert NODE in queue.per_request_queues["r0"].ready_node_names
+    assert NODE not in queue.per_request_queues["r1"].ready_node_names
+    assert NODE not in queue.per_request_queues["r2"].ready_node_names
+
+
+def test_pop_ready_rids_is_all_or_nothing_on_graph_readiness():
+    sched = _sched()
+    queue = _FakeQueue(["r0"], not_ready_rids=["r1"])
+    manager = _FakeWorkerGraphsManager(queue)
+
+    assert sched.pop_ready_rids(manager, NODE, WALK, ["r0", "r1"]) is None
+    # NOTHING was consumed: r0 is still ready for a later attempt.
+    assert NODE in queue.per_request_queues["r0"].ready_node_names
+    assert sched.batch_number == 0
+
+
+def test_pop_ready_rids_is_all_or_nothing_on_engine_readiness():
+    sched = _sched(_FakeEngine(not_ready=["r1"]))
+    queue = _FakeQueue(["r0", "r1"])
+    manager = _FakeWorkerGraphsManager(queue)
+
+    assert sched.pop_ready_rids(manager, NODE, WALK, ["r0", "r1"]) is None
+    assert NODE in queue.per_request_queues["r0"].ready_node_names
+    assert NODE in queue.per_request_queues["r1"].ready_node_names
+
+
+def test_pop_ready_rids_empty_set_is_a_valid_no_op():
+    sched = _sched()
+    manager = _FakeWorkerGraphsManager(_FakeQueue(["r0"]))
+    assert sched.pop_ready_rids(manager, NODE, WALK, []) == ({}, {})
+    assert sched.batch_number == 0
+
+
+def test_serial_tp_follow_path_still_serves_via_shared_pop():
+    """Refactor guard: ``_try_schedule_tp_follow`` now goes through
+    ``pop_ready_rids``; the observable serial behaviour is unchanged, and the
+    batch carries the head's seq."""
+    sched = _sched()
+    manager = _FakeWorkerGraphsManager(_FakeQueue(["r0", "r1"]))
+    sched.register_tp_follow(_head(["r0", "r1"], seq=9))
+    batch = sched.get_next_batch(manager)
+    assert batch is not None
+    assert set(batch.node_objects) == {"r0", "r1"}
+    assert batch.tp_seq == 9
+    assert sched.peek_tp_follow() is None
+
+
+def test_serial_tp_follow_waits_when_a_rid_is_not_ready_and_pops_nothing():
+    sched = _sched()
+    queue = _FakeQueue(["r0"], not_ready_rids=["r1"])
+    manager = _FakeWorkerGraphsManager(queue)
+    sched.register_tp_follow(_head(["r0", "r1"]))
+    assert sched.get_next_batch(manager) is None
+    assert NODE in queue.per_request_queues["r0"].ready_node_names
+    assert len(sched.tp_batches_pending_schedule) == 1
+
+
+# ------------------------------------------------------------ FIFO accessors
+
+def test_fifo_accessors_touch_only_the_head_and_keep_order():
+    sched = _sched()
+    a, b = _head(["r0"], seq=1, from_seq=0), _head(["r1"], seq=2, from_seq=1)
+    sched.register_tp_follow(a)
+    sched.register_tp_follow(b)
+
+    assert sched.peek_tp_follow() is a
+    assert list(sched.tp_batches_pending_schedule) == [a, b]
+    assert sched.pop_tp_follow_head() is a
+    assert sched.peek_tp_follow() is b
+    assert sched.pop_tp_follow_head() is b
+    assert sched.peek_tp_follow() is None
+
+

--- a/test/modular/test_tp_async_follow_verdict.py
+++ b/test/modular/test_tp_async_follow_verdict.py
@@ -1,0 +1,432 @@
+"""TP async scheduling — a follower must always SETTLE the leader's decision
+about step N before it post-processes N, and it must never guess.
+
+The leader broadcasts its speculation DURING its forward N; a follower can
+finish N first (faster rank, slow leader build). If a follower went serial
+whenever the head had not arrived yet, a head landing later could reach the
+serial path with a continuing rid whose loop ended at N — a batch the serial
+readiness check can never build, while the leader runs it (one wasted
+forward) and then hangs in the collective. So:
+
+* the leader ALWAYS sends one of {speculative head from N, ``TPNoSpeculation``
+  marker for N} for every lockstep step it looked at speculating from;
+* the follower's ``_await_tp_follow_step`` — one loop that both waits for N
+  and watches the FIFO — builds a head the moment it lands (during N, the
+  point of the flag), and once N has finished does not return without a
+  decision: builds the head from N's real outputs, or goes serial on the
+  marker; N's verdict — ``admit_error`` / ``failed_requests`` on its
+  ``ExecutingBatch``, written by the GPU thread before N's future resolves —
+  drops a head without building it (the verdicts on which the leader clears
+  its own speculation before threading);
+* a step whose forward raised is closed (``_close_tp_follow_step``): its head
+  is dropped, queued or arriving.
+
+Drives the real ``Worker`` methods unbound on a minimal stub with a real
+``MicroScheduler`` for the FIFO, the pattern ``test_worker_message_handling``
+uses. ``_try_follow_speculation`` is stubbed per test — its own build logic
+is exercised against the graph API elsewhere; here we pin the protocol.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mstar.engine.resources.step import FULL_ADMIT_OK  # noqa: E402
+from mstar.utils.containers import RecentSet  # noqa: E402
+from mstar.utils.ipc_format import ScheduleTPNode, TPNoSpeculation  # noqa: E402
+from mstar.worker.micro_scheduler import MicroScheduler  # noqa: E402
+from mstar.worker.worker import Worker, _parse_tp_async_sched  # noqa: E402
+
+NODE = "LLM"
+WALK = "decode"
+
+
+class _FakeEngineManager:
+    def get_engine(self, node_name):
+        return types.SimpleNamespace(check_ready=lambda *a: FULL_ADMIT_OK)
+
+
+class _Communicator:
+    """wait_for_work delivers one queued message batch per call; the test
+    pushes messages via ``inbox`` (drained by the next ``_process_messages``)
+    or schedules them in ``deliveries`` (wait number -> messages that land on
+    that wait). Raises if the follower keeps waiting after everything was
+    delivered — that would be a hang."""
+
+    def __init__(self, stub):
+        self.stub = stub
+        self.inbox = []
+        self.deliveries = {}
+        self.waits = 0
+        self.max_waits = 50
+
+    def wait_for_work(self, timeout_ms=50):
+        self.waits += 1
+        if self.waits > self.max_waits:
+            raise TimeoutError("follower waited too long — would hang")
+        self.inbox.extend(self.deliveries.pop(self.waits, []))
+
+
+def _stub():
+    stub = types.SimpleNamespace()
+    stub.worker_id = "w1"
+    stub.tp_async_sched = True
+    stub.tp_async_nodes = None
+    stub._tp_async_for = lambda n: Worker._tp_async_for(stub, n)
+    stub._tp_nospec = RecentSet(Worker._TP_NOSPEC_KEEP)
+    stub._tp_leader_gap_warned = False
+    stub.scheduler = MicroScheduler(
+        engine_manager=_FakeEngineManager(), parallel_leader_nodes=set(),
+    )
+    stub.communicator = _Communicator(stub)
+    stub._check_ready_tensors = lambda: None
+    stub._poll_stream_buffers = lambda: None
+    stub.build_results = []   # what _try_follow_speculation returns, in order
+
+    def _process_messages():
+        while stub.communicator.inbox:
+            msg = stub.communicator.inbox.pop(0)
+            if isinstance(msg, TPNoSpeculation):
+                stub._register_tp_nospec(msg)
+            else:
+                stub._register_tp_follow(msg)
+
+    def _try_follow(pending):
+        # like the real one: a successful build consumes the FIFO head
+        if stub.build_results:
+            res = stub.build_results.pop(0)
+            if res is not None and stub.scheduler.peek_tp_follow() is not None:
+                stub.scheduler.pop_tp_follow_head()
+            return res
+        return None
+
+    stub._process_messages = _process_messages
+    stub._try_follow_speculation = _try_follow
+    stub._register_tp_follow = lambda m: Worker._register_tp_follow(stub, m)
+    stub._register_tp_nospec = lambda m: Worker._register_tp_nospec(stub, m)
+    stub._close_tp_follow_step = lambda p: Worker._close_tp_follow_step(stub, p)
+    stub._await_tp_follow_step = (
+        lambda p, arm: Worker._await_tp_follow_step(stub, p, arm)
+    )
+    stub._step_voids_head = Worker._step_voids_head
+    return stub
+
+
+def _leader_stub():
+    stub = types.SimpleNamespace()
+    stub.tp_async_sched = True
+    stub.tp_async_nodes = None
+    stub._tp_async_for = lambda n: Worker._tp_async_for(stub, n)
+    stub.parallel_nodes = {NODE}
+    stub.parallel_leader_nodes = {NODE}
+    stub._is_tp_lead_pending = lambda p: Worker._is_tp_lead_pending(stub, p)
+    stub._tp_lead_needs_marker = (
+        lambda p, sp: Worker._tp_lead_needs_marker(stub, p, sp)
+    )
+    return stub
+
+
+def _pending(tp_seq, future=None, admit_error=None, failed_requests=()):
+    """``admit_error`` / ``failed_requests`` are N's verdict, on its
+    ``ExecutingBatch`` the way the GPU thread leaves them."""
+    return types.SimpleNamespace(
+        node_name=NODE, graph_walk=WALK, tp_seq=tp_seq, future=future,
+        batch=types.SimpleNamespace(node_objects={"r0": object()}),
+        node_batch=types.SimpleNamespace(
+            admit_error=admit_error,
+            failed_requests={rid: "boom" for rid in failed_requests},
+        ),
+    )
+
+
+def _future(stub, output, done_after=0):
+    """N's future: done once the follower has waited ``done_after`` times."""
+    return types.SimpleNamespace(
+        done=lambda: stub.communicator.waits >= done_after,
+        result=lambda: output,
+    )
+
+
+def _output():
+    """N's outputs: rid -> name -> tensors. Carries no verdict (see _pending)."""
+    return {"r0": {}}
+
+
+def _head(rids, seq, from_seq):
+    return ScheduleTPNode(
+        node_name=NODE, graph_walk=WALK, request_ids=list(rids),
+        speculative=True, spec_seq=seq, spec_from_seq=from_seq,
+    )
+
+
+def _nospec(from_seq):
+    return TPNoSpeculation(node_name=NODE, graph_walk=WALK, spec_from_seq=from_seq)
+
+
+# ------------------------------------------------------------- the switch
+
+def test_env_parses_master_switch_and_node_list():
+    assert _parse_tp_async_sched("0") == (False, None)
+    assert _parse_tp_async_sched("") == (False, None)
+    assert _parse_tp_async_sched("1") == (True, None)
+    assert _parse_tp_async_sched("thinker, talker") == (
+        True, frozenset({"thinker", "talker"}),
+    )
+
+
+def test_node_list_narrows_which_parallel_nodes_take_part():
+    """Per-node control: a rank whose list excludes NODE behaves exactly as
+    with the flag off for NODE — leader owes no marker, follower records
+    nothing and queues heads verbatim for the serial path."""
+    ld = _leader_stub()
+    ld.tp_async_nodes = frozenset({"talker"})
+    assert not ld._tp_lead_needs_marker(_pending(4), None)
+    ld.tp_async_nodes = frozenset({NODE})
+    assert ld._tp_lead_needs_marker(_pending(4), None)
+
+    s = _stub()
+    s.tp_async_nodes = frozenset({"talker"})
+    s._register_tp_nospec(_nospec(4))
+    assert 4 not in s._tp_nospec
+    h = _head(["r0"], seq=5, from_seq=4)
+    s._register_tp_follow(h)
+    assert s.scheduler.peek_tp_follow() is h
+
+
+# ------------------------------------------------------- the leader's duty
+
+def test_leader_owes_a_marker_whenever_no_head_went_out():
+    """A follower settles on {head from s, marker for s}; the leader must send
+    one of them for EVERY lockstep step it looked at speculating from — also
+    when it did speculate, but into a non-parallel node, which is never
+    broadcast (tp_seq stays -1). Missing that marker hangs the followers."""
+    ld = _leader_stub()
+    p = _pending(4)
+    assert ld._tp_lead_needs_marker(p, None)
+    assert ld._tp_lead_needs_marker(p, types.SimpleNamespace(tp_seq=-1))
+    assert not ld._tp_lead_needs_marker(p, types.SimpleNamespace(tp_seq=5))
+
+
+def test_only_the_leader_of_a_lockstep_node_owes_a_marker():
+    ld = _leader_stub()
+    ld.parallel_leader_nodes = set()     # a follower shard of NODE
+    assert not ld._tp_lead_needs_marker(_pending(4), None)
+    ld = _leader_stub()
+    ld.tp_async_sched = False
+    assert not ld._tp_lead_needs_marker(_pending(4), None)
+
+
+# ------------------------------------------------------------- registration
+
+def test_nospec_marker_is_recorded_and_never_queued():
+    s = _stub()
+    s._register_tp_nospec(_nospec(4))
+    assert 4 in s._tp_nospec
+    assert s.scheduler.peek_tp_follow() is None
+
+
+def test_head_for_a_closed_step_is_dropped_on_arrival():
+    s = _stub()
+    s._close_tp_follow_step(_pending(4))
+    s._register_tp_follow(_head(["r0"], seq=5, from_seq=4))
+    assert s.scheduler.peek_tp_follow() is None
+
+
+def test_close_drops_an_already_queued_head_for_that_step_only():
+    s = _stub()
+    other = _head(["r9"], seq=9, from_seq=8)
+    s.scheduler.register_tp_follow(_head(["r0"], seq=5, from_seq=4))
+    s.scheduler.register_tp_follow(other)
+    s._close_tp_follow_step(_pending(4))
+    assert s.scheduler.peek_tp_follow() is other
+
+
+def test_plain_and_unrelated_speculative_messages_queue_normally():
+    s = _stub()
+    plain = ScheduleTPNode(NODE, WALK, ["r0"], spec_seq=3)
+    h = _head(["r0"], seq=5, from_seq=4)
+    s._register_tp_follow(plain)
+    s._register_tp_follow(h)
+    assert list(s.scheduler.tp_batches_pending_schedule) == [plain, h]
+
+
+def test_flag_off_ignores_markers_and_queues_heads_verbatim():
+    """A rank running with the flag off records nothing and never
+    second-guesses a head: the serial path runs whatever the leader sent."""
+    s = _stub()
+    s.tp_async_sched = False
+    s._register_tp_nospec(_nospec(4))
+    assert 4 not in s._tp_nospec
+    h = _head(["r0"], seq=5, from_seq=4)
+    s._register_tp_follow(h)
+    assert s.scheduler.peek_tp_follow() is h
+
+
+def test_empty_schedule_message_is_dropped_not_queued():
+    """Defensive: the serial path indexes request_ids[0]."""
+    s = _stub()
+    s._register_tp_follow(ScheduleTPNode(NODE, WALK, [], spec_seq=3))
+    assert s.scheduler.peek_tp_follow() is None
+
+
+def test_nospec_store_is_bounded():
+    s = _stub()
+    for i in range(Worker._TP_NOSPEC_KEEP + 10):
+        s._register_tp_nospec(_nospec(i))
+    assert len(s._tp_nospec) == Worker._TP_NOSPEC_KEEP
+    assert 0 not in s._tp_nospec and 9 not in s._tp_nospec
+    assert Worker._TP_NOSPEC_KEEP + 9 in s._tp_nospec
+
+
+# ------------------------------------------------------------------- await
+
+def _await(s, pending, arm=None):
+    return s._await_tp_follow_step(pending, arm or (lambda sp: None))
+
+
+def test_await_builds_a_queued_head_and_arms_it():
+    s = _stub()
+    spec = object()
+    s.build_results = [spec]
+    s.scheduler.register_tp_follow(_head(["r0"], seq=5, from_seq=4))
+    armed = []
+    out = _output()
+    assert _await(s, _pending(4, _future(s, out)), armed.append) == (out, spec)
+    assert armed == [spec]
+    assert s.communicator.waits == 0
+
+
+def test_await_goes_serial_on_the_marker_without_waiting():
+    s = _stub()
+    s._register_tp_nospec(_nospec(4))
+    out = _output()
+    assert _await(s, _pending(4, _future(s, out))) == (out, None)
+    assert s.communicator.waits == 0
+
+
+def test_await_builds_a_head_that_lands_while_N_runs():
+    """The point of the flag: the head is built DURING N. The call returns
+    (output None) so the caller awaits N with the speculation already armed."""
+    s = _stub()
+    spec = object()
+    s.build_results = [spec]
+    s.communicator.deliveries = {1: [_head(["r0"], seq=5, from_seq=4)]}
+    armed = []
+    got = _await(s, _pending(4, _future(s, _output(), done_after=10)), armed.append)
+    assert got == (None, spec) and armed == [spec]
+    assert s.communicator.waits == 1
+
+
+def test_await_returns_on_the_marker_while_N_runs():
+    s = _stub()
+    s.communicator.deliveries = {1: [_nospec(4)]}
+    got = _await(s, _pending(4, _future(s, _output(), done_after=10)))
+    assert got == (None, None)
+    assert s.communicator.waits == 1
+
+
+def test_await_keeps_waiting_after_N_finished_until_a_decision():
+    """N finished first (fast rank, slow leader build). No guessing: wait for
+    the head, then build it from N's real outputs."""
+    s = _stub()
+    spec = object()
+    s.build_results = [spec]
+    out = _output()
+    s.communicator.deliveries = {4: [_head(["r0"], seq=5, from_seq=4)]}
+    assert _await(s, _pending(4, _future(s, out, done_after=2))) == (out, spec)
+    assert s.communicator.waits == 4
+    assert s.scheduler.peek_tp_follow() is None   # consumed by the build
+
+
+def test_await_waits_for_a_late_marker_then_goes_serial():
+    s = _stub()
+    out = _output()
+    s.communicator.deliveries = {3: [_nospec(4)]}
+    assert _await(s, _pending(4, _future(s, out))) == (out, None)
+    assert s.communicator.waits == 3
+
+
+def test_await_drops_the_head_on_allocation_failure_without_building():
+    s = _stub()
+    s.build_results = [object()]   # would build if asked — it must not be
+    s.scheduler.register_tp_follow(_head(["r0"], seq=5, from_seq=4))
+    out = _output()
+    pending = _pending(4, _future(s, out), admit_error="kv cache: out of pages")
+    assert _await(s, pending) == (out, None)
+    assert s.scheduler.peek_tp_follow() is None
+    assert s.build_results, "head must be dropped, not built"
+
+
+def test_await_drops_the_head_on_failed_rids_without_building():
+    """Same verdict class as allocation failure: the leader clears its whole
+    speculation on ``failed_requests`` before threading, so the follower must
+    not build (and then unwind) what the leader will not run."""
+    s = _stub()
+    s.build_results = [object()]
+    s.scheduler.register_tp_follow(_head(["r0"], seq=5, from_seq=4))
+    out = _output()
+    pending = _pending(4, _future(s, out), failed_requests=["r0"])
+    assert _await(s, pending) == (out, None)
+    assert s.scheduler.peek_tp_follow() is None
+    assert s.build_results, "head must be dropped, not built"
+
+
+def test_await_has_no_verdict_to_apply_while_N_still_runs():
+    """admit_error is N's verdict; while N runs there is none yet, so a
+    head that lands early is built (the leader built it during N too — the
+    shared clear-or-thread flow after N voids it on both ranks alike). The
+    verdict is only read once ``future.done()``, never before."""
+    s = _stub()
+    spec = object()
+    s.build_results = [spec]
+    s.communicator.deliveries = {1: [_head(["r0"], seq=5, from_seq=4)]}
+    pending = _pending(
+        4, _future(s, _output(), done_after=10), admit_error="kv cache: out of pages",
+    )
+    assert _await(s, pending) == (None, spec)
+
+
+def test_await_retries_until_the_head_is_buildable():
+    """Fresh rid not ready on this rank yet: keep polling readiness, do not
+    go serial (the leader will run that composition)."""
+    s = _stub()
+    spec = object()
+    s.build_results = [None, None, spec]
+    s.scheduler.register_tp_follow(_head(["r0", "f1"], seq=5, from_seq=4))
+    out = _output()
+    assert _await(s, _pending(4, _future(s, out))) == (out, spec)
+    assert s.communicator.waits == 2
+
+
+def test_await_goes_serial_when_the_leader_moved_past_the_step():
+    """The decision about s is sent before anything the leader broadcasts
+    after s (per-peer FIFO). A later message at the FIFO front with no
+    decision recorded therefore means none is coming — e.g. the leader runs
+    with the flag off — so the follower goes serial instead of spinning."""
+    s = _stub()
+    later = ScheduleTPNode(NODE, WALK, ["r0"], spec_seq=6)   # plain, later
+    s.scheduler.register_tp_follow(later)
+    out = _output()
+    assert _await(s, _pending(4, _future(s, out))) == (out, None)
+    assert s.communicator.waits == 0
+    assert s.scheduler.peek_tp_follow() is later   # left for the serial path
+    assert 4 in s._tp_nospec
+
+
+def test_await_treats_a_later_head_at_the_front_the_same_way():
+    s = _stub()
+    later = _head(["r9"], seq=9, from_seq=8)
+    s.scheduler.register_tp_follow(later)
+    got = _await(s, _pending(4, _future(s, _output(), done_after=10)))
+    assert got == (None, None)                     # N still runs; caller awaits it
+    assert s.scheduler.peek_tp_follow() is later
+
+
+def test_await_never_returns_without_a_decision_once_N_finished():
+    s = _stub()   # nothing ever arrives
+    with pytest.raises(TimeoutError):
+        _await(s, _pending(4, _future(s, _output())))

--- a/test/modular/test_tp_async_lockstep_sim.py
+++ b/test/modular/test_tp_async_lockstep_sim.py
@@ -1,0 +1,74 @@
+"""Invariant checks for the TP async-scheduling protocol model.
+
+See tp_async_sim.py for the model. These tests pin the two results that gate
+the implementation:
+
+1. B1 (gated commit/cancel) and B2 with void-only Cancel hold I1–I4 across
+   every interleaving of the failure matrix, at 2 and 3 ranks.
+2. The naive Cancel semantics (retract the spec batch from any rank that has
+   not executed it yet — which is what "drop if unbuilt / unwind if built"
+   means without a gate) is REFUTED: it desyncs the collective order.
+   Kept as a negative control so the constraint survives refactors.
+"""
+
+try:
+    from .tp_async_sim import SCENARIOS, explore
+except ImportError:  # collected without package context
+    import os
+    import sys
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from tp_async_sim import SCENARIOS, explore
+
+
+def _run(mode, scenario, nranks=2):
+    comp0, script, must = SCENARIOS[scenario]
+    return explore(mode, nranks, comp0, script, scenario, must)
+
+
+def test_serial_baseline_holds():
+    for name in SCENARIOS:
+        assert _run("SERIAL", name).ok
+
+
+def test_b1_holds_all_scenarios_2_and_3_ranks():
+    for nranks in (2, 3):
+        for name in SCENARIOS:
+            res = _run("B1", name, nranks)
+            assert res.ok, (name, nranks, res.violations[:1])
+
+
+def test_b2_void_holds_all_scenarios_2_and_3_ranks():
+    for nranks in (2, 3):
+        for name in SCENARIOS:
+            res = _run("B2_VOID", name, nranks)
+            assert res.ok, (name, nranks, res.violations[:1])
+
+
+def test_b2_local_holds_all_scenarios_2_and_3_ranks():
+    """The implemented protocol (MSTAR_TP_ASYNC_SCHED=1): no cancel message,
+    each rank derives the void when it completes the parent step, and a spec
+    can only launch after that on its own rank. Must hold everywhere the
+    signalled-retract variant fails."""
+    for nranks in (2, 3):
+        for name in SCENARIOS:
+            res = _run("B2_LOCAL", name, nranks)
+            assert res.ok, (name, nranks, res.violations[:1])
+
+
+def test_b2_local_pays_no_wasted_forward_on_structural_cancel():
+    """Where VOID must run S everywhere and discard it, LOCAL never launches
+    it: the structural scenario costs LOCAL only the stop-waste (2), while
+    VOID pays the voided forward on top (3)."""
+    assert _run("B2_LOCAL", "structural-cancel").max_waste == 2
+    assert _run("B2_VOID", "structural-cancel").max_waste == 3
+
+
+def test_b2_retract_is_refuted_on_structural_cancel():
+    res = _run("B2_RETRACT", "structural-cancel")
+    assert res.violations, "retract semantics unexpectedly held — model changed?"
+    assert any("I1" in kind for kind, _ in res.violations)
+
+
+def test_b2_waste_matches_design_prediction():
+    # expected run-ahead cost: one wasted forward per request end at B=1
+    assert _run("B2_VOID", "clean-3step").max_waste == 1

--- a/test/modular/test_tp_async_sched_agreement.py
+++ b/test/modular/test_tp_async_sched_agreement.py
@@ -1,0 +1,70 @@
+"""``MSTAR_TP_ASYNC_SCHED`` must agree across the ranks of a lockstep instance.
+
+The flag is per-rank env. A leader without it never sends a decision the
+async follower waits for; a leader with it sends heads a serial follower
+cannot always build. ``Worker._verify_tp_async_sched_agrees`` all_gathers
+the per-node verdict at startup and refuses a mismatch.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mstar.worker.worker import Worker  # noqa: E402
+
+
+class _Group:
+    """A CommGroup stand-in whose all_gather returns preset per-rank values."""
+
+    def __init__(self, members, gathered):
+        self.world_size = len(members)
+        self.group_members = list(members)
+        self._gathered = gathered
+
+    def all_gather(self, input_, dim=0):
+        return torch.tensor(self._gathered, dtype=input_.dtype)
+
+
+def _worker(node, *, async_on, tp_group, sp_group=None):
+    groups = types.SimpleNamespace(
+        get_tp_config_for_node=lambda n: tp_group,
+        get_sp_config_for_node=lambda n: sp_group or _Group([0], [int(async_on)]),
+    )
+    return types.SimpleNamespace(
+        parallel_nodes={node},
+        parallel_groups=groups,
+        device="cpu",
+        _tp_async_for=lambda n: async_on,
+    )
+
+
+def _check(worker):
+    Worker._verify_tp_async_sched_agrees(worker)
+
+
+def test_agreeing_ranks_pass():
+    _check(_worker("thinker", async_on=True, tp_group=_Group([0, 1], [1, 1])))
+    _check(_worker("thinker", async_on=False, tp_group=_Group([0, 1], [0, 0])))
+
+
+def test_non_parallel_group_is_skipped():
+    _check(_worker("thinker", async_on=True, tp_group=_Group([0], [1])))
+
+
+def test_tp_mismatch_is_refused():
+    with pytest.raises(RuntimeError, match="disagrees"):
+        _check(_worker("thinker", async_on=True, tp_group=_Group([0, 1], [1, 0])))
+
+
+def test_sp_mismatch_is_refused():
+    with pytest.raises(RuntimeError, match="disagrees"):
+        _check(_worker(
+            "dit", async_on=True,
+            tp_group=_Group([0], [1]),
+            sp_group=_Group([0, 1], [1, 0]),
+        ))

--- a/test/modular/test_tp_follow_targeted_gate.py
+++ b/test/modular/test_tp_follow_targeted_gate.py
@@ -104,11 +104,8 @@ def test_targeted_call_never_pops_tp_follow():
 
     # Even an exactly-matching target must be refused: the targeted caller
     # (the speculation merge) may reject the batch, and a popped message
-    # has no re-queue path. ``get_next_batch`` targets a (node, walk) pair;
-    # the partial filters are pinned on ``_try_schedule_tp_follow`` directly.
+    # has no re-queue path.
     assert sched.get_next_batch(manager, target=(NODE, WALK)) is None
-    assert sched._try_schedule_tp_follow(manager, target_node_name=NODE) is None
-    assert sched._try_schedule_tp_follow(manager, target_graph_walk=WALK) is None
     assert len(sched.tp_batches_pending_schedule) == 1
 
     # The refusals consumed nothing: an untargeted call still builds the

--- a/test/modular/test_tp_follow_targeted_gate.py
+++ b/test/modular/test_tp_follow_targeted_gate.py
@@ -1,0 +1,157 @@
+"""The TP-follow FIFO must never be popped by a targeted get_next_batch call.
+
+A ScheduleTPNode is a mandate from the TP group leader: rank 0 has already
+committed to the batch and will sit on the collective inside the forward
+until every follower joins it (see the note in MicroScheduler.get_next_batch).
+Once the message is popped from the FIFO, nothing on a follower worker will
+ever reschedule that batch — followers cannot initiate scheduling for
+parallel nodes — so whoever pops it must submit it unconditionally.
+
+The only targeted caller in-tree is the speculation fresh-rid merge in
+``worker._try_speculate_next``, which is a discretionary consumer: it may
+reject rids from the batch it is handed (the "in-flight rid wins" branch).
+Handing it a TP-follow batch therefore risks stranding a popped
+ScheduleTPNode with no re-queue path, hanging the whole TP group at the next
+collective. The guard under test: targeted calls leave the FIFO untouched;
+untargeted calls still serve it, in order.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mstar.engine.resources.step import FULL_ADMIT_OK  # noqa: E402
+from mstar.graph.base import GraphNode  # noqa: E402
+from mstar.utils.ipc_format import ScheduleTPNode  # noqa: E402
+from mstar.worker.micro_scheduler import MicroScheduler  # noqa: E402
+
+
+class _FakeEngine:
+    def check_ready(self, node_name, rid, fwd_info):
+        return FULL_ADMIT_OK
+
+
+class _FakeEngineManager:
+    def get_engine(self, node_name):
+        return _FakeEngine()
+
+
+class _FakeRequestGraph:
+    def __init__(self, ready_node_names):
+        self.ready_node_names = set(ready_node_names)
+
+
+class _FakeQueue:
+    """Just enough of RequestQueues for the TP-follow path."""
+
+    def __init__(self, rids, node_name):
+        self.per_request_queues = {
+            rid: _FakeRequestGraph({node_name}) for rid in rids
+        }
+
+    def pop_ready_nodes(self, rid, node_names):
+        wg = self.per_request_queues[rid]
+        popped = [
+            GraphNode(name=name, input_names=set(), outputs=[])
+            for name in node_names if name in wg.ready_node_names
+        ]
+        wg.ready_node_names -= set(node_names)
+        return popped
+
+    def get_ready_node_names(self):
+        # No locally-initiated work: this worker is a pure TP follower.
+        return {}
+
+
+class _FakeWorkerGraphsManager:
+    def __init__(self, queue):
+        self.queues = {"wg0": queue}
+        self.per_request_info = {}
+
+    def get_partition_for_node(self, node_name):
+        return "p0"
+
+    def get_worker_graph_id_for_node(self, rid, node_name, graph_walk=None):
+        return "wg0"
+
+    def get_fwd_info(self, rid, partition):
+        return None
+
+
+NODE = "LLM"
+WALK = "decode"
+
+
+def _setup(rids=("r0", "r1")):
+    sched = MicroScheduler(
+        engine_manager=_FakeEngineManager(),
+        # Follower role: NODE is parallel here but this rank does not lead it.
+        parallel_leader_nodes=set(),
+    )
+    queue = _FakeQueue(rids, NODE)
+    manager = _FakeWorkerGraphsManager(queue)
+    return sched, manager
+
+
+def _msg(rids=("r0", "r1")):
+    return ScheduleTPNode(node_name=NODE, graph_walk=WALK, request_ids=list(rids))
+
+
+def test_targeted_call_never_pops_tp_follow():
+    sched, manager = _setup()
+    sched.register_tp_follow(_msg())
+
+    # Even an exactly-matching target must be refused: the targeted caller
+    # (the speculation merge) may reject the batch, and a popped message
+    # has no re-queue path. ``get_next_batch`` targets a (node, walk) pair;
+    # the partial filters are pinned on ``_try_schedule_tp_follow`` directly.
+    assert sched.get_next_batch(manager, target=(NODE, WALK)) is None
+    assert sched._try_schedule_tp_follow(manager, target_node_name=NODE) is None
+    assert sched._try_schedule_tp_follow(manager, target_graph_walk=WALK) is None
+    assert len(sched.tp_batches_pending_schedule) == 1
+
+    # The refusals consumed nothing: an untargeted call still builds the
+    # full batch afterwards.
+    batch = sched.get_next_batch(manager)
+    assert batch is not None
+    assert batch.node_name == NODE
+    assert set(batch.node_objects) == {"r0", "r1"}
+
+
+def test_untargeted_call_serves_and_drains():
+    sched, manager = _setup()
+    sched.register_tp_follow(_msg())
+
+    batch = sched.get_next_batch(manager)
+    assert batch is not None
+    assert batch.node_name == NODE
+    assert batch.graph_walk == WALK
+    assert set(batch.node_objects) == {"r0", "r1"}
+    assert len(sched.tp_batches_pending_schedule) == 0
+
+
+def test_exclude_target_skips_head_but_keeps_it_queued():
+    sched, manager = _setup()
+    sched.register_tp_follow(_msg())
+
+    assert sched.get_next_batch(manager, exclude_target=(NODE, WALK)) is None
+    assert len(sched.tp_batches_pending_schedule) == 1
+
+    batch = sched.get_next_batch(manager)
+    assert batch is not None
+    assert set(batch.node_objects) == {"r0", "r1"}
+
+
+def test_fifo_order_survives_refused_targeted_calls():
+    sched, manager = _setup(rids=("r0", "r1", "r2", "r3"))
+    sched.register_tp_follow(_msg(("r0", "r1")))
+    sched.register_tp_follow(_msg(("r2", "r3")))
+
+    assert sched.get_next_batch(manager, target=(NODE, WALK)) is None
+
+    first = sched.get_next_batch(manager)
+    assert set(first.node_objects) == {"r0", "r1"}
+    second = sched.get_next_batch(manager)
+    assert set(second.node_objects) == {"r2", "r3"}
+    assert len(sched.tp_batches_pending_schedule) == 0

--- a/test/modular/test_tp_spec_wire_format.py
+++ b/test/modular/test_tp_spec_wire_format.py
@@ -1,0 +1,101 @@
+"""Wire-format contract for TP async scheduling (implementation map row 3).
+
+Pins the properties the rest of the protocol is built on:
+
+1. Tagging ``ScheduleTPNode`` with speculation does not disturb today's serial
+   broadcast — existing three-arg construction still works and is
+   non-speculative by omission.
+2. A speculative head names itself (``spec_seq``) and the batch it was built
+   from (``spec_from_seq``); a follower matches ``spec_from_seq`` against its
+   own in-flight batch to decide whether it may build the head early.
+3. There is NO cancel/commit message type: voids are derived from state that
+   is identical on every rank, never signalled (see the ``ScheduleTPNode``
+   docstring and ``tp_async_sim.py`` for why a signalled retract is unsafe).
+   The only other message is ``TPNoSpeculation`` — "no head from step s" —
+   which carries no verdict, only the absence of a head.
+
+The *semantics* (void-only, symmetric derivation) are enforced by the CPU
+model checker in ``tp_async_sim.py``; these tests only pin the carrier.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Import mstar from THIS worktree, not the venv's editable install. Without
+# this, the PEP-660 finder falls back to the primary checkout and the test
+# silently validates code that isn't the code under change (the 2026-08-09
+# lesson that made 2/4 of the tp-follow fence tests "fail").
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mstar.utils.ipc_format import (  # noqa: E402
+    ScheduleTPNode,
+    TPNoSpeculation,
+    WorkerMessage,
+    WorkerMessageType,
+)
+
+
+def test_existing_construction_is_unchanged_and_non_speculative():
+    """Today's leader broadcast site passes three positional args. It must keep
+    compiling AND must not accidentally become speculative."""
+    msg = ScheduleTPNode("node_a", "decode", ["r1", "r2"])
+    assert msg.node_name == "node_a"
+    assert msg.graph_walk == "decode"
+    assert msg.request_ids == ["r1", "r2"]
+    assert msg.speculative is False
+    assert msg.spec_seq == -1
+    assert msg.spec_from_seq == -1
+
+
+def test_speculative_head_names_itself_and_its_parent():
+    msg = ScheduleTPNode(
+        "node_a", "decode", ["r1"], speculative=True, spec_seq=7, spec_from_seq=6
+    )
+    assert msg.speculative is True
+    assert msg.spec_seq == 7
+    assert msg.spec_from_seq == 6
+
+
+def test_no_cancel_or_commit_message_type():
+    """Voids are derived on every rank from replicated state, never signalled.
+    A cancel type reappearing here means someone re-introduced the retract
+    race the model checker refutes (``B2_RETRACT``)."""
+    names = {m.name for m in WorkerMessageType}
+    assert "CANCEL_SPEC" not in names
+    assert "COMMIT_SPEC" not in names
+    assert "SCHEDULE_TP" in names
+    assert "TP_NO_SPEC" in names
+
+
+def test_no_spec_marker_names_the_step_and_round_trips():
+    import pickle
+
+    msg = TPNoSpeculation("n", "decode", spec_from_seq=6)
+    wrapped = WorkerMessage(message_type=WorkerMessageType.TP_NO_SPEC, body=msg)
+    back = pickle.loads(pickle.dumps(wrapped))
+    assert back.message_type is WorkerMessageType.TP_NO_SPEC
+    assert back.body == msg and back.body.spec_from_seq == 6
+
+
+def test_wrapped_head_dispatches_on_schedule_tp():
+    wrapped = WorkerMessage(
+        message_type=WorkerMessageType.SCHEDULE_TP,
+        body=ScheduleTPNode("n", "decode", ["r1"], speculative=True, spec_seq=3, spec_from_seq=2),
+    )
+    assert wrapped.message_type is WorkerMessageType.SCHEDULE_TP
+    assert wrapped.body.spec_seq == 3
+
+
+def test_seqs_round_trip_through_pickle():
+    """TP messages travel as pickled dataclasses over ZMQ, so the tags have to
+    survive that specific path — not a dict round trip."""
+    import pickle
+
+    msg = ScheduleTPNode(
+        "n", "decode", ["r1"], speculative=True, spec_seq=11, spec_from_seq=10
+    )
+    back = pickle.loads(pickle.dumps(msg))
+    assert back == msg
+    assert back.speculative is True
+    assert back.spec_seq == 11 and back.spec_from_seq == 10

--- a/test/modular/tp_async_sim.py
+++ b/test/modular/tp_async_sim.py
@@ -1,0 +1,466 @@
+"""CPU lockstep simulator for the TP async-scheduling protocol.
+
+Models the leader/follower worker protocol for speculative scheduling on
+lockstep-parallel (TP) nodes — the case ``_can_speculate`` currently refuses
+— as an explicit-state model checker: every interleaving of
+{follower message processing, per-rank GPU progress, leader spec build, leader
+post-step} is explored by DFS over a small scripted workload, and the design's
+invariants are checked at every terminal state.
+
+Invariants (checked at every terminal state):
+  I1 lockstep   — every rank posts the identical batch sequence in identical
+                  order (a divergence is the NCCL-hang class).
+  I2 KV symmetry — spec allocation/rewind identical across ranks (modeled as
+                  per-batch page liveness).
+  I3 atomic enqueue — a gated batch never executes before its Commit
+                  (structural: the GPU action refuses gated heads).
+  I4 liveness   — a run that cannot progress and is not terminal is a deadlock.
+
+Modes:
+  SERIAL      — today's path, no speculation (harness sanity baseline).
+  B1          — gated commit/cancel: all ranks hold spec batch S at the launch
+                gate until Commit(seq)/Cancel(seq).
+  B2_RETRACT  — run-ahead where Cancel removes S from any rank that has not
+                executed it yet. Deliberately included as the naive reading of
+                "cancel": the checker is expected to REFUTE it (I1).
+  B2_VOID     — run-ahead where a broadcast S is *always* executed by every
+                rank; Cancel only voids its effects (outputs dropped, pages
+                freed). This is the semantics the design must specify.
+  B2_LOCAL    — the IMPLEMENTED protocol (MSTAR_TP_ASYNC_SCHED=1): no Cancel
+                message at all. A rank may launch spec batch S only after it
+                has itself completed S's parent step N, and at that moment it
+                applies the same verdict the leader applies at its post(N) —
+                derived from state that is identical on every rank
+                (structural failure on N → drop S locally, never run it).
+                A SPEC that arrives after the rank already completed N is
+                reconciled on arrival. Retract is safe here for the reason
+                B2_RETRACT is not: verdict(N) happens-before launch(S) on
+                every rank, so no rank can have run S when another voids it.
+
+Follower behavior encodes a property of the graph layer: spec batches are
+buildable from replicated graph state alone (``speculative_signals``
+placeholders, graph/base.py), so a follower builds S without waiting for its
+own step-N completion.
+
+No mstar imports, no third-party deps. Run directly:
+    python3 test/modular/tp_async_sim.py
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+
+STATE_CAP = 400_000
+
+# ---------------------------------------------------------------------------
+# World representation (plain dicts/tuples so states hash cheaply)
+# ---------------------------------------------------------------------------
+# batch: (kind, step, rids, seq)   kind in {"step", "spec"}
+# msg:   ("STEP", batch) | ("SPEC", batch) | ("COMMIT", seq) | ("CANCEL", seq)
+# rank:  {"fifo": tuple(msg), "q": tuple((batch, gated, void)),
+#         "exec": tuple(batch), "live": frozenset(batch), "voided": frozenset(seq)}
+
+
+def _new_rank():
+    return {
+        "fifo": (), "q": (), "exec": (),
+        "live": frozenset(), "voided": frozenset(),
+    }
+
+
+def make_world(mode, nranks, comp0, script):
+    w = {
+        "mode": mode,
+        "nranks": nranks,
+        "script": script,
+        "seq": 0,
+        "L": {
+            "step": 0,
+            "comp": tuple(comp0),
+            "cur": None,          # batch currently owed a post-step
+            "spec": None,         # outstanding spec batch for step+1
+            "spec_closed": False, # spec window consumed for this step
+            "waste": 0,
+            "done": False,
+        },
+        "ranks": [_new_rank() for _ in range(nranks)],
+    }
+    b = ("step", 0, tuple(comp0), 0)
+    _broadcast(w, ("STEP", b))
+    _build(w, 0, b, gated=False)
+    w["L"]["cur"] = b
+    return w
+
+
+def _broadcast(w, msg):
+    for r in range(1, w["nranks"]):
+        w["ranks"][r]["fifo"] = w["ranks"][r]["fifo"] + (msg,)
+
+
+def _build(w, rank, batch, gated):
+    rk = w["ranks"][rank]
+    rk["live"] = rk["live"] | {batch}
+    rk["q"] = rk["q"] + ((batch, gated, False),)
+
+
+def _unbuild(w, rank, seq, executed_ok):
+    """Cancel handling on one rank. Returns True if state changed."""
+    rk = w["ranks"][rank]
+    mode = w["mode"]
+    inq = [(b, g, v) for (b, g, v) in rk["q"] if b[0] == "spec" and b[3] == seq]
+    ran = [b for b in rk["exec"] if b[0] == "spec" and b[3] == seq]
+    if mode == "B1":
+        # gate guarantees not executed; remove from queue, free pages
+        assert not ran, "B1: cancelled spec executed before commit (I3 breach)"
+        if inq:
+            batch = inq[0][0]
+            rk["q"] = tuple(e for e in rk["q"] if e[0] != batch)
+            rk["live"] = rk["live"] - {batch}
+        return True
+    if mode == "B2_RETRACT":
+        if ran:
+            rk["live"] = rk["live"] - {ran[0]}      # void after the fact
+        elif inq:
+            batch = inq[0][0]
+            rk["q"] = tuple(e for e in rk["q"] if e[0] != batch)
+            rk["live"] = rk["live"] - {batch}        # retract pre-execution
+        return True
+    if mode == "B2_VOID":
+        # never retract: mark void; pages freed at/after execution
+        if ran:
+            rk["live"] = rk["live"] - {ran[0]}
+        else:
+            rk["voided"] = rk["voided"] | {seq}
+        return True
+    raise AssertionError(mode)
+
+
+def _local_verdict_on_step(w, rank, step):
+    """B2_LOCAL: rank ``rank`` just completed ``step``. Apply the verdict for
+    any spec speculated FROM ``step`` that this rank holds: structural failure
+    on ``step`` → retract it locally (it never launches here — and, by the
+    same rule on every rank, nowhere else either); otherwise release its
+    launch gate. Same information the leader uses in its post(step)."""
+    rk = w["ranks"][rank]
+    structural = bool(w["script"].get(step, {}).get("structural"))
+    newq = []
+    for (b, g, v) in rk["q"]:
+        if b[0] == "spec" and b[1] == step + 1:
+            if structural:
+                rk["live"] = rk["live"] - {b}
+                continue          # retract: verdict(N) precedes launch(S) here
+            newq.append((b, False, v))   # release the local launch gate
+        else:
+            newq.append((b, g, v))
+    rk["q"] = tuple(newq)
+
+
+def _local_verdict_on_arrival(w, rank, spec):
+    """B2_LOCAL: a SPEC for parent step ``spec[1]-1`` arrives at ``rank``.
+    If the rank already completed the parent, reconcile now (this is
+    ``Worker._register_tp_follow``): drop on structural, else build ungated.
+    Otherwise build gated; ``_local_verdict_on_step`` will release it."""
+    rk = w["ranks"][rank]
+    parent = spec[1] - 1
+    done = any(b[1] == parent for b in rk["exec"])
+    if not done:
+        _build(w, rank, spec, gated=True)
+        return
+    if w["script"].get(parent, {}).get("structural"):
+        return  # dropped on arrival, never enters the queue
+    _build(w, rank, spec, gated=False)
+
+
+# ---------------------------------------------------------------------------
+# Actions
+# ---------------------------------------------------------------------------
+
+def enabled_actions(w):
+    acts = []
+    L = w["L"]
+    # follower message processing (strict FIFO order = ZMQ stream)
+    for r in range(1, w["nranks"]):
+        if w["ranks"][r]["fifo"]:
+            acts.append(("proc", r))
+    # per-rank GPU progress; gated head blocks the queue (I3 by construction)
+    for r in range(w["nranks"]):
+        q = w["ranks"][r]["q"]
+        if q and not q[0][1]:
+            acts.append(("gpu", r))
+    if not L["done"]:
+        # leader spec build for step+1, inside the open window
+        if (w["mode"] != "SERIAL" and L["spec"] is None and not L["spec_closed"]
+                and L["comp"]):
+            acts.append(("spec",))
+        # leader post-step once its own GPU finished the current batch
+        if L["cur"] is not None and L["cur"] in w["ranks"][0]["exec"]:
+            acts.append(("post",))
+    return acts
+
+
+def apply_action(w, act):
+    w = copy.deepcopy(w)
+    kind = act[0]
+    if kind == "proc":
+        _do_proc(w, act[1])
+    elif kind == "gpu":
+        _do_gpu(w, act[1])
+    elif kind == "spec":
+        _do_spec(w)
+    elif kind == "post":
+        _do_post(w)
+    return w
+
+
+def _do_proc(w, r):
+    rk = w["ranks"][r]
+    msg, rk["fifo"] = rk["fifo"][0], rk["fifo"][1:]
+    tag = msg[0]
+    if tag == "STEP":
+        _build(w, r, msg[1], gated=False)
+    elif tag == "SPEC":
+        if w["mode"] == "B2_LOCAL":
+            _local_verdict_on_arrival(w, r, msg[1])
+        else:
+            # Buildable now — placeholder inputs, no wait on local step-N
+            _build(w, r, msg[1], gated=(w["mode"] == "B1"))
+    elif tag == "COMMIT":
+        seq = msg[1]
+        rk["q"] = tuple(
+            (b, False if (b[0] == "spec" and b[3] == seq) else g, v)
+            for (b, g, v) in rk["q"]
+        )
+    elif tag == "CANCEL":
+        _unbuild(w, r, msg[1], executed_ok=True)
+
+
+def _do_gpu(w, r):
+    rk = w["ranks"][r]
+    (batch, gated, void), rk["q"] = rk["q"][0], rk["q"][1:]
+    assert not gated, "I3 breach: gated batch executed"
+    rk["exec"] = rk["exec"] + (batch,)
+    if batch[0] == "spec" and batch[3] in rk["voided"]:
+        rk["live"] = rk["live"] - {batch}
+        rk["voided"] = rk["voided"] - {batch[3]}
+    if w["mode"] == "B2_LOCAL" and r != 0:
+        # A follower's "await(N)" is completing N: the moment it decides
+        # about specs speculated from N. The leader decides at post(N) — it
+        # may still be BUILDING S when its GPU finishes N.
+        _local_verdict_on_step(w, r, batch[1])
+
+
+def _do_spec(w):
+    L = w["L"]
+    ev = w["script"].get(L["step"], {})
+    L["spec_closed"] = True
+    if ev.get("alloc_fail"):
+        return  # spec build failed → serial fallback this step
+    w["seq"] += 1
+    b = ("spec", L["step"] + 1, L["comp"], w["seq"])
+    _broadcast(w, ("SPEC", b))
+    # B1: gated on Commit. B2_LOCAL: gated on the leader's OWN completion of
+    # step N (released/dropped in _local_verdict_on_step). B2_*: run-ahead.
+    _build(w, 0, b, gated=(w["mode"] in ("B1", "B2_LOCAL")))
+    L["spec"] = b
+
+
+def _do_post(w):
+    L = w["L"]
+    mode = w["mode"]
+    ev = w["script"].get(L["step"], {})
+    stops = frozenset(ev.get("stop", ())) & set(L["comp"])
+    structural = bool(ev.get("structural"))
+    new_comp = tuple(x for x in L["comp"] if x not in stops)
+    new_comp = new_comp + tuple(ev.get("arrival", ()))
+    S = L["spec"]
+
+    def _serial_next():
+        if new_comp:
+            b = ("step", L["step"] + 1, new_comp, 0)
+            _broadcast(w, ("STEP", b))
+            _build(w, 0, b, gated=False)
+            L["cur"] = b
+        else:
+            L["done"] = True
+            L["cur"] = None
+
+    if S is None:
+        _serial_next()
+    elif mode == "B2_LOCAL":
+        # No message. The leader applies its own verdict for step N to the
+        # S it built (gated on itself until now): structural → retract
+        # locally and reschedule; else release and continue the chain.
+        # Followers reach the identical verdict at their own completion of N
+        # (_local_verdict_on_step / _local_verdict_on_arrival).
+        _local_verdict_on_step(w, 0, L["step"])
+        if structural:
+            _serial_next()
+        else:
+            if stops:
+                L["waste"] += len(stops & set(S[2]))
+            L["cur"] = S
+    elif mode == "B1":
+        if not structural and not stops:
+            _broadcast(w, ("COMMIT", S[3]))
+            rk = w["ranks"][0]
+            rk["q"] = tuple(
+                (b, False if b == S else g, v) for (b, g, v) in rk["q"]
+            )
+            L["cur"] = S
+        else:
+            _broadcast(w, ("CANCEL", S[3]))
+            _unbuild(w, 0, S[3], executed_ok=False)
+            _serial_next()
+    elif structural:
+        # structural invalidation → cancel + authoritative reschedule.
+        # S still executes on every rank under VOID; RETRACT is the bug.
+        _broadcast(w, ("CANCEL", S[3]))
+        _unbuild(w, 0, S[3], executed_ok=True)
+        L["waste"] += 1
+        _serial_next()
+    else:
+        # implicit commit; stopped rids ride along as waste
+        if stops:
+            L["waste"] += len(stops & set(S[2]))
+        L["cur"] = S
+    L["comp"] = new_comp
+    if not L["done"]:
+        L["step"] += 1
+        L["spec"] = None
+        L["spec_closed"] = False
+        if not L["comp"] and L["cur"] is None:
+            L["done"] = True
+
+
+# ---------------------------------------------------------------------------
+# Checker
+# ---------------------------------------------------------------------------
+
+def world_key(w):
+    L = w["L"]
+    return (
+        w["seq"], L["step"], L["comp"], L["cur"], L["spec"], L["spec_closed"],
+        L["waste"], L["done"],
+        tuple(
+            (rk["fifo"], rk["q"], rk["exec"],
+             frozenset(rk["live"]), frozenset(rk["voided"]))
+            for rk in w["ranks"]
+        ),
+    )
+
+
+def is_terminal(w):
+    if not w["L"]["done"]:
+        return False
+    return all(not rk["fifo"] and not rk["q"] for rk in w["ranks"])
+
+
+@dataclass
+class Result:
+    scenario: str
+    mode: str
+    states: int = 0
+    terminals: int = 0
+    max_waste: int = 0
+    violations: list = field(default_factory=list)  # (kind, trace)
+
+    @property
+    def ok(self):
+        return not self.violations
+
+
+def check_terminal(w, must_execute):
+    execs = [rk["exec"] for rk in w["ranks"]]
+    if any(e != execs[0] for e in execs[1:]):
+        return "I1 divergence: " + " | ".join(
+            ",".join(f"{b[0]}{b[1]}" for b in e) for e in execs
+        )
+    lives = [rk["live"] for rk in w["ranks"]]
+    if any(lv != lives[0] for lv in lives[1:]):
+        return "I2 page-liveness asymmetry"
+    for rid in must_execute:
+        if not any(rid in b[2] for b in execs[0]):
+            return f"liveness: rid {rid} never executed"
+    return None
+
+
+def explore(mode, nranks, comp0, script, scenario, must_execute=()):
+    res = Result(scenario, mode)
+    root = make_world(mode, nranks, comp0, script)
+    seen = set()
+    stack = [(root, ())]
+    while stack:
+        w, trace = stack.pop()
+        k = world_key(w)
+        if k in seen:
+            continue
+        seen.add(k)
+        res.states += 1
+        if res.states > STATE_CAP:
+            raise RuntimeError(f"state cap hit: {scenario}/{mode}")
+        acts = enabled_actions(w)
+        if not acts:
+            if is_terminal(w):
+                res.terminals += 1
+                res.max_waste = max(res.max_waste, w["L"]["waste"])
+                err = check_terminal(w, must_execute)
+                if err and len(res.violations) < 3:
+                    res.violations.append((err, trace))
+            elif len(res.violations) < 3:
+                res.violations.append(("I4 deadlock", trace))
+            continue
+        for a in acts:
+            try:
+                stack.append((apply_action(w, a), trace + (a,)))
+            except AssertionError as e:  # I3 breach surfaces here
+                res.violations.append((f"I3/assert: {e}", trace + (a,)))
+    return res
+
+
+# ---------------------------------------------------------------------------
+# Scenarios — the failure matrix
+# ---------------------------------------------------------------------------
+
+SCENARIOS = {
+    # name: (comp0, script, must_execute)
+    "clean-3step": (("r0",), {2: {"stop": {"r0"}}}, ()),
+    "midstream-stop": (("r0", "r1"),
+                       {1: {"stop": {"r0"}}, 3: {"stop": {"r1"}}}, ()),
+    "alloc-fail": (("r0",),
+                   {1: {"alloc_fail": True}, 2: {"stop": {"r0"}}}, ()),
+    "structural-cancel": (("r0", "r1"),
+                          {1: {"structural": True}, 2: {"stop": {"r0", "r1"}}}, ()),
+    "late-arrival": (("r0",),
+                     {1: {"arrival": ("r1",)}, 3: {"stop": {"r0", "r1"}}},
+                     ("r1",)),
+}
+
+MODES = ("SERIAL", "B1", "B2_VOID", "B2_LOCAL", "B2_RETRACT")
+
+
+def run_all(nranks=2):
+    results = []
+    for name, (comp0, script, must) in SCENARIOS.items():
+        for mode in MODES:
+            results.append(explore(mode, nranks, comp0, script, name, must))
+    return results
+
+
+def main():
+    for nranks in (2, 3):
+        print(f"\n=== {nranks} ranks ===")
+        print(f"{'scenario':<18} {'mode':<11} {'states':>7} {'terms':>6} "
+              f"{'waste':>5}  result")
+        for r in run_all(nranks):
+            verdict = "PASS" if r.ok else f"FAIL ({r.violations[0][0]})"
+            print(f"{r.scenario:<18} {r.mode:<11} {r.states:>7} "
+                  f"{r.terminals:>6} {r.max_waste:>5}  {verdict}")
+            if r.violations:
+                kind, trace = r.violations[0]
+                print(f"{'':<18} shortest-found trace: "
+                      f"{' '.join('/'.join(map(str, a)) for a in trace)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
TP nodes are scheduled serially: the leader builds step N+1 after N finishes, sends `ScheduleTPNode`, followers build after it arrives. So build + plan + prepare sit on the critical path every step on every rank. `_can_speculate` refuses TP nodes because followers can't start anything on their own.

With `MSTAR_TP_ASYNC_SCHED=1` (default off):

- the leader speculates N+1 during forward N (same machinery single workers already use) and broadcasts it immediately
- followers rebuild the same batch themselves during their forward N from replicated state (same rid helper as the leader, `pop_ready_rids` all-or-nothing in wire order), then do exactly what the leader does: reserve slot, pre-plan, wait for N, clear or submit
- there is no commit/cancel message. Everything the leader decides after N (admit error, per-rid failure, rid finished its loop) is a function of state every rank has, so followers decide it themselves. The only thing they can't know is whether the leader speculated at all, so the leader always sends either the head or a `TPNoSpeculation` marker per step, and a follower settles that before it post-processes N

Why no cancel: `test/modular/tp_async_sim.py` is a small exhaustive model checker over rank interleavings. Run-ahead + cancel fails it: one rank can drop the batch after a faster rank already ran it, which desyncs the collectives = NCCL hang. Gated commit passes but costs a round trip per step. This protocol launches a spec on a rank only after that rank finished the parent step and applied its own verdict. Passes all scenarios at 2 and 3 ranks, the failing variant is kept as a negative test.

**Rebased onto resource pools (#228) as a fresh branch off main.** The hook points moved (`NodeOutput` is gone, a step's verdict is `ExecutingBatch.admit_error` / `failed_requests`; the per-step TP barrier is gone), the protocol didn't. The KV-cache-group check from the previous round is dropped: `Engine.load_model` enforces it now. `MSTAR_ENGINE_STEP_SYNC` must stay 0 with this flag (documented): it holds the GPU thread until N drains, which serialises the overlap.

Also in here: `tp_seq` on batches, fresh rids returned to their ready queues when a spec is cleared (existing single-worker leak), `pop_ready_rids` treats unknown rids as not ready, a step whose forward raised drops its head, a startup check that the flag agrees across the instance, env var docs. Per-rid `failed_requests` are assumed symmetric across ranks, same as the serial TP path already assumes.

Tested on this tree:
- qwen3omni thinker TP2, 3×H100, bench text_to_text temp 0, two boots per arm: async vs serial **+7 % / +8 % / +19 %** at B = 1 / 8 / 16 (136 / 527 / 884 vs 127 / 488 / 745 tok/s). Protocol active every step on both ranks, 0 warnings.
- The last commit fixes a stall found on the way: the thinker's decode `prepare_inputs` built `pos_ids` with a pageable `torch.tensor(..., device=cuda)`, which stream-syncs every step so prepare(N+1) waited for step N. With `torch.full` async reaches 166 / 711 / 1171 tok/s = **+32 / +45 / +57 %** over serial; serial unchanged (it builds N+1 after N anyway).
- 109 CPU tests on real triton/flashinfer (lane tests + `test_micro_scheduler` + worker suites); the `test/modular` failure set is identical to main on the same machine.
- flag off: nothing changes, `ScheduleTPNode` gets 3 new defaulted fields.

Merges clean into #243. Main's greedy decode is currently nondeterministic request-to-request on this model, so the old byte-identity probe can't gate this round.
