### PR TITLE
Ragged prefill wrapper

### DIFF
--- a/docs/adding_models.rst
+++ b/docs/adding_models.rst
@@ -1083,11 +1083,6 @@ The V-JEPA2 AC predictor is the reference implementation. See
 before the region, a captured block loop that reads the KV cache over a fixed per-step
 sequence, and an eager section after the region.
 
-BAGEL's ViT tower is the packed, cacheless counterpart. See
-``mstar/model/bagel/submodules.py``, region ``"vit_block_loop"``: a
-``PiecewisePackedConfig`` whose region declares only ragged attention, with patch
-embedding and the RoPE gathers left eager because they are data-dependent indexing.
-
 .. code-block:: python
 
    from mstar.engine.cuda_graph_config import (
@@ -1151,6 +1146,11 @@ Second, the same block loop is used on both the captured path and the eager path
 code exists in one place only. Third, the region's ``declare_step`` covers only the
 captured path. The eager path is covered by the submodule's own ``declare_step``, as shown
 under **Splitting the declaration** above.
+
+BAGEL's ViT tower is the packed, cacheless counterpart. See
+``mstar/model/bagel/submodules.py``, region ``"vit_block_loop"``: a
+``PiecewisePackedConfig`` whose region declares only ragged attention, with patch
+embedding and the RoPE gathers left eager because they are data-dependent indexing.
 
 .. _config-yaml:
 

--- a/docs/adding_models.rst
+++ b/docs/adding_models.rst
@@ -247,7 +247,8 @@ three common fields:
 - ``depends_on()`` returns the keys of other specs that this spec is built against.
   ``AttentionSpec`` and ``PositionSpec`` depend on the ``kv_cache`` key they name. If a
   spec names a dependency that the model does not declare, loading fails immediately,
-  rather than during a forward pass.
+  rather than during a forward pass. ``RaggedAttentionSpec`` is the one attention spec
+  that depends on nothing: it names no cache, because it has none.
 
 The spec types are:
 
@@ -270,6 +271,14 @@ The spec types are:
    * - ``CrossAttentionSpec(config=CrossAttentionConfig(...))``
      - Attention over a context that is written once and never extended. See
        `Cross-attention (encoder-decoder models)`_.
+   * - ``RaggedAttentionSpec(config=RaggedAttentionConfig(...))``
+     - Cacheless (ragged) varlen self-attention over the segments packed into one
+       forward. Nothing is paged, and nothing carries to the next step.
+       ``RaggedAttentionConfig`` holds ``num_qo_heads``, ``num_kv_heads`` and
+       ``head_dim`` (all pre-sharding, as in ``KVConfig``), an ``sm_scale`` that
+       defaults to ``head_dim ** -0.5``, ``flashinfer_backend``, and the two
+       CUDA-graph ceilings ``max_segments_per_request`` and
+       ``max_tokens_per_request``. See `Cacheless attention (encoder towers)`_.
    * - ``PositionSpec(config=PositionConfig(kv_cache=...))``
      - Position tracking and RoPE. ``scheme`` is ``PosScheme.SEQUENTIAL`` or
        ``PosScheme.BLOCK``. The RoPE parameters are set here: ``rope_theta``,
@@ -341,8 +350,14 @@ appears in no spec, so it receives no resources:
        and a ``CrossAttentionSpec`` over that second cache.
    * - A node that samples with two different sets of parameters
      - Two ``SamplerSpec`` objects that both name the node, under different keys.
+   * - An encoder tower that attends within the segments of one packed forward
+     - A ``RaggedAttentionSpec``, and nothing else. No ``KVSpec`` and no
+       ``PositionSpec``: there is no cache to page and no counter to advance. Needed
+       only if the tower's attention must run inside a CUDA graph; see
+       `Cacheless attention (encoder towers)`_.
    * - ViT, VAE or audio encoder, codec decoder, projection stage, combine stage
-     - Nothing. Declare no spec that names the node.
+     - Usually nothing. Declare no spec that names the node, unless the node needs the
+       row above.
 
 Two samplers on one node
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -425,6 +440,58 @@ writes into the context label::
 A model with several context sources, such as "audio" and "image", declares one
 ``CrossAttentionSpec`` per source. Each source is a separate resource, and the source name
 is also the key that the layer binds to.
+
+.. _Cacheless attention (encoder towers):
+
+Cacheless attention (encoder towers)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A ViT or audio encoder attends within its own sequence and keeps nothing afterwards.
+Several images are packed into one forward, and each must attend only within its own
+span. That is varlen, or "ragged", attention: the whole layout belongs to this step, and
+nothing carries to the next.
+
+Such a tower needs no resource at all if it calls a varlen kernel directly, passing
+``cu_seqlens`` as an argument. Declare a ``RaggedAttentionSpec`` when the tower must run
+inside a CUDA graph. The plan is what makes that possible: the engine plans the layout
+outside the graph, into buffers whose addresses do not change, and the captured region
+attends through them. A kernel that reads ``cu_seqlens`` as an argument, or builds its
+mask from it, cannot be captured this way.
+
+BAGEL's SigLIP2 tower is the reference implementation. The spec stands alone, over the
+encoder node only, and names no cache:
+
+.. code-block:: python
+
+   RaggedAttentionSpec(
+       resource_key=VIT_ATTN, nodes={"vit_encoder"},
+       config=RaggedAttentionConfig(
+           num_qo_heads=vit.num_attention_heads,
+           num_kv_heads=vit.num_attention_heads,
+           head_dim=vit.hidden_size // vit.num_attention_heads,
+           # one image, hence one attending segment, per request
+           max_segments_per_request=1,
+       ),
+   )
+
+A layer binds the key as it binds any other resource, then attends through the resource's
+``run(q, k, v, label=None)``. There is no KV write to pair it with, so no
+``AttentionCallable`` is involved.
+
+The step is an ordinary ``AttentionStep``, and its ``segments`` are the entire layout.
+There is no cache to read the layout off, so a label that carries no segment in the
+declaration cannot be attended: the forward raises, rather than silently reusing the
+previous step's plan. Because the tower is normally captured as a piecewise region, that
+declaration lives in the region's ``declare_step``, and names no ``KVStep``. See
+``mstar/model/bagel/submodules.py``, region ``"vit_block_loop"``, and `Piecewise CUDA
+graphs (capturing an inner loop)`_.
+
+.. note::
+
+   The eager varlen path is sometimes good to have. The BAGEL ViT has a head dimension of
+   72, which the FlashInfer kernel — it supports only a few fixed head dimensions — forces
+   us to zero-pad to 128. So that tower attends through the resource only when it is
+   replaying a captured graph, and runs flash-attn varlen otherwise.
 
 Step 3 — Declare the computation graph
 --------------------------------------
@@ -594,7 +661,9 @@ resource key:
 - The ``segments`` argument of ``SubmoduleStep`` is a default value. Any ``ResourceStep``
   that does not set its own ``segments`` uses this list.
 - ``KVStep(commit=, combined_labels=, pre_forks=, post_forks=)``. See below.
-- ``AttentionStep(causal=)`` describes the attention plan.
+- ``AttentionStep(causal=)`` describes the attention plan. A ``RaggedAttentionSpec``
+  steps through this same type. There, the segments are the whole layout rather than an
+  extension of a cache. See `Cacheless attention (encoder towers)`_.
 - ``PositionStep(pos_ids=, advance=)``. With ``pos_ids=None``, positions are derived from
   the stream counters. Pass explicit ids, keyed by plan label, when the model computes
   positions itself.
@@ -948,7 +1017,9 @@ Both types share the base ``PiecewiseCudaGraphConfig`` fields:
   ``declare_step`` because the region has its own shape. The runner admits, plans and
   commits this step on each replay. This field replaces the removed ``uses_kv_cache``,
   ``plan_fn``, ``advance_seq_lens`` and ``cache_labels`` fields. A region that reads a KV
-  cache declares a ``KVStep`` and an ``AttentionStep`` here.
+  cache declares a ``KVStep`` and an ``AttentionStep`` here. A cacheless region that uses
+  ragged attention declares only an ``AttentionStep``, against its
+  ``RaggedAttentionSpec`` key.
 - ``lease_before_step`` makes the runner take this region's CUDA-graph slot before the
   outer ``declare_step`` runs, and report the slot in that call's ``piecewise_leases``
   argument. The region still declares, plans and commits its own work. The lease only
@@ -1011,6 +1082,11 @@ The V-JEPA2 AC predictor is the reference implementation. See
 ``mstar/model/vjepa2/submodules.py``, region ``"block_loop"``. It has an eager section
 before the region, a captured block loop that reads the KV cache over a fixed per-step
 sequence, and an eager section after the region.
+
+BAGEL's ViT tower is the packed, cacheless counterpart. See
+``mstar/model/bagel/submodules.py``, region ``"vit_block_loop"``: a
+``PiecewisePackedConfig`` whose region declares only ragged attention, with patch
+embedding and the RoPE gathers left eager because they are data-dependent indexing.
 
 .. code-block:: python
 
@@ -1131,6 +1207,11 @@ that a misspelled setting is never silently ignored:
    * - ``AttentionSpec`` / ``CrossAttentionSpec``
      - ``backend`` (``flashinfer`` / ``dense``), ``flashinfer_backend``
        (``auto`` / ``fa2`` / ``fa3``)
+   * - ``RaggedAttentionSpec``
+     - ``flashinfer_backend`` (``auto`` / ``fa2`` / ``fa3``),
+       ``max_segments_per_request``, ``max_tokens_per_request``. The two ceilings size
+       CUDA-graph buckets, which is a memory-against-coverage trade the deployment makes,
+       not the model.
 
 Tune the cache shape on the KV resource, not on the attention resource that reads it. For
 example, ``configs/qwen3tts.yaml`` selects FA2 under ``talker_attn``, while
@@ -1263,15 +1344,18 @@ logic), and a VAE decoder. It has four more nodes for the CFG-parallel image-gen
 path described below: ``init_latents``, the two branch nodes ``LLM_cfg_text`` and
 ``LLM_cfg_img``, and ``combine_cfg``.
 
-Only the three LLM nodes need resources, and all three share one set of them: the same KV
-pool, attention, positions and sampler. Each spec names all three nodes in its ``nodes``
-field:
+The three LLM nodes share one set of resources: the same KV pool, attention, positions and
+sampler. Each of those specs names all three nodes in its ``nodes`` field. The ViT encoder
+declares one resource of its own, a ``RaggedAttentionSpec`` with no cache behind it, so
+that its block loop can be CUDA-graph captured:
 
 .. code-block:: python
 
    def get_node_resources(self) -> list[NodeResourceSpec]:
        nodes = set(self._LLM_NODES)   # {"LLM", "LLM_cfg_text", "LLM_cfg_img"}
        return [
+           RaggedAttentionSpec(resource_key=VIT_ATTN, nodes={"vit_encoder"},
+                               config=RaggedAttentionConfig(...)),
            KVSpec(resource_key="kv", nodes=nodes, config=self._kv_config()),
            AttentionSpec(resource_key="attn", nodes=nodes,
                          config=AttentionConfig(kv_cache="kv")),
@@ -1282,10 +1366,10 @@ field:
                        vocab_size=self.config.vocab_size),
        ]
 
-No spec names the encoders, ``init_latents``, ``combine_cfg`` or the VAE decoder, so those
-nodes receive no resources. The CFG nodes are always declared, but they are used only when
-the config enables CFG-parallel mode, described under Step 6. A single-GPU config never
-routes requests to them.
+No spec names the VAE encoder, ``init_latents``, ``combine_cfg`` or the VAE decoder, so
+those nodes receive no resources. The CFG nodes are always declared, but they are used
+only when the config enables CFG-parallel mode, described under Step 6. A single-GPU
+config never routes requests to them.
 
 **Per-request resources.** Whether a request uses classifier-free guidance determines
 which cache labels it reads. This is a property of the request, not of the deployment.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -20,10 +20,11 @@ High-level components
   runs each step's resource lifecycle: admit, plan, forward, commit.
 - **Resources** (``mstar/engine/resources/``): the state that a node's compute uses. This
   includes paged KV caches, the attention planned over them (FlashInfer or dense),
-  cross-attention over a fixed context, position embeddings, and samplers. A model
+  cross-attention over a fixed context, cacheless (ragged) attention for encoder towers
+  that attend within one packed forward, position embeddings, and samplers. A model
   declares which resources each node needs, and the engine builds them. A node that
-  declares no resources receives none. ViT and VAE encoders, codec decoders, and
-  projection and combine stages are examples.
+  declares no resources receives none. VAE encoders, codec decoders, and projection and
+  combine stages are examples.
 - **Models** (``mstar/model/``): each model declares its computation graph, tokenization,
   node resources, and submodules. Registered via ``mstar/model/registry.py``.
 - **Graph** (``mstar/graph/``): computation-graph primitives — ``GraphNode``,

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -98,6 +98,45 @@ Communication
      - Under ``--log-stats``: how often the arena logs its occupancy /
        fragmentation snapshot (segments, free bytes, largest contiguous
        free block, pinned bytes).
+
+Models
+------
+
+Per-model knobs, read when the submodule is built. They are scoped to one
+model, so they are named for it.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 14 58
+
+   * - Variable
+     - Default
+     - Meaning
+   * - ``MSTAR_VIT_BATCHING``
+     - ``0``
+     - BAGEL: batch several requests through the ViT encoder in one forward.
+       Off by default because flash-attn's varlen reductions across packed
+       images produce small bf16 drift, which at greedy ``temperature=0`` can
+       flip a downstream LLM argmax. When off, ``prefill_vit`` runs one
+       request at a time.
+   * - ``MSTAR_VIT_CUDA_GRAPH``
+     - ``0``
+     - BAGEL: CUDA-graph capture of the ViT block loop, over the node's ragged
+       attention resource (see :doc:`adding_models`). Off by default: capture
+       costs one graph per (batch size, token bucket) and the eager
+       flash-attn path is already fast. The win is removing per-layer launch
+       overhead on small images.
+   * - ``MSTAR_VIT_CG_TOKEN_BUCKETS``
+     - ``512,1024,2048,4096,4900``
+     - Comma-separated token-count buckets to capture, when
+       ``MSTAR_VIT_CUDA_GRAPH=1``. A batch longer than the largest bucket runs
+       eagerly. ``4900`` is ``70*70``, the exact length the ``vllm``
+       preprocess option emits.
+   * - ``MSTAR_VIT_CG_BATCH_SIZES``
+     - ``1,2,4``
+     - Comma-separated batch sizes to capture. Read only when
+       ``MSTAR_VIT_BATCHING=1``; otherwise only batch size 1 is captured.
+
 Serving (Rust frontend)
 -----------------------
 

--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -197,6 +197,8 @@ them by that name:
        max_num_pages: 1024      # also: page_size, max_seq_len, cpu_offload_pages
      talker_attn:
        flashinfer_backend: fa2  # also: backend (flashinfer / dense)
+     vit_attn:                  # a cacheless (ragged) attention resource
+       max_segments_per_request: 2  # also: max_tokens_per_request, flashinfer_backend
 
 Use one block per resource. A model with two caches, such as Whisper's decoder cache and
 its encoder context, can therefore size each one separately. If a block names a resource

--- a/mstar/engine/resources/__init__.py
+++ b/mstar/engine/resources/__init__.py
@@ -19,6 +19,10 @@ from mstar.engine.resources.attn.config import (
     CrossAttentionConfig,
     CrossAttentionSpec,
 )
+from mstar.engine.resources.attn.ragged.config import (
+    RaggedAttentionConfig,
+    RaggedAttentionSpec,
+)
 from mstar.engine.resources.base import CGSlotSpec, PublishedInfo, Resource
 from mstar.engine.resources.kv.config import (
     KVConfig,
@@ -88,6 +92,8 @@ __all__ = [
     "PositionSpec",
     "PositionStep",
     "PublishedInfo",
+    "RaggedAttentionConfig",
+    "RaggedAttentionSpec",
     "Resource",
     "ResourceReqConfig",
     "ResourceStep",

--- a/mstar/engine/resources/attn/ragged/base.py
+++ b/mstar/engine/resources/attn/ragged/base.py
@@ -1,0 +1,33 @@
+"""The cacheless attention resource: the spec-time factory.
+
+Sibling of ``attn.base``'s ``AttentionManager``, for attention that is not
+backed by a KV cache, e.g., an encoder tower attending within variable-length
+segments of one packed forward. There is nothing to page, nothing to advance,
+and nothing to carry between steps: the resource holds only planned wrappers.
+"""
+
+from mstar.engine.resources.attn.ragged.config import RaggedAttentionSpec
+from mstar.engine.resources.base import AttentionResource, EngineResourceInfo
+
+
+class RaggedAttnManager(AttentionResource):
+    # Remains abstract except for build; will build based on the backend.
+
+    @classmethod
+    def build(cls, spec: RaggedAttentionSpec, info: EngineResourceInfo):
+        # NOTE: only flashinfer backend for now, to add more backends, we would
+        # have to add ``backend: AttnBackend`` to the RaggedAttentionSpec.
+        # Deferred so naming the spec does not load FlashInfer, and because
+        # `flashinfer` imports this class back.
+        from mstar.engine.resources.attn.ragged.flashinfer import (
+            FlashInferRaggedManager,
+        )
+
+        config = spec.config
+        if info.joint_comm_group is not None:
+            config.shard(info.joint_comm_group.world_size)
+        return FlashInferRaggedManager(
+            device=info.device,
+            dtype=info.kv_dtype,
+            config=config,
+        )

--- a/mstar/engine/resources/attn/ragged/config.py
+++ b/mstar/engine/resources/attn/ragged/config.py
@@ -1,0 +1,100 @@
+"""What a model declares about cacheless (ragged) attention.
+
+Kept free of the manager and its kernels, like the other resources' configs, so
+a submodule can declare a step without pulling FlashInfer in behind it.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from mstar.engine.resources.spec import NodeResourceSpec
+
+if TYPE_CHECKING:
+    from mstar.engine.resources.base import Resource
+
+
+@dataclass
+class RaggedAttentionConfig:
+    """Varlen self-attention over segments packed into one forward, with no KV
+    cache: the whole layout is this step's, and nothing carries to the next.
+
+    Head counts are **pre-sharding**; the engine narrows them to the rank's
+    slice at build, as it does for a ``KVConfig``.
+    """
+
+    num_qo_heads: int
+    num_kv_heads: int
+    head_dim: int
+
+    # Defaults to head_dim ** -0.5 on the TRUE head dim; FlashInfer's own
+    # default would derive it from the padded one (see `padded_head_dim`).
+    sm_scale: float | None = None
+
+    # Per-request ceiling sizing a CUDA-graph bucket: a capture at batch size
+    # `bs` gets `bs` times this. A "segment" is an independently-attending
+    # span, not a request — a request carrying several images contributes
+    # several.
+    max_segments_per_request: int = 1
+    # Only for a runner that buckets by batch size alone; elsewhere the
+    # bucket's own token count is the ceiling and this stays None.
+    max_tokens_per_request: int | None = None
+
+    flashinfer_backend: str = "auto"
+
+    def __post_init__(self):
+        if self.sm_scale is None:
+            self.sm_scale = self.head_dim ** -0.5
+        self._unsharded_qo_heads = self.num_qo_heads
+        self._unsharded_kv_heads = self.num_kv_heads
+
+    def shard(self, num_shards: int) -> None:
+        """Narrow the head counts to one rank's slice; see ``KVConfig.shard``.
+
+        Idempotent, so a rebuild (or a second manager over one config) is free.
+        """
+        from mstar.distributed.utils import divide
+
+        if num_shards >= self._unsharded_kv_heads:
+            # fewer KV heads than ranks — every rank replicates one
+            self.num_kv_heads = 1
+        else:
+            self.num_kv_heads = divide(self._unsharded_kv_heads, num_shards)
+        self.num_qo_heads = divide(self._unsharded_qo_heads, num_shards)
+
+    def max_segments_for(self, bs: int) -> int:
+        return bs * self.max_segments_per_request
+
+    def max_tokens_for(self, bs: int) -> int | None:
+        if self.max_tokens_per_request is None:
+            return None
+        return bs * self.max_tokens_per_request
+
+
+@dataclass
+class RaggedAttentionSpec(NodeResourceSpec):
+    config: RaggedAttentionConfig
+
+    @property
+    def resource_class(self) -> "type[Resource]":
+        from mstar.engine.resources.attn.ragged.base import RaggedAttnManager
+
+        return RaggedAttnManager
+
+    def apply_yaml_overrides(
+        self,
+        flashinfer_backend: str | None = None,
+        max_segments_per_request: int | None = None,
+        max_tokens_per_request: int | None = None,
+    ):
+        """Which kernel to run is the deployment's call as much as the model's —
+        an image that cannot build FA3 pins FA2 here.
+
+        The two ceilings are here rather than on the model because they size
+        CUDA-graph buckets, which is a deployment's memory/coverage trade.
+        """
+        if flashinfer_backend is not None:
+            self.config.flashinfer_backend = flashinfer_backend
+        if max_segments_per_request is not None:
+            self.config.max_segments_per_request = max_segments_per_request
+        if max_tokens_per_request is not None:
+            self.config.max_tokens_per_request = max_tokens_per_request

--- a/mstar/engine/resources/attn/ragged/flashinfer.py
+++ b/mstar/engine/resources/attn/ragged/flashinfer.py
@@ -1,0 +1,192 @@
+"""Cacheless varlen attention through FlashInfer's ragged prefill wrapper."""
+
+from collections.abc import Iterable
+
+import torch
+
+from mstar.engine.resources.attn.base import WorkspacePool
+from mstar.engine.resources.attn.config import AttentionStep
+from mstar.engine.resources.attn.ragged.base import RaggedAttnManager
+from mstar.engine.resources.attn.ragged.config import RaggedAttentionConfig
+from mstar.engine.resources.attn.ragged.wrappers import RaggedPrefillWrapper
+from mstar.engine.resources.base import CGSlotKey
+from mstar.engine.resources.step import Segment, SlotLease, StepContext
+
+
+class FlashInferRaggedManager(RaggedAttnManager):
+    def __init__(
+        self,
+        device: torch.device,
+        dtype: torch.dtype,
+        config: RaggedAttentionConfig,
+    ):
+        self._config = config
+        self._device = device
+        self._dtype = dtype
+
+        # label -> the wrapper this step's `run` attends through
+        self._current_plan_states: dict[str, RaggedPrefillWrapper] = {}
+
+        # Persistent, because constructing one allocates FlashInfer's own
+        # buffers and is far from free per step.
+        self._eager_plan_states: dict[str, RaggedPrefillWrapper] = {}
+        self._cg_plan_states: dict[CGSlotKey, RaggedPrefillWrapper] = {}
+
+        self._preplan_states: dict[str, RaggedPrefillWrapper] = {}
+        self._preplanned = False
+
+        self._workspaces = WorkspacePool(device)
+
+        self._kwargs = dict(
+            device=device,
+            q_data_type=dtype,
+            num_qo_heads=config.num_qo_heads,
+            num_kv_heads=config.num_kv_heads,
+            head_dim=config.head_dim,
+            sm_scale=config.sm_scale,
+            backend=config.flashinfer_backend,
+        )
+
+    def _cg_wrapper(
+        self, lease: SlotLease, label: str, num_rows: int,
+    ) -> RaggedPrefillWrapper:
+        """The captured-graph wrapper for one (bucket, slot, label).
+
+        Built on the first plan for that key, like the paged backend's. Its
+        static buffers are fixed for its lifetime, so they are sized off the
+        config's per-request ceilings and the bucket — NOT off this first
+        plan's ``num_rows``, which is only one of the layouts the bucket will
+        replay.
+        """
+        key = CGSlotKey(bucket=lease.bucket, slot=lease.slot, label=label)
+        wrapper = self._cg_plan_states.get(key)
+        if wrapper is not None:
+            return wrapper
+
+        bucket = lease.bucket
+        max_segments = max(self._config.max_segments_for(bucket.bs), num_rows)
+        # the bucket's own token count is the ceiling; the per-request override
+        # is for a runner that buckets by batch size alone
+        max_tokens = max(
+            bucket.num_tokens, self._config.max_tokens_for(bucket.bs) or 0
+        )
+        wrapper = RaggedPrefillWrapper(
+            workspace_buffer=self._workspaces.get(label, lease.slot),
+            use_cuda_graph=True,
+            max_num_segments=max_segments,
+            max_total_tokens=max_tokens,
+            **self._kwargs,
+        )
+        self._cg_plan_states[key] = wrapper
+        return wrapper
+
+    def _eager_wrapper(self, label: str) -> RaggedPrefillWrapper:
+        """The persistent eager wrapper for one label."""
+        wrapper = self._eager_plan_states.get(label)
+        if wrapper is None:
+            wrapper = self._eager_plan_states[label] = RaggedPrefillWrapper(
+                workspace_buffer=self._workspaces.get(label),
+                **self._kwargs,
+            )
+        return wrapper
+
+    @property
+    def supports_preplan(self):
+        return True
+
+    @staticmethod
+    def _group_segments_by_label(
+        segments: Iterable[Segment],
+    ) -> dict[str, list[Segment]]:
+        res: dict[str, list[Segment]] = {}
+        for seg in segments:
+            res.setdefault(seg.label, []).append(seg)
+        return res
+
+    # NOTE: can reuse the same AttentionStep dataclass as KV-backed attention
+    def plan(self, step: AttentionStep, ctx: StepContext):
+        self.reset_default_cursors()
+
+        lease = ctx.slot_lease
+        assert not ctx.is_preplan or lease is not None, (
+            "preplan requires a cuda graph step: eager wrappers share one "
+            "workspace per label with the forward still in flight"
+        )
+        assert not (self._preplanned and ctx.is_preplan), (
+            "ragged attention preplan is already pending; clear_preplan before "
+            "planning a different step ahead"
+        )
+
+        if self._preplanned:
+            # the wrappers were planned a step early against this same step's
+            # layout; nothing left to do but promote them
+            self._current_plan_states = self._preplan_states
+            self._preplan_states = {}
+            self._preplanned = False
+            return
+
+        # a preplan leases a different cg slot, so its wrappers and workspaces
+        # are disjoint from the ones the in-flight forward reads
+        plan_states = self._preplan_states if ctx.is_preplan \
+            else self._current_plan_states
+
+        # A label's segments are its whole layout — there is no cache to read
+        # them off, so an undeclared label is unattendable. Clear rather than
+        # update, so last step's wrapper can't be attended through by mistake.
+        plan_states.clear()
+        # cu_seqlens on the CPU: FlashInfer's plan wants it there anyway, and
+        # building it on device would sync (fatally so under preplan)
+        for label, segments in self._group_segments_by_label(
+            step.segments or ()
+        ).items():
+            cu = [0]
+            for seg in segments:
+                cu.append(cu[-1] + seg.span)
+            cu_seqlens = torch.tensor(cu, dtype=torch.int32)
+            if lease is not None:
+                wrapper = self._cg_wrapper(lease, label, len(segments))
+            else:
+                wrapper = self._eager_wrapper(label)
+
+            # TODO: cache the latest plan state
+            wrapper.plan(cu_seqlens=cu_seqlens, causal=step.causal)
+            plan_states[label] = wrapper
+
+        self._preplanned = ctx.is_preplan
+
+    def clear_preplan(self):
+        # rebind rather than clear: a consumed preplan dict is the live one
+        self._preplanned = False
+        self._preplan_states = {}
+
+    ### Submodule-level functionality
+
+    def num_segments(self, label: str | None = None) -> int:
+        """Real (unpadded) segment count this step planned under ``label``."""
+        return self._wrapper(label).num_segments
+
+    def _wrapper(self, label: str | None) -> RaggedPrefillWrapper:
+        if label is None:
+            label = self._default_label
+        wrapper = self._current_plan_states.get(label)
+        if wrapper is None:
+            raise KeyError(
+                f"ragged attention has no plan for label {label!r}; this step "
+                f"planned {sorted(self._current_plan_states)}. Every label a "
+                "forward attends must carry a segment in the step declaration."
+            )
+        return wrapper
+
+    @torch.compiler.disable
+    def run(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+        label: str | None = None,
+    ) -> torch.Tensor:
+        """One layer's varlen self-attention over this step's packed segments.
+
+        Not behind a custom op, unlike the paged backend's ``run``: the ragged
+        caller (an encoder tower) has no per-layer KV write to keep in the same
+        graph, so the break this costs is one per layer of a region that is
+        CUDA-graph captured rather than compiled.
+        """
+        return self._wrapper(label).run(q, k, v)

--- a/mstar/engine/resources/attn/ragged/flashinfer.py
+++ b/mstar/engine/resources/attn/ragged/flashinfer.py
@@ -48,7 +48,7 @@ class FlashInferRaggedManager(RaggedAttnManager):
         )
 
     def _cg_wrapper(
-        self, lease: SlotLease, label: str, num_rows: int,
+        self, lease: SlotLease, label: str,
     ) -> RaggedPrefillWrapper:
         """The captured-graph wrapper for one (bucket, slot, label).
 
@@ -64,7 +64,7 @@ class FlashInferRaggedManager(RaggedAttnManager):
             return wrapper
 
         bucket = lease.bucket
-        max_segments = max(self._config.max_segments_for(bucket.bs), num_rows)
+        max_segments = self._config.max_segments_for(bucket.bs)
         # the bucket's own token count is the ceiling; the per-request override
         # is for a runner that buckets by batch size alone
         max_tokens = max(
@@ -144,7 +144,7 @@ class FlashInferRaggedManager(RaggedAttnManager):
                 cu.append(cu[-1] + seg.span)
             cu_seqlens = torch.tensor(cu, dtype=torch.int32)
             if lease is not None:
-                wrapper = self._cg_wrapper(lease, label, len(segments))
+                wrapper = self._cg_wrapper(lease, label)
             else:
                 wrapper = self._eager_wrapper(label)
 

--- a/mstar/engine/resources/attn/ragged/flashinfer.py
+++ b/mstar/engine/resources/attn/ragged/flashinfer.py
@@ -142,7 +142,14 @@ class FlashInferRaggedManager(RaggedAttnManager):
             cu = [0]
             for seg in segments:
                 cu.append(cu[-1] + seg.span)
-            cu_seqlens = torch.tensor(cu, dtype=torch.int32)
+            # Pinned and freshly built per plan: the graph wrapper hands this
+            # straight to FlashInfer's non-blocking H2D, so a reused buffer could
+            # be overwritten while its DMA is still in flight. A fresh pinned
+            # allocation is held by the caching host allocator until the copy
+            # retires, keeping the plan async without a per-step sync.
+            cu_seqlens = torch.tensor(
+                cu, dtype=torch.int32, pin_memory=torch.cuda.is_available()
+            )
             if lease is not None:
                 wrapper = self._cg_wrapper(lease, label)
             else:

--- a/mstar/engine/resources/attn/ragged/wrappers.py
+++ b/mstar/engine/resources/attn/ragged/wrappers.py
@@ -1,0 +1,170 @@
+import torch
+
+# Head dims the FlashInfer prefill kernels are instantiated for. An unsupported
+# one fails to BUILD (SM90: static_assert in hopper/prefill_sm90.cuh).
+SUPPORTED_HEAD_DIMS = (64, 128, 256)
+
+
+def padded_head_dim(head_dim: int) -> int:
+    """Smallest FlashInfer-supported head dim >= ``head_dim``."""
+    for supported in SUPPORTED_HEAD_DIMS:
+        if head_dim <= supported:
+            return supported
+    raise ValueError(
+        f"head_dim {head_dim} exceeds the largest supported ({SUPPORTED_HEAD_DIMS[-1]})"
+    )
+
+
+class RaggedPrefillWrapper:
+    """Varlen self-attention over packed segments, with no KV cache; attention
+    is within variable-length segments packed into one ``[total_tokens, H, D]``
+    tensor. ``cu_seqlens`` is both ``qo_indptr`` and ``kv_indptr``.
+    """
+
+    def __init__(
+        self,
+        workspace_buffer: torch.Tensor,
+        num_qo_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        max_num_segments: int | None = None,
+        max_total_tokens: int | None = None,
+        device: torch.device = torch.device("cuda"),
+        use_cuda_graph: bool = False,
+        sm_scale: float | None = None,
+        q_data_type: torch.dtype = torch.bfloat16,
+        kv_layout: str = "NHD",
+        backend: str = "auto",
+    ):
+        self.device = device
+        self.num_qo_heads = num_qo_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.padded_head_dim = padded_head_dim(head_dim)
+        self.sm_scale = float(sm_scale) if sm_scale is not None else head_dim ** -0.5
+        self.q_data_type = q_data_type
+        self.use_cuda_graph = use_cuda_graph
+        self.max_num_segments = max_num_segments
+        self.max_total_tokens = max_total_tokens
+        self._num_segments = 0
+
+        import flashinfer
+
+        if use_cuda_graph:
+            assert max_num_segments is not None, "max_num_segments required for CUDA graph mode"
+            assert max_total_tokens is not None, "max_total_tokens required for CUDA graph mode"
+            assert max_num_segments > 0, "max_num_segments must be positive"
+
+            self._qo_indptr_buf = torch.zeros(
+                max_num_segments + 1, dtype=torch.int32, device=device
+            )
+            self._kv_indptr_buf = torch.zeros(
+                max_num_segments + 1, dtype=torch.int32, device=device
+            )
+            self.attn_wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+                workspace_buffer,
+                kv_layout,
+                use_cuda_graph=True,
+                qo_indptr_buf=self._qo_indptr_buf,
+                kv_indptr_buf=self._kv_indptr_buf,
+                backend=backend,
+            )
+            # Host staging for the padded indptr; FlashInfer's plan moves it to
+            # host anyway, so building it here avoids a D2H sync per plan.
+            self._cu_host = torch.zeros(
+                max_num_segments + 1,
+                dtype=torch.int32,
+                pin_memory=torch.cuda.is_available(),
+            )
+            # FlashInfer latches max rows on the FIRST plan; prime at the
+            # bucket ceiling so a small first plan can't cap it.
+            self.plan(self._max_layout_cu_seqlens())
+        else:
+            self._qo_indptr_buf = None
+            self._kv_indptr_buf = None
+            self._cu_host = None
+            self.attn_wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+                workspace_buffer, kv_layout, backend=backend
+            )
+
+    @property
+    def num_segments(self) -> int:
+        """Real (unpadded) segment count from the most recent ``plan``."""
+        return self._num_segments
+
+    def _max_layout_cu_seqlens(self) -> torch.Tensor:
+        """``max_total_tokens`` spread over all segments, remainder on the first."""
+        n, total = self.max_num_segments, self.max_total_tokens
+        lens = [total // n] * n
+        lens[0] += total % n
+        cu = [0]
+        for seg_len in lens:
+            cu.append(cu[-1] + seg_len)
+        return torch.tensor(cu, dtype=torch.int32)
+
+    def _prepare_cu_seqlens(self, cu_seqlens: torch.Tensor) -> torch.Tensor:
+        n_seg = int(cu_seqlens.numel()) - 1
+        if not self.use_cuda_graph:
+            self._num_segments = n_seg
+            return cu_seqlens.to(torch.int32)
+
+        if n_seg > self.max_num_segments:
+            raise ValueError(
+                f"RaggedPrefillWrapper: {n_seg} segments exceeds the "
+                f"{self.max_num_segments} this graph-mode wrapper was built for"
+            )
+        host = cu_seqlens.to(device="cpu", dtype=torch.int32)
+        total_tokens = int(host[-1])
+        if total_tokens > self.max_total_tokens:
+            raise ValueError(
+                f"RaggedPrefillWrapper: {total_tokens} tokens exceeds the "
+                f"{self.max_total_tokens} this graph-mode wrapper was built for"
+            )
+        self._cu_host[: n_seg + 1].copy_(host)
+        # Repeating the final offset appends zero-length segments — pads the
+        # segment count to the fixed size without adding tokens.
+        self._cu_host[n_seg + 1:] = total_tokens
+        self._num_segments = n_seg
+        return self._cu_host
+
+    @torch.compiler.disable
+    def plan(self, cu_seqlens: torch.Tensor, causal: bool=False) -> None:
+        """Plan one packed layout. ``cu_seqlens``: ``[num_segments + 1]``, [0] == 0.
+
+        CPU tensor preferred; a GPU one costs a sync. Safe to call before every
+        replay — values are copied through the static buffers, not rebound.
+        """
+        cu = self._prepare_cu_seqlens(cu_seqlens)
+        self.attn_wrapper.plan(
+            cu,
+            cu,
+            self.num_qo_heads,
+            self.num_kv_heads,
+            self.padded_head_dim,
+            causal=causal,
+            sm_scale=self.sm_scale,
+            q_data_type=self.q_data_type,
+        )
+
+    def _pad_head_dim(self, t: torch.Tensor) -> torch.Tensor:
+        if t.shape[-1] == self.padded_head_dim:
+            return t.contiguous()
+        return torch.nn.functional.pad(t, (0, self.padded_head_dim - t.shape[-1]))
+
+    @torch.compiler.disable
+    def run(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        """Run planned varlen self-attention.
+
+        Args:
+            q, k, v: [total_tokens, num_heads, head_dim], packed by cu_seqlens
+        Returns:
+            output: [total_tokens, num_qo_heads, head_dim]
+
+        Rows past the planned ``cu_seqlens[-1]`` are untouched, so an oversized
+        static buffer replays fine — the caller slices.
+        """
+        qp, kp, vp = (self._pad_head_dim(t.to(self.q_data_type)) for t in (q, k, v))
+        out = self.attn_wrapper.run(qp, kp, vp)
+        if self.padded_head_dim != self.head_dim:
+            return out[..., : self.head_dim].contiguous()
+        return out

--- a/mstar/engine/resources/attn/ragged/wrappers.py
+++ b/mstar/engine/resources/attn/ragged/wrappers.py
@@ -47,6 +47,7 @@ class RaggedPrefillWrapper:
         self.max_num_segments = max_num_segments
         self.max_total_tokens = max_total_tokens
         self._num_segments = 0
+        self._total_tokens = 0
 
         import flashinfer
 
@@ -69,12 +70,14 @@ class RaggedPrefillWrapper:
                 kv_indptr_buf=self._kv_indptr_buf,
                 backend=backend,
             )
-            # Host staging for the padded indptr; FlashInfer's plan moves it to
-            # host anyway, so building it here avoids a D2H sync per plan.
-            self._cu_host = torch.zeros(
-                max_num_segments + 1,
-                dtype=torch.int32,
-                pin_memory=torch.cuda.is_available(),
+            # Own the output: the kernel writes only the planned rows, and it
+            # reads KV past cu_seqlens[-1] to the last segment's tile boundary,
+            # masking additively. A NaN/Inf left in that tail by another
+            # graph's freed pool block survives the mask and poisons the last
+            # segment. ``plan`` keeps the window finite.
+            self._out_buf = torch.zeros(
+                max_total_tokens, num_qo_heads, self.padded_head_dim,
+                dtype=q_data_type, device=device,
             )
             # FlashInfer latches max rows on the FIRST plan; prime at the
             # bucket ceiling so a small first plan can't cap it.
@@ -82,7 +85,8 @@ class RaggedPrefillWrapper:
         else:
             self._qo_indptr_buf = None
             self._kv_indptr_buf = None
-            self._cu_host = None
+            # eager callers pass exact-size q/k/v; no tail to read
+            self._out_buf = None
             self.attn_wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
                 workspace_buffer, kv_layout, backend=backend
             )
@@ -120,12 +124,27 @@ class RaggedPrefillWrapper:
                 f"RaggedPrefillWrapper: {total_tokens} tokens exceeds the "
                 f"{self.max_total_tokens} this graph-mode wrapper was built for"
             )
-        self._cu_host[: n_seg + 1].copy_(host)
+        self._num_segments = n_seg
+        self._total_tokens = total_tokens
+        # FlashInfer's plan copies this into the static device buffer with a
+        # non-blocking H2D that can still be in flight when the next step plans,
+        # so the source must be a fresh buffer per plan (never reused) and, to
+        # stay async, pinned — the caching host allocator then holds it until the
+        # copy retires. The graph step already declares a layout padded to the
+        # captured segment count (padding rows attend nothing), so the fresh
+        # pinned buffer the caller hands us is already the right size: use it.
+        if n_seg == self.max_num_segments:
+            return host
+        # A shorter layout is staged into a fresh pinned buffer padded to size.
+        cu = torch.empty(
+            self.max_num_segments + 1, dtype=torch.int32,
+            pin_memory=torch.cuda.is_available(),
+        )
+        cu[: n_seg + 1].copy_(host)
         # Repeating the final offset appends zero-length segments — pads the
         # segment count to the fixed size without adding tokens.
-        self._cu_host[n_seg + 1:] = total_tokens
-        self._num_segments = n_seg
-        return self._cu_host
+        cu[n_seg + 1:] = total_tokens
+        return cu
 
     @torch.compiler.disable
     def plan(self, cu_seqlens: torch.Tensor, causal: bool=False) -> None:
@@ -145,6 +164,10 @@ class RaggedPrefillWrapper:
             sm_scale=self.sm_scale,
             q_data_type=self.q_data_type,
         )
+        if self._out_buf is not None:
+            # rows this layout leaves unwritten, zeroed outside the graph where
+            # the real token count is known; see __init__
+            self._out_buf[self._total_tokens:].zero_()
 
     def _pad_head_dim(self, t: torch.Tensor) -> torch.Tensor:
         if t.shape[-1] == self.padded_head_dim:
@@ -160,11 +183,22 @@ class RaggedPrefillWrapper:
         Returns:
             output: [total_tokens, num_qo_heads, head_dim]
 
-        Rows past the planned ``cu_seqlens[-1]`` are untouched, so an oversized
-        static buffer replays fine — the caller slices.
+        Only rows before the planned ``cu_seqlens[-1]`` are computed; the rest
+        read back zero. An oversized static buffer replays fine, but the caller
+        must still slice — the padding rows are not a valid result.
         """
         qp, kp, vp = (self._pad_head_dim(t.to(self.q_data_type)) for t in (q, k, v))
-        out = self.attn_wrapper.run(qp, kp, vp)
+        if self._out_buf is None:
+            out = self.attn_wrapper.run(qp, kp, vp)
+        else:
+            n = qp.shape[0]
+            assert n <= self.max_total_tokens, (
+                f"RaggedPrefillWrapper: {n} rows exceeds the "
+                f"{self.max_total_tokens} this graph-mode wrapper was built for"
+            )
+            out = self.attn_wrapper.run(qp, kp, vp, out=self._out_buf[:n])
         if self.padded_head_dim != self.head_dim:
             return out[..., : self.head_dim].contiguous()
-        return out
+        # `out` is the shared buffer the next call overwrites; the padded
+        # branch above already returns a copy
+        return out.clone() if self._out_buf is not None else out

--- a/mstar/model/bagel/bagel_model.py
+++ b/mstar/model/bagel/bagel_model.py
@@ -50,6 +50,8 @@ from mstar.engine.resources import (
     NodeResourceSpec,
     PositionConfig,
     PositionSpec,
+    RaggedAttentionConfig,
+    RaggedAttentionSpec,
     ResourceReqConfig,
     SamplerSpec,
     SamplingReqConfig,
@@ -69,7 +71,7 @@ from mstar.model.bagel.components.autoencoder import BagelAutoEncoder
 from mstar.model.bagel.components.language_model import BagelForCausalLM
 from mstar.model.bagel.components.modeling_utils import BagelMLPconnector, PositionEmbedding, TimestepEmbedder
 from mstar.model.bagel.components.tokenization import BagelTokenizer, add_special_tokens
-from mstar.model.bagel.components.vit_encoder import BagelVisionModel
+from mstar.model.bagel.components.vit_encoder import VIT_ATTN, BagelVisionModel
 from mstar.model.bagel.config import load_bagel_config
 from mstar.model.bagel.submodules import (
     CombineCFGSubmodule,
@@ -619,7 +621,8 @@ class BagelModel(Model):
         )
 
     def get_node_resources(self) -> list[NodeResourceSpec]:
-        """The KV cache, the attention over it, positions, and the sampler.
+        """The KV cache, the attention over it, positions, and the sampler,
+        plus the ViT's own cacheless attention.
 
         The labels here are the names the layers bind against
         (``Attention(attn_key=..., kv_key=..., pos_key=...)``) and the names
@@ -628,7 +631,22 @@ class BagelModel(Model):
         """
         kv_config = self._kv_config()
         nodes = set(self._LLM_NODES)
+        vit = self.config.vit_config
         return [
+            # The ViT tower attends within one packed forward and caches
+            # nothing, so this stands alone: no KV resource behind it, and only
+            # the captured block loop plans it (eager runs flash-attn — see
+            # `BagelViTAttention.attend`).
+            RaggedAttentionSpec(
+                resource_key=VIT_ATTN, nodes={"vit_encoder"},
+                config=RaggedAttentionConfig(
+                    num_qo_heads=vit.num_attention_heads,
+                    num_kv_heads=vit.num_attention_heads,
+                    head_dim=vit.hidden_size // vit.num_attention_heads,
+                    # one image, hence one attending segment, per request
+                    max_segments_per_request=1,
+                ),
+            ),
             KVSpec(resource_key="kv", nodes=nodes, config=kv_config),
             AttentionSpec(
                 resource_key="attn", nodes=nodes,

--- a/mstar/model/bagel/components/vit_encoder.py
+++ b/mstar/model/bagel/components/vit_encoder.py
@@ -62,29 +62,10 @@ def _sdpa_varlen(
     )
     return out.squeeze(0).transpose(0, 1).contiguous()
 
-@torch.compiler.disable
-def run_attention(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cu_seqlens: torch.Tensor,
-    max_seqlen: int,
-    causal: bool = False,
-    scale: float | None = None,
-) -> torch.Tensor:
-    # cu_seqlens isolates per-image attention when multiple images are packed.
-    # flashinfer's varlen kernels silently miscompute at SigLIP2's head_dim=72.
-    if _FLASH_ATTN_AVAILABLE:
-        return flash_attn_varlen_func(
-            q, k, v,
-            cu_seqlens_q=cu_seqlens,
-            cu_seqlens_k=cu_seqlens,
-            max_seqlen_q=max_seqlen,
-            max_seqlen_k=max_seqlen,
-            causal=causal,
-            softmax_scale=scale,
-        )
-    return _sdpa_varlen(q, k, v, cu_seqlens, causal=causal, scale=scale)
+# Resource key BAGEL declares its ViT's cacheless attention under. The layers
+# bind against it (``BagelViTAttention.bind_resources``) and the piecewise
+# region's ``declare_step`` names it.
+VIT_ATTN = "vit_attn"
 
 
 class RotaryEmbedding2D(torch.nn.Module):
@@ -206,6 +187,55 @@ class BagelViTAttention(nn.Module):
         self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
         self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
 
+        # The engine's cacheless attention resource, bound at load; used only
+        # for a step the encoder pointed at it. See `attend` / `BagelViTEncoder.bind_step`.
+        self.ragged_attn = None
+        self.use_ragged = False
+
+    def bind_resources(self, resources: dict) -> None:
+        """See ``NodeSubmodule.bind_node_resources``. ``.get``: a deployment
+        that declares no ViT attention resource keeps the eager path."""
+        self.ragged_attn = resources.get(VIT_ATTN)
+
+    @torch.compiler.disable
+    def attend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+        causal: bool = False,
+        scale: float | None = None,
+    ) -> torch.Tensor:
+        """Varlen attention; ``cu_seqlens`` isolates per-image attention when
+        several images are packed into one forward.
+
+        Two backends, picked by the step's ``use_ragged`` cursor:
+
+        - set (captured path) — the engine's ragged attention resource,
+          planned OUTSIDE the graph by the piecewise runner. The only
+          capture-legal option: flash-attn's varlen entry point is not
+          reliably capturable, and the SDPA fallback builds its mask from data.
+          The layout lives in the plan, so ``cu_seqlens`` goes unread here.
+        - clear (eager path) — flash-attn varlen, preferred when not
+          capturing: FlashInfer has no kernel for SigLIP2's head_dim=72 and
+          has to zero-pad q/k/v to 128, which flash-attn does not.
+        """
+        if self.use_ragged:
+            return self.ragged_attn.run(q, k, v)
+        if _FLASH_ATTN_AVAILABLE:
+            return flash_attn_varlen_func(
+                q, k, v,
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=causal,
+                softmax_scale=scale,
+            )
+        return _sdpa_varlen(q, k, v, cu_seqlens, causal=causal, scale=scale)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -239,7 +269,7 @@ class BagelViTAttention(nn.Module):
             q = torch.cat([qh, qw], dim=-1)
             k = torch.cat([kh, kw], dim=-1)
 
-        attn_output = run_attention(
+        attn_output = self.attend(
             q,
             k,
             v,
@@ -318,6 +348,27 @@ class BagelViTEncoder(nn.Module):
             [BagelViTEncoderLayer(config) for _ in range(config.num_hidden_layers)]
         )
 
+    @property
+    def ragged_available(self) -> bool:
+        """Whether a ragged attention resource was bound — i.e. whether the
+        captured path is possible at all on this deployment."""
+        return self.layers[0].self_attn.ragged_attn is not None
+
+    def bind_step(self, use_ragged: bool) -> None:
+        """Point the whole stack at this step's attention backend.
+
+        Only a captured region binds the resource: outside one nothing planned
+        a layout, and attending an unplanned resource is an error rather than
+        something to fall back from.
+        """
+        if use_ragged and not self.ragged_available:
+            raise RuntimeError(
+                "BagelViTEncoder: no ragged attention resource bound; declare "
+                f"a RaggedAttentionSpec under {VIT_ATTN!r} for this node"
+            )
+        for layer in self.layers:
+            layer.self_attn.use_ragged = use_ragged
+
     def forward(
         self,
         inputs_embeds: torch.Tensor,
@@ -352,33 +403,68 @@ class BagelVisionTransformer(nn.Module):
         self.encoder = BagelViTEncoder(config)
         self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
 
+    def embed(
+        self,
+        packed_pixel_values: torch.Tensor,
+        packed_flattened_position_ids: torch.LongTensor,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Preamble: patch embedding plus the gathered 2D-RoPE tables.
+
+        Split out from ``forward`` so a caller can run it eagerly and hand the
+        results to a captured block loop — the gathers are data-dependent
+        indexing that has no business inside a graph.
+        """
+        hidden_states = self.embeddings(
+            packed_pixel_values=packed_pixel_values,
+            packed_flattened_position_ids=packed_flattened_position_ids
+        )
+
+        rope_inputs = {}
+        if self.config.rope:
+            rope_inputs.update(
+                cos_h = self.rope.cos_h[packed_flattened_position_ids],
+                sin_h = self.rope.sin_h[packed_flattened_position_ids],
+                cos_w = self.rope.cos_w[packed_flattened_position_ids],
+                sin_w = self.rope.sin_w[packed_flattened_position_ids]
+            )
+        return hidden_states, rope_inputs
+
+    def encode(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.IntTensor,
+        max_seqlen: int,
+        use_ragged: bool = False,
+        **rope_inputs,
+    ) -> torch.Tensor:
+        """The capturable tail: encoder block loop plus post-layernorm.
+
+        Constant for a fixed token layout, so this is the region a piecewise
+        CUDA graph records. ``use_ragged`` selects the attention backend for
+        the whole stack — see ``BagelViTAttention.attend``.
+        """
+        self.encoder.bind_step(use_ragged)
+        last_hidden_state = self.encoder(
+            inputs_embeds=hidden_states, cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen, **rope_inputs
+        )
+        return self.post_layernorm(last_hidden_state)
+
     def forward(
         self,
         packed_pixel_values: torch.Tensor,
         packed_flattened_position_ids: torch.LongTensor,
         cu_seqlens: torch.IntTensor,
         max_seqlen: int,
+        use_ragged: bool = False,
     ) -> torch.Tensor:
-        hidden_states = self.embeddings(
-            packed_pixel_values=packed_pixel_values,
-            packed_flattened_position_ids=packed_flattened_position_ids
+        hidden_states, rope_inputs = self.embed(
+            packed_pixel_values, packed_flattened_position_ids
         )
-
-        extra_inputs = {}
-        if self.config.rope:
-            extra_inputs.update(
-                cos_h = self.rope.cos_h[packed_flattened_position_ids],
-                sin_h = self.rope.sin_h[packed_flattened_position_ids],
-                cos_w = self.rope.cos_w[packed_flattened_position_ids],
-                sin_w = self.rope.sin_w[packed_flattened_position_ids]
-            )
-
-        last_hidden_state = self.encoder(
-            inputs_embeds=hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
-            **extra_inputs
+        return self.encode(
+            hidden_states, cu_seqlens, max_seqlen,
+            use_ragged=use_ragged, **rope_inputs,
         )
-        last_hidden_state = self.post_layernorm(last_hidden_state)
-        return last_hidden_state
 
 
 class BagelVisionModel(nn.Module):
@@ -395,6 +481,7 @@ class BagelVisionModel(nn.Module):
         packed_flattened_position_ids: torch.LongTensor,
         cu_seqlens: torch.IntTensor,
         max_seqlen: int,
+        use_ragged: bool = False,
     ) -> torch.Tensor:
 
         return self.vision_model(
@@ -402,4 +489,5 @@ class BagelVisionModel(nn.Module):
             packed_flattened_position_ids=packed_flattened_position_ids,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            use_ragged=use_ragged,
         )

--- a/mstar/model/bagel/submodules.py
+++ b/mstar/model/bagel/submodules.py
@@ -16,6 +16,10 @@ from mstar.conductor.request_info import CurrentForwardPassInfo
 from mstar.engine.cuda_graph_config import (
     BatchedCudaGraphConfig,
     PackedCudaGraphConfig,
+    PiecewiseCallInputs,
+    PiecewiseCaptureShape,
+    PiecewiseCudaGraphConfig,
+    PiecewisePackedConfig,
 )
 from mstar.engine.engine import ExecutingBatch
 from mstar.engine.resources import AttentionStep, KVStep, PositionStep, SamplerStep, Segment, SlotLease, SubmoduleStep
@@ -29,6 +33,7 @@ from mstar.model.bagel.components.modeling_utils import (
     vllm_vae_resize,
     vllm_vit_resize,
 )
+from mstar.model.bagel.components.vit_encoder import VIT_ATTN
 from mstar.model.bagel.config import BagelModelConfig
 from mstar.model.higgs_audio.config import SAMPLER
 from mstar.model.submodule_base import (
@@ -59,6 +64,9 @@ NODE_TO_CFG_LABEL = {
     "LLM_cfg_text": "cfg_text",
     "LLM_cfg_img": "cfg_img",
 }
+
+# The ViT encoder's block loop, as a piecewise capture region
+VIT_BLOCK_LOOP = "vit_block_loop"
 
 
 def requires_cfg_for_inputs(inputs: list) -> bool:
@@ -115,6 +123,27 @@ class ViTEncoderSubmodule(NodeSubmodule):
         self.vit_max_num_patch_per_side = vit_max_num_patch_per_side
         self.transform = ImageTransform(980, 224, 14)
         self.vae_transform = ImageTransform(1024, 512, 16)
+
+        self._vit_batching = os.environ.get("MSTAR_VIT_BATCHING", "0") == "1"
+        # CUDA-graph capture of the ViT block loop, over the engine's ragged
+        # attention resource. Off by default: capture costs one graph per
+        # (bs, token bucket) and the eager flash-attn path is already fast;
+        # the win is removing per-layer launch overhead on small images.
+        self._cuda_graph_enabled = os.environ.get("MSTAR_VIT_CUDA_GRAPH", "0") == "1"
+        self._cg_token_buckets = [
+            int(t) for t in os.environ.get(
+                "MSTAR_VIT_CG_TOKEN_BUCKETS", "512,1024,2048,4096,4900"
+            ).split(",") if t.strip()
+        ]  # 4900 == 70*70, the exact length the "vllm" preprocess option emits
+        self._cg_batch_sizes = [
+            int(b) for b in
+            os.environ.get("MSTAR_VIT_CG_BATCH_SIZES", "1,2,4").split(",")
+            if b.strip()
+        ] if self._vit_batching else [1]
+        # `prepare_inputs` emits exactly one varlen segment (one image) per
+        # request, so the segment ceiling is the batch size. Raise only if that
+        # changes — and raise the resource's `max_segments_per_request` with it.
+        self._max_images_per_request = 1
 
     def prepare_inputs(
         self,
@@ -179,27 +208,161 @@ class ViTEncoderSubmodule(NodeSubmodule):
         max_seqlen: int,
         **kwargs,
     ) -> NameToTensorList:
-        features = self.vit_model(
+        features = self._encode(
+            engine_inputs=engine_inputs,
             packed_pixel_values=packed_pixel_values,
-            packed_flattened_position_ids=packed_position_ids,
+            packed_position_ids=packed_position_ids,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            seq_lens=[int(packed_pixel_values.shape[0])],
         )
         features = self.connector(features)
         features = features + self.vit_pos_embed(packed_position_ids)
         return {"img_emb": [features]}
 
+    def get_piecewise_cuda_graph_configs(
+        self, device: torch.device, autocast_dtype: torch.dtype,
+        tp_world_size: int = 1, **kwargs,
+    ) -> dict[str, PiecewiseCudaGraphConfig]:
+        """Capture the ViT block loop, leaving patch-embed and the RoPE gathers
+        eager — they are data-dependent indexing with no business in a graph."""
+        if not self._cuda_graph_enabled:
+            return {}
+        vit_config = self.vit_model.vision_model.config
+        hidden = vit_config.hidden_size
+        rope_dim = (hidden // vit_config.num_attention_heads) // 2
+
+        def make_static_inputs(shape: PiecewiseCaptureShape):
+            statics = {
+                "hidden_states": torch.zeros(
+                    shape.total_tokens, hidden, dtype=autocast_dtype, device=device
+                )
+            }
+            if vit_config.rope:
+                for name in ("cos_h", "sin_h", "cos_w", "sin_w"):
+                    statics[name] = torch.zeros(
+                        shape.total_tokens, rope_dim,
+                        dtype=autocast_dtype, device=device,
+                    )
+            return statics
+
+        def declare_step(
+            request_ids: list[str], seq_lens: list[int],
+        ) -> SubmoduleStep:
+            # One segment per row: `_images_per_request` is 1, so a request's
+            # tokens are one independently-attending image. Padding rows come
+            # through with span 0 and attend nothing.
+            return SubmoduleStep(
+                segments=[
+                    Segment(request_id=rid, label="main", span=seq_len)
+                    for rid, seq_len in zip(request_ids, seq_lens, strict=True)
+                ],
+                steps={VIT_ATTN: AttentionStep(causal=False)},
+            )
+
+        return {
+            VIT_BLOCK_LOOP: PiecewisePackedConfig(
+                capture_fn=self._capture_block_loop,
+                make_static_inputs=make_static_inputs,
+                declare_step=declare_step,
+                total_tokens=sorted(self._cg_token_buckets),
+                capture_batch_sizes=sorted(self._cg_batch_sizes),
+            )
+        }
+
+    def _capture_block_loop(
+        self, inp: PiecewiseCallInputs,
+    ) -> dict[str, torch.Tensor]:
+        """The captured region. Reads the runner-owned buffers, never rebinds.
+
+        ``cu_seqlens`` / ``max_seqlen`` go unused on this path: the layout
+        lives in the ragged attention resource, which the runner plans outside
+        the graph before every replay.
+        """
+        rope_inputs = {
+            name: inp.static_inputs[name]
+            for name in ("cos_h", "sin_h", "cos_w", "sin_w")
+            if name in inp.static_inputs
+        }
+        out = self.vit_model.vision_model.encode(
+            inp.static_inputs["hidden_states"],
+            cu_seqlens=None,
+            max_seqlen=0,
+            use_ragged=True,
+            **rope_inputs,
+        )
+        return {"hidden_states": out}
+
+    def _encode(
+        self,
+        engine_inputs: ModelInputsFromEngine,
+        packed_pixel_values: torch.Tensor,
+        packed_position_ids: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+        seq_lens: list[int],
+    ) -> torch.Tensor:
+        """ViT features for a packed batch, through the captured block loop
+        when one fits and eager flash-attn otherwise.
+
+        Only the replay is kept out of dynamo's reach; ``embed`` and ``encode``
+        stay traceable, which is worth ~7% on this tower.
+        """
+        vision_model = self.vit_model.vision_model
+        hidden_states, rope_inputs = vision_model.embed(
+            packed_pixel_values, packed_position_ids
+        )
+        captured = self._replay_block_loop(
+            engine_inputs, hidden_states, rope_inputs, cu_seqlens, seq_lens,
+        )
+        if captured is not None:
+            return captured
+        return vision_model.encode(
+            hidden_states, cu_seqlens, max_seqlen, use_ragged=False, **rope_inputs
+        )
+
+    @torch.compiler.disable
+    def _replay_block_loop(
+        self,
+        engine_inputs: ModelInputsFromEngine,
+        hidden_states: torch.Tensor,
+        rope_inputs: dict[str, torch.Tensor],
+        cu_seqlens: torch.Tensor,
+        seq_lens: list[int],
+    ) -> torch.Tensor | None:
+        """The captured block loop's output, or None when it can't serve this
+        batch and the caller should run eager."""
+        runner = engine_inputs.piecewise_runners.get(VIT_BLOCK_LOOP)
+        if runner is None or not runner.can_run(
+            len(seq_lens), int(hidden_states.shape[0])
+        ):
+            return None
+        # A captured bucket fixes the segment count at bs * images_per_request;
+        # a request carrying more images than that takes the eager path rather
+        # than tripping the wrapper's guard.
+        n_segments = int(cu_seqlens.numel()) - 1
+        if n_segments > len(seq_lens) * self._max_images_per_request:
+            return None
+        out = runner.run(
+            static_inputs={"hidden_states": hidden_states, **rope_inputs},
+            request_ids=list(engine_inputs.request_ids),
+            seq_lens=seq_lens,
+        )
+        # a view: the connector consumes it within this step
+        return out.get_view("hidden_states")
+
     def can_batch(self, batch: ExecutingBatch, model_inputs: list[NodeInputs]) -> bool:
-        # Opt-in via MSTAR_VIT_BATCHING=1. Off by default because flashattn
-        # varlen reductions across packed images produce small bf16 drift,
-        # which at greedy temperature=0 can flip downstream LLM argmax.
-        if os.environ.get("MSTAR_VIT_BATCHING", "0") != "1":
+        # Opt-in via MSTAR_VIT_BATCHING=1.
+        if not self._vit_batching:
             return False
         return batch.graph_walk == "prefill_vit" and len(model_inputs) > 1
 
     def max_batch_size(self, graph_walk: str):
+        if not self._vit_batching:
+            return 1
         if graph_walk == "prefill_vit":
-            return 32
+            # low batch size, as higher batch sizes can cause performance degredation
+            return 4
         return None
 
     def preprocess(
@@ -245,11 +408,13 @@ class ViTEncoderSubmodule(NodeSubmodule):
         seq_lens: list[int],
         **kwargs,
     ) -> dict[str, NameToTensorList]:
-        features = self.vit_model(
+        features = self._encode(
+            engine_inputs=engine_inputs,
             packed_pixel_values=packed_pixel_values,
-            packed_flattened_position_ids=packed_position_ids,
+            packed_position_ids=packed_position_ids,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            seq_lens=seq_lens,
         )
         features = self.connector(features)
         features = features + self.vit_pos_embed(packed_position_ids)

--- a/mstar/model/bagel/submodules.py
+++ b/mstar/model/bagel/submodules.py
@@ -249,7 +249,7 @@ class ViTEncoderSubmodule(NodeSubmodule):
         def declare_step(
             request_ids: list[str], seq_lens: list[int],
         ) -> SubmoduleStep:
-            # One segment per row: `_images_per_request` is 1, so a request's
+            # One segment per row: `_max_images_per_request` is 1, so a request's
             # tokens are one independently-attending image. Padding rows come
             # through with span 0 and attend nothing.
             return SubmoduleStep(
@@ -337,7 +337,7 @@ class ViTEncoderSubmodule(NodeSubmodule):
             len(seq_lens), int(hidden_states.shape[0])
         ):
             return None
-        # A captured bucket fixes the segment count at bs * images_per_request;
+        # A captured bucket fixes the segment count at bs * max_images_per_request;
         # a request carrying more images than that takes the eager path rather
         # than tripping the wrapper's guard.
         n_segments = int(cu_seqlens.numel()) - 1

--- a/test/modular/test_ragged_attention.py
+++ b/test/modular/test_ragged_attention.py
@@ -1,0 +1,593 @@
+"""Ragged (cacheless) attention: the FlashInfer wrapper, the resource that
+plans it, and both under CUDA-graph capture.
+
+The load-bearing property throughout: a graph captured once per bucket can be
+re-planned before each replay against a different varlen layout, with the
+segment count padded out by zero-length segments. Everything runs at
+head_dim=72, which FlashInfer has no kernel for, so the pad-to-128 path is
+always exercised.
+"""
+
+from __future__ import annotations
+
+import sys
+
+sys.path.insert(0, ".")
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from mstar.engine.cuda_graph_config import (
+    PiecewiseCallInputs,
+    PiecewiseCaptureShape,
+    PiecewisePackedConfig,
+)
+from mstar.engine.cuda_graph_runner import PiecewiseCudaGraphRunner
+from mstar.engine.resources import (
+    AttentionStep,
+    BucketKey,
+    RaggedAttentionConfig,
+    RaggedAttentionSpec,
+    Segment,
+    SlotLease,
+    StepContext,
+    StepRunner,
+    SubmoduleStep,
+)
+from mstar.engine.resources.attn.ragged.flashinfer import FlashInferRaggedManager
+from mstar.engine.resources.attn.ragged.wrappers import (
+    SUPPORTED_HEAD_DIMS,
+    RaggedPrefillWrapper,
+    padded_head_dim,
+)
+from mstar.engine.resources.base import EngineResourceInfo, build_resource
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="ragged attention requires CUDA"
+)
+
+DEVICE = torch.device("cuda:0")
+DTYPE = torch.bfloat16
+HEADS, HEAD_DIM = 4, 72
+WIDTH = HEADS * HEAD_DIM
+MAX_SEGMENTS, MAX_TOKENS = 4, 512
+TOL = 3e-2                      # bf16 vs an fp32 reference; observed ~8e-3
+ATTN = "ragged"
+
+
+@pytest.fixture(autouse=True)
+def _small_workspaces(monkeypatch):
+    # WorkspacePool allocates this many MB per (label, slot); the default 512
+    # would be ~half a gigabyte per wrapper for tests that build several.
+    monkeypatch.setenv("MSTAR_WORKSPACE_BUFFER_MB", "64")
+
+
+# --- helpers ---------------------------------------------------------------
+
+def cu(seg_lens: list[int]) -> torch.Tensor:
+    out = [0]
+    for n in seg_lens:
+        out.append(out[-1] + n)
+    return torch.tensor(out, dtype=torch.int32)
+
+
+def qkv(total: int, seed: int = 0):
+    gen = torch.Generator(device=DEVICE).manual_seed(seed)
+    return tuple(
+        torch.randn(total, HEADS, HEAD_DIM, dtype=DTYPE, device=DEVICE, generator=gen)
+        for _ in range(3)
+    )
+
+
+def ref(q, k, v, cu_seqlens, causal=False):
+    """Per-segment SDPA at the true head dim, accumulated in fp32."""
+    out = torch.zeros_like(q)
+    offsets = cu_seqlens.tolist()
+    for start, end in zip(offsets[:-1], offsets[1:], strict=True):
+        if end <= start:
+            continue
+        qs, ks, vs = (t[start:end].transpose(0, 1).unsqueeze(0).float() for t in (q, k, v))
+        o = F.scaled_dot_product_attention(qs, ks, vs, scale=HEAD_DIM ** -0.5, is_causal=causal)
+        out[start:end] = o.squeeze(0).transpose(0, 1).to(out.dtype)
+    return out
+
+
+def close(got, want, tol=TOL):
+    err = (got.float() - want.float()).abs().max().item()
+    assert err < tol, f"max_abs_err={err} exceeds {tol}"
+
+
+def workspace():
+    return torch.empty(64 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+
+
+def wrapper(**overrides) -> RaggedPrefillWrapper:
+    kwargs = dict(
+        workspace_buffer=workspace(), num_qo_heads=HEADS, num_kv_heads=HEADS,
+        head_dim=HEAD_DIM, device=DEVICE, q_data_type=DTYPE,
+    )
+    kwargs.update(overrides)
+    return RaggedPrefillWrapper(**kwargs)
+
+
+def graph_wrapper() -> RaggedPrefillWrapper:
+    return wrapper(
+        max_num_segments=MAX_SEGMENTS, max_total_tokens=MAX_TOKENS, use_cuda_graph=True
+    )
+
+
+# --- head-dim padding ------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("head_dim", "expected"), [(64, 64), (72, 128), (128, 128), (129, 256), (256, 256)]
+)
+def test_padded_head_dim_rounds_up(head_dim, expected):
+    assert padded_head_dim(head_dim) == expected
+
+
+def test_padded_head_dim_rejects_oversized():
+    with pytest.raises(ValueError, match="exceeds the largest supported"):
+        padded_head_dim(SUPPORTED_HEAD_DIMS[-1] + 1)
+
+
+def test_sm_scale_uses_true_head_dim_not_padded():
+    """FlashInfer's own default would derive it from the padded dim."""
+    w = wrapper()
+    assert w.padded_head_dim == 128
+    assert w.sm_scale == pytest.approx(HEAD_DIM ** -0.5)
+
+
+# --- the wrapper, eager ----------------------------------------------------
+
+@pytest.mark.parametrize("seg_lens", [[128, 96, 40], [7, 1, 300]], ids=["mixed", "ragged"])
+def test_eager_matches_reference(seg_lens):
+    w, layout = wrapper(), cu(seg_lens)
+    q, k, v = qkv(sum(seg_lens))
+    w.plan(layout)
+    close(w.run(q, k, v), ref(q, k, v, layout))
+    assert w.num_segments == len(seg_lens)
+
+
+def test_eager_causal_matches_reference():
+    w, layout = wrapper(), cu([128, 96, 40])
+    q, k, v = qkv(264)
+    w.plan(layout, causal=True)
+    close(w.run(q, k, v), ref(q, k, v, layout, causal=True))
+
+
+def test_eager_accepts_device_cu_seqlens():
+    """Works, just costs a sync — encoders build cu_seqlens on device today."""
+    w, layout = wrapper(), cu([128, 96, 40])
+    q, k, v = qkv(264)
+    w.plan(layout.to(DEVICE))
+    close(w.run(q, k, v), ref(q, k, v, layout))
+
+
+# --- the wrapper, under CUDA graph -----------------------------------------
+
+def capture_wrapper(w):
+    static = tuple(
+        torch.zeros(MAX_TOKENS, HEADS, HEAD_DIM, dtype=DTYPE, device=DEVICE) for _ in range(3)
+    )
+    w.plan(cu([MAX_TOKENS // MAX_SEGMENTS] * MAX_SEGMENTS))
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            w.run(*static)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out = w.run(*static)
+    torch.cuda.synchronize()
+    return graph, static, out
+
+
+def replay(w, graph, static, out, seg_lens, seed=0):
+    total = sum(seg_lens)
+    q, k, v = qkv(total, seed=seed)
+    layout = cu(seg_lens)
+    w.plan(layout)
+    for buf, real in zip(static, (q, k, v), strict=True):
+        buf.zero_()
+        buf[:total].copy_(real)
+    graph.replay()
+    torch.cuda.synchronize()
+    return out[:total], ref(q, k, v, layout)
+
+
+@pytest.mark.parametrize(
+    "seg_lens",
+    [[128] * 4, [100, 60, 30, 20], [100, 60, 30, 0], [190, 20, 0, 0], [7, 0, 0, 0]],
+    ids=["as_captured", "shorter", "one_pad", "two_pad", "mostly_pad"],
+)
+def test_graph_replay_matches_reference(seg_lens):
+    w = graph_wrapper()
+    close(*replay(w, *capture_wrapper(w), seg_lens))
+
+
+def test_graph_replay_stable_across_changing_layouts():
+    """Re-planning one captured wrapper repeatedly must not leak state."""
+    w = graph_wrapper()
+    graph, static, out = capture_wrapper(w)
+    layouts = [[128] * 4, [100, 60, 30, 0], [7, 0, 0, 0], [64] * 4]
+    for i, seg_lens in enumerate(layouts * 2):
+        close(*replay(w, graph, static, out, seg_lens, seed=i))
+
+
+def test_graph_mode_pads_fewer_segments():
+    w = graph_wrapper()
+    w.plan(cu([10, 20]))
+    assert w.num_segments == 2
+    assert w._cu_host.tolist() == [0, 10, 30, 30, 30]
+
+
+def test_graph_mode_rejects_too_many_segments():
+    with pytest.raises(ValueError, match="segments exceeds"):
+        graph_wrapper().plan(cu([10] * (MAX_SEGMENTS + 1)))
+
+
+def test_graph_mode_rejects_too_many_tokens():
+    with pytest.raises(ValueError, match="tokens exceeds"):
+        graph_wrapper().plan(cu([MAX_TOKENS, 1]))
+
+
+def test_graph_mode_priming_survives_a_small_first_plan():
+    """FlashInfer latches max rows on the first plan; the ctor primes at the
+    ceiling so planning small first can't cap the bucket below its own size."""
+    w = graph_wrapper()
+    w.plan(cu([8] * 4))
+    w.plan(cu([MAX_TOKENS // MAX_SEGMENTS] * MAX_SEGMENTS))
+    assert w.num_segments == MAX_SEGMENTS
+
+
+def test_graph_mode_requires_bucket_bounds():
+    with pytest.raises(AssertionError, match="max_num_segments required"):
+        wrapper(use_cuda_graph=True)
+
+
+# --- the resource ----------------------------------------------------------
+
+def manager(**config_overrides) -> FlashInferRaggedManager:
+    kwargs = dict(num_qo_heads=HEADS, num_kv_heads=HEADS, head_dim=HEAD_DIM)
+    kwargs.update(config_overrides)
+    spec = RaggedAttentionSpec(
+        resource_key=ATTN, nodes={"encoder"}, config=RaggedAttentionConfig(**kwargs),
+    )
+    return build_resource(
+        spec, EngineResourceInfo(device=DEVICE, kv_dtype=DTYPE),
+    )
+
+
+def ctx(rids, lease=None, is_preplan=False) -> StepContext:
+    return StepContext(
+        request_ids=list(rids), graph_walk="encode", slot=0, capture=False,
+        is_preplan=is_preplan, slot_lease=lease,
+    )
+
+
+def bucket(bs: int, num_tokens: int) -> BucketKey:
+    return BucketKey(graph_walk="__piecewise__", bs=bs, num_tokens=num_tokens)
+
+
+def segments(*spans, label="main"):
+    return tuple(
+        Segment(request_id=f"r{i}", label=label, span=span)
+        for i, span in enumerate(spans)
+    )
+
+
+def step(*spans, causal=False, label="main"):
+    """``AttentionStep.causal`` defaults to True (the KV-backed common case);
+    an encoder tower declares it off, so spell it out here."""
+    return AttentionStep(segments=segments(*spans, label=label), causal=causal)
+
+
+def test_spec_declares_no_dependencies():
+    """Nothing is cached, so nothing has to plan before it — unlike the paged
+    backend, which reads its layout off a KV plan."""
+    assert manager().depends_on() == set()
+
+
+def test_shards_head_counts_at_build():
+    """Head counts are declared pre-sharding; the engine narrows them."""
+
+    class _Group:
+        world_size = 2
+
+    spec = RaggedAttentionSpec(
+        resource_key=ATTN, nodes={"encoder"},
+        config=RaggedAttentionConfig(
+            num_qo_heads=HEADS, num_kv_heads=HEADS, head_dim=HEAD_DIM,
+        ),
+    )
+    mgr = build_resource(
+        spec,
+        EngineResourceInfo(device=DEVICE, kv_dtype=DTYPE, joint_comm_group=_Group()),
+    )
+    assert mgr._kwargs["num_qo_heads"] == HEADS // 2
+    # head_dim never shards
+    assert mgr._kwargs["head_dim"] == HEAD_DIM
+
+
+def test_plan_then_run_matches_reference():
+    mgr = manager()
+    spans = [128, 96]
+    mgr.plan(step(*spans), ctx(["r0", "r1"]))
+    q, k, v = qkv(sum(spans))
+    close(mgr.run(q, k, v), ref(q, k, v, cu(spans)))
+    assert mgr.num_segments() == 2
+
+
+def test_step_causal_flag_reaches_the_kernel():
+    """``AttentionStep.causal`` defaults True for the KV-backed case; a ragged
+    step that declares it must actually mask."""
+    mgr = manager()
+    spans = [128, 96]
+    q, k, v = qkv(sum(spans))
+    mgr.plan(step(*spans, causal=True), ctx(["r0", "r1"]))
+    close(mgr.run(q, k, v), ref(q, k, v, cu(spans), causal=True))
+
+
+def test_plan_groups_segments_by_label():
+    """Two labels in one step are two independent layouts, each with its own
+    persistent wrapper."""
+    mgr = manager()
+    two_labels = AttentionStep(causal=False, segments=(
+        Segment("r0", "main", 64), Segment("r1", "main", 32),
+        Segment("r0", "other", 16),
+    ))
+    mgr.plan(two_labels, ctx(["r0", "r1"]))
+    assert sorted(mgr._current_plan_states) == ["main", "other"]
+    assert mgr.num_segments("main") == 2
+    assert mgr.num_segments("other") == 1
+    assert mgr._current_plan_states["main"] is not mgr._current_plan_states["other"]
+
+
+def test_plan_clears_labels_the_step_did_not_declare():
+    """A stale wrapper is a stale layout: attending it would silently read the
+    previous step's segmentation."""
+    mgr = manager()
+    mgr.plan(
+        AttentionStep(causal=False, segments=(
+            Segment("r0", "main", 8), Segment("r0", "other", 8),
+        )),
+        ctx(["r0"]),
+    )
+    mgr.plan(step(8), ctx(["r0"]))
+    assert list(mgr._current_plan_states) == ["main"]
+    with pytest.raises(KeyError, match="no plan for label 'other'"):
+        mgr.run(*qkv(8), label="other")
+
+
+def test_eager_wrappers_are_reused_across_steps():
+    """Constructing one allocates FlashInfer's own buffers; a step must not."""
+    mgr = manager()
+    mgr.plan(step(64), ctx(["r0"]))
+    first = mgr._current_plan_states["main"]
+    mgr.plan(step(32, 16), ctx(["r0", "r1"]))
+    assert mgr._current_plan_states["main"] is first
+
+
+def test_cg_wrapper_is_sized_by_the_config_not_the_first_plan():
+    """The static buffers are fixed for the wrapper's life, so a small first
+    plan must not cap the bucket: every later layout would overrun them."""
+    mgr = manager(max_segments_per_request=3)
+    lease = SlotLease(slot=0, bucket=bucket(bs=2, num_tokens=MAX_TOKENS))
+    mgr.plan(step(8), ctx(["r0"], lease=lease))
+    w = mgr._current_plan_states["main"]
+    assert w.max_num_segments == 2 * 3
+    assert w.max_total_tokens == MAX_TOKENS
+    assert w.use_cuda_graph
+
+
+def test_cg_wrapper_is_per_bucket_slot_and_label():
+    mgr = manager()
+    small = step(8, 8)
+    seen = []
+    for lease in (
+        SlotLease(slot=0, bucket=bucket(2, 256)),
+        SlotLease(slot=1, bucket=bucket(2, 256)),
+        SlotLease(slot=0, bucket=bucket(2, 512)),
+        SlotLease(slot=0, bucket=bucket(2, 256)),  # back to the first
+    ):
+        mgr.plan(small, ctx(["r0", "r1"], lease=lease))
+        seen.append(mgr._current_plan_states["main"])
+    assert len({id(w) for w in seen}) == 3
+    assert seen[0] is seen[3]
+
+
+def test_eager_and_captured_wrappers_do_not_share():
+    """A captured wrapper's buffers are baked into a graph; an eager re-plan
+    through the same object would corrupt them."""
+    mgr = manager()
+    small = step(8, 8)
+    mgr.plan(small, ctx(["r0", "r1"], lease=SlotLease(slot=0, bucket=bucket(2, 256))))
+    captured = mgr._current_plan_states["main"]
+    mgr.plan(small, ctx(["r0", "r1"]))
+    assert mgr._current_plan_states["main"] is not captured
+
+
+def test_zero_span_padding_rows_attend_nothing():
+    """A captured replay pads its batch with zero-length rows; the real rows'
+    output must be identical to the same layout without them."""
+    mgr = manager()
+    spans = [96, 40]
+    lease = SlotLease(slot=0, bucket=bucket(bs=4, num_tokens=256))
+    q, k, v = qkv(sum(spans))
+
+    mgr.plan(step(*spans, 0, 0), ctx(["r0", "r1", "r2", "r3"], lease=lease))
+    assert mgr.num_segments() == 4
+    close(mgr.run(q, k, v), ref(q, k, v, cu(spans)))
+
+
+def test_preplan_promotes_on_the_next_plan():
+    """Pre-planning a step ahead parks the wrappers; the real plan promotes
+    them rather than re-planning."""
+    mgr = manager()
+    two = step(64, 32)
+    lease = SlotLease(slot=1, bucket=bucket(2, 256))
+    mgr.plan(two, ctx(["r0", "r1"], lease=lease, is_preplan=True))
+    assert mgr._current_plan_states == {}
+    parked = mgr._preplan_states["main"]
+
+    mgr.plan(two, ctx(["r0", "r1"], lease=lease))
+    assert mgr._current_plan_states["main"] is parked
+    assert mgr._preplan_states == {}
+    q, k, v = qkv(96)
+    close(mgr.run(q, k, v), ref(q, k, v, cu([64, 32])))
+
+
+def test_preplan_requires_a_capture_slot():
+    """Eager wrappers share one workspace per label with the in-flight forward."""
+    mgr = manager()
+    with pytest.raises(AssertionError, match="preplan requires a cuda graph step"):
+        mgr.plan(step(8), ctx(["r0"], is_preplan=True))
+
+
+def test_clear_preplan_drops_a_pending_one():
+    mgr = manager()
+    lease = SlotLease(slot=1, bucket=bucket(1, 256))
+    one = step(8)
+    mgr.plan(one, ctx(["r0"], lease=lease, is_preplan=True))
+    mgr.clear_preplan()
+    # not a promotion: the next plan re-plans from scratch
+    mgr.plan(one, ctx(["r0"], lease=lease, is_preplan=True))
+
+
+def test_run_without_a_plan_names_the_label():
+    mgr = manager()
+    with pytest.raises(KeyError, match="no plan for label 'main'"):
+        mgr.run(*qkv(8))
+
+
+def test_default_label_cursor_resets_each_plan():
+    mgr = manager()
+    mgr.set_default_label("other")
+    mgr.plan(step(8), ctx(["r0"]))
+    assert mgr.default_label == "main"
+
+
+# --- through the piecewise runner ------------------------------------------
+
+PW_TOKENS, PW_BS = 256, 2
+
+
+def piecewise_runner(mgr, capture_fn):
+    resources = {ATTN: mgr}
+    step_runner = StepRunner(resources, node_resources={"encoder": [ATTN]})
+
+    def declare_step(request_ids, seq_lens):
+        return SubmoduleStep(
+            segments=[
+                Segment(request_id=rid, label="main", span=n)
+                for rid, n in zip(request_ids, seq_lens, strict=True)
+            ],
+            steps={ATTN: AttentionStep(causal=False)},
+        )
+
+    runner = PiecewiseCudaGraphRunner(
+        label="encoder_block_loop",
+        config=PiecewisePackedConfig(
+            capture_fn=capture_fn,
+            make_static_inputs=lambda shape: {
+                "x": torch.zeros(shape.total_tokens, WIDTH, dtype=DTYPE, device=DEVICE)
+            },
+            declare_step=declare_step,
+            total_tokens=[PW_TOKENS],
+            capture_batch_sizes=[PW_BS],
+        ),
+        resources=resources,
+        step_runner=step_runner,
+        device=DEVICE,
+        autocast_dtype=DTYPE,
+        node_name="encoder",
+    )
+    runner.warmup_and_capture()
+    assert runner.any_graphs, "capture produced no graphs"
+    return runner
+
+
+def _attend_block(inp: PiecewiseCallInputs) -> dict[str, torch.Tensor]:
+    attn = inp.resources[ATTN]
+    x = inp.static_inputs["x"].reshape(-1, HEADS, HEAD_DIM)
+    return {"x": attn.run(x, x, x).reshape(-1, WIDTH)}
+
+
+def test_piecewise_bucket_sizes_its_own_wrapper():
+    mgr = manager()
+    piecewise_runner(mgr, _attend_block)
+    (w,) = mgr._cg_plan_states.values()
+    # segment ceiling = bs * max_segments_per_request; token ceiling = bucket
+    assert w.max_num_segments == PW_BS
+    assert w.max_total_tokens == PW_TOKENS
+
+
+@pytest.mark.parametrize(
+    "seg_lens",
+    [[128, 128], [100, 60], [200, 0], [64, 64]],
+    ids=["as_captured", "shorter", "one_empty", "small"],
+)
+def test_piecewise_replay_matches_reference(seg_lens):
+    mgr = manager()
+    runner = piecewise_runner(mgr, _attend_block)
+    total = sum(seg_lens)
+    gen = torch.Generator(device=DEVICE).manual_seed(3)
+    x = torch.randn(total, WIDTH, dtype=DTYPE, device=DEVICE, generator=gen)
+
+    out = runner.run(
+        static_inputs={"x": x},
+        request_ids=[f"r{i}" for i in range(len(seg_lens))],
+        seq_lens=seg_lens,
+    )
+    flat = x.reshape(-1, HEADS, HEAD_DIM)
+    want = ref(flat, flat, flat, cu(seg_lens)).reshape(-1, WIDTH)
+    close(out.get_view("x"), want)
+
+
+def test_piecewise_replay_stable_across_changing_layouts():
+    """One captured bucket, re-planned per replay, must not drift."""
+    mgr = manager()
+    runner = piecewise_runner(mgr, _attend_block)
+    for i, seg_lens in enumerate([[128, 128], [64, 32], [200, 56], [128, 128]]):
+        total = sum(seg_lens)
+        gen = torch.Generator(device=DEVICE).manual_seed(i)
+        x = torch.randn(total, WIDTH, dtype=DTYPE, device=DEVICE, generator=gen)
+        out = runner.run(
+            static_inputs={"x": x},
+            request_ids=[f"r{j}" for j in range(len(seg_lens))],
+            seq_lens=seg_lens,
+        )
+        flat = x.reshape(-1, HEADS, HEAD_DIM)
+        want = ref(flat, flat, flat, cu(seg_lens)).reshape(-1, WIDTH)
+        close(out.get_view("x"), want)
+
+
+def test_piecewise_pads_a_short_batch_with_zero_length_rows():
+    """One real request into a bs=2 bucket: the padding row contributes a
+    zero-length segment and the real output is unaffected."""
+    mgr = manager()
+    runner = piecewise_runner(mgr, _attend_block)
+    gen = torch.Generator(device=DEVICE).manual_seed(7)
+    x = torch.randn(150, WIDTH, dtype=DTYPE, device=DEVICE, generator=gen)
+
+    out = runner.run(static_inputs={"x": x}, request_ids=["r0"], seq_lens=[150])
+    flat = x.reshape(-1, HEADS, HEAD_DIM)
+    want = ref(flat, flat, flat, cu([150])).reshape(-1, WIDTH)
+    close(out.get_view("x"), want)
+    assert mgr.num_segments() == PW_BS  # the padding row still plans a row
+
+
+def test_capture_shape_partition_fits_the_bucket():
+    """The capture-time plan partitions the token bucket across the batch; the
+    wrapper's guards must accept it."""
+    shapes = PiecewisePackedConfig(
+        capture_fn=_attend_block,
+        make_static_inputs=lambda shape: {},
+        total_tokens=[PW_TOKENS],
+    ).get_capture_shapes([PW_BS])
+    (shape,) = shapes
+    assert isinstance(shape, PiecewiseCaptureShape)
+    assert sum(shape.seq_lens) == PW_TOKENS == shape.total_tokens
+    assert len(shape.seq_lens) == PW_BS

--- a/test/modular/test_ragged_attention.py
+++ b/test/modular/test_ragged_attention.py
@@ -216,6 +216,25 @@ def test_graph_replay_stable_across_changing_layouts():
         close(*replay(w, graph, static, out, seg_lens, seed=i))
 
 
+def test_graph_replay_survives_a_poisoned_output_tail():
+    """The kernel writes only the planned rows, and reads KV past
+    ``cu_seqlens[-1]`` out to the last segment's tile boundary, masking that
+    overread additively. Finite values die correctly but NaN/Inf survive
+    (NaN + -inf = NaN), so a poisoned tail would corrupt the last segment's
+    real rows. The wrapper owns the output buffer and re-zeros the tail on
+    every plan so no such value can be there.
+    """
+    w = graph_wrapper()
+    graph, static, out = capture_wrapper(w)
+    seg_lens = [100, 60, 30, 0]
+    total = sum(seg_lens)
+
+    w._out_buf[total:].fill_(float("nan"))
+    close(*replay(w, graph, static, out, seg_lens))
+    assert torch.isfinite(out[:total]).all()
+    assert (w._out_buf[total:] == 0).all()
+
+
 def test_graph_mode_pads_fewer_segments():
     w = graph_wrapper()
     w.plan(cu([10, 20]))


### PR DESCRIPTION
<!-- Thanks for contributing to M*! Keep this short. -->

## What does this PR do?

<!-- Briefly describe the change, and link any related issue (e.g. "Closes #123"). -->
Addresses an issue found during the review of #150: neither engine has support for a ragged attention flashinfer wrapper (needed to cuda-graph ragged attention), meaning that the encoder submodule had to do all of the plumbing for flashinfer ragged attention planing itself.  

This PR adds a ragged attention wrapper as a new `Resource` type, modeled off of the flash-infer cache manager, allowing models to perform flashinfer ragged attention without model-specific code. 

## How was it tested?

<!-- Commands you ran, or why tests aren't applicable. -->
Some unit tests from Claude.

Migrated BAGEL ViT encoder, benchmarked T2I on coriander and checked outputs were correct.

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
