### PR TITLE
api: return 400 for malformed model kwargs

### DIFF
--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -777,9 +777,8 @@ async def generate(
     else:
         in_mods = [p.modality for p in parts]
 
-    parsed_kwargs = json.loads(model_kwargs) if model_kwargs else None
-
     try:
+        parsed_kwargs = json.loads(model_kwargs) if model_kwargs else None
         request_id = api_server.submit_request(
             text=text,
             file_paths=file_paths or None,
@@ -810,6 +809,11 @@ async def generate(
             "outputs": outputs,
         })
 
+    except json.JSONDecodeError as e:
+        raise HTTPException(
+            status_code=400,
+            detail="model_kwargs must be valid JSON",
+        ) from e
     except HTTPException:
         raise
     except Exception as e:

--- a/mstar/api_server/entrypoint.py
+++ b/mstar/api_server/entrypoint.py
@@ -779,6 +779,19 @@ async def generate(
 
     try:
         parsed_kwargs = json.loads(model_kwargs) if model_kwargs else None
+    except json.JSONDecodeError as e:
+        raise HTTPException(
+            status_code=400,
+            detail="model_kwargs must be valid JSON",
+        ) from e
+
+    if parsed_kwargs is not None and not isinstance(parsed_kwargs, dict):
+        raise HTTPException(
+            status_code=400,
+            detail="model_kwargs must be a JSON object",
+        )
+
+    try:
         request_id = api_server.submit_request(
             text=text,
             file_paths=file_paths or None,
@@ -809,11 +822,6 @@ async def generate(
             "outputs": outputs,
         })
 
-    except json.JSONDecodeError as e:
-        raise HTTPException(
-            status_code=400,
-            detail="model_kwargs must be valid JSON",
-        ) from e
     except HTTPException:
         raise
     except Exception as e:

--- a/test/modular/test_generate_route.py
+++ b/test/modular/test_generate_route.py
@@ -1,3 +1,5 @@
+import json
+
 from fastapi.testclient import TestClient
 
 from mstar.api_server import entrypoint
@@ -13,3 +15,30 @@ def test_generate_rejects_malformed_model_kwargs(monkeypatch):
 
     assert response.status_code == 400
     assert response.json() == {"detail": "model_kwargs must be valid JSON"}
+
+
+def test_generate_rejects_non_object_model_kwargs(monkeypatch):
+    monkeypatch.setattr(entrypoint, "api_server", object())
+
+    client = TestClient(entrypoint.app)
+    for model_kwargs in ("[1, 2]", '"hello"', "42", "true"):
+        response = client.post(
+            "/generate",
+            data={"model_kwargs": model_kwargs},
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "model_kwargs must be a JSON object"}
+
+
+def test_generate_does_not_mislabel_downstream_json_errors(monkeypatch):
+    class FailingServer:
+        def submit_request(self, **kwargs):
+            raise json.JSONDecodeError("downstream failure", "{}", 0)
+
+    monkeypatch.setattr(entrypoint, "api_server", FailingServer())
+
+    response = TestClient(entrypoint.app).post("/generate")
+
+    assert response.status_code == 500
+    assert response.json()["detail"].startswith("downstream failure")

--- a/test/modular/test_generate_route.py
+++ b/test/modular/test_generate_route.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+
+from mstar.api_server import entrypoint
+
+
+def test_generate_rejects_malformed_model_kwargs(monkeypatch):
+    monkeypatch.setattr(entrypoint, "api_server", object())
+
+    response = TestClient(entrypoint.app).post(
+        "/generate",
+        data={"model_kwargs": "{"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "model_kwargs must be valid JSON"}


### PR DESCRIPTION
Fixes the malformed model_kwargs item in #211. The native generate route parsed this field before its error handler, so invalid JSON escaped as a 500 text response. Parsing now happens inside the guarded block and returns a 400 JSON response. Deferred upload cleanup still runs. Verification: five focused route and result delivery tests passed, full Ruff passed, and the diff check passed. I used OpenAI Codex interactively for navigation, editing, and tests. I reviewed the change and remain responsible for it.