### PR TITLE
fix: per-device autocast check instead of CUDA-only

### DIFF
--- a/mstar/engine/resources/position/manager.py
+++ b/mstar/engine/resources/position/manager.py
@@ -304,8 +304,8 @@ class RopeManager(PositionManager):
         rope_dtype = rope_dtype if rope_dtype is not None else config.rope_dtype
         if rope_dtype is not None:
             q, k = q.to(rope_dtype), k.to(rope_dtype)
-        elif torch.is_autocast_enabled():
-            dtype = torch.get_autocast_gpu_dtype()
+        elif torch.is_autocast_enabled(device_type=q.device.type):
+            dtype = torch.get_autocast_dtype(device_type=q.device.type)
             q, k = q.to(dtype), k.to(dtype)
         elif q.dtype == torch.float32:
             q, k = q.to(torch.bfloat16), k.to(torch.bfloat16)


### PR DESCRIPTION
## Summary

Fixes #239.

### The bug

```
elif torch.is_autocast_enabled():
    dtype = torch.get_autocast_gpu_dtype()
```

`torch.is_autocast_enabled()` with no arguments only checks CUDA autocast. If autocast is enabled on a different device (e.g. XPU), this returns False, the code falls through to the `float32` fallback, and may produce wrong computations.

### Fix

Use per-device autocast checks:

```
elif torch.is_autocast_enabled(device_type=q.device.type):
    dtype = torch.get_autocast_dtype(device_type=q.device.type)
```

This queries the actual device the tensors are on, so autocast is correctly detected regardless of device type (CUDA, XPU, etc.).

### Impact

- No change for CUDA autocast (existing behavior preserved)
- Correct behavior for non-CUDA devices (XPU, etc.)
- No API or interface changes