### PR TITLE
docs: resolve version from the m-star distribution

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,19 +1,13 @@
 import os
 import sys
 from datetime import datetime
+from importlib.metadata import version as _pkg_version
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, PROJECT_ROOT)
 
-try:
-    from mstar import __version__ as package_version
-except Exception:  # noqa: BLE001
-    try:
-        from importlib.metadata import version as _pkg_version
-
-        package_version = _pkg_version("mstar")
-    except Exception:  # noqa: BLE001
-        package_version = "0.0.0"
+# "m-star" is the distribution name whereas "mstar" is the import name.
+package_version = _pkg_version("m-star")
 
 project = "M*"
 author = "M* Team"


### PR DESCRIPTION
## What does this PR do?

The title in the published docs is reading `M* v0.0.0 Documentation`. The cause from #242, which renamed the distribution from `mstar` to `m-star`, and this caused silent exception fallbacks to v0.0.0 in docs/config.py. 

This resolves the version in one step, and removes the exception fallback which was unnecessary, so the failure surfaces.

## How was it tested?

```bash
/path/to/venv -c "from importlib.metadata import version; print(version('m-star'))"
# 0.2.0

/path/to/venv -c "from importlib.metadata import version; print(version('mstar'))"
# PackageNotFoundError: No package metadata was found for mstar
```

## Checklist
- [x] `ruff check .` passes
- [x] Added or updated tests / docs where relevant
