### PR TITLE
api: pass raw request through image edits

### DIFF
--- a/mstar/api_server/openai/serving_images.py
+++ b/mstar/api_server/openai/serving_images.py
@@ -47,7 +47,17 @@ async def create_images(api, model_name, adapter, req, raw_request=None):  # noq
     return {"created": now(), "data": data}
 
 
-async def create_image_edit(api, model_name, adapter, *, prompt, image_bytes, image_filename, model_kwargs):  # noqa: ARG001
+async def create_image_edit(
+    api,
+    model_name,
+    adapter,
+    *,
+    prompt,
+    image_bytes,
+    image_filename,
+    model_kwargs,
+    raw_request=None,
+):  # noqa: ARG001
     # Persist the uploaded image so the model's loader can read it by path
     # (same contract as multipart uploads), then run the image-to-image edit.
     upload_dir = Path(api.upload_dir)
@@ -69,7 +79,7 @@ async def create_image_edit(api, model_name, adapter, *, prompt, image_bytes, im
         request_id=request_id,
     )
 
-    chunks = await api.collect_results(request_id)
+    chunks = await api.collect_results(request_id, raw_request)
     data = [
         {"b64_json": base64.b64encode(c.data).decode("ascii"), "url": None}
         for c in chunks

--- a/test/modular/test_openai_router.py
+++ b/test/modular/test_openai_router.py
@@ -43,6 +43,7 @@ class _StubAPI:
         self.last_submit = None
         self._chunks: dict = {}
         self.next_chunks: list = []
+        self.last_raw_request = None
 
     def submit_request(self, **kw):
         self.last_submit = kw
@@ -50,6 +51,7 @@ class _StubAPI:
         return kw["request_id"]
 
     async def collect_results(self, request_id, raw_request=None):
+        self.last_raw_request = raw_request
         return self._chunks.get(request_id, [])
 
     async def iter_result_chunks(self, request_id):
@@ -153,6 +155,7 @@ def test_images_edits(client_and_stub):
     mk = stub.last_submit["model_kwargs"]
     assert mk.get("cfg_img_scale") == 2.0 and mk.get("cfg_interval") == [0.0, 1.0]
     assert "image" in (stub.last_submit["file_paths"] or {})
+    assert stub.last_raw_request is not None
 
 
 def test_videos_generations_wan22(client_and_stub):


### PR DESCRIPTION
## Summary

- accept the `raw_request` argument already passed by the `/v1/images/edits` router
- forward it to `collect_results`, matching image generation, chat, and speech handlers
- assert that the FastAPI request reaches the result collector

Closes the `/v1/images/edits` item in #211.

## Root cause

`router.py` calls `create_image_edit(..., raw_request=request)`, while the handler did not accept that keyword, so every Python-frontend image-edit request returned HTTP 500 before inference.

## Validation

- `ruff check --config pyproject.toml mstar/api_server/openai/serving_images.py test/modular/test_openai_router.py`
- Modal CPU route test: `1 passed, 10 deselected`
- Modal H100 BAGEL live matrix after patch:
  - chat: 2/2
  - image generation: 4/4, 1,493,484 output bytes
  - image editing: 2/2 across saturated and trace-timed schedulers, 2,955,461 output bytes

The live edit requests exercised real multipart uploads through `/v1/images/edits` and returned generated 1024x1024 images.
