### PR TITLE
fix(position): respect device-specific autocast state

### DIFF
--- a/mstar/engine/resources/position/manager.py
+++ b/mstar/engine/resources/position/manager.py
@@ -304,8 +304,8 @@ class RopeManager(PositionManager):
         rope_dtype = rope_dtype if rope_dtype is not None else config.rope_dtype
         if rope_dtype is not None:
             q, k = q.to(rope_dtype), k.to(rope_dtype)
-        elif torch.is_autocast_enabled():
-            dtype = torch.get_autocast_gpu_dtype()
+        elif torch.is_autocast_enabled(q.device.type):
+            dtype = torch.get_autocast_dtype(q.device.type)
             q, k = q.to(dtype), k.to(dtype)
         elif q.dtype == torch.float32:
             q, k = q.to(torch.bfloat16), k.to(torch.bfloat16)

--- a/test/modular/test_position_autocast.py
+++ b/test/modular/test_position_autocast.py
@@ -1,0 +1,29 @@
+import sys
+import types
+
+import torch
+
+from mstar.engine.resources.position.config import PositionConfig
+from mstar.engine.resources.position.manager import RopeManager
+
+
+def test_apply_qk_uses_autocast_for_the_tensor_device(monkeypatch):
+    kernel_dtypes = []
+    flashinfer = types.SimpleNamespace(
+        rope=types.SimpleNamespace(
+            apply_rope_pos_ids_inplace=lambda q, k, pos_ids, **kwargs: kernel_dtypes.append((q.dtype, k.dtype)),
+        )
+    )
+    monkeypatch.setitem(sys.modules, "flashinfer", flashinfer)
+
+    manager = RopeManager(PositionConfig(kv_cache="kv"), torch.device("cpu"))
+    manager._current_pos_ids["main"] = torch.arange(1)
+    q = torch.ones((1, 1, 2), dtype=torch.float32)
+    k = q.clone()
+
+    with torch.amp.autocast("cpu", dtype=torch.float16):
+        result_q, result_k = manager.apply_qk(q, k, "main")
+
+    assert kernel_dtypes == [(torch.float16, torch.float16)]
+    assert result_q.dtype == q.dtype
+    assert result_k.dtype == k.dtype


### PR DESCRIPTION
## Summary

- query autocast state for the query tensor's actual device type
- obtain the matching device-specific autocast dtype instead of using the deprecated CUDA-only getter
- add a CPU regression test that exercises the full `RopeManager.apply_qk()` path and captures the dtype passed to the RoPE kernel boundary

Without the device argument, `torch.is_autocast_enabled()` only observes CUDA autocast. An XPU (or other supported device) autocast context therefore fell through to the hard-coded BF16 fallback. The new test uses FP16 CPU autocast specifically so the old fallback cannot satisfy it accidentally.

Closes #239.

## Validation

- `ruff check .`
- `python -m pytest test/modular/test_position_autocast.py -q` — 1 passed with PyTorch 2.9.1+cpu
- `python -m compileall -q mstar/engine/resources/position/manager.py test/modular/test_position_autocast.py`
- `git diff --check`

XPU hardware was not available locally; the regression uses PyTorch's device-specific CPU autocast to exercise the same API path deterministically.

## AI assistance

I used OpenAI Codex to help inspect the affected code and draft and test the fix. I reviewed the complete diff and ran the validation listed above.
