### PR TITLE
Bug fix: gate tensor transport teardown behind a reader-drain barrier (fixes abort-time FileNotFoundError)

### DIFF
--- a/mstar/api_server/data_worker.py
+++ b/mstar/api_server/data_worker.py
@@ -30,7 +30,10 @@ from mstar.utils.ipc_format import (
     AbortRequest,
     ConductorMessage,
     ConductorMessageType,
+    DrainRequest,
     NewRequestConductor,
+    ReadsDone,
+    RemoveRequest,
     TensorReceived,
     UnpersistTensors,
     WorkerMessageType,
@@ -61,6 +64,7 @@ class PreprocessWorker:
         self.result_tensor_input_queue = queue.Queue()
         self.cleanup_request_queue = queue.Queue()
         self.abort_request_queue = queue.Queue()
+        self.reads_done_queue = queue.Queue()
         self.discard_tensor_queue = queue.Queue()
         self.output_queue = queue.Queue()
         self.profile_queue = queue.Queue()
@@ -98,6 +102,7 @@ class PreprocessWorker:
                 profile_queue=self.profile_queue,
                 cleanup_request_queue=self.cleanup_request_queue,
                 abort_request_queue=self.abort_request_queue,
+                reads_done_queue=self.reads_done_queue,
                 discard_tensor_queue=self.discard_tensor_queue,
                 stop_event=self.stop_event,
                 communicator=self.communicator,
@@ -114,8 +119,22 @@ class PreprocessWorker:
         self.request_input_queue.put(input)
 
     def abort_request(self, request_id: str):
+        # Forward the abort to the conductor and begin draining our own reads
+        # (the worker thread ACKs READS_DONE once they finish). The hard cleanup
+        # of the persisted input signals waits for the conductor's
+        # REMOVE_REQUEST, so a worker still reading them can't be unlinked
+        # out from under it. Drop only the main-thread bookkeeping here.
         self.abort_request_queue.put(request_id)
-        self.cleanup_request(request_id)
+        self.output_loop_idxs.pop(request_id, None)
+        self.per_request_reading_tensors.pop(request_id, None)
+
+    def finished_reading(self, request_id: str):
+        """Happy path: the API server finished delivering this request's outputs
+        (drained), so we have no more reads. Tell the conductor via READS_DONE;
+        it will send REMOVE_REQUEST to trigger the hard cleanup."""
+        self.reads_done_queue.put(request_id)
+        self.output_loop_idxs.pop(request_id, None)
+        self.per_request_reading_tensors.pop(request_id, None)
 
     def new_result_tensors(self, input: ResultTensors):
         name = input.graph_edge.name
@@ -231,6 +250,7 @@ class PreprocessWorkerThread:
         profile_queue: queue.Queue,
         cleanup_request_queue: queue.Queue,
         abort_request_queue: queue.Queue,
+        reads_done_queue: queue.Queue,
         discard_tensor_queue: queue.Queue,
         stop_event: threading.Event,
         communicator: BaseCommunicator,
@@ -243,9 +263,15 @@ class PreprocessWorkerThread:
         self.result_tensor_queue = result_tensor_queue
         self.cleanup_request_queue = cleanup_request_queue
         self.abort_request_queue = abort_request_queue
+        self.reads_done_queue = reads_done_queue
         self.discard_tensor_queue = discard_tensor_queue
         self.out_queue = out_queue
         self.profile_queue = profile_queue
+
+        # Teardown drain: rids we've stopped reading for (until REMOVE_REQUEST),
+        # and those we've already ACKed READS_DONE for (avoid double-ACK).
+        self._draining_rids: set[str] = set()
+        self._reads_done_sent: set[str] = set()
 
         self.stop_event = stop_event
         self.device = device
@@ -510,7 +536,52 @@ class PreprocessWorkerThread:
                     self.tensor_manager.set_persist(
                         body.request_id, uuid, persist=False
                     )
+            elif message.message_type == WorkerMessageType.DRAIN_REQUEST:
+                body: DrainRequest = message.body
+                self._begin_drain(body.request_id)
+            elif message.message_type == WorkerMessageType.REMOVE_REQUEST:
+                body: RemoveRequest = message.body
+                self._hard_cleanup(body.request_id)
         return did_work
+
+    def _begin_drain(self, request_id: str) -> None:
+        """Stop reading this rid; ACK READS_DONE once in-flight reads finish.
+        Idempotent — abort self-initiates while the conductor may also drive it."""
+        self._draining_rids.add(request_id)
+        self._complete_drain_if_ready(request_id)
+
+    def _complete_drain_if_ready(self, request_id: str) -> None:
+        if request_id not in self._draining_rids:
+            return
+        if request_id in self._reads_done_sent:
+            return
+        if self.tensor_manager.has_inflight_reads(request_id):
+            return  # let _process_read_tensors resolve the futures; retry
+        self._send_reads_done(request_id)
+
+    def _send_reads_done(self, request_id: str) -> None:
+        if request_id in self._reads_done_sent:
+            return
+        self._reads_done_sent.add(request_id)
+        self.communicator.send(
+            "conductor",
+            ConductorMessage(
+                message_type=ConductorMessageType.READS_DONE,
+                body=ReadsDone(
+                    request_id=request_id,
+                    entity_id="api_server_preprocess_worker",
+                ),
+            ),
+        )
+
+    def _hard_cleanup(self, request_id: str) -> None:
+        """Phase-2 teardown: unconditionally drop all tensor state for the rid
+        (unlink the input-signal SHM). Safe now that every reader has drained."""
+        self._draining_rids.discard(request_id)
+        self._reads_done_sent.discard(request_id)
+        self.tensor_manager.force_cleanup_request(request_id)
+        self.tensor_uuid_to_metadata_per_request.pop(request_id, None)
+        self.request_model_kwargs.pop(request_id, None)
 
     def run(self):
         while not self.stop_event.is_set():
@@ -525,6 +596,11 @@ class PreprocessWorkerThread:
                 while not self.result_tensor_queue.empty():
                     did_work = True
                     result = self.result_tensor_queue.get()
+                    # Draining for teardown: don't start new reads — ack the
+                    # tensors back so the producing worker can free its buffers.
+                    if result.request_id in self._draining_rids:
+                        self._discard_result_tensor(result)
+                        continue
                     try:
                         self._read_result_tensor(result)
                     except Exception as exc:  # noqa: BLE001 — must reach the client
@@ -538,13 +614,22 @@ class PreprocessWorkerThread:
                         )
                 while not self.abort_request_queue.empty():
                     did_work = True
+                    rid = self.abort_request_queue.get()
                     self.communicator.send(
                         "conductor",
                         ConductorMessage(
                             message_type=ConductorMessageType.ABORT_REQUEST,
-                            body=AbortRequest(request_id=self.abort_request_queue.get()),
+                            body=AbortRequest(request_id=rid),
                         ),
                     )
+                    # Begin draining our own reads immediately, overlapping with
+                    # the conductor round-trip (it also sends a DrainRequest).
+                    self._begin_drain(rid)
+                while not self.reads_done_queue.empty():
+                    did_work = True
+                    # Happy path: the API server drained this request's outputs,
+                    # so we have no more reads — ACK so the conductor can Remove.
+                    self._send_reads_done(self.reads_done_queue.get())
                 while not self.discard_tensor_queue.empty():
                     did_work = True
                     self._discard_result_tensor(self.discard_tensor_queue.get())
@@ -556,6 +641,9 @@ class PreprocessWorkerThread:
                         del self.tensor_uuid_to_metadata_per_request[req_id]
                     self.request_model_kwargs.pop(req_id, None)
                 did_work = self._process_read_tensors() or did_work
+                # Reads may have just resolved; ACK any drains now free of them.
+                for rid in list(self._draining_rids):
+                    self._complete_drain_if_ready(rid)
                 if not self.in_queue.empty():
                     did_work = True
                     pre_input = self.in_queue.get()
@@ -570,7 +658,10 @@ class PreprocessWorkerThread:
                         self._fail_request(
                             pre_input.request_id, exc, "preprocessing",
                         )
-                        self.tensor_manager.cleanup_request(pre_input.request_id)
+                        # Never reached the conductor, so there are no remote
+                        # readers to race: hard-drop the (possibly persisted)
+                        # input signals directly.
+                        self.tensor_manager.force_cleanup_request(pre_input.request_id)
                         self.request_model_kwargs.pop(pre_input.request_id, None)
             except Exception:
                 logger.exception("PreprocessWorkerThread error")

--- a/mstar/api_server/data_worker.py
+++ b/mstar/api_server/data_worker.py
@@ -128,11 +128,14 @@ class PreprocessWorker:
         self.output_loop_idxs.pop(request_id, None)
         self.per_request_reading_tensors.pop(request_id, None)
 
-    def finished_reading(self, request_id: str):
-        """Happy path: the API server finished delivering this request's outputs
-        (drained), so we have no more reads. Tell the conductor via READS_DONE;
-        it will send REMOVE_REQUEST to trigger the hard cleanup."""
-        self.reads_done_queue.put(request_id)
+    def finished_reading(self, request_id: str, drained: bool = True):
+        """The API server is done with this request's outputs. Tell the
+        conductor via READS_DONE; it will send REMOVE_REQUEST to trigger the
+        hard cleanup. ``drained`` means every chunk was delivered, so no read
+        can still be in flight and the ACK can go out immediately; pass False
+        when delivery was abandoned (TTL, client gone) and the ACK must wait
+        for any in-flight read."""
+        self.reads_done_queue.put((request_id, drained))
         self.output_loop_idxs.pop(request_id, None)
         self.per_request_reading_tensors.pop(request_id, None)
 
@@ -544,6 +547,17 @@ class PreprocessWorkerThread:
                 self._hard_cleanup(body.request_id)
         return did_work
 
+    def _finish_reading(self, request_id: str, drained: bool) -> None:
+        """The API server is done with this rid's outputs. ``drained`` (every
+        chunk delivered) means no read can still be in flight, so ACK straight
+        away — the happy path pays nothing. Otherwise delivery was abandoned
+        (TTL, client gone) with reads possibly still running, so gate the ACK on
+        them; ACKing there would let the conductor unlink under a read."""
+        if drained:
+            self._send_reads_done(request_id)
+        else:
+            self._begin_drain(request_id)
+
     def _begin_drain(self, request_id: str) -> None:
         """Stop reading this rid; ACK READS_DONE once in-flight reads finish.
         Idempotent — abort self-initiates while the conductor may also drive it."""
@@ -627,9 +641,7 @@ class PreprocessWorkerThread:
                     self._begin_drain(rid)
                 while not self.reads_done_queue.empty():
                     did_work = True
-                    # Happy path: the API server drained this request's outputs,
-                    # so we have no more reads — ACK so the conductor can Remove.
-                    self._send_reads_done(self.reads_done_queue.get())
+                    self._finish_reading(*self.reads_done_queue.get())
                 while not self.discard_tensor_queue.empty():
                     did_work = True
                     self._discard_result_tensor(self.discard_tensor_queue.get())

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -345,15 +345,17 @@ class APIServer:
                 req.event.set()
                 # Snapshot the data worker's tx/rx now: the request is done (all
                 # final chunks received), so the worker thread is no longer mutating
-                # this rid's transport state, and we must read it before
-                # cleanup_request drops it. Extends so it combines with the
-                # conductor's worker-side transfers (set in the request_complete
-                # handler).
+                # this rid's transport state, and we must read it before the hard
+                # cleanup drops it. Extends so it combines with the conductor's
+                # worker-side transfers (set in the request_complete handler).
                 if self.log_stats:
                     profile = req.profile
                     profile.tx_info.extend(self.preprocess_worker.get_tx_info(rid))
                     profile.rx_info.extend(self.preprocess_worker.get_rx_info(rid))
-            self.preprocess_worker.cleanup_request(rid)
+            # We're done delivering this request's outputs (all chunks in, or the
+            # TTL gave up): tell the conductor via READS_DONE. It drives the hard
+            # cleanup with a RemoveRequest once every reader has drained.
+            self.preprocess_worker.finished_reading(rid)
             self.recently_completed.pop(rid, None)
 
     def _process_messages(self) -> None:

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -321,10 +321,10 @@ class APIServer:
                 )
             )
             if drained or req is None:
-                stale.append((rid, False))
+                stale.append((rid, False, drained))
             elif (now - ts) >= self._recently_completed_ttl:
-                stale.append((rid, True))
-        for rid, lost_outputs in stale:
+                stale.append((rid, True, drained))
+        for rid, lost_outputs, drained in stale:
             # only set the event when there are no more pending chunks
             req = self.pending_requests.get(rid)
             if req is not None:
@@ -354,8 +354,10 @@ class APIServer:
                     profile.rx_info.extend(self.preprocess_worker.get_rx_info(rid))
             # We're done delivering this request's outputs (all chunks in, or the
             # TTL gave up): tell the conductor via READS_DONE. It drives the hard
-            # cleanup with a RemoveRequest once every reader has drained.
-            self.preprocess_worker.finished_reading(rid)
+            # cleanup with a RemoveRequest once every reader has drained. Only
+            # the drained case is known to have no read left in flight; the
+            # others make the data worker gate the ACK on its own reads first.
+            self.preprocess_worker.finished_reading(rid, drained=drained)
             self.recently_completed.pop(rid, None)
 
     def _process_messages(self) -> None:

--- a/mstar/api_server/openai/router.py
+++ b/mstar/api_server/openai/router.py
@@ -120,12 +120,12 @@ async def images_generations(request: ImageGenerationRequest, raw_request: Reque
 
 
 @router.post("/v1/videos/generations")
-async def videos_generations(request: VideoGenerationRequest):
+async def videos_generations(request: VideoGenerationRequest, raw_request: Request):
     api, model_name, adapter, err = _resolve("supports_videos")
     if err is not None:
         return err
     try:
-        result = await serving_videos.create_videos(api, model_name, adapter, request)
+        result = await serving_videos.create_videos(api, model_name, adapter, request, raw_request)
     except Exception as e:  # noqa: BLE001
         default_status = 400 if isinstance(e, (ValueError, TypeError)) else 500
         return _error(getattr(e, "status_code", default_status), str(getattr(e, "detail", e)), "server_error")

--- a/mstar/api_server/openai/serving_videos.py
+++ b/mstar/api_server/openai/serving_videos.py
@@ -11,7 +11,7 @@ from mstar.api_server.openai._util import now, rid
 logger = logging.getLogger(__name__)
 
 
-async def create_videos(api, model_name, adapter, req):  # noqa: ARG001
+async def create_videos(api, model_name, adapter, req, raw_request=None):  # noqa: ARG001
     args = adapter.video_to_request(req, api.upload_dir)
     request_id = rid("vid")
 
@@ -25,7 +25,7 @@ async def create_videos(api, model_name, adapter, req):  # noqa: ARG001
         request_id=request_id,
     )
 
-    chunks = await api.collect_results(request_id)
+    chunks = await api.collect_results(request_id, raw_request)
     # Each video chunk is an mp4 (H.264); return it base64-encoded, mirroring the
     # image endpoint's b64_json shape. A sound request additionally emits a raw
     # 16-bit PCM audio chunk, which is muxed into the mp4 as an AAC track (one

--- a/mstar/communication/tensors.py
+++ b/mstar/communication/tensors.py
@@ -804,7 +804,24 @@ class TensorCommunicationManager(ABC):
     def increment_ref(self, request_id: str, uuid: str, n: int = 1):
         self.tensor_store.increment_ref(request_id, uuid, n=n)
 
+    def has_inflight_reads(self, request_id: str) -> bool:
+        """Whether any async read for this request is still touching a remote
+        segment. Synchronous (SHM) reads complete inside ``start_read_tensors``
+        with ``future=None``, so they never count here; only outstanding
+        async (RDMA) futures do. Gates the READS_DONE ACK during a drain.
+        """
+        return any(
+            ep.request_id == request_id
+            and ep.future is not None and not ep.future.done()
+            for ep in self.pending
+        )
+
     def cleanup_request(self, request_id: str):
+        """Refcount/persist-respecting teardown: drop tensors that are safe to
+        GC, defer any still referenced or persisted. Does NOT force-drop
+        persisted signals — that is the conductor-coordinated hard cleanup
+        (``force_cleanup_request``), sent only once every reader has drained.
+        """
         self.read_finished.pop(request_id, None)
         self.buffered_shards.pop(request_id, None)
         self.sharding_configs.pop(request_id, None)
@@ -812,13 +829,34 @@ class TensorCommunicationManager(ABC):
         self.req_tx_info.pop(request_id, None)
         for uuid in self.tensor_store.get_all_uuids(request_id):
             self.uuid_to_shard_dim.pop(uuid, None)
-            self.tensor_store.set_metadata(request_id, uuid, persist=False)
             if not self.tensor_store.can_gc(request_id, uuid):
                 logger.warning(
                     "Deferring cleanup of tensor uuid %s "
-                    "(awaiting TENSOR_RECEIVED ACK)", uuid
+                    "(awaiting TENSOR_RECEIVED ACK or unpersist)", uuid
                 )
                 continue
+            self._cleanup_by_uuid(request_id, uuid)
+
+        self._collect_and_send_acks(
+            request_id,
+            sum([ep.graph_edges for ep in self.pending if ep.request_id == request_id], start=[]),
+        )
+        self.pending = [ep for ep in self.pending if ep.request_id != request_id]
+
+    def force_cleanup_request(self, request_id: str):
+        """Unconditional teardown: drop every tensor for the request and unlink
+        its SHM, ignoring ref counts and persist markers. Safe only after every
+        reader has confirmed (READS_DONE) it has no in-flight reads for the
+        request. Also reclaims non-persisted buffers whose readers drained
+        before ACKing (which ``cleanup_request`` would otherwise defer forever).
+        """
+        self.read_finished.pop(request_id, None)
+        self.buffered_shards.pop(request_id, None)
+        self.sharding_configs.pop(request_id, None)
+        self.req_rx_info.pop(request_id, None)
+        self.req_tx_info.pop(request_id, None)
+        for uuid in self.tensor_store.get_all_uuids(request_id):
+            self.uuid_to_shard_dim.pop(uuid, None)
             self._cleanup_by_uuid(request_id, uuid)
 
         self._collect_and_send_acks(

--- a/mstar/communication/tensors.py
+++ b/mstar/communication/tensors.py
@@ -816,11 +816,13 @@ class TensorCommunicationManager(ABC):
             for ep in self.pending
         )
 
-    def cleanup_request(self, request_id: str):
-        """Refcount/persist-respecting teardown: drop tensors that are safe to
-        GC, defer any still referenced or persisted. Does NOT force-drop
-        persisted signals — that is the conductor-coordinated hard cleanup
-        (``force_cleanup_request``), sent only once every reader has drained.
+    def cleanup_request(self, request_id: str, force: bool = False):
+        """Teardown for a request's tensor state.
+
+        Default (soft): drop tensors that are safe to GC, defer any still
+        referenced or persisted. Does NOT force-drop persisted signals — that
+        is the conductor-coordinated hard cleanup, see
+        :meth:`force_cleanup_request`.
         """
         self.read_finished.pop(request_id, None)
         self.buffered_shards.pop(request_id, None)
@@ -829,7 +831,7 @@ class TensorCommunicationManager(ABC):
         self.req_tx_info.pop(request_id, None)
         for uuid in self.tensor_store.get_all_uuids(request_id):
             self.uuid_to_shard_dim.pop(uuid, None)
-            if not self.tensor_store.can_gc(request_id, uuid):
+            if not self.tensor_store.can_gc(request_id, uuid) and not force:
                 logger.warning(
                     "Deferring cleanup of tensor uuid %s "
                     "(awaiting TENSOR_RECEIVED ACK or unpersist)", uuid
@@ -848,22 +850,9 @@ class TensorCommunicationManager(ABC):
         its SHM, ignoring ref counts and persist markers. Safe only after every
         reader has confirmed (READS_DONE) it has no in-flight reads for the
         request. Also reclaims non-persisted buffers whose readers drained
-        before ACKing (which ``cleanup_request`` would otherwise defer forever).
+        before ACKing (which the soft path would otherwise defer forever).
         """
-        self.read_finished.pop(request_id, None)
-        self.buffered_shards.pop(request_id, None)
-        self.sharding_configs.pop(request_id, None)
-        self.req_rx_info.pop(request_id, None)
-        self.req_tx_info.pop(request_id, None)
-        for uuid in self.tensor_store.get_all_uuids(request_id):
-            self.uuid_to_shard_dim.pop(uuid, None)
-            self._cleanup_by_uuid(request_id, uuid)
-
-        self._collect_and_send_acks(
-            request_id,
-            sum([ep.graph_edges for ep in self.pending if ep.request_id == request_id], start=[]),
-        )
-        self.pending = [ep for ep in self.pending if ep.request_id != request_id]
+        self.cleanup_request(request_id, force=True)
 
 
 # ---------------------------------------------------------------------------

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -33,10 +33,12 @@ from mstar.profile.format import RxInfo, TxInfo
 from mstar.profile.worker import GraphTimings
 from mstar.utils.ipc_format import (
     ConductorMessageType,
+    DrainRequest,
     FailRequests,
     InputSignals,
     NewRequest,
     NewRequestConductor,
+    ReadsDone,
     RemoveRequest,
     UnpersistTensors,
     WorkerGraphsDone,
@@ -203,6 +205,19 @@ class RequestData:
         ]
 
 
+@dataclass
+class DrainingRequest:
+    """Teardown barrier state: a request whose participants are draining their
+    reads. Once every entity in ``expected_acks`` has sent READS_DONE it is safe
+    to send the hard RemoveRequest to all ``participants``."""
+    expected_acks: set[str]
+    participants: set[str]
+    # Set for the fail path: the client notification is deferred until the
+    # barrier completes (so the API server doesn't tear down mid-read).
+    failure_error: str | None = None
+    failure_status: int = 500
+
+
 class Conductor:
     def __init__(
         self,
@@ -217,6 +232,12 @@ class Conductor:
         tcp_transfer_device=""
     ):
         self.requests: dict[str, RequestData] = {}
+        # Requests in teardown: kept in self.requests (so they still count toward
+        # concurrency until their GPU state is freed) with barrier state here.
+        self.draining: dict[str, DrainingRequest] = {}
+        # READS_DONE that arrived before the barrier was registered (the
+        # preprocess worker self-drains on abort before we process ABORT_REQUEST).
+        self._early_reads_done: dict[str, set[str]] = {}
         self.model = model
         self.hostname = hostname
         self.socket_path_prefix = socket_path_prefix
@@ -789,14 +810,79 @@ class Conductor:
             if graph_walk in self.worker_graphs[wg_id].graph_walks
         }
 
+    PREPROCESS_WORKER = "api_server_preprocess_worker"
+
+    def _request_workers(self, request_data: RequestData) -> set[str]:
+        return {
+            worker_id
+            for worker_ids in request_data.worker_graph_to_workers.values()
+            for worker_id in worker_ids
+        }
+
+    def _register_draining(
+        self, request_id: str, expected_acks: set[str], participants: set[str],
+        failure_error: str | None = None, failure_status: int = 500,
+    ):
+        """Start the teardown barrier for a request. Applies any READS_DONE that
+        raced ahead of registration, and finalizes immediately if already
+        satisfied (e.g. a happy path with no outstanding reader)."""
+        expected_acks = set(expected_acks) - self._early_reads_done.pop(request_id, set())
+        self.draining[request_id] = DrainingRequest(
+            expected_acks=expected_acks,
+            participants=participants,
+            failure_error=failure_error,
+            failure_status=failure_status,
+        )
+        if not expected_acks:
+            self._finalize_draining(request_id)
+
+    def _finalize_draining(self, request_id: str):
+        """Every reader has drained: send the hard RemoveRequest to all
+        participants, notify the client on the fail path, then free state."""
+        dr = self.draining.pop(request_id, None)
+        if dr is None:
+            return
+        for entity in dr.participants:
+            self.communicator.send(
+                entity,
+                WorkerMessage(
+                    message_type=WorkerMessageType.REMOVE_REQUEST,
+                    body=RemoveRequest(request_id),
+                ),
+            )
+        if dr.failure_error is not None:
+            self.communicator.send(
+                "api_server",
+                APIServerMessage(
+                    message_type="request_failed",
+                    body=RequestFailed(
+                        request_id=request_id,
+                        error_message=dr.failure_error,
+                        status=dr.failure_status,
+                    ),
+                ),
+            )
+        self.requests.pop(request_id, None)
+        logger.info("Tore down request %s; freed worker resources", request_id)
+        self._try_admit_waiting()
+
+    def _handle_reads_done(self, body: ReadsDone):
+        dr = self.draining.get(body.request_id)
+        if dr is None:
+            # Raced ahead of registration (preprocess-worker self-drain on abort).
+            self._early_reads_done.setdefault(body.request_id, set()).add(body.entity_id)
+            return
+        dr.expected_acks.discard(body.entity_id)
+        if not dr.expected_acks:
+            self._finalize_draining(body.request_id)
+
     def _fail_requests(self, body: FailRequests):
-        """Tear down requests a worker reported as unservable and tell the
-        client. Mirrors ``_process_request_done``, but the api-server side
-        turns the message into an HTTP error / stream error event.
-        """
+        """Tear down requests a worker reported as unservable. Routes through the
+        drain barrier; the client is notified (request_failed) only once every
+        reader has drained, so no output is unlinked under an in-flight read."""
         for rid, error_message in body.errors.items():
             request_data = self.requests.get(rid)
-            if request_data is None:
+            if request_data is None or rid in self.draining:
                 # Expected under TP: every rank raises symmetrically and each
                 # reports the failure, so only the first report finds the
                 # request. Also covers a client abort racing the failure.
@@ -806,17 +892,7 @@ class Conductor:
                 )
                 continue
             logger.error("Request %s failed on a worker: %s", rid, error_message)
-            self._remove_request(rid, request_data)
-            self.communicator.send(
-                "api_server",
-                APIServerMessage(
-                    message_type="request_failed",
-                    body=RequestFailed(
-                        request_id=rid,
-                        error_message=error_message,
-                    ),
-                ),
-            )
+            self._remove_request(rid, request_data, failure_error=error_message)
 
     def _abort_request(self, request_id: str):
         """Tear down a request the client abandoned, freeing its worker GPU state."""
@@ -827,33 +903,36 @@ class Conductor:
                 return
 
         request_data = self.requests.get(request_id)
-        if request_data is None:
-            logger.info("Abort for request %s ignored; already finished or unknown", request_id)
+        if request_data is None or request_id in self.draining:
+            logger.info("Abort for request %s ignored; already finished, unknown, or draining", request_id)
             return
         self._remove_request(request_id, request_data)
 
-    def _remove_request(self, request_id: str, request_data: RequestData):
-        """Drop conductor state for a request and free its worker GPU state.
-
-        Shared by the abort (client went away) and fail (worker can't serve
-        it) paths; neither notifies the api server from here.
+    def _remove_request(
+        self, request_id: str, request_data: RequestData,
+        failure_error: str | None = None,
+    ):
+        """Begin teardown for an abort/fail: drain every participant's reads,
+        then (on the barrier's completion) hard-remove. Shared by the abort
+        (client went away) and fail (worker can't serve it) paths.
         """
-        workers = {
-            worker_id
-            for worker_ids in request_data.worker_graph_to_workers.values()
-            for worker_id in worker_ids
-        }
-        for worker_id in workers:
+        workers = self._request_workers(request_data)
+        participants = workers | {self.PREPROCESS_WORKER}
+        for entity in participants:
             self.communicator.send(
-                worker_id,
+                entity,
                 WorkerMessage(
-                    message_type=WorkerMessageType.REMOVE_REQUEST,
-                    body=RemoveRequest(request_id),
+                    message_type=WorkerMessageType.DRAIN_REQUEST,
+                    body=DrainRequest(request_id),
                 ),
             )
-        del self.requests[request_id]
-        logger.info("Tore down request %s; freed worker resources", request_id)
-        self._try_admit_waiting()
+        logger.info("Draining request %s (%d participants) before teardown", request_id, len(participants))
+        self._register_draining(
+            request_id,
+            expected_acks=participants,
+            participants=participants,
+            failure_error=failure_error,
+        )
 
     def _process_request_done(
         self, request_id: str
@@ -862,14 +941,18 @@ class Conductor:
         logger.info("Request %s done", request_id)
         request_data = self.requests[request_id]
         request_data.conductor_finish_time = time.perf_counter()
-        for worker_ids in request_data.worker_graph_to_workers.values():
-            for worker_id in worker_ids:
-                msg = WorkerMessage(
-                    message_type=WorkerMessageType.REMOVE_REQUEST,
-                    body=RemoveRequest(request_id)
-                )
-                self.communicator.send(worker_id, msg)
 
+        # Unpersist anything still held, with correct ref counts, so producers
+        # reclaim it as the final reads ACK — before the hard teardown.
+        still_persisted = [
+            info
+            for infos in request_data.persist_signals.values()
+            for info in infos
+        ]
+        if still_persisted:
+            self._un_persist_tensors(request_id, still_persisted)
+
+        # Tell the client immediately (no added completion latency).
         self.communicator.send(
             "api_server",
             APIServerMessage(
@@ -885,8 +968,22 @@ class Conductor:
                 )
             )
         )
-        del self.requests[request_id]
-        self._try_admit_waiting()
+
+        # Workers are done reading (the graph finished); the only remaining
+        # reader is the preprocess worker still delivering outputs. Defer the
+        # hard RemoveRequest until it signals READS_DONE, so a worker output
+        # isn't unlinked under an in-flight read.
+        # NOTE: "workers done reading" assumes a well-behaved graph. A model bug
+        # that emits extra/erroneous tensors could leave a worker read scheduled
+        # past completion, which this path won't wait for. Gating the happy path
+        # on per-worker READS_DONE too (like abort/fail) would handle that
+        # robustly — TODO once the barrier has proven out.
+        workers = self._request_workers(request_data)
+        self._register_draining(
+            request_id,
+            expected_acks={self.PREPROCESS_WORKER},
+            participants=workers | {self.PREPROCESS_WORKER},
+        )
 
     def _process_worker_graphs_done(
         self, body: WorkerGraphsDone
@@ -1162,9 +1259,13 @@ class Conductor:
                         self._abort_request(message.body.request_id)
                     elif message.message_type == ConductorMessageType.FAIL_REQUESTS:
                         self._fail_requests(message.body)
+                    elif message.message_type == ConductorMessageType.READS_DONE:
+                        self._handle_reads_done(message.body)
                     elif message.message_type == ConductorMessageType.WORKER_GRAPHS_DONE:
                         rid = message.body.request_id
-                        if rid not in self.requests:
+                        # Draining requests linger in self.requests (concurrency
+                        # accounting) but are being torn down — ignore late dones.
+                        if rid not in self.requests or rid in self.draining:
                             logger.debug(
                                 "WORKER_GRAPHS_DONE for unknown request %s (already completed?)", rid
                             )
@@ -1185,7 +1286,7 @@ class Conductor:
                 completed_requests = []
 
                 for request_id, partition_name, p_done in done_partition_forwards:
-                    if request_id not in self.requests:
+                    if request_id not in self.requests or request_id in self.draining:
                         continue  # already completed by another partition in this cycle
                     all_done = self._process_done_forward(
                         request_id, partition_name,
@@ -1195,7 +1296,7 @@ class Conductor:
                         completed_requests.append(request_id)
 
                 for request_id in dict.fromkeys(completed_requests):
-                    if request_id in self.requests:
+                    if request_id in self.requests and request_id not in self.draining:
                         self._process_request_done(request_id)
             except Exception:
                 logger.exception("Conductor error in main loop")

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -6,7 +6,7 @@ import os
 import signal
 import socket
 import time
-from collections import defaultdict
+from collections import defaultdict, deque
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -235,9 +235,25 @@ class Conductor:
         # Requests in teardown: kept in self.requests (so they still count toward
         # concurrency until their GPU state is freed) with barrier state here.
         self.draining: dict[str, DrainingRequest] = {}
+        # Backstop for a participant that never ACKs (crashed, hung, OOMed): the
+        # barrier is force-finalized so one faulty worker can't hold a
+        # concurrency slot — or the client's failure notification — forever.
+        self._drain_ttl_s = float(os.environ.get("MSTAR_DRAIN_TTL_S", "120"))
+
         # READS_DONE that arrived before the barrier was registered (the
         # preprocess worker self-drains on abort before we process ABORT_REQUEST).
         self._early_reads_done: dict[str, set[str]] = {}
+        # Aborts for requests we haven't ingested yet: the preprocess worker
+        # forwards ABORT_REQUEST from its abort queue before it finishes
+        # preprocessing, so it can outrun the NEW_REQUEST it aborts.
+        self._early_abort_requests: set[str] = set()
+        # (deadline, rid) FIFOs — expiry sweeps for the three above, so an entry
+        # whose awaited message never arrives can't pile up. Deadlines are all
+        # the same TTL from insertion, so each deque stays sorted.
+        self._draining_deadlines: deque[tuple[float, str]] = deque()
+        self._early_reads_done_deadlines: deque[tuple[float, str]] = deque()
+        self._early_abort_deadlines: deque[tuple[float, str]] = deque()
+
         self.model = model
         self.hostname = hostname
         self.socket_path_prefix = socket_path_prefix
@@ -635,6 +651,18 @@ class Conductor:
         When a new request comes in from the API server, assign workers,
         initialize partition states, and kick off all partitions.
         """
+
+        if body.request_id in self._early_abort_requests:
+            # The abort outran this NEW_REQUEST. The preprocess worker's input
+            # signals exist only now, so this is the first moment we can safely
+            # tell it to drop them; it has already stopped reading the rid.
+            self._early_abort_requests.discard(body.request_id)
+            self._early_reads_done.pop(body.request_id, None)
+            self._send_remove_to_preprocess_worker(body.request_id)
+            logger.info(
+                "Request %s was aborted before ingest; dropping", body.request_id
+            )
+            return
         if (self.max_concurrent_requests is not None
                 and len(self.requests) >= self.max_concurrent_requests):
             logger.info(
@@ -833,8 +861,20 @@ class Conductor:
             failure_error=failure_error,
             failure_status=failure_status,
         )
+        self._draining_deadlines.append(
+            (time.perf_counter() + self._drain_ttl_s, request_id)
+        )
         if not expected_acks:
             self._finalize_draining(request_id)
+
+    def _send_remove_to_preprocess_worker(self, request_id: str):
+        self.communicator.send(
+            self.PREPROCESS_WORKER,
+            WorkerMessage(
+                message_type=WorkerMessageType.REMOVE_REQUEST,
+                body=RemoveRequest(request_id),
+            ),
+        )
 
     def _finalize_draining(self, request_id: str):
         """Every reader has drained: send the hard RemoveRequest to all
@@ -870,11 +910,50 @@ class Conductor:
         dr = self.draining.get(body.request_id)
         if dr is None:
             # Raced ahead of registration (preprocess-worker self-drain on abort).
+            if body.request_id not in self._early_reads_done:
+                self._early_reads_done_deadlines.append(
+                    (time.perf_counter() + self._drain_ttl_s, body.request_id)
+                )
             self._early_reads_done.setdefault(body.request_id, set()).add(body.entity_id)
             return
         dr.expected_acks.discard(body.entity_id)
         if not dr.expected_acks:
             self._finalize_draining(body.request_id)
+
+    @staticmethod
+    def _pop_expired(deadlines: deque[tuple[float, str]], now: float) -> list[str]:
+        expired = []
+        while deadlines and deadlines[0][0] <= now:
+            expired.append(deadlines.popleft()[1])
+        return expired
+
+    def _sweep_expiry(self):
+        """Expire teardown bookkeeping whose awaited message never arrived: push
+        a stalled drain barrier through, and drop stale early-message entries so
+        they can't accumulate for requests that never come back."""
+        now = time.perf_counter()
+        for request_id in self._pop_expired(self._draining_deadlines, now):
+            dr = self.draining.get(request_id)
+            if dr is None:
+                continue  # finalized normally
+            logger.error(
+                "Drain barrier for request %s timed out after %.0fs with no "
+                "READS_DONE from %s; forcing teardown. A stalled reader may "
+                "still hold one of its segments.",
+                request_id, self._drain_ttl_s, sorted(dr.expected_acks),
+            )
+            self._finalize_draining(request_id)
+        for request_id in self._pop_expired(self._early_abort_deadlines, now):
+            if request_id in self._early_abort_requests:
+                self._early_abort_requests.discard(request_id)
+                logger.debug(
+                    "Dropping stale abort tombstone for request %s", request_id
+                )
+        for request_id in self._pop_expired(self._early_reads_done_deadlines, now):
+            if self._early_reads_done.pop(request_id, None) is not None:
+                logger.debug(
+                    "Dropping stale early READS_DONE for request %s", request_id
+                )
 
     def _fail_requests(self, body: FailRequests):
         """Tear down requests a worker reported as unservable. Routes through the
@@ -898,13 +977,32 @@ class Conductor:
         """Tear down a request the client abandoned, freeing its worker GPU state."""
         for i, body in enumerate(self.waiting_queue):
             if body.request_id == request_id:
+                # Queued, never dispatched: the preprocess worker is the only
+                # holder of its (persisted) input signals, so hard-remove there.
                 self.waiting_queue.pop(i)
+                self._early_reads_done.pop(request_id, None)
+                self._send_remove_to_preprocess_worker(request_id)
                 logger.info("Aborted request %s before admission", request_id)
                 return
 
         request_data = self.requests.get(request_id)
-        if request_data is None or request_id in self.draining:
-            logger.info("Abort for request %s ignored; already finished, unknown, or draining", request_id)
+        if request_data is None:
+            # Either already torn down (nothing to do) or the abort outran its
+            # NEW_REQUEST. Tombstone it: _ingest_request drops the request and
+            # removes the preprocess worker's signals once they exist. Sending
+            # the RemoveRequest here instead would land before they do and leak
+            # the segment. The tombstone expires on its own (see _sweep_expiry).
+            self._early_abort_requests.add(request_id)
+            self._early_abort_deadlines.append(
+                (time.perf_counter() + self._drain_ttl_s, request_id)
+            )
+            logger.info(
+                "Abort for request %s: unknown; already finished, or racing its "
+                "own ingest", request_id,
+            )
+            return
+        if request_id in self.draining:
+            logger.info("Abort for request %s ignored; already draining", request_id)
             return
         self._remove_request(request_id, request_data)
 
@@ -1298,6 +1396,9 @@ class Conductor:
                 for request_id in dict.fromkeys(completed_requests):
                     if request_id in self.requests and request_id not in self.draining:
                         self._process_request_done(request_id)
+
+                self._sweep_expiry()
+
             except Exception:
                 logger.exception("Conductor error in main loop")
             finally:

--- a/mstar/conductor/conductor.py
+++ b/mstar/conductor/conductor.py
@@ -942,17 +942,7 @@ class Conductor:
         request_data = self.requests[request_id]
         request_data.conductor_finish_time = time.perf_counter()
 
-        # Unpersist anything still held, with correct ref counts, so producers
-        # reclaim it as the final reads ACK — before the hard teardown.
-        still_persisted = [
-            info
-            for infos in request_data.persist_signals.values()
-            for info in infos
-        ]
-        if still_persisted:
-            self._un_persist_tensors(request_id, still_persisted)
-
-        # Tell the client immediately (no added completion latency).
+        # Tell the client first, so nothing below adds to completion latency.
         self.communicator.send(
             "api_server",
             APIServerMessage(
@@ -968,6 +958,16 @@ class Conductor:
                 )
             )
         )
+
+        # Unpersist anything still held, with correct ref counts, so producers
+        # reclaim it as the final reads ACK — before the hard teardown.
+        still_persisted = [
+            info
+            for infos in request_data.persist_signals.values()
+            for info in infos
+        ]
+        if still_persisted:
+            self._un_persist_tensors(request_id, still_persisted)
 
         # Workers are done reading (the graph finished); the only remaining
         # reader is the preprocess worker still delivering outputs. Defer the

--- a/mstar/utils/ipc_format.py
+++ b/mstar/utils/ipc_format.py
@@ -31,6 +31,7 @@ class MessageBody:
 
 class WorkerMessageType(Enum):
     NEW_REQUEST = "new_request"
+    DRAIN_REQUEST = "drain_request"
     REMOVE_REQUEST = "remove_request"
     INPUT_SIGNALS = "input_signals"
     UNPERSIST_TENSORS = "unpersist"
@@ -55,6 +56,14 @@ class MessageSource(IntEnum):
 
 @dataclass
 class RemoveRequest(MessageBody):
+    request_id: str
+    source: int = MessageSource.CONDUCTOR
+
+
+@dataclass
+class DrainRequest(MessageBody):
+    # Phase-1 teardown: stop reading this request and confirm no reads remain.
+    # Hard cleanup (RemoveRequest) follows once every reader has ACKed via READS_DONE.
     request_id: str
     source: int = MessageSource.CONDUCTOR
 
@@ -110,6 +119,7 @@ class ConductorMessageType(Enum):
     SETUP_DONE = "setup_done"
     ABORT_REQUEST = "abort_request"
     FAIL_REQUESTS = "fail_requests"
+    READS_DONE = "reads_done"
 
 
 @dataclass
@@ -148,6 +158,14 @@ class SetupDone(MessageBody):
 @dataclass
 class AbortRequest(MessageBody):
     request_id: str
+
+
+@dataclass
+class ReadsDone(MessageBody):
+    """An entity confirming it has no in-flight reads for a request and will
+    start none — the conductor's gate before sending the hard RemoveRequest."""
+    request_id: str
+    entity_id: str
 
 
 @dataclass

--- a/mstar/worker/micro_scheduler.py
+++ b/mstar/worker/micro_scheduler.py
@@ -142,9 +142,11 @@ class MicroScheduler:
         # Shared by reference with Worker._pending_removes.
         self.pending_removes: set[str] = set()
 
-        # rid -> number of tp follow batches in the queue. Used in the fail/abort
-        # path, where we need to drain the TP queue before aborting
-        self.pending_tp_follow_count: dict[str, int] = {}
+        # rid -> number of committed (ZMQ received) tp follow batches still
+        # queued. On the fail/abort path we drain these before ACKing READS_DONE
+        # so the worker graph queues aren't torn down while a follow still needs
+        # to pop from them.
+        self.pending_tp_follow_count: dict[str, int] = defaultdict(int)
 
     def _select_node_rr(
         self, node_name_to_requests: dict[str, list[ReadyNodeEntry]]
@@ -234,9 +236,9 @@ class MicroScheduler:
                 request_to_worker_graph[rid] = wgid
 
         for rid in first_tp_node.request_ids:
-            self.tp_batches_pending_schedule[rid] -= 1
-            if self.tp_batches_pending_schedule[rid] <= 0:
-                self.tp_batches_pending_schedule.pop(rid)
+            self.pending_tp_follow_count[rid] -= 1
+            if self.pending_tp_follow_count[rid] <= 0:
+                self.pending_tp_follow_count.pop(rid, None)
 
         self.batch_number += 1
         self.node_and_walk_to_last_batch_num[(
@@ -678,4 +680,5 @@ class MicroScheduler:
         self.held_until.pop(rid, None)
         self._drop_backlogged_rid(rid)
         self.tp_batches_pending_schedule.pop(rid, None)
+        self.pending_tp_follow_count.pop(rid, None)
 

--- a/mstar/worker/micro_scheduler.py
+++ b/mstar/worker/micro_scheduler.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from collections import deque
+from collections import defaultdict, deque
 from dataclasses import dataclass
 from enum import Enum
 
@@ -142,6 +142,10 @@ class MicroScheduler:
         # Shared by reference with Worker._pending_removes.
         self.pending_removes: set[str] = set()
 
+        # rid -> number of tp follow batches in the queue. Used in the fail/abort
+        # path, where we need to drain the TP queue before aborting
+        self.pending_tp_follow_count: dict[str, int] = {}
+
     def _select_node_rr(
         self, node_name_to_requests: dict[str, list[ReadyNodeEntry]]
     ):
@@ -170,6 +174,8 @@ class MicroScheduler:
         self, message: ScheduleTPNode
     ):
         self.tp_batches_pending_schedule.append(message)
+        for rid in message.request_ids:
+            self.pending_tp_follow_count[rid] += 1
 
     def _try_schedule_tp_follow(
         self, worker_graphs_manager: WorkerGraphsManager,
@@ -226,6 +232,11 @@ class MicroScheduler:
                 assert len(popped) == 1
                 node_objects[rid] = popped[0]
                 request_to_worker_graph[rid] = wgid
+
+        for rid in first_tp_node.request_ids:
+            self.tp_batches_pending_schedule[rid] -= 1
+            if self.tp_batches_pending_schedule[rid] <= 0:
+                self.tp_batches_pending_schedule.pop(rid)
 
         self.batch_number += 1
         self.node_and_walk_to_last_batch_num[(
@@ -666,4 +677,5 @@ class MicroScheduler:
         self.admit_errors.pop(rid, None)
         self.held_until.pop(rid, None)
         self._drop_backlogged_rid(rid)
+        self.tp_batches_pending_schedule.pop(rid, None)
 

--- a/mstar/worker/micro_scheduler.py
+++ b/mstar/worker/micro_scheduler.py
@@ -679,6 +679,5 @@ class MicroScheduler:
         self.admit_errors.pop(rid, None)
         self.held_until.pop(rid, None)
         self._drop_backlogged_rid(rid)
-        self.tp_batches_pending_schedule.pop(rid, None)
         self.pending_tp_follow_count.pop(rid, None)
 

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -538,6 +538,8 @@ class Worker:
             return
         if self.tensor_manager.has_inflight_reads(request_id):
             return  # let get_ready_tensors resolve the futures; retry next iter
+        if self.scheduler.tp_batches_pending_schedule[request_id] > 0:
+            return # need to wait for TP follow batches to drain
         self._reads_done_sent.add(request_id)
         self.communicator.send(
             "conductor",
@@ -2662,7 +2664,7 @@ class Worker:
                 # thread then admits, plans and runs it inline; the slot is
                 # leased inside exec, once the token count is known.
                 # send messages to follower ranks if relevant
-                self.maybe_send_zmq_to_tp_followers(node_batch)
+                self._maybe_send_zmq_to_tp_followers(node_batch)
 
                 future = gpu_executor.submit(
                     self._execute_on_gpu_thread, batch, node_batch, None,

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -2664,7 +2664,7 @@ class Worker:
                 # thread then admits, plans and runs it inline; the slot is
                 # leased inside exec, once the token count is known.
                 # send messages to follower ranks if relevant
-                self._maybe_send_zmq_to_tp_followers(node_batch)
+                self.maybe_send_zmq_to_tp_followers(node_batch)
 
                 future = gpu_executor.submit(
                     self._execute_on_gpu_thread, batch, node_batch, None,

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -33,10 +33,12 @@ from mstar.streaming.stream_buffer import StreamBuffer
 from mstar.utils.ipc_format import (
     ConductorMessage,
     ConductorMessageType,
+    DrainRequest,
     FailRequests,
     InputSignals,
     MessageSource,
     NewRequest,
+    ReadsDone,
     RemoveRequest,
     ScheduleTPNode,
     SetupDone,
@@ -294,6 +296,14 @@ class Worker:
         #   PendingLoopStop.
         self._in_flight_rids: set[str] = set()
         self._pending_removes: set[str] = set()
+        # Teardown drain (abort/fail): _pending_drains hold DrainRequests deferred
+        # behind an in-flight GPU step; _draining_rids have stopped reading and
+        # persist until REMOVE_REQUEST (so no read can restart after READS_DONE);
+        # _reads_done_sent tracks which have already ACKed.
+        self._pending_drains: set[str] = set()
+        self._draining_rids: set[str] = set()
+        self._reads_done_sent: set[str] = set()
+
         self._pending_loop_stops: set[PendingLoopStop] = set()
         # Let the scheduler see deferred removes so it stops initiating new work
         # for those rids (shared by reference — mutations are visible to both).
@@ -366,6 +376,9 @@ class Worker:
     # ------------------------------------------------------------------
 
     def _add_new_request(self, body: NewRequest) -> None:
+        if body.request_id in self._draining_rids:
+            # Being torn down (out-of-order NEW after DRAIN); don't start reads.
+            return
         logger.debug("Worker %s received request %s", self.worker_id, body.request_id)
         now = _time.monotonic()
         for node_name in self.engine_manager.evictable_nodes():
@@ -454,15 +467,96 @@ class Worker:
                     )
                 )
 
+        # Hard cleanup: force-drop every tensor for the rid (unlink SHM),
+        # ignoring ref counts / persist. Safe because the conductor only sends
+        # REMOVE_REQUEST once every reader has confirmed drained (READS_DONE) —
+        # on the abort/fail path via a prior DrainRequest, on the happy path
+        # once the api server finished reading the outputs.
+        self._draining_rids.discard(body.request_id)
+        self._pending_drains.discard(body.request_id)
+        self._reads_done_sent.discard(body.request_id)
         self.engine_manager.remove_request(body.request_id)
         self.worker_graphs_manager.remove_request(body.request_id)
-        self.tensor_manager.cleanup_request(body.request_id)
+        self.tensor_manager.force_cleanup_request(body.request_id)
         self.profile_info.pop_request(body.request_id)
         self.streaming_buffers.pop(body.request_id, None)
         self.scheduler.clear_rid(body.request_id)
 
         for node_name in self.engine_manager.evictable_nodes():
             self._last_active.pop((body.request_id, node_name), None)
+
+    def _drain_request(self, body: DrainRequest) -> None:
+        """Phase-1 teardown (abort/fail): stop scheduling and reading this rid,
+        then ACK READS_DONE once its in-flight reads finish. The hard cleanup
+        (force_cleanup_request) waits for the conductor's REMOVE_REQUEST, sent
+        only after every reader has ACKed."""
+        if self.is_tp_follower and body.source not in (
+            MessageSource.TP_RANK_0, MessageSource.SELF
+        ):
+            return  # honor only the leader's forwarded drain, like REMOVE_REQUEST
+
+        # Defer behind an in-flight GPU step, same as REMOVE_REQUEST: clearing
+        # the scheduler while a step references the rid would race the GPU thread.
+        if body.request_id in self._in_flight_rids:
+            self._pending_drains.add(body.request_id)
+            return
+
+        self._begin_drain(body.request_id)
+
+    def _begin_drain(self, request_id: str) -> None:
+        # Fan the drain to TP followers so each rank drains and ACKs its own
+        # READS_DONE (the conductor waits on every rank).
+        cfg = self.worker_graphs_manager.per_request_info.get(request_id)
+        if cfg is not None:
+            followers: set[str] = set()
+            for group in cfg.sharding_config.groups:
+                if group.tp_size > 1 and group._tp_rank == 0:
+                    followers.update(group._workers[1:])
+            for worker in followers:
+                self.communicator.send(
+                    worker, msg=WorkerMessage(
+                        message_type=WorkerMessageType.DRAIN_REQUEST,
+                        body=DrainRequest(
+                            request_id=request_id,
+                            source=MessageSource.TP_RANK_0,
+                        )
+                    )
+                )
+
+        # Stop initiating new GPU work; new reads are gated on _draining_rids.
+        # Keep engine / tensor state until REMOVE_REQUEST.
+        self.scheduler.clear_rid(request_id)
+        self._draining_rids.add(request_id)
+        self._complete_drain_if_ready(request_id)
+
+    def _complete_drain_if_ready(self, request_id: str) -> None:
+        """ACK READS_DONE once no async read for the rid is still in flight.
+        The rid stays in _draining_rids (reads gated) until REMOVE_REQUEST."""
+        if request_id not in self._draining_rids:
+            return
+        if request_id in self._reads_done_sent:
+            return
+        if self.tensor_manager.has_inflight_reads(request_id):
+            return  # let get_ready_tensors resolve the futures; retry next iter
+        self._reads_done_sent.add(request_id)
+        self.communicator.send(
+            "conductor",
+            ConductorMessage(
+                message_type=ConductorMessageType.READS_DONE,
+                body=ReadsDone(
+                    request_id=request_id, entity_id=self.worker_id
+                ),
+            ),
+        )
+
+    def _apply_pending_drains(self, in_flight_rids: set[str]) -> None:
+        """Begin drains that were deferred behind an in-flight GPU step, and
+        re-check draining rids whose reads may now have finished."""
+        for rid in [r for r in self._pending_drains if r not in in_flight_rids]:
+            self._pending_drains.discard(rid)
+            self._begin_drain(rid)
+        for rid in list(self._draining_rids):
+            self._complete_drain_if_ready(rid)
 
     def _handle_tensor_received(self, body: TensorReceived) -> None:
         """Sender-side cleanup: receiver confirmed RDMA read, free source buffers."""
@@ -472,6 +566,10 @@ class Worker:
             )
 
     def _process_new_inputs(self, body: InputSignals) -> None:
+        # Draining for teardown: don't start new reads for this rid. The
+        # producer's segment may be unlinked once every reader ACKs READS_DONE.
+        if body.request_id in self._draining_rids:
+            return
         logger.debug(
             "Received new signals %s at worker %s for request %s",
             format_graph_edge_list(body.inputs), self.worker_id, body.request_id
@@ -590,6 +688,8 @@ class Worker:
                 continue
             if message.message_type == WorkerMessageType.NEW_REQUEST:
                 self._add_new_request(message.body)
+            elif message.message_type == WorkerMessageType.DRAIN_REQUEST:
+                self._drain_request(message.body)
             elif message.message_type == WorkerMessageType.REMOVE_REQUEST:
                 self._remove_request(message.body)
             elif message.message_type == WorkerMessageType.INPUT_SIGNALS:
@@ -2283,6 +2383,7 @@ class Worker:
                 # readiness scans. They are in no batch, so nothing else would
                 # ever fail them.
                 self._fail_requests(self.scheduler.take_admit_errors())
+                self._apply_pending_drains(self._in_flight_rids)
 
                 # 1. CPU preamble — overlaps with GPU(N).
                 # synchronize=False on every range so torch.cuda.synchronize()
@@ -2512,6 +2613,7 @@ class Worker:
                     # are safe to apply now.
                     in_flight = set(spec_pending.batch.node_objects.keys()) if spec_pending else set()
                     self._apply_pending_removes_safe_to_drop(in_flight)
+                    self._apply_pending_drains(in_flight)
                     _set_pending(None)
 
                 if spec_pending is not None:

--- a/mstar/worker/worker.py
+++ b/mstar/worker/worker.py
@@ -523,9 +523,9 @@ class Worker:
                     )
                 )
 
-        # Stop initiating new GPU work; new reads are gated on _draining_rids.
-        # Keep engine / tensor state until REMOVE_REQUEST.
-        self.scheduler.clear_rid(request_id)
+        # Stop new leader work but keep draining committed TP batches (failed_rids
+        # is exactly this gate); keep engine/tensor/queue state until REMOVE.
+        self.scheduler.fail_rids({request_id})
         self._draining_rids.add(request_id)
         self._complete_drain_if_ready(request_id)
 
@@ -538,8 +538,8 @@ class Worker:
             return
         if self.tensor_manager.has_inflight_reads(request_id):
             return  # let get_ready_tensors resolve the futures; retry next iter
-        if self.scheduler.tp_batches_pending_schedule[request_id] > 0:
-            return # need to wait for TP follow batches to drain
+        if self.scheduler.pending_tp_follow_count.get(request_id, 0) > 0:
+            return  # wait for committed TP-follow batches to drain first
         self._reads_done_sent.add(request_id)
         self.communicator.send(
             "conductor",

--- a/test/modular/test_api_completion_guard.py
+++ b/test/modular/test_api_completion_guard.py
@@ -52,15 +52,23 @@ def test_preprocess_failure_emits_error_chunk():
     wt.out_queue = queue.Queue()
     wt.result_tensor_queue = queue.Queue()
     wt.cleanup_request_queue = queue.Queue()
+    wt.abort_request_queue = queue.Queue()
+    wt.reads_done_queue = queue.Queue()
+    wt.discard_tensor_queue = queue.Queue()
     wt.stop_event = threading.Event()
     wt.communicator = SimpleNamespace(get_all_new_messages=lambda: [])
     cleaned = []
     wt.tensor_manager = SimpleNamespace(
-        cleanup_request=cleaned.append, get_ready_tensors=lambda: {}
+        force_cleanup_request=cleaned.append,
+        has_inflight_reads=lambda rid: False,
+        get_ready_tensors=lambda: {},
     )
     wt.model = _RejectingModel()
     wt.device = "cpu"
     wt.tensor_uuid_to_metadata_per_request = {}
+    wt.request_model_kwargs = {}
+    wt._draining_rids = set()
+    wt._reads_done_sent = set()
 
     wt.in_queue.put(PreprocessInput(
         request_id="r1", text="x", file_paths=None,

--- a/test/modular/test_api_result_delivery.py
+++ b/test/modular/test_api_result_delivery.py
@@ -93,6 +93,7 @@ def test_result_reads_drain_ahead_of_preprocess():
         profile_queue=queue.Queue(),
         cleanup_request_queue=queue.Queue(),
         abort_request_queue=queue.Queue(),
+        reads_done_queue=queue.Queue(),
         discard_tensor_queue=queue.Queue(),
         stop_event=stop,
         communicator=_RecordingCommunicator(),
@@ -138,7 +139,9 @@ class _StubPreprocessWorker:
     def received_final_chunks(self, rid, final_outputs):
         return self.final
 
-    def cleanup_request(self, rid):
+    def finished_reading(self, rid):
+        # New teardown: the API server signals READS_DONE to the conductor
+        # instead of cleaning up locally; the conductor drives the hard cleanup.
         self.cleaned.append(rid)
 
 

--- a/test/modular/test_api_result_delivery.py
+++ b/test/modular/test_api_result_delivery.py
@@ -132,6 +132,7 @@ class _StubPreprocessWorker:
         self.pending = pending
         self.final = final
         self.cleaned = []
+        self.drained_flags = []
 
     def has_pending_tensors(self, rid):
         return self.pending
@@ -139,10 +140,11 @@ class _StubPreprocessWorker:
     def received_final_chunks(self, rid, final_outputs):
         return self.final
 
-    def finished_reading(self, rid):
+    def finished_reading(self, rid, drained=True):
         # New teardown: the API server signals READS_DONE to the conductor
         # instead of cleaning up locally; the conductor drives the hard cleanup.
         self.cleaned.append(rid)
+        self.drained_flags.append(drained)
 
 
 def _pending_request():
@@ -180,6 +182,9 @@ def test_ttl_expiry_with_undelivered_chunks_fails_request():
     assert req.error_status == 500
     assert "r1" not in server.recently_completed
     assert pw.cleaned == ["r1"]
+    # Chunks were still pending, so reads may be in flight: the READS_DONE ACK
+    # must be gated on them rather than sent outright.
+    assert pw.drained_flags == [False]
 
 
 def test_drained_completion_stays_successful():
@@ -193,6 +198,21 @@ def test_drained_completion_stays_successful():
 
     assert req.event.is_set()
     assert req.error is None
+    # Fully delivered: ACK immediately, no drain check on the happy path.
+    assert pw.drained_flags == [True]
+
+
+def test_client_gone_gates_the_reads_done_ack():
+    """The client handler pops pending_requests on its own timeout, which can
+    happen with chunks still in flight — that ACK must be gated too."""
+    pw = _StubPreprocessWorker(pending=True, final=False)
+    server = _api_server_stub(pw)
+    server.recently_completed["r4"] = time.time()
+
+    server._prune_recently_completed()
+
+    assert pw.cleaned == ["r4"]
+    assert pw.drained_flags == [False]
 
 
 def test_stream_carries_error_as_final_chunk():

--- a/test/modular/test_request_failure_propagation.py
+++ b/test/modular/test_request_failure_propagation.py
@@ -31,8 +31,9 @@ from mstar.api_server.request_types import (
     ResultChunk,
     ResultTensors,
 )
+from mstar.conductor.conductor import Conductor
 from mstar.profile.format import RequestProfile, RequestTiming
-from mstar.utils.ipc_format import ConductorMessageType, FailRequests
+from mstar.utils.ipc_format import ConductorMessageType, FailRequests, ReadsDone, WorkerMessageType
 from mstar.worker.micro_scheduler import MicroScheduler, ScheduledBatch
 from mstar.worker.worker import PendingBatch, Worker
 
@@ -158,6 +159,127 @@ def test_error_handler_also_fails_the_batch_built_this_iteration():
     )
     w._handle_main_loop_error(RuntimeError("boom"), (None, None), scheduled)
     assert set(w.sent[0][1].body.errors) == {"r1", "r2"}
+
+
+# ── scheduler ──────────────────────────────────────────────────────────────
+
+
+def _scheduler():
+    s = MicroScheduler.__new__(MicroScheduler)
+    s.failed_rids = set()
+    s.held_until = {}
+    s.pending_removes = set()
+    s.tp_batches_pending_schedule = []
+    s.pending_tp_follow_count = {}
+    s.engine_manager = SimpleNamespace(
+        get_engine=lambda name: SimpleNamespace(check_ready=lambda *a: True)
+    )
+    return s
+
+
+def _graphs_manager(rids):
+    return SimpleNamespace(
+        per_request_info={rid: object() for rid in rids},
+        queues={"wg": SimpleNamespace(
+            get_ready_node_names=lambda: {rid: ["node"] for rid in rids}
+        )},
+        get_partition_for_node=lambda name: "default",
+        get_graph_walk=lambda rid, part: "walk",
+        get_fwd_info=lambda rid, part: None,
+    )
+
+
+def test_failed_rid_is_not_reported_as_ready_work():
+    s = _scheduler()
+    mgr = _graphs_manager(["r1"])
+    assert s.has_ready_excluding(mgr, None) is True
+    s.fail_rids({"r1"})
+    assert s.has_ready_excluding(mgr, None) is False
+
+
+def test_clear_rid_releases_a_failed_request():
+    s = _scheduler()
+    s.fail_rids({"r1"})
+    s.held_until["r1"] = time.monotonic() + 100
+    s.clear_rid("r1")
+    assert s.failed_rids == set() and s.held_until == {}
+
+
+# ── conductor ──────────────────────────────────────────────────────────────
+
+
+def _conductor(rids):
+    c = Conductor.__new__(Conductor)
+    c.sent = []
+    c.communicator = SimpleNamespace(
+        send=lambda entity_id, msg: c.sent.append((entity_id, msg))
+    )
+    c.requests = {
+        rid: SimpleNamespace(worker_graph_to_workers={"wg": ["w0"]}) for rid in rids
+    }
+    c.draining = {}
+    c._early_reads_done = {}
+    c.waiting_queue = []
+    c._try_admit_waiting = lambda: None
+    return c
+
+
+def _drain_all(c, rid):
+    """Deliver READS_DONE from every participant so the barrier finalizes."""
+    for entity in ["w0", "api_server_preprocess_worker"]:
+        c._handle_reads_done(ReadsDone(request_id=rid, entity_id=entity))
+
+
+def test_conductor_tears_down_and_notifies_per_rid():
+    c = _conductor(["r1", "r2"])
+    c._fail_requests(FailRequests(errors={"r1": "boom", "r2": "bang"}))
+
+    # Phase 1: drain the readers first — nothing torn down or notified yet.
+    assert set(c.requests) == {"r1", "r2"}
+    drains = {
+        m.body.request_id for e, m in c.sent
+        if m.message_type == WorkerMessageType.DRAIN_REQUEST
+    }
+    assert drains == {"r1", "r2"}
+    assert not [m for e, m in c.sent if e == "api_server"]
+
+    # Phase 2: once every reader has drained, hard-remove and notify the client.
+    c.sent.clear()
+    _drain_all(c, "r1")
+    _drain_all(c, "r2")
+    assert c.requests == {}
+    removes = {
+        m.body.request_id for e, m in c.sent
+        if m.message_type == WorkerMessageType.REMOVE_REQUEST
+    }
+    assert removes == {"r1", "r2"}
+    failures = {
+        m.body.request_id: m.body for e, m in c.sent
+        if e == "api_server" and m.message_type == "request_failed"
+    }
+    assert failures["r1"].error_message == "boom"
+    assert failures["r2"].error_message == "bang"
+    assert failures["r1"].status == 500
+
+
+def test_duplicate_failure_report_is_ignored():
+    """Under TP every rank raises symmetrically and each reports it; only the
+    first report may start the teardown."""
+    c = _conductor(["r1"])
+    c._fail_requests(FailRequests(errors={"r1": "boom"}))
+    c.sent.clear()
+    c._fail_requests(FailRequests(errors={"r1": "boom"}))  # already draining
+    assert c.sent == []
+
+
+def test_one_unknown_rid_does_not_block_the_others():
+    c = _conductor(["r2"])
+    c._fail_requests(FailRequests(errors={"gone": "boom", "r2": "bang"}))
+    drains = {
+        m.body.request_id for e, m in c.sent
+        if m.message_type == WorkerMessageType.DRAIN_REQUEST
+    }
+    assert drains == {"r2"}
 
 
 # ── api server ─────────────────────────────────────────────────────────────

--- a/test/modular/test_request_failure_propagation.py
+++ b/test/modular/test_request_failure_propagation.py
@@ -1,0 +1,307 @@
+"""Runtime inference errors must reach the client as a structured failure
+instead of a blanket request timeout (issue #123).
+
+What is left here after the resource-pool refactor is the part of that chain
+that does not live in the engine: the worker turning a crash into a
+FAIL_REQUESTS report (and never re-awaiting the future that raised), the api
+server releasing the waiting client with an error, and the data worker turning
+a postprocess blow-up into an error chunk.
+
+The neighbouring pieces are covered elsewhere:
+
+* engine-side attribution (admit refusals, per-rid stage failures) ->
+  ``test_admit_failure_handling.py``
+* excising a reported failure from the finished batch ->
+  ``test_failed_request_reporting.py``
+* the scheduler refusing to schedule a failed rid ->
+  ``test_micro_scheduler.py``
+* the conductor's teardown drain barrier -> ``test_teardown_barrier.py``
+"""
+
+import queue
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+from mstar.api_server.entrypoint import APIServer, PendingRequest
+from mstar.api_server.request_types import (
+    APIServerMessage,
+    RequestFailed,
+    ResultChunk,
+    ResultTensors,
+)
+from mstar.profile.format import RequestProfile, RequestTiming
+from mstar.utils.ipc_format import ConductorMessageType, FailRequests
+from mstar.worker.micro_scheduler import MicroScheduler, ScheduledBatch
+from mstar.worker.worker import PendingBatch, Worker
+
+# ── worker ─────────────────────────────────────────────────────────────────
+
+
+def _worker(known_rids=("r1", "r2")):
+    w = Worker.__new__(Worker)
+    w.worker_id = "w0"
+    w.sent = []
+    w.communicator = SimpleNamespace(
+        send=lambda entity_id, msg: w.sent.append((entity_id, msg))
+    )
+    w.worker_graphs_manager = SimpleNamespace(
+        per_request_info={rid: object() for rid in known_rids}
+    )
+    w.scheduler = MicroScheduler.__new__(MicroScheduler)
+    w.scheduler.failed_rids = set()
+    w.scheduler.held_until = {}
+    w.scheduler.admit_errors = {}
+    w.scheduler.backlog = {}
+    return w
+
+
+def test_fail_requests_reports_per_rid_errors_once():
+    w = _worker()
+    w._fail_requests({"r1": "boom", "r2": "bang"})
+    assert len(w.sent) == 1
+    entity, msg = w.sent[0]
+    assert entity == "conductor"
+    assert msg.message_type == ConductorMessageType.FAIL_REQUESTS
+    assert msg.body == FailRequests(errors={"r1": "boom", "r2": "bang"})
+    assert w.scheduler.failed_rids == {"r1", "r2"}
+
+
+def test_fail_requests_ignores_rids_the_worker_already_dropped():
+    """The conductor answers a failure by tearing the request down. It won't
+    start one for a request it no longer tracks, so reporting an unknown rid
+    would pin it in failed_rids forever."""
+    w = _worker(known_rids=("r1",))
+    w._fail_requests({"gone": "boom"})
+    assert w.sent == []
+    assert w.scheduler.failed_rids == set()
+
+
+def _pending_batch(rids, future=None):
+    return PendingBatch(
+        batch=ScheduledBatch(
+            node_name="node", graph_walk="walk",
+            node_objects={
+                rid: SimpleNamespace(_speculatively_scheduled=True) for rid in rids
+            },
+            request_to_worker_graph={rid: "wg" for rid in rids},
+        ),
+        # _handle_main_loop_error works off the ScheduledBatch alone; the
+        # ExecutingBatch is never touched on this path.
+        node_batch=None, node_name="node",
+        partition="default", graph_walk="walk", future=future,
+    )
+
+
+def test_crashed_forward_fails_the_whole_batch():
+    """A raise the worker can't attribute to one rid fails every request the
+    iteration touched, rather than dropping them into the request timeout."""
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        w = _worker()
+        w._in_flight_rids = {"r1"}
+        pending = _pending_batch(["r1"], future=executor.submit(lambda: 1 / 0))
+        try:
+            pending.future.result()
+        except ZeroDivisionError as exc:
+            w._handle_main_loop_error(exc, (pending, None), None)
+
+        assert len(w.sent) == 1
+        errors = w.sent[0][1].body.errors
+        assert set(errors) == {"r1"}
+        assert "ZeroDivisionError" in errors["r1"]
+        # The node must not stay flagged as speculatively scheduled, or it can
+        # never be re-queued.
+        assert all(
+            not n._speculatively_scheduled
+            for n in pending.batch.node_objects.values()
+        )
+    finally:
+        executor.shutdown(wait=True)
+
+
+def test_error_handler_drains_the_speculative_batch_still_on_the_gpu():
+    """The spec batch's future was submitted before the crash; abandoning it
+    would leave the GPU thread writing into a batch nobody collects."""
+    executor = ThreadPoolExecutor(max_workers=1)
+    started = threading.Event()
+    release = threading.Event()
+
+    def _slow():
+        started.set()
+        release.wait(10)
+        return "done"
+
+    try:
+        w = _worker()
+        w._in_flight_rids = set()
+        spec = _pending_batch(["r2"], future=executor.submit(_slow))
+        started.wait(10)
+        release.set()
+        w._handle_main_loop_error(RuntimeError("boom"), (None, spec), None)
+
+        assert spec.future.done()
+        assert set(w.sent[0][1].body.errors) == {"r2"}
+    finally:
+        release.set()
+        executor.shutdown(wait=True)
+
+
+def test_error_handler_also_fails_the_batch_built_this_iteration():
+    w = _worker()
+    w._in_flight_rids = {"r1"}
+    scheduled = ScheduledBatch(
+        node_name="node", graph_walk="walk",
+        node_objects={"r2": SimpleNamespace(_speculatively_scheduled=True)},
+        request_to_worker_graph={"r2": "wg"},
+    )
+    w._handle_main_loop_error(RuntimeError("boom"), (None, None), scheduled)
+    assert set(w.sent[0][1].body.errors) == {"r1", "r2"}
+
+
+# ── api server ─────────────────────────────────────────────────────────────
+
+
+def _api_server(messages):
+    s = APIServer.__new__(APIServer)
+    s.pending_requests = {}
+    s.recently_completed = {}
+    s._recently_completed_ttl = 15.0
+    s.request_lock = threading.Lock()
+    s.running = True
+    s.log_stats = False
+    s.cleaned = []
+    s.communicator = SimpleNamespace(
+        get_all_new_messages=lambda: messages.pop(0) if messages else []
+    )
+    s.preprocess_worker = SimpleNamespace(
+        get_profile_updates=lambda: [],
+        get_result_chunks=lambda: [],
+        has_pending_tensors=lambda rid: False,
+        received_final_chunks=lambda rid, outs: False,
+        # The teardown drain: the api server reports it is done reading and the
+        # conductor drives the hard cleanup.
+        finished_reading=s.cleaned.append,
+        new_result_tensors=lambda body: None,
+        discard_result_tensors=lambda body: None,
+    )
+    return s
+
+
+def _pending_request(streaming=False):
+    return PendingRequest(
+        streaming=streaming,
+        input_modalities=["text"],
+        output_modalities=["text"],
+        profile=RequestProfile(rid="r1", timing=RequestTiming(recv_time=0.0)),
+    )
+
+
+def _drain(server):
+    thread = threading.Thread(target=server._process_messages, daemon=True)
+    thread.start()
+    try:
+        yield_deadline = time.time() + 10
+        while time.time() < yield_deadline:
+            if server.pending_requests["r1"].event.is_set():
+                return
+            time.sleep(0.005)
+        raise AssertionError("request was never released")
+    finally:
+        server.running = False
+        thread.join(timeout=10)
+
+
+def test_engine_failure_releases_the_client_with_an_error():
+    server = _api_server([[APIServerMessage(
+        message_type="request_failed",
+        body=RequestFailed(request_id="r1", error_message="boom", status=500),
+    )]])
+    server.pending_requests["r1"] = _pending_request()
+    _drain(server)
+
+    req = server.pending_requests["r1"]
+    assert req.error == "boom"
+    assert req.error_status == 500
+    # Parked for cleanup so the data worker's per-request state is reclaimed.
+    assert "r1" in server.recently_completed
+
+
+def test_engine_failure_does_not_clobber_an_earlier_error():
+    server = _api_server([[APIServerMessage(
+        message_type="request_failed",
+        body=RequestFailed(request_id="r1", error_message="downstream", status=500),
+    )]])
+    req = _pending_request()
+    req.error = "bad input"
+    req.error_status = 400
+    server.pending_requests["r1"] = req
+    _drain(server)
+    assert req.error == "bad input" and req.error_status == 400
+
+
+# ── data worker ────────────────────────────────────────────────────────────
+
+
+def _preprocess_thread(model):
+    from mstar.api_server.data_worker import PreprocessWorkerThread
+
+    wt = PreprocessWorkerThread.__new__(PreprocessWorkerThread)
+    wt.out_queue = queue.Queue()
+    wt.model = model
+    wt.request_model_kwargs = {}
+    wt.tensor_uuid_to_metadata_per_request = {"r1": {"u1": {}}}
+    wt.enable_prof = False
+    return wt
+
+
+def test_output_postprocess_failure_becomes_an_error_chunk():
+    """A model that blows up postprocessing a result tensor must fail that
+    request, not silently drop the chunk and leave the client hanging."""
+
+    class _BadModel:
+        def postprocess(self, tensor, modality, request_kwargs=None):
+            raise RuntimeError("decode failed")
+
+    wt = _preprocess_thread(_BadModel())
+    dereferenced = []
+    edge = SimpleNamespace(
+        name="text_output", tensor_info=[SimpleNamespace(uuid="u1")],
+    )
+    wt.tensor_manager = SimpleNamespace(
+        get_ready_tensors=lambda: {"r1": [edge]},
+        get_tensor=lambda request_id, uuid: object(),
+        dereference=lambda request_id, uuid: dereferenced.append(uuid),
+    )
+
+    assert wt._process_read_tensors() is True
+    chunk: ResultChunk = wt.out_queue.get_nowait()
+    assert chunk.request_id == "r1"
+    assert chunk.modality == "error"
+    assert b"decode failed" in chunk.data
+    assert chunk.metadata["status"] == 500
+    # The tensor is still released even though postprocessing died.
+    assert dereferenced == ["u1"]
+
+
+def test_result_transfer_failure_answers_for_every_queued_tensor():
+    """The API server decrements its outstanding-read count once per chunk, so
+    a read that never starts owes one error chunk per tensor it dropped."""
+    wt = _preprocess_thread(model=None)
+    edge = SimpleNamespace(
+        name="text_output",
+        tensor_info=[SimpleNamespace(uuid="u1"), SimpleNamespace(uuid="u2")],
+    )
+    result = ResultTensors(
+        request_id="r1", modality="text", graph_edge=edge, loop_indices=None,
+    )
+    try:
+        raise RuntimeError("arena full")
+    except RuntimeError as exc:
+        wt._fail_request(
+            "r1", exc, "text output transfer",
+            count=len(result.graph_edge.tensor_info),
+        )
+    assert wt.out_queue.qsize() == 2
+    assert b"arena full" in wt.out_queue.get_nowait().data

--- a/test/modular/test_request_failure_propagation.py
+++ b/test/modular/test_request_failure_propagation.py
@@ -182,7 +182,7 @@ def _api_server(messages):
         received_final_chunks=lambda rid, outs: False,
         # The teardown drain: the api server reports it is done reading and the
         # conductor drives the hard cleanup.
-        finished_reading=s.cleaned.append,
+        finished_reading=lambda rid, drained=True: s.cleaned.append(rid),
         new_result_tensors=lambda body: None,
         discard_result_tensors=lambda body: None,
     )

--- a/test/modular/test_request_failure_propagation.py
+++ b/test/modular/test_request_failure_propagation.py
@@ -31,9 +31,8 @@ from mstar.api_server.request_types import (
     ResultChunk,
     ResultTensors,
 )
-from mstar.conductor.conductor import Conductor
 from mstar.profile.format import RequestProfile, RequestTiming
-from mstar.utils.ipc_format import ConductorMessageType, FailRequests, ReadsDone, WorkerMessageType
+from mstar.utils.ipc_format import ConductorMessageType, FailRequests
 from mstar.worker.micro_scheduler import MicroScheduler, ScheduledBatch
 from mstar.worker.worker import PendingBatch, Worker
 
@@ -159,127 +158,6 @@ def test_error_handler_also_fails_the_batch_built_this_iteration():
     )
     w._handle_main_loop_error(RuntimeError("boom"), (None, None), scheduled)
     assert set(w.sent[0][1].body.errors) == {"r1", "r2"}
-
-
-# ── scheduler ──────────────────────────────────────────────────────────────
-
-
-def _scheduler():
-    s = MicroScheduler.__new__(MicroScheduler)
-    s.failed_rids = set()
-    s.held_until = {}
-    s.pending_removes = set()
-    s.tp_batches_pending_schedule = []
-    s.pending_tp_follow_count = {}
-    s.engine_manager = SimpleNamespace(
-        get_engine=lambda name: SimpleNamespace(check_ready=lambda *a: True)
-    )
-    return s
-
-
-def _graphs_manager(rids):
-    return SimpleNamespace(
-        per_request_info={rid: object() for rid in rids},
-        queues={"wg": SimpleNamespace(
-            get_ready_node_names=lambda: {rid: ["node"] for rid in rids}
-        )},
-        get_partition_for_node=lambda name: "default",
-        get_graph_walk=lambda rid, part: "walk",
-        get_fwd_info=lambda rid, part: None,
-    )
-
-
-def test_failed_rid_is_not_reported_as_ready_work():
-    s = _scheduler()
-    mgr = _graphs_manager(["r1"])
-    assert s.has_ready_excluding(mgr, None) is True
-    s.fail_rids({"r1"})
-    assert s.has_ready_excluding(mgr, None) is False
-
-
-def test_clear_rid_releases_a_failed_request():
-    s = _scheduler()
-    s.fail_rids({"r1"})
-    s.held_until["r1"] = time.monotonic() + 100
-    s.clear_rid("r1")
-    assert s.failed_rids == set() and s.held_until == {}
-
-
-# ── conductor ──────────────────────────────────────────────────────────────
-
-
-def _conductor(rids):
-    c = Conductor.__new__(Conductor)
-    c.sent = []
-    c.communicator = SimpleNamespace(
-        send=lambda entity_id, msg: c.sent.append((entity_id, msg))
-    )
-    c.requests = {
-        rid: SimpleNamespace(worker_graph_to_workers={"wg": ["w0"]}) for rid in rids
-    }
-    c.draining = {}
-    c._early_reads_done = {}
-    c.waiting_queue = []
-    c._try_admit_waiting = lambda: None
-    return c
-
-
-def _drain_all(c, rid):
-    """Deliver READS_DONE from every participant so the barrier finalizes."""
-    for entity in ["w0", "api_server_preprocess_worker"]:
-        c._handle_reads_done(ReadsDone(request_id=rid, entity_id=entity))
-
-
-def test_conductor_tears_down_and_notifies_per_rid():
-    c = _conductor(["r1", "r2"])
-    c._fail_requests(FailRequests(errors={"r1": "boom", "r2": "bang"}))
-
-    # Phase 1: drain the readers first — nothing torn down or notified yet.
-    assert set(c.requests) == {"r1", "r2"}
-    drains = {
-        m.body.request_id for e, m in c.sent
-        if m.message_type == WorkerMessageType.DRAIN_REQUEST
-    }
-    assert drains == {"r1", "r2"}
-    assert not [m for e, m in c.sent if e == "api_server"]
-
-    # Phase 2: once every reader has drained, hard-remove and notify the client.
-    c.sent.clear()
-    _drain_all(c, "r1")
-    _drain_all(c, "r2")
-    assert c.requests == {}
-    removes = {
-        m.body.request_id for e, m in c.sent
-        if m.message_type == WorkerMessageType.REMOVE_REQUEST
-    }
-    assert removes == {"r1", "r2"}
-    failures = {
-        m.body.request_id: m.body for e, m in c.sent
-        if e == "api_server" and m.message_type == "request_failed"
-    }
-    assert failures["r1"].error_message == "boom"
-    assert failures["r2"].error_message == "bang"
-    assert failures["r1"].status == 500
-
-
-def test_duplicate_failure_report_is_ignored():
-    """Under TP every rank raises symmetrically and each reports it; only the
-    first report may start the teardown."""
-    c = _conductor(["r1"])
-    c._fail_requests(FailRequests(errors={"r1": "boom"}))
-    c.sent.clear()
-    c._fail_requests(FailRequests(errors={"r1": "boom"}))  # already draining
-    assert c.sent == []
-
-
-def test_one_unknown_rid_does_not_block_the_others():
-    c = _conductor(["r2"])
-    c._fail_requests(FailRequests(errors={"gone": "boom", "r2": "bang"}))
-    drains = {
-        m.body.request_id for e, m in c.sent
-        if m.message_type == WorkerMessageType.DRAIN_REQUEST
-    }
-    assert drains == {"r2"}
 
 
 # ── api server ─────────────────────────────────────────────────────────────

--- a/test/modular/test_shm_tensor_comm.py
+++ b/test/modular/test_shm_tensor_comm.py
@@ -297,6 +297,95 @@ def test_ack_unread_tensors_lets_producer_reclaim_buffer():
 
 
 # ---------------------------------------------------------------------------
+# Teardown: cleanup_request (soft) vs force_cleanup_request (hard) + drain gate
+# ---------------------------------------------------------------------------
+
+def _store_persisted_input(mgr, request_id, name="in"):
+    """Mirror the data worker's input-signal path: store, register for send, and
+    mark persisted (ref_cnt stays 0 — persist is the only thing holding it)."""
+    info = mgr.store_and_return_tensor_info(request_id, {name: [torch.randn(4, 8)]})
+    tensor_info = info[name][0]
+    mgr.register_for_send(request_id, [tensor_info])
+    mgr.set_persist(request_id, tensor_info.uuid, persist=True)
+    return tensor_info.uuid
+
+
+def test_cleanup_request_defers_persisted_tensor():
+    """Regression for the abort SHM bug: a persisted input-signal (ref_cnt==0,
+    kept alive only by the persist flag) must NOT be unlinked by cleanup_request.
+    Force-dropping it here is exactly what unlinked a segment under a peer's
+    still-scheduled read and killed the rank."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mgr = _make_manager(
+            tmpdir, entity_id="api_server_preprocess_worker", request_id="req1"
+        )
+        uuid = _store_persisted_input(mgr, "req1")
+        path = os.path.join(tmpdir, f"mstar_api_server_preprocess_worker_{uuid}")
+        assert os.path.isfile(path)
+        assert not mgr.tensor_store.can_gc("req1", uuid)  # persist holds it
+
+        mgr.cleanup_request("req1")
+        assert os.path.isfile(path)  # deferred, not force-unlinked
+
+
+def test_force_cleanup_request_drops_persisted_tensor():
+    """Phase-2 hard cleanup drops the persisted signal unconditionally — safe
+    only after every reader has drained (READS_DONE)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mgr = _make_manager(
+            tmpdir, entity_id="api_server_preprocess_worker", request_id="req1"
+        )
+        uuid = _store_persisted_input(mgr, "req1")
+        path = os.path.join(tmpdir, f"mstar_api_server_preprocess_worker_{uuid}")
+        assert os.path.isfile(path)
+
+        mgr.force_cleanup_request("req1")
+        assert not os.path.isfile(path)
+        assert not mgr.tensor_store.check_uuid_presence("req1", uuid)
+
+
+def test_force_cleanup_request_reclaims_unacked_buffer():
+    """Hard cleanup also reclaims a non-persisted output buffer still held by its
+    awaiting-ack ref — the ~leaked segments cleanup_request would defer forever."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        producer = _make_manager(tmpdir, entity_id="worker_0", request_id="req1")
+        _, uuid = _produce_registered_output(producer, "req1")
+        shm_path = os.path.join(tmpdir, f"mstar_worker_0_{uuid}")
+        assert os.path.isfile(shm_path)
+        assert not producer.tensor_store.can_gc("req1", uuid)  # held by send ref
+
+        producer.force_cleanup_request("req1")
+        assert not os.path.isfile(shm_path)  # dropped regardless of ref count
+
+
+def test_has_inflight_reads_tracks_pending_futures():
+    """The drain gate: only an outstanding async read future counts. Synchronous
+    (SHM) reads land in pending with future=None and are already done."""
+    from mstar.communication.tensors import FutureAndPointers
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mgr = _make_manager(tmpdir, request_id="req1")
+        assert not mgr.has_inflight_reads("req1")
+
+        # Completed synchronous read (future=None) does not count.
+        mgr.pending.append(
+            FutureAndPointers(future=None, graph_edges=[], request_id="req1")
+        )
+        assert not mgr.has_inflight_reads("req1")
+
+        # An unresolved async future does.
+        class _Fut:
+            def done(self):
+                return False
+
+        mgr.pending.append(
+            FutureAndPointers(future=_Fut(), graph_edges=[], request_id="req1")
+        )
+        assert mgr.has_inflight_reads("req1")
+        assert not mgr.has_inflight_reads("other-req")
+
+
+# ---------------------------------------------------------------------------
 # Factory tests
 # ---------------------------------------------------------------------------
 

--- a/test/modular/test_teardown_barrier.py
+++ b/test/modular/test_teardown_barrier.py
@@ -1,0 +1,189 @@
+"""Teardown barrier (conductor side): the hard RemoveRequest that unlinks a
+segment is sent only after every reader has drained (READS_DONE).
+
+Covers the happy path (defer Remove until the preprocess worker finished
+delivering outputs, and unpersist still-held signals with correct counts) and
+the abort/fail path (drain all workers + preprocess worker, then Remove).
+"""
+
+import types
+
+import torch
+
+from mstar.conductor.conductor import Conductor, RequestData
+from mstar.graph.base import TensorPointerInfo
+from mstar.utils.ipc_format import (
+    FailRequests,
+    ReadsDone,
+    UnpersistTensors,
+    WorkerMessageType,
+)
+
+PREPROCESS = "api_server_preprocess_worker"
+
+
+def _request_data(workers=("w0",), persist_signals=None, ref_cnts=None):
+    return RequestData(
+        persist_signals=persist_signals or {},
+        persist_signal_ref_cnt=ref_cnts or {},
+        worker_graph_to_workers={"wg": list(workers)},
+        all_worker_graph_ids={"wg"},
+        max_output_tokens=1,
+        random_seed=0,
+        sampling_config={},
+    )
+
+
+def _conductor(requests):
+    c = Conductor.__new__(Conductor)
+    c.sent = []
+    c.admits = 0
+    c.communicator = types.SimpleNamespace(
+        send=lambda entity_id, msg: c.sent.append((entity_id, msg))
+    )
+    c.requests = dict(requests)
+    c.draining = {}
+    c._early_reads_done = {}
+    c.waiting_queue = []
+    c.enable_prof = False
+    c._try_admit_waiting = lambda: setattr(c, "admits", c.admits + 1)
+    return c
+
+
+def _by_type(c, message_type):
+    return [
+        (e, m) for e, m in c.sent
+        if getattr(m, "message_type", None) == message_type
+    ]
+
+
+def _drain_targets(c, rid):
+    return {
+        e for e, m in _by_type(c, WorkerMessageType.DRAIN_REQUEST)
+        if m.body.request_id == rid
+    }
+
+
+def _remove_targets(c, rid):
+    return {
+        e for e, m in _by_type(c, WorkerMessageType.REMOVE_REQUEST)
+        if m.body.request_id == rid
+    }
+
+
+# ── abort / fail path ───────────────────────────────────────────────────────
+
+def test_abort_drains_all_participants_then_removes():
+    c = _conductor({"r1": _request_data(workers=("w0", "w1"))})
+    c._abort_request("r1")
+
+    # Phase 1: drain every worker + the preprocess worker; nothing removed yet.
+    assert _drain_targets(c, "r1") == {"w0", "w1", PREPROCESS}
+    assert _remove_targets(c, "r1") == set()
+    assert "r1" in c.requests and "r1" in c.draining
+
+    # Partial ACKs do not finalize.
+    c._handle_reads_done(ReadsDone(request_id="r1", entity_id="w0"))
+    c._handle_reads_done(ReadsDone(request_id="r1", entity_id="w1"))
+    assert _remove_targets(c, "r1") == set()
+    assert "r1" in c.requests
+
+    # Final ACK (preprocess worker) completes the barrier: hard-remove + admit.
+    c._handle_reads_done(ReadsDone(request_id="r1", entity_id=PREPROCESS))
+    assert _remove_targets(c, "r1") == {"w0", "w1", PREPROCESS}
+    assert "r1" not in c.requests and "r1" not in c.draining
+    assert c.admits == 1
+
+
+def test_abort_of_unknown_request_sends_nothing():
+    c = _conductor({})
+    c._abort_request("nope")
+    assert c.sent == []
+
+
+def test_second_abort_while_draining_is_ignored():
+    c = _conductor({"r1": _request_data()})
+    c._abort_request("r1")
+    c.sent.clear()
+    c._abort_request("r1")  # already draining
+    assert c.sent == []
+
+
+def test_fail_defers_client_notification_until_barrier_completes():
+    c = _conductor({"r1": _request_data()})
+    c._fail_requests(FailRequests(errors={"r1": "boom"}))
+
+    # Draining, but the client is not told yet.
+    assert _drain_targets(c, "r1") == {"w0", PREPROCESS}
+    assert not [m for e, m in c.sent if e == "api_server"]
+
+    c.sent.clear()
+    c._handle_reads_done(ReadsDone(request_id="r1", entity_id="w0"))
+    c._handle_reads_done(ReadsDone(request_id="r1", entity_id=PREPROCESS))
+    failures = [
+        m for e, m in c.sent
+        if e == "api_server" and m.message_type == "request_failed"
+    ]
+    assert len(failures) == 1
+    assert failures[0].body.error_message == "boom"
+    assert _remove_targets(c, "r1") == {"w0", PREPROCESS}
+
+
+# ── happy path ──────────────────────────────────────────────────────────────
+
+def test_done_completes_client_immediately_but_defers_remove():
+    c = _conductor({"r1": _request_data(workers=("w0", "w1"))})
+    c._process_request_done("r1")
+
+    # Client told right away; workers assumed done so only the preprocess worker
+    # must ACK — no Remove yet.
+    completes = [m for e, m in c.sent if e == "api_server"
+                 and m.message_type == "request_complete"]
+    assert len(completes) == 1
+    assert _remove_targets(c, "r1") == set()
+    assert c.draining["r1"].expected_acks == {PREPROCESS}
+    assert "r1" in c.requests
+
+    c._handle_reads_done(ReadsDone(request_id="r1", entity_id=PREPROCESS))
+    assert _remove_targets(c, "r1") == {"w0", "w1", PREPROCESS}
+    assert "r1" not in c.requests
+    assert c.admits == 1
+
+
+def test_done_unpersists_still_held_signals_with_ref_counts():
+    info = TensorPointerInfo(
+        dims=(4,), dtype=torch.float32, stride=(1,), nbytes=16, address=0,
+        uuid="u1", source_session_id="s", source_entity="w0",
+    )
+    rd = _request_data(
+        persist_signals={"emb": [info]}, ref_cnts={"u1": 3},
+    )
+    c = _conductor({"r1": rd})
+    c._process_request_done("r1")
+
+    unpersists = [
+        (e, m) for e, m in c.sent
+        if getattr(m, "message_type", None) == WorkerMessageType.UNPERSIST_TENSORS
+    ]
+    assert len(unpersists) == 1
+    entity, msg = unpersists[0]
+    assert entity == "w0"
+    assert isinstance(msg.body, UnpersistTensors)
+    assert msg.body.uuid_to_ref_count == {"u1": 3}
+
+
+# ── ordering race: ACK before registration ──────────────────────────────────
+
+def test_reads_done_racing_registration_is_not_lost():
+    """The preprocess worker self-drains on abort and can ACK before the
+    conductor processes ABORT_REQUEST. That early ACK must still count."""
+    c = _conductor({"r1": _request_data()})
+    # Preprocess worker's READS_DONE lands before the barrier is registered.
+    c._handle_reads_done(ReadsDone(request_id="r1", entity_id=PREPROCESS))
+    assert "r1" in c._early_reads_done
+
+    c._abort_request("r1")
+    # Only w0 was still outstanding; deliver it and the barrier finalizes.
+    c._handle_reads_done(ReadsDone(request_id="r1", entity_id="w0"))
+    assert _remove_targets(c, "r1") == {"w0", PREPROCESS}
+    assert "r1" not in c.requests

--- a/test/modular/test_teardown_barrier.py
+++ b/test/modular/test_teardown_barrier.py
@@ -30,7 +30,9 @@ def _request_data(workers=("w0",), persist_signals=None, ref_cnts=None):
         all_worker_graph_ids={"wg"},
         max_output_tokens=1,
         random_seed=0,
-        sampling_config={},
+        # Post-resource-pool refactor: requests carry per-resource configs
+        # rather than a sampling_config. The barrier never reads them.
+        resource_configs={},
     )
 
 

--- a/test/modular/test_teardown_barrier.py
+++ b/test/modular/test_teardown_barrier.py
@@ -7,6 +7,7 @@ the abort/fail path (drain all workers + preprocess worker, then Remove).
 """
 
 import types
+from collections import deque
 
 import torch
 
@@ -14,6 +15,7 @@ from mstar.conductor.conductor import Conductor, RequestData
 from mstar.graph.base import TensorPointerInfo
 from mstar.utils.ipc_format import (
     FailRequests,
+    NewRequestConductor,
     ReadsDone,
     UnpersistTensors,
     WorkerMessageType,
@@ -36,7 +38,18 @@ def _request_data(workers=("w0",), persist_signals=None, ref_cnts=None):
     )
 
 
-def _conductor(requests):
+def _new_request(rid):
+    return NewRequestConductor(
+        request_id=rid,
+        initial_signals={},
+        initial_input_modalities=["text"],
+        initial_output_modalities=["text"],
+        input_metadata={},
+        model_kwargs={},
+    )
+
+
+def _conductor(requests, drain_ttl_s=120.0):
     c = Conductor.__new__(Conductor)
     c.sent = []
     c.admits = 0
@@ -45,7 +58,12 @@ def _conductor(requests):
     )
     c.requests = dict(requests)
     c.draining = {}
+    c._drain_ttl_s = drain_ttl_s
     c._early_reads_done = {}
+    c._early_abort_requests = set()
+    c._draining_deadlines = deque()
+    c._early_reads_done_deadlines = deque()
+    c._early_abort_deadlines = deque()
     c.waiting_queue = []
     c.enable_prof = False
     c._try_admit_waiting = lambda: setattr(c, "admits", c.admits + 1)
@@ -101,6 +119,17 @@ def test_abort_of_unknown_request_sends_nothing():
     c = _conductor({})
     c._abort_request("nope")
     assert c.sent == []
+
+
+def test_abort_of_queued_request_removes_preprocess_state():
+    """A request aborted out of the waiting queue never reached a worker, so the
+    preprocess worker is the only holder of its persisted input signals."""
+    c = _conductor({})
+    c.waiting_queue = [_new_request("r1")]
+    c._abort_request("r1")
+
+    assert c.waiting_queue == []
+    assert _remove_targets(c, "r1") == {PREPROCESS}
 
 
 def test_second_abort_while_draining_is_ignored():
@@ -189,3 +218,73 @@ def test_reads_done_racing_registration_is_not_lost():
     c._handle_reads_done(ReadsDone(request_id="r1", entity_id="w0"))
     assert _remove_targets(c, "r1") == {"w0", PREPROCESS}
     assert "r1" not in c.requests
+
+
+# ── ordering race: abort before ingest ──────────────────────────────────────
+
+def test_abort_racing_ingest_drops_the_request_and_removes_signals():
+    """The preprocess worker forwards ABORT_REQUEST before it finishes
+    preprocessing, so the abort can outrun the NEW_REQUEST it aborts. The
+    request must never be dispatched, and its input signals must be removed —
+    but only once ingest proves they exist."""
+    c = _conductor({})
+    c._abort_request("r1")
+    assert "r1" in c._early_abort_requests
+    # Nothing sent yet: a RemoveRequest here would beat the signals into being.
+    assert c.sent == []
+
+    c._ingest_request(_new_request("r1"))
+    assert "r1" not in c.requests and c.waiting_queue == []
+    assert _remove_targets(c, "r1") == {PREPROCESS}
+    assert "r1" not in c._early_abort_requests
+
+
+def test_abort_racing_ingest_discards_its_early_reads_done():
+    c = _conductor({})
+    c._abort_request("r1")
+    c._handle_reads_done(ReadsDone(request_id="r1", entity_id=PREPROCESS))
+    c._ingest_request(_new_request("r1"))
+    assert "r1" not in c._early_reads_done
+
+
+# ── expiry sweeps ───────────────────────────────────────────────────────────
+
+def test_drain_barrier_times_out_and_force_finalizes():
+    """A participant that never ACKs (crashed/hung) must not hold the request —
+    or, on the fail path, the client's notification — forever."""
+    c = _conductor({"r1": _request_data()}, drain_ttl_s=0.0)
+    c._fail_requests(FailRequests(errors={"r1": "boom"}))
+    assert "r1" in c.draining  # w0 and the preprocess worker never ACK
+
+    c._sweep_expiry()
+    assert "r1" not in c.draining and "r1" not in c.requests
+    assert _remove_targets(c, "r1") == {"w0", PREPROCESS}
+    failures = [
+        m for e, m in c.sent
+        if e == "api_server" and m.message_type == "request_failed"
+    ]
+    assert len(failures) == 1
+    assert c.admits == 1
+
+
+def test_sweep_leaves_a_live_barrier_alone():
+    c = _conductor({"r1": _request_data()})
+    c._abort_request("r1")
+    c._sweep_expiry()
+    assert "r1" in c.draining
+    assert _remove_targets(c, "r1") == set()
+
+
+def test_stale_early_entries_are_swept():
+    """Early ACKs and abort tombstones for requests that never come back must
+    not pile up."""
+    c = _conductor({}, drain_ttl_s=0.0)
+    c._handle_reads_done(ReadsDone(request_id="gone", entity_id="w0"))
+    c._abort_request("also-gone")
+    assert c._early_reads_done and c._early_abort_requests
+
+    c._sweep_expiry()
+    assert not c._early_reads_done
+    assert not c._early_abort_requests
+    assert not c._early_reads_done_deadlines
+    assert not c._early_abort_deadlines

--- a/test/modular/test_worker_drain.py
+++ b/test/modular/test_worker_drain.py
@@ -1,0 +1,212 @@
+"""Worker- and preprocess-worker-side teardown drain.
+
+DRAIN_REQUEST stops scheduling/reading a request and ACKs READS_DONE once its
+in-flight reads finish; the hard cleanup (force_cleanup_request) waits for the
+conductor's REMOVE_REQUEST. No read may start for a draining request.
+"""
+
+from types import SimpleNamespace
+
+from mstar.utils.ipc_format import (
+    ConductorMessageType,
+    DrainRequest,
+    InputSignals,
+    MessageSource,
+    RemoveRequest,
+)
+from mstar.worker.worker import Worker
+
+
+# ── worker ──────────────────────────────────────────────────────────────────
+
+def _worker(
+    known_rids=("X",), in_flight=(), draining=(), reads_done=(),
+    pending_drains=(), inflight_reads=False, is_follower=False,
+):
+    w = Worker.__new__(Worker)
+    w.worker_id = "w0"
+    w.is_tp_follower = is_follower
+    w.sent = []
+    w.cleared = []
+    w.forced = []
+    w.communicator = SimpleNamespace(send=lambda e, m: w.sent.append((e, m)))
+    w._in_flight_rids = set(in_flight)
+    w._pending_drains = set(pending_drains)
+    w._draining_rids = set(draining)
+    w._reads_done_sent = set(reads_done)
+    w._pending_removes = set()
+    w._last_active = {}
+    w.streaming_buffers = {}
+    w.scheduler = SimpleNamespace(clear_rid=lambda rid: w.cleared.append(rid))
+    w.worker_graphs_manager = SimpleNamespace(
+        per_request_info={
+            rid: SimpleNamespace(sharding_config=SimpleNamespace(groups=[]))
+            for rid in known_rids
+        },
+        remove_request=lambda rid: None,
+    )
+    w.engine_manager = SimpleNamespace(
+        remove_request=lambda rid: None, lru_tracked_nodes=lambda: [],
+    )
+    w.profile_info = SimpleNamespace(pop_request=lambda rid: None)
+    w.tensor_manager = SimpleNamespace(
+        has_inflight_reads=lambda rid: inflight_reads,
+        force_cleanup_request=lambda rid: w.forced.append(rid),
+    )
+    return w
+
+
+def _reads_done(w):
+    return [
+        m for e, m in w.sent
+        if e == "conductor" and m.message_type == ConductorMessageType.READS_DONE
+    ]
+
+
+def test_drain_acks_reads_done_when_no_inflight_reads():
+    w = _worker(inflight_reads=False)
+    Worker._drain_request(w, DrainRequest(request_id="X"))
+
+    assert "X" in w._draining_rids  # reads gated until REMOVE
+    assert "X" in w._reads_done_sent
+    assert "X" in w.cleared  # scheduler stopped from starting new work
+    acks = _reads_done(w)
+    assert len(acks) == 1
+    assert acks[0].body.request_id == "X"
+    assert acks[0].body.entity_id == "w0"
+
+
+def test_drain_waits_for_inflight_reads_then_acks():
+    w = _worker(inflight_reads=True)
+    Worker._drain_request(w, DrainRequest(request_id="X"))
+    assert "X" in w._draining_rids and not _reads_done(w)
+
+    # Async reads finish; the run-loop hook re-checks and now ACKs.
+    w.tensor_manager.has_inflight_reads = lambda rid: False
+    Worker._apply_pending_drains(w, set())
+    assert len(_reads_done(w)) == 1
+
+
+def test_drain_deferred_behind_inflight_gpu_step():
+    w = _worker(in_flight=("X",))
+    Worker._drain_request(w, DrainRequest(request_id="X"))
+    # Held until the GPU step referencing the rid is gone.
+    assert "X" in w._pending_drains and "X" not in w._draining_rids
+    assert not _reads_done(w)
+
+    Worker._apply_pending_drains(w, set())  # step finished
+    assert "X" in w._draining_rids and len(_reads_done(w)) == 1
+
+
+def test_follower_ignores_conductor_drain():
+    w = _worker(is_follower=True)
+    Worker._drain_request(w, DrainRequest(request_id="X"))  # source=CONDUCTOR
+    assert "X" not in w._draining_rids and not w.sent
+
+    # ... but honors the leader's forwarded drain.
+    Worker._drain_request(
+        w, DrainRequest(request_id="X", source=MessageSource.TP_RANK_0)
+    )
+    assert "X" in w._draining_rids and len(_reads_done(w)) == 1
+
+
+def test_drain_acks_only_once():
+    w = _worker(inflight_reads=False)
+    Worker._drain_request(w, DrainRequest(request_id="X"))
+    Worker._drain_request(w, DrainRequest(request_id="X"))
+    assert len(_reads_done(w)) == 1
+
+
+def test_remove_force_cleans_and_clears_drain_state():
+    w = _worker(draining=("X",), reads_done=("X",))
+    Worker._remove_request(w, RemoveRequest(request_id="X"))
+    assert w.forced == ["X"]
+    assert "X" not in w._draining_rids
+    assert "X" not in w._reads_done_sent
+
+
+def test_process_new_inputs_skips_reads_for_draining_rid():
+    w = _worker(draining=("X",))
+
+    def _boom(*a, **k):
+        raise AssertionError("must not start a read while draining")
+
+    w.tensor_manager.start_read_tensors = _boom
+    # Returns before touching the read path.
+    Worker._process_new_inputs(
+        w, InputSignals(request_id="X", inputs=[], request_info=None)
+    )
+
+
+def test_add_new_request_skips_draining_rid():
+    w = _worker(draining=("X",))
+    # Bails before touching engine/graph managers (out-of-order NEW after DRAIN).
+    Worker._add_new_request(w, SimpleNamespace(request_id="X"))
+
+
+# ── preprocess worker ───────────────────────────────────────────────────────
+
+def _preprocess(inflight_reads=False):
+    from mstar.api_server.data_worker import PreprocessWorkerThread
+
+    wt = PreprocessWorkerThread.__new__(PreprocessWorkerThread)
+    wt._draining_rids = set()
+    wt._reads_done_sent = set()
+    wt.sent = []
+    wt.forced = []
+    wt.communicator = SimpleNamespace(send=lambda e, m: wt.sent.append((e, m)))
+    wt.tensor_manager = SimpleNamespace(
+        has_inflight_reads=lambda rid: inflight_reads,
+        force_cleanup_request=lambda rid: wt.forced.append(rid),
+    )
+    wt.tensor_uuid_to_metadata_per_request = {}
+    wt.request_model_kwargs = {}
+    return wt
+
+
+def _pw_reads_done(wt):
+    return [
+        m for e, m in wt.sent
+        if e == "conductor" and m.message_type == ConductorMessageType.READS_DONE
+    ]
+
+
+def test_preprocess_drain_acks_when_reads_done():
+    wt = _preprocess(inflight_reads=False)
+    wt._begin_drain("X")
+    assert "X" in wt._reads_done_sent
+    acks = _pw_reads_done(wt)
+    assert len(acks) == 1
+    assert acks[0].body.entity_id == "api_server_preprocess_worker"
+
+
+def test_preprocess_drain_waits_for_reads():
+    wt = _preprocess(inflight_reads=True)
+    wt._begin_drain("X")
+    assert "X" in wt._draining_rids and not _pw_reads_done(wt)
+
+    wt.tensor_manager.has_inflight_reads = lambda rid: False
+    wt._complete_drain_if_ready("X")
+    assert len(_pw_reads_done(wt)) == 1
+
+
+def test_preprocess_reads_done_idempotent():
+    wt = _preprocess()
+    wt._send_reads_done("X")
+    wt._send_reads_done("X")
+    assert len(_pw_reads_done(wt)) == 1
+
+
+def test_preprocess_hard_cleanup_force_drops_and_clears():
+    wt = _preprocess()
+    wt._draining_rids.add("X")
+    wt._reads_done_sent.add("X")
+    wt.tensor_uuid_to_metadata_per_request["X"] = {"u": {}}
+    wt.request_model_kwargs["X"] = {}
+
+    wt._hard_cleanup("X")
+    assert wt.forced == ["X"]
+    assert "X" not in wt._draining_rids
+    assert "X" not in wt._reads_done_sent
+    assert "X" not in wt.tensor_uuid_to_metadata_per_request
+    assert "X" not in wt.request_model_kwargs

--- a/test/modular/test_worker_drain.py
+++ b/test/modular/test_worker_drain.py
@@ -16,7 +16,6 @@ from mstar.utils.ipc_format import (
 )
 from mstar.worker.worker import Worker
 
-
 # ── worker ──────────────────────────────────────────────────────────────────
 
 def _worker(
@@ -37,7 +36,7 @@ def _worker(
     w._pending_removes = set()
     w._last_active = {}
     w.streaming_buffers = {}
-    w.scheduler = SimpleNamespace(clear_rid=lambda rid: w.cleared.append(rid))
+    w.scheduler = SimpleNamespace(clear_rid=lambda rid: w.cleared.append(rid)) # noqa: PLW0108
     w.worker_graphs_manager = SimpleNamespace(
         per_request_info={
             rid: SimpleNamespace(sharding_config=SimpleNamespace(groups=[]))
@@ -51,7 +50,7 @@ def _worker(
     w.profile_info = SimpleNamespace(pop_request=lambda rid: None)
     w.tensor_manager = SimpleNamespace(
         has_inflight_reads=lambda rid: inflight_reads,
-        force_cleanup_request=lambda rid: w.forced.append(rid),
+        force_cleanup_request=lambda rid: w.forced.append(rid), # noqa: PLW0108
     )
     return w
 
@@ -157,7 +156,7 @@ def _preprocess(inflight_reads=False):
     wt.communicator = SimpleNamespace(send=lambda e, m: wt.sent.append((e, m)))
     wt.tensor_manager = SimpleNamespace(
         has_inflight_reads=lambda rid: inflight_reads,
-        force_cleanup_request=lambda rid: wt.forced.append(rid),
+        force_cleanup_request=lambda rid: wt.forced.append(rid), # noqa: PLW0108
     )
     wt.tensor_uuid_to_metadata_per_request = {}
     wt.request_model_kwargs = {}

--- a/test/modular/test_worker_drain.py
+++ b/test/modular/test_worker_drain.py
@@ -20,13 +20,14 @@ from mstar.worker.worker import Worker
 
 def _worker(
     known_rids=("X",), in_flight=(), draining=(), reads_done=(),
-    pending_drains=(), inflight_reads=False, is_follower=False,
+    pending_drains=(), inflight_reads=False, is_follower=False, tp_follow=(),
 ):
     w = Worker.__new__(Worker)
     w.worker_id = "w0"
     w.is_tp_follower = is_follower
     w.sent = []
     w.cleared = []
+    w.failed = set()
     w.forced = []
     w.communicator = SimpleNamespace(send=lambda e, m: w.sent.append((e, m)))
     w._in_flight_rids = set(in_flight)
@@ -36,7 +37,11 @@ def _worker(
     w._pending_removes = set()
     w._last_active = {}
     w.streaming_buffers = {}
-    w.scheduler = SimpleNamespace(clear_rid=lambda rid: w.cleared.append(rid)) # noqa: PLW0108
+    w.scheduler = SimpleNamespace(
+        clear_rid=lambda rid: w.cleared.append(rid),  # noqa: PLW0108
+        fail_rids=lambda rids: w.failed.update(rids),  # noqa: PLW0108
+        pending_tp_follow_count=dict.fromkeys(tp_follow, 1),
+    )
     w.worker_graphs_manager = SimpleNamespace(
         per_request_info={
             rid: SimpleNamespace(sharding_config=SimpleNamespace(groups=[]))
@@ -68,7 +73,8 @@ def test_drain_acks_reads_done_when_no_inflight_reads():
 
     assert "X" in w._draining_rids  # reads gated until REMOVE
     assert "X" in w._reads_done_sent
-    assert "X" in w.cleared  # scheduler stopped from starting new work
+    assert "X" in w.failed  # scheduler stopped from starting new leader work
+    assert "X" not in w.cleared  # but state kept until REMOVE
     acks = _reads_done(w)
     assert len(acks) == 1
     assert acks[0].body.request_id == "X"
@@ -82,6 +88,19 @@ def test_drain_waits_for_inflight_reads_then_acks():
 
     # Async reads finish; the run-loop hook re-checks and now ACKs.
     w.tensor_manager.has_inflight_reads = lambda rid: False
+    Worker._apply_pending_drains(w, set())
+    assert len(_reads_done(w)) == 1
+
+
+def test_drain_waits_for_committed_tp_follow_batches():
+    """A queued TP-follow batch (leader already sent the ZMQ) must drain before
+    READS_DONE, or REMOVE tears the worker-graph queues out from under it."""
+    w = _worker(tp_follow=("X",))
+    Worker._drain_request(w, DrainRequest(request_id="X"))
+    assert "X" in w._draining_rids and not _reads_done(w)
+
+    # The follow batch gets scheduled; count drops to 0.
+    w.scheduler.pending_tp_follow_count.pop("X")
     Worker._apply_pending_drains(w, set())
     assert len(_reads_done(w)) == 1
 

--- a/test/modular/test_worker_drain.py
+++ b/test/modular/test_worker_drain.py
@@ -215,6 +215,28 @@ def test_preprocess_reads_done_idempotent():
     assert len(_pw_reads_done(wt)) == 1
 
 
+def test_preprocess_finished_reading_acks_immediately_when_drained():
+    """Happy path: delivery completed, so the ACK goes out without paying for a
+    drain check (and without gating on reads that cannot exist)."""
+    wt = _preprocess(inflight_reads=True)  # would block a gated ACK
+    wt._finish_reading("X", drained=True)
+    assert len(_pw_reads_done(wt)) == 1
+    assert "X" not in wt._draining_rids
+
+
+def test_preprocess_finished_reading_gates_ack_when_not_drained():
+    """Abandoned delivery (TTL / client gone): reads may still be in flight, so
+    the ACK must wait for them rather than let the conductor unlink under one."""
+    wt = _preprocess(inflight_reads=True)
+    wt._finish_reading("X", drained=False)
+    assert not _pw_reads_done(wt)
+    assert "X" in wt._draining_rids
+
+    wt.tensor_manager.has_inflight_reads = lambda rid: False
+    wt._complete_drain_if_ready("X")
+    assert len(_pw_reads_done(wt)) == 1
+
+
 def test_preprocess_hard_cleanup_force_drops_and_clears():
     wt = _preprocess()
     wt._draining_rids.add("X")

--- a/test/modular/test_worker_drain.py
+++ b/test/modular/test_worker_drain.py
@@ -50,7 +50,7 @@ def _worker(
         remove_request=lambda rid: None,
     )
     w.engine_manager = SimpleNamespace(
-        remove_request=lambda rid: None, lru_tracked_nodes=lambda: [],
+        remove_request=lambda rid: None, evictable_nodes=lambda: [],
     )
     w.profile_info = SimpleNamespace(pop_request=lambda rid: None)
     w.tensor_manager = SimpleNamespace(


### PR DESCRIPTION
## Problem

Aborting a request could unlink a preprocess-worker input-signal SHM segment (or a buffer with an active RDMA read) while an engine rank still had a scheduled read of it, so the rank's read hit `FileNotFoundError`, the main loop died, and every in-flight request on that rank failed.

Root cause: `cleanup_request` force-cleared the `persist` flag, GC-ing a persisted signal (`ref_cnt==0`, kept alive only by persist) the instant a request was torn down, with no ordering against peers still reading it. Persist signals do not get a valid refcout because we don't know a priori where/to how many places they will get sent; that is determined by arbitrary model-level behavior and tracked at runtime by the conductor, only sent to the appropriate entities when the model (on the conductor end) decides to "unpersist" a tensor.

## Fix

Teardown becomes a conductor-coordinated barrier: the hard cleanup that unlinks a segment (`RemoveRequest` → `force_cleanup_request`) is sent only after every reader has confirmed it has drained via a new `READS_DONE` ACK.

- **Abort/fail**: conductor sends `DrainRequest` to all workers + the preprocess worker; each stops scheduling/reading the rid, waits for its in-flight reads to finish, and ACKs `READS_DONE`. Once all ACK, the conductor sends `RemoveRequest`. Fail defers `request_failed` to the client until then.
    - **TP followers** also wait to drain their follow queues before sending an ACK to the conductor, to avoid deadlocking other ranks on collectives. This may result in one step of extra work on an abort (the same price as speculative scheduling, e.g.).
- **Happy path**: in the interest of unchanged client latency, `request_complete` still fires immediately, still-held signals are unpersisted with correct ref counts, and `RemoveRequest` is deferred until the preprocess worker's `READS_DONE` (workers assumed done reading).
- `cleanup_request` no longer force-drops persisted signals; `force_cleanup_request` is the new unconditional hard drop, used only post-barrier (also reclaims leaked non-persisted buffers).

## Files
`ipc_format` (DrainRequest, READS_DONE) · `tensors` (force_cleanup_request, has_inflight_reads, drop the force-unpersist) · `worker` (drain handler, hard Remove, read-gates) · `data_worker` (drain-on-abort, drain/remove handlers, finished_reading) · `conductor` (barrier state machine) · `entrypoint` (emit READS_DONE at drained).

## Testing
+23 CPU unit tests (transport regression, conductor barrier, worker/preprocess drain); updated 3 tests to the new contract. Full modular suite: no new failures.

Ran cosmos3 TP2 SP2 under a mixed image/video workload and mixture of aborted/not aborted requests: `1285 aborts + 215 completions, concurrency 14, mixed modality — 0 failures`, with no SHM leak detected ether.

## Known tradeoff
`RemoveRequest` now frees worker KV only after the barrier, so a completed request holds its slot slightly longer under load. Client completion latency is unchanged. Splitting teardown (free KV at done, gate only the unlink) can be a follow-up.

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
