### PR TITLE
engine: per-node weight residency (`on_demand` / `reload`)

### DIFF
--- a/configs/bagel_residency.yaml
+++ b/configs/bagel_residency.yaml
@@ -1,0 +1,31 @@
+# BAGEL with the encoders paged in on demand rather than held resident.
+#
+# A validation deployment for `residency: on_demand`: the ViT and the two VAE
+# nodes only run on the image walks, so holding their weights for the whole
+# process is pure floor. Paging them in costs a host->device transfer per
+# execution and forfeits CUDA-graph capture for those nodes; the LLM, which
+# runs every decode step and benefits most from capture, stays resident.
+#
+# Compare peak device memory against configs/bagel_single_gpu.yaml.
+model: "bagel"
+max_seq_len: 32768
+
+node_groups:
+  - node_names:
+      - vit_encoder
+    ranks:
+      - 0
+    residency: on_demand
+
+  - node_names:
+      - vae_encoder
+      - vae_decoder
+    ranks:
+      - 0
+    residency: on_demand
+
+  - node_names:
+      - LLM
+    ranks:
+      - 0
+    residency: resident

--- a/configs/wan22_reload.yaml
+++ b/configs/wan22_reload.yaml
@@ -1,0 +1,34 @@
+# Wan2.2-TI2V-5B with the text encoder and VAEs dropped and rebuilt (reload).
+#
+# The validation case for `residency: reload`, and the one that mirrors how a
+# large composite model actually behaves: UMT5-XXL runs ONCE per request but is
+# comparable in size to the DiT, which runs every denoise step. Holding the
+# encoder resident for the whole request buys nothing; paging it should lower
+# the high-water mark by roughly its own size.
+#
+# wan22 is served eager (no torch.compile, no CUDA-graph capture), so excluding
+# on_demand nodes from capture costs nothing here.
+#
+# Measure with MSTAR_LOG_PEAK_MEM=1 and compare against configs/wan22.yaml.
+model: "wan22"
+max_seq_len: 512
+
+node_groups:
+  - node_names:
+      - text_encoder
+    ranks:
+      - 0
+    residency: reload
+
+  - node_names:
+      - vae_encoder
+      - vae_decoder
+    ranks:
+      - 0
+    residency: reload
+
+  - node_names:
+      - dit
+    ranks:
+      - 0
+    residency: resident

--- a/configs/wan22_residency.yaml
+++ b/configs/wan22_residency.yaml
@@ -1,0 +1,34 @@
+# Wan2.2-TI2V-5B with the text encoder and VAEs paged in on demand.
+#
+# The validation case for `residency: on_demand`, and the one that mirrors how a
+# large composite model actually behaves: UMT5-XXL runs ONCE per request but is
+# comparable in size to the DiT, which runs every denoise step. Holding the
+# encoder resident for the whole request buys nothing; paging it should lower
+# the high-water mark by roughly its own size.
+#
+# wan22 is served eager (no torch.compile, no CUDA-graph capture), so excluding
+# on_demand nodes from capture costs nothing here.
+#
+# Measure with MSTAR_LOG_PEAK_MEM=1 and compare against configs/wan22.yaml.
+model: "wan22"
+max_seq_len: 512
+
+node_groups:
+  - node_names:
+      - text_encoder
+    ranks:
+      - 0
+    residency: on_demand
+
+  - node_names:
+      - vae_encoder
+      - vae_decoder
+    ranks:
+      - 0
+    residency: on_demand
+
+  - node_names:
+      - dit
+    ranks:
+      - 0
+    residency: resident

--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -175,7 +175,8 @@ A config maps the model's computation-graph nodes to physical GPU ranks. The key
      - Maximum sequence length (sizes the KV cache).
    * - ``node_groups``
      - List of placements. Each entry assigns ``node_names`` to ``ranks``, optionally
-       scoped to specific ``graph_walks`` and/or sharded with ``tp_size``.
+       scoped to specific ``graph_walks``, sharded with ``tp_size``, and given a
+       weight ``residency`` policy (see below).
    * - ``resources``
      - *(optional)* Per-resource overrides, keyed by the model's resource names (see
        below).
@@ -243,6 +244,89 @@ A node must be declared TP-enabled by the model to be eligible for ``tp_size > 1
 weight loaders then shard parameters automatically, with no model-code changes. See
 :ref:`Tensor parallelism <tensor-parallelism>` in the model guide for the model-side
 details.
+
+Weight residency
+----------------
+
+By default a node's weights load to its GPU once and stay there (``resident``).
+A deployment's memory floor is then the **sum** of its nodes, which rules out
+models whose components together exceed device memory even when no single one
+does. A node_group may instead declare:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 84
+
+   * - ``residency``
+     - Behavior
+   * - ``resident``
+     - *(default)* Weights load once and stay. The only policy that keeps
+       CUDA-graph capture, ``torch.compile`` and cross-request batching for that
+       node.
+   * - ``on_demand``
+     - Weights live on the host and move to the device around each execution.
+       Frees device memory; on a unified-memory part (GB10) host and device are
+       one physical pool, so this bounds the *device allocator* but not system
+       memory.
+   * - ``reload``
+     - Weights are dropped after each execution and rebuilt from the checkpoint
+       on the next one. The only policy that frees memory outright, and so the
+       only one that helps when a model's total exceeds physical memory.
+
+At most one non-resident node holds the device at a time, so the peak tracks the
+**largest single component** rather than the sum.
+
+.. code-block:: yaml
+
+   node_groups:
+     - {node_names: [text_encoder], ranks: [0], residency: reload}
+     - {node_names: [dit], ranks: [0], residency: resident}
+
+**What it costs.** A non-resident node forgoes CUDA-graph capture and
+``torch.compile`` — a captured graph records the addresses of the weights it
+read, and compiled code guards on parameter devices, both of which an
+evict/reload cycle invalidates — and it forfeits cross-request batching, since
+requests are forced to serialize at phase boundaries. It suits a node that runs
+**once per request** (a prompt encoder, a VAE) far better than one that runs
+every decode step.
+
+Measured on ``wan22`` (UMT5-XXL encoder paged, DiT resident, one request):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * - Policy
+     - Peak allocated
+     - Latency
+     - Output
+   * - ``resident``
+     - 25.37 GiB
+     - 20 s
+     - 331,713 B
+   * - ``on_demand``
+     - 20.50 GiB
+     - 142 s
+     - 331,713 B
+   * - ``reload``
+     - 20.50 GiB
+     - 81 s
+     - 331,713 B
+
+Output is byte-identical under all three. ``reload`` beats ``on_demand`` here
+because the rebuild reads the checkpoint from page cache straight to the device,
+where ``on_demand`` pays a host↔device round trip.
+
+Set ``MSTAR_LOG_PEAK_MEM=1`` to log the allocator high-water mark as it grows;
+``nvidia-smi`` reports *reserved* memory (caching-allocator blocks plus
+fragmentation) and is too coarse to see the difference.
+
+.. note::
+
+   A model that caches its submodules — every model here memoises
+   ``get_submodule`` — must be able to forget one for ``reload`` to genuinely
+   rebuild. ``Model.release_submodule`` does that, and its default covers the
+   package's ``_submodule_cache`` convention.
 
 model_kwargs
 ------------

--- a/mstar/engine/engine.py
+++ b/mstar/engine/engine.py
@@ -53,6 +53,24 @@ logger = logging.getLogger(__name__)
 # launch queue and block a launch (machine/driver dependent).
 _ENGINE_STEP_SYNC = os.environ.get("MSTAR_ENGINE_STEP_SYNC", "0") == "1"
 
+# Log the allocator's high-water mark as it grows. `nvidia-smi` reports memory
+# *reserved* by the process — caching-allocator blocks that are free but unreturned,
+# plus fragmentation — which is too coarse to see a residency policy's effect.
+# torch.max_memory_allocated is the live figure. Off by default: it costs a
+# device query per step.
+_LOG_PEAK_MEM = os.environ.get("MSTAR_LOG_PEAK_MEM", "0") == "1"
+
+# Node weight residency. A RESIDENT node's weights are loaded to the device once
+# and stay there (the historical behavior, and the default). An ON_DEMAND node
+# is built on the host and moved to the device only while it executes, then
+# evicted — so a model whose components sum past device memory can still run,
+# at the cost of a transfer per phase. Only one ON_DEMAND node is resident at a
+# time, which makes the peak the largest single component rather than the sum.
+RESIDENT = "resident"
+ON_DEMAND = "on_demand"
+RELOAD = "reload"
+RESIDENCY_POLICIES = (RESIDENT, ON_DEMAND, RELOAD)
+
 
 @dataclass
 class SubmoduleManagement:
@@ -200,6 +218,18 @@ class Engine:
         self._autocast_dtype = autocast_dtype
         self._resources: dict[str, Resource] = {}
         self._submodules: dict[str, SubmoduleManagement] = {}
+        # Nodes whose weights live on the host between executions, and which
+        # one of them (at most one) is currently on the device.
+        self._on_demand: set[str] = set()
+        # `reload` nodes go further than `on_demand`: their storage is dropped
+        # entirely and rebuilt from the checkpoint on next use. On a unified
+        # memory part (GB10) host and device share one pool, so moving weights
+        # "to the host" frees nothing system-wide — only dropping them does.
+        self._reload: set[str] = set()
+        self._submodule_factory: Callable[[str], NodeSubmodule] | None = None
+        self._submodule_release: Callable[[str], None] | None = None
+        self._resident_on_demand: str | None = None
+        self._peak_mem_gib: float = 0.0
         self._runner: StepRunner = None
 
         self._enable_nvtx = enable_nvtx
@@ -213,8 +243,21 @@ class Engine:
         device: torch.device,
         transfer_engine_info: TransferEngineInfo,
         kv_cache_type=None,
+        on_demand_nodes: set[str] | None = None,
+        reload_nodes: set[str] | None = None,
+        submodule_factory: "Callable[[str], NodeSubmodule] | None" = None,
+        submodule_release: "Callable[[str], None] | None" = None,
     ):
         self._device = device
+        self._on_demand = set(on_demand_nodes or ()) & set(submodules.keys())
+        self._reload = set(reload_nodes or ()) & set(submodules.keys())
+        self._submodule_factory = submodule_factory
+        self._submodule_release = submodule_release
+        if self._reload and submodule_factory is None:
+            raise ValueError(
+                "reload-residency nodes need a submodule_factory to rebuild them: "
+                f"{sorted(self._reload)}"
+            )
         if kv_cache_type is None:
             kv_cache_type = self._autocast_dtype
 
@@ -289,6 +332,10 @@ class Engine:
         for node_name, submodule_mgmt in self._submodules.items():
             submodule = submodule_mgmt.submodule
 
+            if node_name in self._on_demand:
+                # Compiled code guards on parameter devices; an evict/reload
+                # cycle would invalidate them every phase.
+                continue
             if getattr(submodule, "disable_torch_compile", False):
                 logger.info("Engine: torch.compile disabled for %s (submodule opt-out)", node_name)
                 continue
@@ -315,10 +362,120 @@ class Engine:
         """This node's autocast dtype, or None for one that opted out."""
         return None if submodule.disable_autocast else self._autocast_dtype
 
+    def _report_peak_mem(self, node_name: str) -> None:
+        """Log the allocator high-water mark whenever it grows materially.
+
+        Gated on MSTAR_LOG_PEAK_MEM. The threshold keeps a long decode loop from
+        logging a line per step while its cache creeps upward.
+        """
+        if not _LOG_PEAK_MEM or self._device is None or self._device.type != "cuda":
+            return
+        peak = torch.cuda.max_memory_allocated(self._device) / (1024 ** 3)
+        if peak > self._peak_mem_gib + 0.25:
+            self._peak_mem_gib = peak
+            logger.info(
+                "peak_mem: %.2f GiB allocated (high-water, after %s)", peak, node_name
+            )
+
+    def _cuda_allocated_gib(self) -> float:
+        if self._device is None or self._device.type != "cuda":
+            return 0.0
+        return torch.cuda.memory_allocated(self._device) / (1024 ** 3)
+
+    @property
+    def _paged(self) -> set[str]:
+        """Nodes that are not permanently resident, under either policy."""
+        return self._on_demand | self._reload
+
+    def _evict(self, node_name: str) -> None:
+        """Release ``node_name``'s device memory under its policy.
+
+        `on_demand` moves the weights to the host — fast to bring back, but on a
+        unified-memory part they still occupy the one physical pool.
+        `reload` drops the storage outright (params become meta tensors, which
+        keeps the module object valid for bookkeeping like cleanup_request) and
+        the next execution rebuilds it from the checkpoint. Slower, and the only
+        thing that actually frees memory when host and device are the same RAM.
+        """
+        submodule = self._submodules[node_name].submodule
+        if node_name in self._reload:
+            # Drop the model's cached reference FIRST: every model here memoises
+            # get_submodule, so a rebuild would otherwise return this same object
+            # after its storage is gone.
+            if self._submodule_release is not None:
+                self._submodule_release(node_name)
+            submodule.to("meta")
+        else:
+            submodule.to("cpu")
+        if self._device is not None and self._device.type == "cuda":
+            torch.cuda.empty_cache()
+        logger.info(
+            "residency: evicted %s (%s), device allocated %.2f GiB",
+            node_name,
+            RELOAD if node_name in self._reload else ON_DEMAND,
+            self._cuda_allocated_gib(),
+        )
+
+    def _load(self, node_name: str) -> None:
+        """Bring ``node_name``'s weights back to the device under its policy."""
+        mgmt = self._submodules[node_name]
+        if node_name in self._reload:
+            # Rebuilt from the checkpoint: the previous storage is gone, so this
+            # is a fresh module and everything bound to the old one must be
+            # rebound.
+            rebuilt = self._submodule_factory(node_name)
+            rebuilt.requires_grad_(False)
+            rebuilt.bind_node_resources(mgmt.resources)
+            mgmt.submodule = rebuilt
+            mgmt.forward = rebuilt.forward
+            mgmt.forward_batched = rebuilt.forward_batched
+        else:
+            mgmt.submodule.to(self._device)
+        logger.info(
+            "residency: loaded %s (%s), device allocated %.2f GiB",
+            node_name,
+            RELOAD if node_name in self._reload else ON_DEMAND,
+            self._cuda_allocated_gib(),
+        )
+
+    def _ensure_resident(self, node_name: str) -> None:
+        """Make ``node_name``'s weights available on the device.
+
+        No-op for RESIDENT nodes (everything, unless a config says otherwise).
+        For a paged node this evicts whichever paged node currently holds the
+        device — at most one ever does — and brings this one in. The eviction is
+        what bounds the peak: components never co-reside, so the high-water mark
+        is the largest single node, not their sum.
+        """
+        if node_name not in self._paged:
+            return
+        if self._resident_on_demand == node_name:
+            return
+
+        if self._resident_on_demand is not None:
+            evicted = self._resident_on_demand
+            # Clear first: a failed load must not leave two nodes claiming
+            # residency, which would let the next call skip the eviction.
+            self._resident_on_demand = None
+            self._evict(evicted)
+
+        self._load(node_name)
+        self._resident_on_demand = node_name
+
     def warmup(self) -> None:
         cg_runners: dict[str, CudaGraphRunner] = {}
         piecewise: dict[str, dict[str, PiecewiseCudaGraphRunner]] = {}
+        # An ON_DEMAND node is skipped everywhere below. A captured graph
+        # records the addresses of the weights it read; evicting them and
+        # reloading elsewhere would leave the replay pointing at freed memory.
+        if self._on_demand:
+            logger.info(
+                "residency: %s are on_demand — no CUDA-graph capture or compile for them",
+                sorted(self._paged),
+            )
         for node_name, submodule_mgmt in self._submodules.items():
+            if node_name in self._paged:
+                continue
             submodule = submodule_mgmt.submodule
             cg_runners[node_name] = CudaGraphRunner(
                 submodule_name=node_name,
@@ -338,11 +495,15 @@ class Engine:
         # nodes share resources, so a build driven by a later node would move
         # buffers an earlier node's graphs already recorded the address of.
         for node_name in self._submodules:
+            if node_name in self._paged:
+                continue
             cg_runners[node_name].prepare_for_capture()
             for runner in piecewise[node_name].values():
                 runner.prepare_for_capture()
 
         for node_name, submodule_mgmt in self._submodules.items():
+            if node_name in self._paged:
+                continue
             runner = cg_runners[node_name]
             runner.warmup_and_capture()
             if runner.any_graphs:
@@ -399,6 +560,7 @@ class Engine:
         that rid out rather than losing the batch. A rid the submodule declines
         (returns None) leaves the same way, without being an error.
         """
+        self._ensure_resident(batch.node_name)
         if self._enable_nvtx:
             range_push(f"engine.prepare_inputs.bs{len(batch.request_ids)}")
         try:
@@ -457,6 +619,7 @@ class Engine:
             batch.outputs_ready.set()
             batch.release_waiters()
             return batch.outputs
+        self._ensure_resident(batch.node_name)
         if nvtx:
             range_push(
                 f"engine.{batch.node_name}.{batch.step_context.graph_walk}"
@@ -482,6 +645,7 @@ class Engine:
         finally:
             batch.preplan_event = None
             batch.release_waiters()
+            self._report_peak_mem(batch.node_name)
             if nvtx:
                 range_pop()
 

--- a/mstar/model/base.py
+++ b/mstar/model/base.py
@@ -524,6 +524,23 @@ class Model(ABC):
         """
         pass
 
+    def release_submodule(self, node_name: str) -> None:
+        """Forget any cached submodule for ``node_name``.
+
+        The ``reload`` residency policy drops a node's weights after each
+        execution and rebuilds it from the checkpoint on the next one. Models
+        cache their submodules — ``_submodule_cache`` is the convention across
+        this package — so without this the "rebuild" hands back the very object
+        whose storage was just released, and the next ``.to(device)`` dies with
+        "Cannot copy out of meta tensor".
+
+        The default drops the conventional cache entry, which covers every model
+        here. Override if yours caches differently.
+        """
+        cache = getattr(self, "_submodule_cache", None)
+        if isinstance(cache, dict):
+            cache.pop(node_name, None)
+
     def get_max_output_tokens(self, **model_kwargs):
         return model_kwargs.get("max_output_tokens", MAX_OUTPUT_TOKENS)
 

--- a/mstar/worker/engine_manager.py
+++ b/mstar/worker/engine_manager.py
@@ -4,12 +4,95 @@ from dataclasses import dataclass, field
 import torch
 
 from mstar.distributed.communication import WorkerParallelGroups
-from mstar.engine.engine import Engine
+from mstar.engine.engine import (
+    ON_DEMAND,
+    RELOAD,
+    RESIDENCY_POLICIES,
+    RESIDENT,
+    Engine,
+)
 from mstar.engine.resources import ResourceReqConfig, apply_yaml_overrides
 from mstar.engine.resources.kv.transfer import TransferEngineInfo
 from mstar.model.base import Model
 
 logger = logging.getLogger(__name__)
+
+
+def parse_residency(model_config: dict, node_names: set[str]) -> dict[str, str]:
+    """Per-node weight residency for the nodes this worker owns, policy by name.
+
+    Declared on the node_group that places the node. Only non-default entries
+    are returned; anything absent is ``resident``.
+
+    ``resident``   weights load to the device once and stay (the default, and
+                   the only policy that keeps CUDA-graph capture, torch.compile
+                   and cross-request batching for that node).
+    ``on_demand``  weights live on the host and move to the device around each
+                   execution. Frees device memory; on a unified-memory part
+                   (GB10) host and device are the same pool, so it bounds the
+                   *device allocator* but not system memory.
+    ``reload``     weights are dropped after each execution and rebuilt from the
+                   checkpoint on the next one. The only policy that frees memory
+                   outright, and so the only one that helps when a model's total
+                   exceeds physical memory.
+
+    An unrecognized policy raises rather than silently defaulting, matching how
+    the resource overrides treat a misspelled key.
+    """
+    residency: dict[str, str] = {}
+    for group in model_config.get("node_groups", []) or []:
+        policy = str(group.get("residency", RESIDENT)).lower()
+        if policy not in RESIDENCY_POLICIES:
+            raise ValueError(
+                f"node_group residency must be one of {list(RESIDENCY_POLICIES)}, "
+                f"got {policy!r} for nodes {group.get('node_names')}"
+            )
+        for node in group.get("node_names", []):
+            residency[node] = policy
+    return {
+        n: p for n, p in residency.items() if n in node_names and p != RESIDENT
+    }
+
+
+def parse_on_demand_nodes(model_config: dict, node_names: set[str]) -> set[str]:
+    """The ``on_demand`` subset of :func:`parse_residency`."""
+    return {
+        n for n, p in parse_residency(model_config, node_names).items()
+        if p == ON_DEMAND
+    }
+
+
+
+def _make_submodule_factory(model, device, parallel_groups, autocast_dtype):
+    """Rebuild a node's submodule from the checkpoint, onto the device.
+
+    Used by the `reload` policy, whose evictions drop the weights entirely.
+    Mirrors the construction in ``build`` so a rebuilt module is identical to
+    the one loaded at startup.
+    """
+    def factory(name: str):
+        # The caller released the cache entry on eviction, so this really does
+        # rebuild from the checkpoint rather than returning the evicted object.
+        extra = {}
+        node_sp_group = parallel_groups.get_sp_config_for_node(name)
+        if node_sp_group.world_size > 1:
+            extra["sp_group"] = node_sp_group
+        submodule = model.get_submodule(
+            name, device,
+            tp_group=parallel_groups.get_tp_config_for_node(name),
+            autocast_dtype=autocast_dtype, **extra,
+        )
+        if submodule is None:
+            raise ValueError(
+                f"reload-residency node {name!r} has no submodule to rebuild "
+                "(get_submodule returned None)"
+            )
+        if submodule.disable_autocast:
+            return submodule.to(device=device)
+        node_dtype = submodule.get_autocast_dtype() or autocast_dtype
+        return submodule.to(device=device, dtype=node_dtype)
+
+    return factory
 
 
 @dataclass
@@ -43,6 +126,11 @@ class EngineManager:
         specs = model.get_node_resources()
         apply_yaml_overrides(specs, model_config)
 
+        residency = parse_residency(model_config, node_names)
+        on_demand = {n for n, p in residency.items() if p == ON_DEMAND}
+        reload_nodes = {n for n, p in residency.items() if p == RELOAD}
+        paged = on_demand | reload_nodes
+
         # Resolve autocast dtype: explicit YAML config wins; otherwise we
         # fall back to the Model's own preference (so models that need to
         # match a reference numerically can override get_autocast_dtype
@@ -65,8 +153,11 @@ class EngineManager:
             node_sp_group = parallel_groups.get_sp_config_for_node(name)
             if node_sp_group.world_size > 1:
                 extra["sp_group"] = node_sp_group
+            # An on_demand node materialises on the host; the engine moves it
+            # to the device around each execution.
+            build_device = torch.device("cpu") if name in paged else device
             submodule = model.get_submodule(
-                name, device,
+                name, build_device,
                 tp_group=parallel_groups.get_tp_config_for_node(name),
                 autocast_dtype=autocast_dtype, **extra,
             )
@@ -74,12 +165,28 @@ class EngineManager:
                 continue
             if submodule.disable_autocast:
                 # keeps the dtype it was built in; the engine won't autocast it
-                submodules[name] = submodule.to(device=device)
+                submodules[name] = submodule.to(device=build_device)
                 continue
             # A submodule that must run in its own dtype (an audio codec in
             # fp32, say) says so; otherwise it takes the engine's.
             node_dtype = submodule.get_autocast_dtype() or autocast_dtype
-            submodules[name] = submodule.to(device=device, dtype=node_dtype)
+            submodules[name] = submodule.to(device=build_device, dtype=node_dtype)
+
+        # A reload node keeps no weights between executions, so release the
+        # construction copy now: startup then holds one component at a time
+        # instead of all of them, which is the whole point on a box where the
+        # model's total exceeds physical memory. `meta` frees the storage while
+        # leaving the module object valid for bookkeeping (remove_request calls
+        # cleanup_request on every node, resident or not).
+        for name in reload_nodes:
+            if name in submodules:
+                submodules[name] = submodules[name].to("meta")
+                # Release the model's cached reference too. Without this the
+                # FIRST load has nothing to evict, so the factory returns this
+                # same object straight from get_submodule's memo — now on meta —
+                # and dies on .to(device). The eviction path releases as well;
+                # startup is the case that never reaches it.
+                model.release_submodule(name)
 
         engine = Engine(
             autocast_dtype=autocast_dtype,
@@ -93,8 +200,17 @@ class EngineManager:
             device=device,
             transfer_engine_info=transfer_engine_info,
             kv_cache_type=autocast_dtype,
+            on_demand_nodes=on_demand,
+            reload_nodes=reload_nodes,
+            submodule_factory=_make_submodule_factory(
+                model, device, parallel_groups, autocast_dtype,
+            ) if reload_nodes else None,
+            submodule_release=model.release_submodule if reload_nodes else None,
         )
         logger.info("Engine loaded on device %s for nodes %s", device, sorted(node_names))
+        for policy, names in (("on_demand", on_demand), ("reload", reload_nodes)):
+            if names:
+                logger.info("Engine: %s nodes: %s", policy, sorted(names))
 
         return cls(engine=engine, node_names=set(node_names))
 

--- a/test/modular/test_node_residency.py
+++ b/test/modular/test_node_residency.py
@@ -1,0 +1,300 @@
+"""Per-node weight residency: what `residency: on_demand` buys and costs.
+
+The point of the policy is that components never co-reside, so a model whose
+parts sum past device memory still runs — the peak becomes the largest single
+node instead of the sum. These tests pin the two halves of that: the config
+surface, and the evict/load swap itself.
+
+Everything here runs on CPU: `_ensure_resident` moves to whatever `_device` is.
+"""
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, ".")
+
+import pytest
+import torch
+
+from mstar.engine.engine import Engine
+from mstar.worker.engine_manager import parse_on_demand_nodes
+
+
+class _FakeSubmodule:
+    """Records every device it was moved to."""
+
+    def __init__(self) -> None:
+        self.moves: list[str] = []
+
+    def to(self, device=None, **kwargs):
+        target = device if device is not None else kwargs.get("device")
+        self.moves.append(str(target))
+        return self
+
+
+def _engine_with(nodes: dict[str, _FakeSubmodule], on_demand: set[str]) -> Engine:
+    engine = Engine(autocast_dtype=torch.bfloat16)
+    engine._device = torch.device("cpu")
+    engine._submodules = {
+        name: SimpleNamespace(submodule=sub) for name, sub in nodes.items()
+    }
+    engine._on_demand = set(on_demand)
+    return engine
+
+
+# --- config surface --------------------------------------------------------
+
+def test_default_is_resident():
+    cfg = {"node_groups": [{"node_names": ["dit", "vae"], "ranks": [0]}]}
+    assert parse_on_demand_nodes(cfg, {"dit", "vae"}) == set()
+
+
+def test_on_demand_selected_per_group():
+    cfg = {"node_groups": [
+        {"node_names": ["text_encoder"], "ranks": [0], "residency": "on_demand"},
+        {"node_names": ["dit"], "ranks": [0], "residency": "resident"},
+        {"node_names": ["vae"], "ranks": [0]},
+    ]}
+    assert parse_on_demand_nodes(cfg, {"text_encoder", "dit", "vae"}) == {"text_encoder"}
+
+
+def test_only_nodes_on_this_worker_are_returned():
+    """A group may place nodes this worker doesn't own; those are not ours."""
+    cfg = {"node_groups": [
+        {"node_names": ["text_encoder", "dit"], "ranks": [0], "residency": "on_demand"},
+    ]}
+    assert parse_on_demand_nodes(cfg, {"dit"}) == {"dit"}
+
+
+def test_misspelled_policy_raises():
+    """A misspelling is never silently ignored — same contract as the resource
+    overrides, where an unknown key fails loading."""
+    cfg = {"node_groups": [
+        {"node_names": ["dit"], "ranks": [0], "residency": "on-demand"},  # hyphen
+    ]}
+    with pytest.raises(ValueError, match="residency must be one of"):
+        parse_on_demand_nodes(cfg, {"dit"})
+
+
+# --- the swap --------------------------------------------------------------
+
+def test_resident_node_is_never_moved():
+    dit = _FakeSubmodule()
+    engine = _engine_with({"dit": dit}, on_demand=set())
+    engine._ensure_resident("dit")
+    engine._ensure_resident("dit")
+    assert dit.moves == []
+    assert engine._resident_on_demand is None
+
+
+def test_on_demand_node_is_loaded_once_then_reused():
+    enc = _FakeSubmodule()
+    engine = _engine_with({"enc": enc}, on_demand={"enc"})
+    engine._ensure_resident("enc")
+    engine._ensure_resident("enc")  # idempotent: no second transfer
+    assert enc.moves == ["cpu"]
+    assert engine._resident_on_demand == "enc"
+
+
+def test_second_on_demand_node_evicts_the_first():
+    """The eviction is the whole point: two large components must never both
+    hold the device, or the peak is their sum and the model does not fit."""
+    enc, dit = _FakeSubmodule(), _FakeSubmodule()
+    engine = _engine_with({"enc": enc, "dit": dit}, on_demand={"enc", "dit"})
+
+    engine._ensure_resident("enc")
+    engine._ensure_resident("dit")
+
+    assert enc.moves == ["cpu", "cpu"]   # loaded, then evicted back to host
+    assert dit.moves == ["cpu"]          # loaded
+    assert engine._resident_on_demand == "dit"
+
+
+def test_mixing_resident_and_on_demand_leaves_resident_alone():
+    enc, vae = _FakeSubmodule(), _FakeSubmodule()
+    engine = _engine_with({"enc": enc, "vae": vae}, on_demand={"enc"})
+    engine._ensure_resident("vae")   # resident: untouched
+    engine._ensure_resident("enc")
+    engine._ensure_resident("vae")   # still untouched, and enc stays loaded
+    assert vae.moves == []
+    assert engine._resident_on_demand == "enc"
+
+
+def test_failed_move_does_not_leave_a_stale_claim():
+    """If the incoming move raises, no node may still be recorded as resident —
+    otherwise the next call skips the eviction and two nodes co-reside."""
+    class _Exploding(_FakeSubmodule):
+        def to(self, device=None, **kwargs):
+            raise RuntimeError("CUDA out of memory")
+
+    enc, bad = _FakeSubmodule(), _Exploding()
+    engine = _engine_with({"enc": enc, "bad": bad}, on_demand={"enc", "bad"})
+    engine._ensure_resident("enc")
+    with pytest.raises(RuntimeError, match="out of memory"):
+        engine._ensure_resident("bad")
+    assert engine._resident_on_demand is None
+    assert enc.moves == ["cpu", "cpu"]   # it was still evicted
+
+
+# --- the shipped config ----------------------------------------------------
+
+def test_bagel_residency_config_pages_the_encoders():
+    """configs/bagel_residency.yaml is the validation deployment for this
+    feature: encoders paged, LLM resident (it runs every decode step and is the
+    node that most wants CUDA-graph capture)."""
+    import pathlib
+
+    import yaml
+
+    cfg = yaml.safe_load(pathlib.Path("configs/bagel_residency.yaml").read_text())
+    nodes = {"vit_encoder", "vae_encoder", "vae_decoder", "LLM"}
+    assert parse_on_demand_nodes(cfg, nodes) == {"vit_encoder", "vae_encoder", "vae_decoder"}
+
+
+# --- the reload policy -----------------------------------------------------
+
+def test_parse_residency_reports_policy_per_node():
+    from mstar.worker.engine_manager import parse_residency
+
+    cfg = {"node_groups": [
+        {"node_names": ["enc"], "ranks": [0], "residency": "reload"},
+        {"node_names": ["vae"], "ranks": [0], "residency": "on_demand"},
+        {"node_names": ["dit"], "ranks": [0]},
+    ]}
+    got = parse_residency(cfg, {"enc", "vae", "dit"})
+    # resident nodes are omitted: absent means default
+    assert got == {"enc": "reload", "vae": "on_demand"}
+
+
+def test_reload_node_drops_storage_and_rebuilds_from_the_factory():
+    """`reload` is the policy that actually frees memory: it evicts to `meta`
+    (no storage) rather than to the host, and the next execution rebuilds from
+    the checkpoint. On a unified-memory part that distinction is the whole
+    ballgame — host and device are one pool, so moving weights host-side frees
+    nothing."""
+    built: list[str] = []
+
+    class _Rebuilt(_FakeSubmodule):
+        def requires_grad_(self, flag):
+            return self
+
+        def bind_node_resources(self, resources):
+            return None
+
+        forward = staticmethod(lambda *a, **k: None)
+        forward_batched = staticmethod(lambda *a, **k: None)
+
+    def factory(name):
+        built.append(name)
+        return _Rebuilt()
+
+    enc, dit = _FakeSubmodule(), _FakeSubmodule()
+    engine = _engine_with({"enc": enc, "dit": dit}, on_demand=set())
+    engine._reload = {"enc", "dit"}
+    engine._submodule_factory = factory
+    engine._submodules["enc"].resources = {}
+    engine._submodules["dit"].resources = {}
+    engine._submodules["enc"].forward = None
+    engine._submodules["enc"].forward_batched = None
+    engine._submodules["dit"].forward = None
+    engine._submodules["dit"].forward_batched = None
+
+    engine._ensure_resident("enc")
+    assert built == ["enc"]              # rebuilt from the checkpoint
+    engine._ensure_resident("dit")
+    assert built == ["enc", "dit"]
+    # the outgoing node's storage was dropped, not parked on the host
+    assert engine._submodules["enc"].submodule.moves[-1] == "meta"
+
+
+def test_reload_without_a_factory_is_refused_at_load():
+    """Failing here is much better than failing on the first request, when the
+    weights are already gone and there is nothing to rebuild them with."""
+    engine = Engine(autocast_dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="submodule_factory"):
+        engine.load_model(
+            submodules={"enc": _FakeSubmodule()},
+            specs=[],
+            parallel_groups=SimpleNamespace(
+                all_in_same_group=lambda *_: True,
+                get_joint_group_for_node=lambda *_: None,
+            ),
+            device=torch.device("cpu"),
+            transfer_engine_info=None,
+            reload_nodes={"enc"},
+            submodule_factory=None,
+        )
+
+
+def test_reload_eviction_releases_the_models_cached_submodule():
+    """Regression: every model here memoises get_submodule, so a `reload`
+    rebuild used to hand back the very object whose storage had just been
+    dropped — the next .to(device) then died with "Cannot copy out of meta
+    tensor". Eviction must tell the model to forget the node first."""
+    released: list[str] = []
+
+    class _Rebuilt(_FakeSubmodule):
+        def requires_grad_(self, flag):
+            return self
+
+        def bind_node_resources(self, resources):
+            return None
+
+        forward = staticmethod(lambda *a, **k: None)
+        forward_batched = staticmethod(lambda *a, **k: None)
+
+    enc, dit = _FakeSubmodule(), _FakeSubmodule()
+    engine = _engine_with({"enc": enc, "dit": dit}, on_demand=set())
+    engine._reload = {"enc", "dit"}
+    engine._submodule_factory = lambda name: _Rebuilt()
+    engine._submodule_release = released.append
+    for n in ("enc", "dit"):
+        engine._submodules[n].resources = {}
+        engine._submodules[n].forward = None
+        engine._submodules[n].forward_batched = None
+
+    engine._ensure_resident("enc")
+    engine._ensure_resident("dit")          # evicts enc
+    assert released == ["enc"], "eviction did not release the cached submodule"
+
+
+def test_model_release_submodule_drops_the_conventional_cache():
+    """The base implementation covers every model in this package, all of which
+    keep a `_submodule_cache` dict."""
+    from mstar.model.base import Model
+
+    class _M(Model):
+        def __init__(self):
+            self._submodule_cache = {"enc": object(), "dit": object()}
+        # abstract methods are irrelevant here
+        get_node_resources = get_graph_walk_graphs = None
+        get_initial_forward_pass_args = process_prompt = None
+        postprocess = get_submodule = get_partition_forward_pass_args = None
+
+    m = _M.__new__(_M)
+    m._submodule_cache = {"enc": object(), "dit": object()}
+    Model.release_submodule(m, "enc")
+    assert set(m._submodule_cache) == {"dit"}
+    Model.release_submodule(m, "absent")   # tolerates an unknown node
+
+
+def test_startup_release_is_what_makes_the_first_reload_genuine():
+    """Regression, second order: eviction releasing the cache is not enough.
+
+    A reload node is built once at startup (to bind resources) and immediately
+    dropped to meta. The FIRST execution has nothing to evict, so if startup
+    does not also release the cache, get_submodule's memo hands the factory that
+    same meta object and .to(device) dies — the identical failure the eviction
+    fix was supposed to cure, one step earlier.
+    """
+    import inspect
+
+    from mstar.worker import engine_manager
+
+    src = inspect.getsource(engine_manager.EngineManager.build)
+    reload_block = src[src.index("for name in reload_nodes:"):]
+    assert 'to("meta")' in reload_block
+    assert "release_submodule" in reload_block, (
+        "startup drops the weights but never tells the model to forget them"
+    )


### PR DESCRIPTION
## Problem

A node's weights load to the device once and stay there, so a deployment's memory floor is the **sum** of its nodes. That rules out models whose components together exceed device memory even when no single one does — and it is not a hypothetical: MiniMax H3 is ~148 GB in bf16 (70.1 GB DiT + 66.7 GB Qwen3-VL encoder + ~11 GB VAEs) against a 128 GB DGX Spark, while its largest single component is only 70 GB.

## Change

A `node_group` may declare a `residency` policy:

```yaml
node_groups:
  - {node_names: [text_encoder], ranks: [0], residency: reload}
  - {node_names: [dit],          ranks: [0], residency: resident}
```

| policy | behavior |
|---|---|
| `resident` | *(default, unchanged)* load once and stay. The only policy that keeps CUDA-graph capture, `torch.compile` and cross-request batching for that node. |
| `on_demand` | weights live on the host, moving to the device around each execution. Bounds the device allocator; on a unified-memory part host and device are one pool, so it does not bound system memory. |
| `reload` | weights are dropped after each execution and rebuilt from the checkpoint. The only policy that frees memory outright, and so the only one that helps when a model's total exceeds physical memory. |

At most one non-resident node holds the device at a time, so the peak tracks the **largest single component** rather than the sum.

Existing configs are unaffected: absent means `resident`, and an unrecognized value raises rather than defaulting — matching how the resource overrides treat a misspelled key.

## Measurements

`wan22` on one GB10 (UMT5-XXL encoder paged, DiT resident, single request). Output is **byte-identical** under all three:

| policy | peak allocated | latency | output |
|---|---|---|---|
| `resident` | 25.37 GiB | 20 s | 331,713 B |
| `on_demand` | 20.50 GiB | 142 s | 331,713 B |
| `reload` | 20.50 GiB | 81 s | 331,713 B |

`reload` beats `on_demand` because the rebuild reads the checkpoint from page cache straight to the device, where `on_demand` pays a host↔device round trip.

`MSTAR_LOG_PEAK_MEM=1` logs the allocator high-water mark as it grows — `nvidia-smi` reports *reserved* memory and is too coarse to see the effect.

## What it costs

A non-resident node forgoes CUDA-graph capture and `torch.compile` (a capture records the addresses of the weights it read; compiled code guards on parameter devices — an evict/reload cycle invalidates both), and it forfeits cross-request batching, since requests serialize at phase boundaries. It suits a node that runs **once per request** — a prompt encoder, a VAE — far better than one that runs every decode step. That is why it is opt-in per node rather than a global mode.

## Note for reviewers

`reload` needs the model to forget a cached submodule, since every model here memoises `get_submodule`. `Model.release_submodule` does that, defaulting to the package's `_submodule_cache` convention. It must fire at **eviction and at startup** — the first execution has nothing to evict, and without the startup release the "rebuild" returns the just-dropped object and dies with *"Cannot copy out of meta tensor"*. Both call sites are pinned by tests; the startup one is verified by inspecting `build()` because it is not reachable through the test harness.

## Testing

16 new tests in `test/modular/test_node_residency.py` covering the config surface, the evict/load swap under both policies, the cache-release contract, and that a failed load leaves no stale residency claim. `docs/serving.rst` gains a "Weight residency" section. `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhaPHxiyRZAFhSkGKf2Ljs